### PR TITLE
Flush ASIC DB on syncd reboot

### DIFF
--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -115,6 +115,13 @@ start() {
         # Leave a mark for syncd scripts running inside docker.
         touch /host/warmboot$DEV/warm-starting
     else
+        # Flush ASIC_DB to prevent stale data issues on syncd restart
+        # This ensures that if syncd restarts before swss, it won't read stale lane maps
+        # Flush ASIC_DB unless in warm boot (do not flush during warm boot)
+        debug "Flushing ASIC_DB before syncd start to prevent stale data on restart..."
+        $SONIC_DB_CLI ASIC_DB FLUSHDB
+        debug "ASIC_DB flushed successfully"
+    else
         rm -f /host/warmboot$DEV/warm-starting
     fi
 

--- a/files/scripts/syncd_common.sh
+++ b/files/scripts/syncd_common.sh
@@ -121,8 +121,8 @@ start() {
         debug "Flushing ASIC_DB before syncd start to prevent stale data on restart..."
         $SONIC_DB_CLI ASIC_DB FLUSHDB
         debug "ASIC_DB flushed successfully"
-    else
-        rm -f /host/warmboot$DEV/warm-starting
+
+	rm -f /host/warmboot$DEV/warm-starting
     fi
 
     startplatform


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To fix https://github.com/sonic-net/sonic-buildimage/issues/25193

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Flush ASIC_DB to prevent stale data issues on syncd restart
This ensures that if syncd restarts before swss, it won't read stale lane maps

#### How to verify it
Cause crash of syncd by killing the syncd process.
Verify no errors are raised in the log.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

