### PR TITLE
Enhance supervisor-proc-exit-listener script to handle redis-communication failure case gracefully

### DIFF
--- a/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
+++ b/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
@@ -110,11 +110,15 @@ def get_autorestart_state(container_name, use_unix_socket_path):
         syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve features table from Config DB: {}".format(e))
         return ""
 
-    if container_name not in features_table:
-        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
+    if not features_table:
+        syslog.syslog(syslog.LOG_WARNING, "Empyt features table")
         return ""
 
-    is_auto_restart = features_table[container_name].get('auto_restart', 'enabled')  ## Use default if field not found
+    if container_name not in features_table:
+        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve feature '{}'".format(container_name))
+        return ""
+
+    is_auto_restart = features_table[container_name].get('auto_restart', 'enabled')  # Use default if field not found
     return is_auto_restart
 
 def load_heartbeat_alert_interval(use_unix_socket_path):

--- a/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
+++ b/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
@@ -103,21 +103,23 @@ def get_autorestart_state(container_name, use_unix_socket_path):
     @return: Return the status of auto-restart feature.
     """
     config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=use_unix_socket_path)
-    config_db.connect()
-    features_table = config_db.get_table(FEATURE_TABLE_NAME)
-    if not features_table:
-        syslog.syslog(syslog.LOG_ERR, "Unable to retrieve features table from Config DB. Exiting...")
-        sys.exit(2)
+    try:
+        config_db.connect()
+        features_table = config_db.get_table(FEATURE_TABLE_NAME)
+    except RuntimeError as e:
+        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve features table from Config DB.")
+        return ""
+
 
     if container_name not in features_table:
-        syslog.syslog(syslog.LOG_ERR, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
-        sys.exit(3)
+        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
+        return ""
 
     is_auto_restart = features_table[container_name].get('auto_restart')
     if not is_auto_restart:
         syslog.syslog(
-            syslog.LOG_ERR, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
-        sys.exit(4)
+            syslog.LOG_WARNING, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
+        return ""
 
     return is_auto_restart
 
@@ -195,7 +197,7 @@ def main(argv):
 
                 if (process_name in critical_process_list or group_name in critical_group_list) and expected == 0:
                     is_auto_restart = get_autorestart_state(container_name, use_unix_socket_path)
-                    if is_auto_restart != "disabled":
+                    if is_auto_restart == "enabled":
                         MSG_FORMAT_STR = "Process '{}' exited unexpectedly. Terminating supervisor '{}'"
                         msg = MSG_FORMAT_STR.format(payload_headers['processname'], container_name)
                         syslog.syslog(syslog.LOG_INFO, msg)

--- a/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
+++ b/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
@@ -107,9 +107,8 @@ def get_autorestart_state(container_name, use_unix_socket_path):
         config_db.connect()
         features_table = config_db.get_table(FEATURE_TABLE_NAME)
     except RuntimeError as e:
-        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve features table from Config DB.")
+        syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve features table from Config DB: {}".format(e))
         return ""
-
 
     if container_name not in features_table:
         syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve feature '{}'. Exiting...".format(container_name))

--- a/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
+++ b/src/sonic-supervisord-utilities/scripts/supervisor-proc-exit-listener
@@ -115,12 +115,7 @@ def get_autorestart_state(container_name, use_unix_socket_path):
         syslog.syslog(syslog.LOG_WARNING, "Unable to retrieve feature '{}'. Exiting...".format(container_name))
         return ""
 
-    is_auto_restart = features_table[container_name].get('auto_restart')
-    if not is_auto_restart:
-        syslog.syslog(
-            syslog.LOG_WARNING, "Unable to determine auto-restart feature status for '{}'. Exiting...".format(container_name))
-        return ""
-
+    is_auto_restart = features_table[container_name].get('auto_restart', 'enabled')  ## Use default if field not found
     return is_auto_restart
 
 def load_heartbeat_alert_interval(use_unix_socket_path):


### PR DESCRIPTION
#### Why I did it
redis-server is considered as critical process in database container. However, currently supervisor-proc-exit-listener will break if redis-server exits. By design, supervisor-proc-exit-listener should
1. periodically logging a critical process is not running if container auto_restart is disabled
2. kill the container if container auto_restart is enabled

This PR will help upervisor-proc-exit-listener achieve designed behavior if redis-server exits

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Kill the redis-server process inside database container.
Observing logs:
```
2025 Oct 31 01:25:27.304563 sonic INFO database#supervisord 2025-10-31 01:25:27,303 WARN exited: redis (terminated by SIGKILL; not expected)
2025 Oct 31 01:25:28.309293 sonic WARNING database#supervisor-proc-exit-listener: Unable to retrieve features table from Config DB: Unable to connect to redis - Connection refused(1): Cannot assign requested address
2025 Oct 31 01:26:28.436837 sonic ERR database#supervisor-proc-exit-listener: Process 'redis' is not running in namespace 'host' (1.0 minutes).
2025 Oct 31 01:27:28.559959 sonic ERR database#supervisor-proc-exit-listener: Process 'redis' is not running in namespace 'host' (2.0 minutes).
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

