### PR TITLE
Changed the trim queue index to 4 for some Broadcom TH5 switches

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -44,6 +44,7 @@ bcm_device:
             l3_ecmp_member_first_lkup_mem_size: 0
             l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
+            sai_pkt_trim_queue_index: 4
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -44,6 +44,7 @@ bcm_device:
             l3_ecmp_member_first_lkup_mem_size: 0
             l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
+            sai_pkt_trim_queue_index: 4
 ---
 device:
     0:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently, Broadcom TH5 switches (Arista 7060X6) use queue 9 to send trimmed packets. This PR changes the `.bcm` config file for two 7060X6 models to use queue 4 for sending trimmed packets.

##### Work item tracking
- Microsoft ADO **(number only)**: 35390583

#### How I did it
Updated the `.bcm` config files for the target models.

#### How to verify it
1. Build an image with these changes (or directly update these files on a TH5 switch).
2. Load the image to your switch (or run `sudo config reload -y` on the switch if you updated these files directly on the switch).
3. Verify that trimmed packets are sent out from queue 4:
```
$ queuestat -p Ethernet64 --all
Last cached time was 2025-10-02T21:22:12.460993
Ethernet64 Last cached time was 2025-10-02T21:22:12.460993
      Port    TxQ    Counter/pkts    Counter/bytes    Drop/pkts    Drop/bytes    Trim/pkts    TrimSent/pkts    TrimDrop/pkts
----------  -----  --------------  ---------------  -----------  ------------  -----------  ---------------  ---------------
Ethernet64    UC0               0                0            0             0            0                0                0
Ethernet64    UC1               1            4,100          861     3,530,100          861              861                0
Ethernet64    UC2               0                0            0             0            0                0                0
Ethernet64    UC3               0                0            0             0            0                0                0
Ethernet64    UC4             861          177,366            0             0            0                0                0
Ethernet64    UC5               0                0            0             0            0                0                0
Ethernet64    UC6               0                0            0             0            0                0                0
Ethernet64    UC7               0                0            0             0            0                0                0
Ethernet64    UC8               0                0            0             0            0                0                0
Ethernet64    UC9               0                0            0             0            0                0                0
Ethernet64   MC10               0                0            0             0            0                0                0
Ethernet64   MC11               0                0            0             0            0              861                0
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202412
- [ ] 202505

Needed in 202412 to update packet trimming behavior.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ 20241211.39] <!-- image version 1 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Changed the trim queue index to 4 for some Broadcom TH5 (Arista 7060X6) switches.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A


