### PR TITLE
lldpmgrd: Interrupt select on signal

### DIFF
--- a/dockers/docker-lldp/lldpmgrd
+++ b/dockers/docker-lldp/lldpmgrd
@@ -309,7 +309,7 @@ class LldpManager(daemon_base.DaemonBase):
 
         # Listen for changes to the PORT table in the CONFIG_DB and APP_DB
         while True:
-            (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS)
+            (state, selectableObj) = sel.select(SELECT_TIMEOUT_MS, interrupt_on_signal=True)
 
             if state == swsscommon.Select.OBJECT:
                 if selectableObj.getFd() == sst_mgmt_ip_confdb.getFd():


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When trying to stop the lldp docker, the SIGTERM sinal is sent to lldpmgrd, but the handling of this signal is delayed because most of the time, lldpmgrd is going to be on the sel.select line, which goes to swss-common's C++ code where it calls `select()`. When the SIGTERM arrives, the `select()` calls returns early with EINTR, but because `interrupt_on_signal` is false, swss-common goes back into the `select()` call.

Because the SIGTERM handler is in Python, but the current call is in C++, the SIGTERM handling doesn't take effect until the call stack returns to Python code, which will take 10 seconds. By that time, docker will kill the docker with SIGKILL.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

To avoid that, set `interrupt_on_signal` to true, which tells swss-common to return to Python code upon a signal, which will let any signal handlers run quickly.

#### How to verify it

Restart the lldp container, and check to see if docker had to send a SIGKILL to docker because it was blocked for 10 seconds, or if SIGTERM worked.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

