### PR TITLE
Increase netlink socket buffer size as ENOMEM received on socket nl_cli.sock_event

### DIFF
--- a/src/libteam/patch/0018-increase-socket-buffer-size-for-scale.patch
+++ b/src/libteam/patch/0018-increase-socket-buffer-size-for-scale.patch
@@ -7,10 +7,10 @@ index 2f430f4..98a704f 100644
  
  /* libnl uses default 32k socket receive buffer size,
 - * which can get too small. Use 960k for all sockets.
-+ * which can get too small. Use 8MB for all sockets.
++ * which can get too small. Use 16MB for all sockets.
   */
 -#define NETLINK_RCVBUF 983040
-+#define NETLINK_RCVBUF 8388608
++#define NETLINK_RCVBUF 16777216
  
  /**
   * @param th		libteam library context

--- a/src/libteam/patch/0018-increase-socket-buffer-size-for-scale.patch
+++ b/src/libteam/patch/0018-increase-socket-buffer-size-for-scale.patch
@@ -1,0 +1,16 @@
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index 2f430f4..98a704f 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -551,9 +551,9 @@ int team_destroy(struct team_handle *th)
+ /* \endcond */
+ 
+ /* libnl uses default 32k socket receive buffer size,
+- * which can get too small. Use 960k for all sockets.
++ * which can get too small. Use 8MB for all sockets.
+  */
+-#define NETLINK_RCVBUF 983040
++#define NETLINK_RCVBUF 8388608
+ 
+ /**
+  * @param th		libteam library context

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -14,3 +14,4 @@
 0014-dont-move-the-port-state-from-disabled-when-admin-state-is-down.patch
 0015-add-support-for-custom-retry.patch
 0016-block-retry-count-changes.patch
+0018-increase-socket-buffer-size-for-scale.patch


### PR DESCRIPTION
In a scaled scenario, when the device had 2000 sub-interfaces(1000 sub-interfaces associated with 2 portchannels each), it was seen that teamsyncd was busy and unable to process the netlink events which led to the buffer being full eventually and leading to loss of further netlink events which caused the portchannel oper_status to be down during interface flap scenarios.

**RCA:**
2000 subinterfaces are flapped which causes a huge churn and generates lot of netlink events
1. teamsyncd receives **ENOMEM** error while reading on socket **th->nl_cli.sock_event** in API **cli_sock_event_handler** due which it invokes API **get_ifinfo_list**.
2. In API get_ifinfo_list, teamsyncd waits  **th->nl_cli.sock** until there is any data to be read and receives **NLE_DUMP_INTR** from kernel and performs a retry operation. The retry mechanism continues for the next 4-5 mins as **NLE_DUMP_INTR** is received everytime during which teamsyncd's Netlink socket gets filled up with all the netlink events that get generated at the same time and further messages get dropped. One of these dropped netlink messages is related to the portchannel's oper_status being UP. Since this message is not received by teamsyncd, the respective value oper_status as UP is not updated for the porchannel in the APPL_DB **LAG_TABLE**.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

