### PR TITLE
[systemd]: Mask systemd-networkd on non-smart-switch platforms

### DIFF
--- a/src/systemd-sonic-generator/systemd-sonic-generator.cpp
+++ b/src/systemd-sonic-generator/systemd-sonic-generator.cpp
@@ -984,6 +984,26 @@ static int render_network_service_for_smart_switch(const std::filesystem::path& 
 }
 
 
+static int mask_networkd_for_non_smart_switch(const std::filesystem::path& install_dir) {
+    if (smart_switch) {
+        return 0;
+    }
+
+    auto service_path = install_dir / "systemd-networkd.service";
+
+    int r = symlink("/dev/null", service_path.c_str());
+
+    if (r < 0) {
+        if (errno == EEXIST)
+            return 0;
+        log_to_kmsg("Error masking %s: %s\n", service_path.c_str(), strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+
 int ssg_main(int argc, char **argv) {
     char* unit_files[MAX_NUM_UNITS];
     std::string install_dir;
@@ -1019,6 +1039,11 @@ int ssg_main(int argc, char **argv) {
         if (render_network_service_for_smart_switch(install_dir) != 0) {
             return -1;
         }
+    }
+
+    // Mask systemd-networkd on non-smart-switch platforms
+    if (mask_networkd_for_non_smart_switch(install_dir) != 0) {
+        return -1;
     }
 
     // For each unit file, get the installation targets and install the unit


### PR DESCRIPTION
#### Why I did it

Fix #25091
Fix #24523

After a successful SONiC warm-reboot, the serial console prints repeated `[DEPEND] Dependency failed for systemd-networkd-persistent-storage.service` and similar messages on non-smart-switch platforms. This is a cosmetic issue that does not affect functionality but is jarring for anyone monitoring startup output.

The root cause is that `systemd-networkd.service` uses an `ExecCondition` to skip execution on non-smart-switch platforms. However, its dependent services (`systemd-networkd-persistent-storage.service`, `systemd-networkd-wait-online.service`) still attempt to start and fail with dependency errors.

#### How I did it

* Added `mask_networkd_for_non_smart_switch()` function to systemd-sonic-generator that creates a symlink to `/dev/null` for `systemd-networkd.service` when not on smart-switch platforms (DPU/NPU)
* The masking occurs at early boot during generator execution, before systemd loads unit files
* Masking systemd-networkd directly causes all dependent services to be automatically skipped by systemd's dependency resolution
* Added `validate_masked_services()` test to verify correct masking behavior across all platform configurations

#### How to verify it

1. Build a SONiC image with this change
2. Boot on a non-smart-switch platform (no DPU/DPUS in platform.json)
3. Perform a warm-reboot: `warm-reboot`
4. Monitor serial console output
5. Verify no "Dependency failed for systemd-networkd-persistent-storage.service" or similar messages appear

#### Description for the changelog

Mask systemd-networkd.service on non-smart-switch platforms to prevent dependency failure