### PR TITLE
[Arista] Use MEDIA_KEY and LANE_SPEED_KEY in media_settings.json file

### DIFF
--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/media_settings.json
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/media_settings.json
@@ -2,9001 +2,8436 @@
     "PORT_MEDIA_SETTINGS": {
         "1": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x8d",
-                    "lane2": "0x8b",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x94",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x8d",
+                        "lane2": "0x8b",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x94",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x8d",
-                    "lane2": "0x8b",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x94",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x8d",
+                        "lane2": "0x8b",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x94",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x8d",
-                    "lane2": "0x8b",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x94",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x8d",
+                        "lane2": "0x8b",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x94",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x55",
-                    "lane2": "0x50",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe7",
-                    "lane2": "0xffffffe9",
-                    "lane3": "0xffffffeb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff9",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x55",
+                        "lane2": "0x50",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe9",
+                        "lane3": "0xffffffeb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "2": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x84",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff6",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x84",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x84",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff6",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x84",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x84",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff6",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x84",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff6",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xffffffec",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x4b",
-                    "lane2": "0x4e",
-                    "lane3": "0x4e",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x4b",
+                        "lane2": "0x4e",
+                        "lane3": "0x4e"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "3": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x50",
-                    "lane1": "0x50",
-                    "lane2": "0x55",
-                    "lane3": "0x55",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe9",
-                    "lane1": "0xffffffe9",
-                    "lane2": "0xffffffe7",
-                    "lane3": "0xffffffe7",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x50",
+                        "lane1": "0x50",
+                        "lane2": "0x55",
+                        "lane3": "0x55"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe9",
+                        "lane1": "0xffffffe9",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "4": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffff8",
-                    "lane6": "0xfffffff8",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xffffffff",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff1",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffff8",
-                    "lane6": "0xfffffff8",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xffffffff",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff1",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffff8",
-                    "lane6": "0xfffffff8",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xffffffff",
-                    "lane6": "0xffffffff",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff1",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffff8",
+                        "lane6": "0xfffffff8",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xffffffff",
+                        "lane6": "0xffffffff",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff1",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "5": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x89",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x89",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+ 		    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x89",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x89",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x89",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff4",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x89",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff4",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "6": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+               },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "7": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "8": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "9": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "10": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x4e",
-                    "lane2": "0x4b",
-                    "lane3": "0x53",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffeb",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffa",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x4e",
+                        "lane2": "0x4b",
+                        "lane3": "0x53"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "11": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+
+                 }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x4b",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffeb",
-                    "lane1": "0xffffffeb",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x4b",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "12": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x53",
-                    "lane2": "0x55",
-                    "lane3": "0x53",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffeb",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffeb",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffa",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffa",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x53",
+                        "lane2": "0x55",
+                        "lane3": "0x53"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffa",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "13": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x4e",
-                    "lane2": "0x53",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffec",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x4e",
+                        "lane2": "0x53",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffec"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "14": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x55",
-                    "lane2": "0x4b",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe7",
-                    "lane1": "0xffffffe7",
-                    "lane2": "0xffffffeb",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff9",
-                    "lane1": "0xfffffff9",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x55",
+                        "lane2": "0x4b",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "15": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x86",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x86",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x86",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x86",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x86",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x86",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x53",
-                    "lane2": "0x55",
-                    "lane3": "0x53",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffeb",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffa",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x53",
+                        "lane2": "0x55",
+                        "lane3": "0x53"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "16": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x4b",
-                    "lane2": "0x59",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe7",
-                    "lane1": "0xffffffeb",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff9",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x4b",
+                        "lane2": "0x59",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffeb",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "17": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x88",
-                    "lane4": "0x8b",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff9",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0xfffffffe",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x3",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x88",
+                        "lane4": "0x8b",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x3",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x88",
-                    "lane4": "0x8b",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff9",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0xfffffffe",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x3",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x88",
+                        "lane4": "0x8b",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x3",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x88",
-                    "lane4": "0x8b",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff9",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0xfffffffe",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x3",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x88",
+                        "lane4": "0x8b",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff9",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0x0",
+                        "lane4": "0xfffffffe",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x3",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x53",
-                    "lane1": "0x53",
-                    "lane2": "0x55",
-                    "lane3": "0x55",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffeb",
-                    "lane3": "0xffffffeb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffa",
-                    "lane3": "0xfffffffa",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x53",
+                        "lane1": "0x53",
+                        "lane2": "0x55",
+                        "lane3": "0x55"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffeb",
+                        "lane3": "0xffffffeb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffa",
+                        "lane3": "0xfffffffa"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "18": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffeb",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffeb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffc",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffeb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffffc"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "19": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x90",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xffffffef",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xffffffef",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x90",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xffffffef",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xffffffef",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x90",
-                    "lane3": "0x90",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xffffffef",
-                    "lane3": "0xffffffef",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x90",
+                        "lane3": "0x90",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xffffffef",
+                        "lane3": "0xffffffef",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x55",
-                    "lane2": "0x50",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe7",
-                    "lane1": "0xffffffe7",
-                    "lane2": "0xffffffe9",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff9",
-                    "lane1": "0xfffffff9",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x55",
+                        "lane2": "0x50",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe9",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "20": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x8d",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x8d",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xfffffff8"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff1",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff1",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff1"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x8d",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x8d",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xfffffff8",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xfffffff8"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff1",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff1",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff1"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x4b",
-                    "lane2": "0x4e",
-                    "lane3": "0x4e",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x4b",
+                        "lane2": "0x4e",
+                        "lane3": "0x4e"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "21": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x89"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x89"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x89"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x89"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x89"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff4"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x89"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff4"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x50",
-                    "lane1": "0x50",
-                    "lane2": "0x55",
-                    "lane3": "0x55",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe9",
-                    "lane1": "0xffffffe9",
-                    "lane2": "0xffffffe7",
-                    "lane3": "0xffffffe7",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x50",
+                        "lane1": "0x50",
+                        "lane2": "0x55",
+                        "lane3": "0x55"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe9",
+                        "lane1": "0xffffffe9",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe7"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "22": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "23": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+
+                  }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "24": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "25": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "26": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "27": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x59",
-                    "lane1": "0x59",
-                    "lane2": "0x59",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe3",
-                    "lane1": "0xffffffe3",
-                    "lane2": "0xffffffe3",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x59",
+                        "lane1": "0x59",
+                        "lane2": "0x59",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe3",
+                        "lane1": "0xffffffe3",
+                        "lane2": "0xffffffe3",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff8",
+                        "lane1": "0xfffffff8",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "28": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x4e",
-                    "lane2": "0x4b",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x4e",
+                        "lane2": "0x4b",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "29": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x50",
-                    "lane2": "0x55",
-                    "lane3": "0x59",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffeb",
-                    "lane1": "0xffffffe9",
-                    "lane2": "0xffffffe7",
-                    "lane3": "0xffffffe3",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x50",
+                        "lane2": "0x55",
+                        "lane3": "0x59"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffeb",
+                        "lane1": "0xffffffe9",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe3"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffc",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff8"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "30": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x53",
-                    "lane2": "0x4e",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffec",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x53",
+                        "lane2": "0x4e",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffec"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "31": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8b",
-                    "lane4": "0x94",
-                    "lane5": "0x88",
-                    "lane6": "0x8b",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff2",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8b",
+                        "lane4": "0x94",
+                        "lane5": "0x88",
+                        "lane6": "0x8b",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffc",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff2",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x4e",
-                    "lane2": "0x4b",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffec",
-                    "lane3": "0xffffffec",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x4e",
+                        "lane2": "0x4b",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffea",
+                        "lane2": "0xffffffec",
+                        "lane3": "0xffffffec"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "32": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x94",
-                    "lane2": "0x88",
-                    "lane3": "0x8b",
-                    "lane4": "0x88",
-                    "lane5": "0x8b",
-                    "lane6": "0x88",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff9",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffffc",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffc",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff2",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff2",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff2",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x94",
+                        "lane2": "0x88",
+                        "lane3": "0x8b",
+                        "lane4": "0x88",
+                        "lane5": "0x8b",
+                        "lane6": "0x88",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff9",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffffc",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffc",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffc",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff2",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xfffffff2",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff2",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x55",
-                    "lane2": "0x50",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe7",
-                    "lane1": "0xffffffe7",
-                    "lane2": "0xffffffe9",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff9",
-                    "lane1": "0xfffffff9",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x55",
+                        "lane2": "0x50",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe9",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "33": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x94",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x88",
-                    "lane4": "0x94",
-                    "lane5": "0x8b",
-                    "lane6": "0x8b",
-                    "lane7": "0x88"
-                },
-                "post1": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffff9",
-                    "lane6": "0xfffffff9",
-                    "lane7": "0xfffffff2"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xffffffff",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffc",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffc"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff2",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff2"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x94",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x88",
+                        "lane4": "0x94",
+                        "lane5": "0x8b",
+                        "lane6": "0x8b",
+                        "lane7": "0x88"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffff9",
+                        "lane6": "0xfffffff9",
+                        "lane7": "0xfffffff2"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0x0",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xffffffff",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffc",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffc"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff2",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff2"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4e",
-                    "lane1": "0x4b",
-                    "lane2": "0x4e",
-                    "lane3": "0x4b",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffea",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffec",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4e",
+                        "lane1": "0x4b",
+                        "lane2": "0x4e",
+                        "lane3": "0x4b"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffea",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffec"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "34": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8d",
-                    "lane6": "0x81",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xffffffee",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8d",
+                        "lane6": "0x81",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8d",
-                    "lane6": "0x81",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xffffffee",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8d",
+                        "lane6": "0x81",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x88",
-                    "lane2": "0x8b",
-                    "lane3": "0x8d",
-                    "lane4": "0x94",
-                    "lane5": "0x8d",
-                    "lane6": "0x81",
-                    "lane7": "0x94"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff1",
-                    "lane7": "0xfffffffd"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff2",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xffffffee",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x2",
-                    "lane2": "0x3",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x88",
+                        "lane2": "0x8b",
+                        "lane3": "0x8d",
+                        "lane4": "0x94",
+                        "lane5": "0x8d",
+                        "lane6": "0x81",
+                        "lane7": "0x94"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff1",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0xfffffffe",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffc",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xffffffff"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff2",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xffffffee",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x2",
+                        "lane2": "0x3",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x55",
-                    "lane1": "0x50",
-                    "lane2": "0x55",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe7",
-                    "lane1": "0xffffffe9",
-                    "lane2": "0xffffffe7",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff9",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x55",
+                        "lane1": "0x50",
+                        "lane2": "0x55",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe7",
+                        "lane1": "0xffffffe9",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff9",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "35": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x90",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xffffffef",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x90",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xffffffef",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x90",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xffffffef",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x90",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xffffffef",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x8d",
-                    "lane1": "0x90",
-                    "lane2": "0x89",
-                    "lane3": "0x8d",
-                    "lane4": "0x90",
-                    "lane5": "0x89",
-                    "lane6": "0x8d",
-                    "lane7": "0x90"
-                },
-                "post1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xffffffff",
-                    "lane2": "0xfffffff4",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xffffffff",
-                    "lane5": "0xfffffff4",
-                    "lane6": "0xfffffffb",
-                    "lane7": "0xffffffff"
-                },
-                "post2": {
-                    "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0x0",
-                    "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffd"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xffffffef",
-                    "lane2": "0xfffffff0",
-                    "lane3": "0xfffffff0",
-                    "lane4": "0xffffffef",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xffffffef"
-                },
-                "pre2": {
-                    "lane0": "0x3",
-                    "lane1": "0x2",
-                    "lane2": "0x2",
-                    "lane3": "0x3",
-                    "lane4": "0x2",
-                    "lane5": "0x2",
-                    "lane6": "0x3",
-                    "lane7": "0x2"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x8d",
+                        "lane1": "0x90",
+                        "lane2": "0x89",
+                        "lane3": "0x8d",
+                        "lane4": "0x90",
+                        "lane5": "0x89",
+                        "lane6": "0x8d",
+                        "lane7": "0x90"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xffffffff",
+                        "lane2": "0xfffffff4",
+                        "lane3": "0xfffffffb",
+                        "lane4": "0xffffffff",
+                        "lane5": "0xfffffff4",
+                        "lane6": "0xfffffffb",
+                        "lane7": "0xffffffff"
+                    },
+                    "post2": {
+                        "lane0": "0xfffffffe",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0x0",
+                        "lane3": "0xfffffffe",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0x0",
+                        "lane6": "0xfffffffe",
+                        "lane7": "0xfffffffd"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xffffffef",
+                        "lane2": "0xfffffff0",
+                        "lane3": "0xfffffff0",
+                        "lane4": "0xffffffef",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xffffffef"
+                    },
+                    "pre2": {
+                        "lane0": "0x3",
+                        "lane1": "0x2",
+                        "lane2": "0x2",
+                        "lane3": "0x3",
+                        "lane4": "0x2",
+                        "lane5": "0x2",
+                        "lane6": "0x3",
+                        "lane7": "0x2"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x4b",
-                    "lane1": "0x4b",
-                    "lane2": "0x4e",
-                    "lane3": "0x4e",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xffffffea",
-                    "lane3": "0xffffffea",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x4b",
+                        "lane1": "0x4b",
+                        "lane2": "0x4e",
+                        "lane3": "0x4e"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffec",
+                        "lane1": "0xffffffec",
+                        "lane2": "0xffffffea",
+                        "lane3": "0xffffffea"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffffb",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         },
         "36": {
             "QSFP-DD-sm_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-nm_850_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "QSFP-DD-active_cable_media_interface": {
-                "main": {
-                    "lane0": "0x89",
-                    "lane1": "0x8d",
-                    "lane2": "0x8d",
-                    "lane3": "0x8d",
-                    "lane4": "0x89",
-                    "lane5": "0x8d",
-                    "lane6": "0x89",
-                    "lane7": "0x8d"
-                },
-                "post1": {
-                    "lane0": "0xfffffff4",
-                    "lane1": "0xfffffffb",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff8",
-                    "lane4": "0xfffffff4",
-                    "lane5": "0xfffffffb",
-                    "lane6": "0xfffffff4",
-                    "lane7": "0xfffffffb"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffd",
-                    "lane4": "0x0",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0x0",
-                    "lane7": "0xfffffffe"
-                },
-                "post3": {
-                    "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffd",
-                    "lane2": "0xffffffff",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffd",
-                    "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffd"
-                },
-                "pre1": {
-                    "lane0": "0xfffffff0",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff1",
-                    "lane3": "0xfffffff1",
-                    "lane4": "0xfffffff0",
-                    "lane5": "0xfffffff0",
-                    "lane6": "0xfffffff0",
-                    "lane7": "0xfffffff0"
-                },
-                "pre2": {
-                    "lane0": "0x2",
-                    "lane1": "0x3",
-                    "lane2": "0x2",
-                    "lane3": "0x2",
-                    "lane4": "0x2",
-                    "lane5": "0x3",
-                    "lane6": "0x2",
-                    "lane7": "0x3"
+                "speed:400GAUI-8|50G": {
+                    "main": {
+                        "lane0": "0x89",
+                        "lane1": "0x8d",
+                        "lane2": "0x8d",
+                        "lane3": "0x8d",
+                        "lane4": "0x89",
+                        "lane5": "0x8d",
+                        "lane6": "0x89",
+                        "lane7": "0x8d"
+                    },
+                    "post1": {
+                        "lane0": "0xfffffff4",
+                        "lane1": "0xfffffffb",
+                        "lane2": "0xfffffff8",
+                        "lane3": "0xfffffff8",
+                        "lane4": "0xfffffff4",
+                        "lane5": "0xfffffffb",
+                        "lane6": "0xfffffff4",
+                        "lane7": "0xfffffffb"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0xfffffffe",
+                        "lane2": "0xfffffffd",
+                        "lane3": "0xfffffffd",
+                        "lane4": "0x0",
+                        "lane5": "0xfffffffe",
+                        "lane6": "0x0",
+                        "lane7": "0xfffffffe"
+                    },
+                    "post3": {
+                        "lane0": "0xfffffffd",
+                        "lane1": "0xfffffffd",
+                        "lane2": "0xffffffff",
+                        "lane3": "0xffffffff",
+                        "lane4": "0xfffffffd",
+                        "lane5": "0xfffffffd",
+                        "lane6": "0xfffffffd",
+                        "lane7": "0xfffffffd"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffff0",
+                        "lane1": "0xfffffff0",
+                        "lane2": "0xfffffff1",
+                        "lane3": "0xfffffff1",
+                        "lane4": "0xfffffff0",
+                        "lane5": "0xfffffff0",
+                        "lane6": "0xfffffff0",
+                        "lane7": "0xfffffff0"
+                    },
+                    "pre2": {
+                        "lane0": "0x2",
+                        "lane1": "0x3",
+                        "lane2": "0x2",
+                        "lane3": "0x2",
+                        "lane4": "0x2",
+                        "lane5": "0x3",
+                        "lane6": "0x2",
+                        "lane7": "0x3"
+                    }
                 }
             },
             "Default": {
-                "main": {
-                    "lane0": "0x50",
-                    "lane1": "0x55",
-                    "lane2": "0x55",
-                    "lane3": "0x50",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post1": {
-                    "lane0": "0xffffffe9",
-                    "lane1": "0xffffffe7",
-                    "lane2": "0xffffffe7",
-                    "lane3": "0xffffffe9",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre1": {
-                    "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff9",
-                    "lane2": "0xfffffff9",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
-                },
-                "pre2": {
-                    "lane0": "0x0",
-                    "lane1": "0x0",
-                    "lane2": "0x0",
-                    "lane3": "0x0",
-                    "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x0",
-                    "lane7": "0x0"
+                "speed:CAUI-4|100GAUI-4|25G": {
+                    "main": {
+                        "lane0": "0x50",
+                        "lane1": "0x55",
+                        "lane2": "0x55",
+                        "lane3": "0x50"
+                    },
+                    "post1": {
+                        "lane0": "0xffffffe9",
+                        "lane1": "0xffffffe7",
+                        "lane2": "0xffffffe7",
+                        "lane3": "0xffffffe9"
+                    },
+                    "post2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "post3": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    },
+                    "pre1": {
+                        "lane0": "0xfffffffb",
+                        "lane1": "0xfffffff9",
+                        "lane2": "0xfffffff9",
+                        "lane3": "0xfffffffb"
+                    },
+                    "pre2": {
+                        "lane0": "0x0",
+                        "lane1": "0x0",
+                        "lane2": "0x0",
+                        "lane3": "0x0"
+                    }
                 }
             }
         }


### PR DESCRIPTION
For x86_64-arista_7800r3a_36dm2_lc, use MEDIA_KEY and LANE_SPEED_KEY in media_settings.json to prevent OA crashes caused by speed misconfiguration.

#### Why I did it
Address https://github.com/aristanetworks/sonic-qual.msft/issues/876

##### Work item tracking
N/A

#### How I did it
Add LANE_SPEED_KEY to media_settings.json so that tuning values are selected based on the configured port speed. If the port speed is not supported by the inserted transceiver, the tuning value will be None and skipped, preventing it from being applied to the hardware. This avoids SAI call failures and, ultimately, OA crashes.

#### How to verify it
On a 7800r3a_36dm2 Linecard,
1. Tested 100G port with 400G optic; 'lane_speed_key' is None and tuning is skipped as there is NO matching key.
2025 Oct  2 05:31:04.377221 cmp235-3 NOTICE pmon#xcvrd: Retrieving media settings for port Ethernet96 speed 100000 num_lanes 4, using key {'vendor_key': 'ARISTA NETWORKS -AOC-D-D-400G-1M ', 'media_key': 'QSFP-DD-active_cable_media_interface', 'lane_speed_key': None, 'medium_lane_speed_key': 'COPPER25000'}

2. Tested a 400G port with 100G optic; Tuning is skipped because the lane_speed_key, 50G, do not match any keys in "Default" case.
2025 Oct  2 05:54:04.181472 cmp235-4 NOTICE pmon#xcvrd: Retrieving media settings for port Ethernet16 speed 400000 num_lanes 8, using key {'vendor_key': 'ARISTA NETWORKS -AOC-Q-Q-100G-1M ', 'media_key': 'QSFP28-100G AOC (Active Optical Cable) or 25GAUI C2M AOC-1.0M', 'lane_speed_key': 'speed:50G', 'medium_lane_speed_key': 'OPTICAL50000'}


#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)
- [x] master
- [x] 202405

#### Description for the changelog
N/A

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
N/A
