### PR TITLE
Fix ASIC Min/Max temperature calculation on NH-4020

### DIFF
--- a/device/nexthop/common/komodo/pcie-variables.yaml
+++ b/device/nexthop/common/komodo/pcie-variables.yaml
@@ -36,6 +36,11 @@
 - name: "switchcard_fpga_bdf"
   lookup_command: "setpci -s 00:02.2 0x19.b | xargs printf '0000:%s:00.0'"
 
+# System identification
+
+- name: "platform"
+  lookup_command: "sonic-cfggen -H -v DEVICE_METADATA.localhost.platform"
+
 # Commands to retrieve sysfs path for specific device.
 
 - name: "hwmon_cpu_sysfs_path"

--- a/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/pddf/pddf-device.json.j2
@@ -1494,7 +1494,11 @@
       "temp1_high_threshold": 95,
       "temp1_high_crit_threshold": 110,
       "fpga_min_rev": "0xe8020214",
-      "value_type": "th5",
+{%- if 'x86_64-nexthop_4010-r' in platform %}
+      "value_type": "th5-320",
+{%- else %}
+      "value_type": "th5-512",
+{%- endif %}
       "reg_addr": "0x24",
       "field_range": "12:0"
     }
@@ -1512,7 +1516,11 @@
       "temp1_high_threshold": 95,
       "temp1_high_crit_threshold": 110,
       "fpga_min_rev": "0xe8020214",
-      "value_type": "th5",
+{%- if 'x86_64-nexthop_4010-r' in platform %}
+      "value_type": "th5-320",
+{%- else %}
+      "value_type": "th5-512",
+{%- endif %}
       "reg_addr": "0x24",
       "field_range": "28:16"
     }

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/thermal.py
@@ -18,8 +18,9 @@ from sonic_platform.syslog import SYSLOG_IDENTIFIER_THERMAL
 
 # Nexthop FPGA thermal sensor value to Celsius conversion
 TYPE_TO_CELSIUS_LAMBDA_DICT = {
-  'th5': lambda field_val:  0.158851 * (3000 - field_val),
-  'th6': lambda field_val:  -0.25968 * (field_val/2 - 1) + 378.85
+    "th5-320": lambda field_val: 0.158851 * (3000 - field_val),
+    "th5-512": lambda field_val: 0.164679 * (3063 - field_val),
+    "th6": lambda field_val: -0.25968 * (field_val / 2 - 1) + 378.85,
 }
 
 thermal_syslogger = syslogger.SysLogger(SYSLOG_IDENTIFIER_THERMAL)


### PR DESCRIPTION
#### Why I did it

ASIC Min/Max temperature calculation function for NH-4020 was incorrect, leading to the reported temperature to be approximately 10C lower than actual.

##### Work item tracking

n/a

#### How I did it

This change updates the formula to accurately track the ASIC temperature.

#### How to verify it

ASIC Min/Max temperature sensor values in `show plat temp` are accurate:

```
admin@golf302:~$ show plat temp | head -n 80
                Sensor    Temperature    High TH    Low TH    Crit High TH    Crit Low TH    Warning          Timestamp
----------------------  -------------  ---------  --------  --------------  -------------  ---------  -----------------
          ASIC Diode 0           64.5      120.0       N/A           127.0            N/A      False  20250626 15:06:51
          ASIC Diode 1         64.313      120.0       N/A           127.0            N/A      False  20250626 15:06:51
              ASIC Max         64.884      105.0       N/A           112.0            N/A      False  20250626 15:06:52
              ASIC Min         51.709      105.0       N/A           112.0            N/A      False  20250626 15:06:52
              ASIC pm0           54.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm1           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm2           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm3           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm4           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm5           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm6           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm7           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm8           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
              ASIC pm9           59.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm10           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm11           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm12           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm13           65.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm14           65.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm15           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm16           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm17           65.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm18           65.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm19           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm20           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm21           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm22           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm23           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm24           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm25           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm26           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm27           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm28           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm29           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm30           57.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm31           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm32           55.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm33           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm34           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm35           59.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm36           57.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm37           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm38           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm39           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm40           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm41           57.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm42           57.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm43           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm44           59.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm45           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm46           59.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm47           59.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm48           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm49           63.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm50           64.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm51           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm52           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm53           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm54           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm55           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm56           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm57           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm58           62.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm59           61.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm60           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm61           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
             ASIC pm62           54.0      105.0       N/A           112.0            N/A      False  20250626 15:06:52
             ASIC pm63           52.0      105.0       N/A           112.0            N/A      False  20250626 15:06:52
          ASIC pm_mgmt           52.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon0           55.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon1           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon2           60.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon3           57.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon4           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon5           56.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon6           54.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon7           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
      ASIC top.pvtmon8           58.0      105.0       N/A           112.0            N/A      False  20250626 15:06:51
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

