### PR TITLE
Fixed teamd crash: ENODEV is received in port_ob_create. Port cleanup logic in teamd_port_remove needs to consider this possibilty

### DIFF
--- a/src/libteam/patch/0017-teamd-crash-fix-if-port-addition-fails.patch
+++ b/src/libteam/patch/0017-teamd-crash-fix-if-port-addition-fails.patch
@@ -1,0 +1,15 @@
+diff --git a/teamd/teamd_runner_lacp.c b/teamd/teamd_runner_lacp.c
+index a3be384..f099042 100644
+--- a/teamd/teamd_runner_lacp.c
++++ b/teamd/teamd_runner_lacp.c
+@@ -1957,6 +1957,10 @@ static void lacp_event_watch_port_removing(struct teamd_context *ctx,
+ 	struct lacp *lacp = priv;
+ 	struct lacp_port *lacp_port = lacp_port_get(lacp, tdport);
+ 
++        if (!lacp_port) {
++            return;
++        }
++
+ 	/* Ensure that no incoming LACPDU is going to be processed. */
+ 	teamd_loop_callback_disable(ctx, LACP_SOCKET_CB_NAME, lacp_port);
+ 	lacp_port_set_state(lacp_port, PORT_STATE_DISABLED);

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -14,3 +14,4 @@
 0014-dont-move-the-port-state-from-disabled-when-admin-state-is-down.patch
 0015-add-support-for-custom-retry.patch
 0016-block-retry-count-changes.patch
+0017-teamd-crash-fix-if-port-addition-fails.patch


### PR DESCRIPTION
Port remove cleanup needs to check if the port is present in the first place before accessing it.

teamd_port_remove
teamd_event_port_removing
lacp_event_watch_port_removing
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
In a scale scenario it was seen that at times, the addition of an interface to a portchannel could happen even before the interface is initialized at the kernel. During this the port cleanup logic causes a crash due to null pointer access.
**Code Flow:**
port_obj_create --> port_priv_init_all --> lacp_port_added --> slow_addr_add --> __slow_addr_add_del --> ioctl returns err code 19(ENODEV -> No such device)
Cleanup Flow in case of error:
port_obj_create --> teamd_port_remove --> teamd_event_port_removing --> lacp_event_watch_port_removing --> lacp_port is not present
 
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

