### PR TITLE
[PDDF] Add IIO, SMBus, scaling and threshold support to voltage sensor base class

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
@@ -64,37 +64,13 @@ class PddfVoltageSensor(VoltageSensorBase):
     # ------------------------------------------------------------------ #
     def get_value(self):
         """Read voltage value in millivolts.  Returns float or None."""
-        if self._sensor_type == 'iio':
-            return self._read_iio()
-        return self._read_hwmon()
-
-    def _read_hwmon(self):
-        """Read via standard PDDF hwmon sysfs path."""
         output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_input")
         if not output:
-            return None
-
-        if output['status'].isalpha():
-            return None
-
-        raw = float(output['status'])
-        return self._scale(raw)
-
-    # ------------------------------------------------------------------ #
-    #  IIO read path
-    # ------------------------------------------------------------------ #
-    def _read_iio(self):
-        """Read voltage via IIO sysfs through the standard PDDF accessor."""
-        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_input")
-        if not output:
-            return None
-
-        if output['status'].isalpha():
             return None
 
         try:
             return self._scale(float(output['status']))
-        except ValueError:
+        except (KeyError, TypeError, ValueError):
             return None
 
     # ------------------------------------------------------------------ #
@@ -120,9 +96,10 @@ class PddfVoltageSensor(VoltageSensorBase):
         output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, attr_name)
         if not output:
             return None
-        if output['status'].isalpha():
+        try:
+            return float(output['status'])
+        except (KeyError, TypeError, ValueError):
             return None
-        return float(output['status'])
 
     def _get_threshold_from_json(self, key):
         """Fallback: look up static threshold from dev_attr in JSON.

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py
@@ -6,7 +6,15 @@ except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
 class PddfVoltageSensor(VoltageSensorBase):
-    """PDDF generic Voltage Sensor class"""
+    """PDDF generic Voltage Sensor class.
+
+    Supports sysfs-backed sensor read methods based on sensor_type in dev_attr:
+      - hwmon (default): reads hwmon sysfs via standard PDDF path
+      - iio: reads IIO sysfs (iio:deviceX/in_voltageN_raw)
+
+    Scaling (multi_factor / decimate_factor) is applied to all reads.
+    Thresholds are read from JSON dev_attr if present, falling back to sysfs.
+    """
     pddf_obj = {}
     plugin_data = {}
 
@@ -23,73 +31,137 @@ class PddfVoltageSensor(VoltageSensorBase):
             raise ValueError(f"Voltage sensor {self.sensor_obj_name} not found in PDDF data")
 
         self.sensor_obj = self.pddf_obj.data[self.sensor_obj_name]
-        self.display_name = self.sensor_obj.get('dev_attr', {}).get('display_name', self.sensor_obj_name)
-        
+
+        # dev_attr may be at top level or under i2c
+        self._top_dev_attr = self.sensor_obj.get('dev_attr', {})
+        self._i2c_dev_attr = self.pddf_obj.get_sensor_i2c_dev_attr(self.sensor_obj)
+
+        self.display_name = (self._top_dev_attr.get('display_name') or
+                             self._i2c_dev_attr.get('display_name', self.sensor_obj_name))
+
+        # Sensor type: 'iio' or '' (hwmon default)
+        self._sensor_type = self._i2c_dev_attr.get('sensor_type', '')
+
+        # Scaling factors (default 1:1 if missing or invalid in JSON)
+        try:
+            self._multi_factor = float(
+                self._top_dev_attr.get('multi_factor',
+                    self._i2c_dev_attr.get('multi_factor', '1')))
+        except (ValueError, TypeError):
+            self._multi_factor = 1.0
+        try:
+            self._decimate_factor = float(
+                self._top_dev_attr.get('decimate_factor',
+                    self._i2c_dev_attr.get('decimate_factor', '1')))
+        except (ValueError, TypeError):
+            self._decimate_factor = 1.0
 
     def get_name(self):
-        if 'dev_attr' in self.sensor_obj.keys():
-            if 'display_name' in self.sensor_obj['dev_attr']:
-                return str(self.sensor_obj['dev_attr']['display_name'])
-        # In case of errors
-        return (self.sensor_obj_name)
-    
+        return self.display_name
 
+    # ------------------------------------------------------------------ #
+    #  Value read — dispatches by sensor_type
+    # ------------------------------------------------------------------ #
     def get_value(self):
+        """Read voltage value in millivolts.  Returns float or None."""
+        if self._sensor_type == 'iio':
+            return self._read_iio()
+        return self._read_hwmon()
+
+    def _read_hwmon(self):
+        """Read via standard PDDF hwmon sysfs path."""
         output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_input")
         if not output:
             return None
 
         if output['status'].isalpha():
-            attr_value = None
-        else:
-            attr_value = float(output['status'])
-        
-        return attr_value
+            return None
+
+        raw = float(output['status'])
+        return self._scale(raw)
+
+    # ------------------------------------------------------------------ #
+    #  IIO read path
+    # ------------------------------------------------------------------ #
+    def _read_iio(self):
+        """Read voltage via IIO sysfs through the standard PDDF accessor."""
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_input")
+        if not output:
+            return None
+
+        if output['status'].isalpha():
+            return None
+
+        try:
+            return self._scale(float(output['status']))
+        except ValueError:
+            return None
+
+    # ------------------------------------------------------------------ #
+    #  Scaling
+    # ------------------------------------------------------------------ #
+    def _scale(self, raw_value):
+        """Apply multi/decimate scaling.  Returns millivolts (whole number)."""
+        if raw_value is None or self._decimate_factor == 0:
+            return None
+        # Truncate to integer millivolts, return as float for API consistency
+        return float(int(raw_value * self._multi_factor / self._decimate_factor))
+
+    # ------------------------------------------------------------------ #
+    #  Thresholds — sysfs first (chip hw), JSON dev_attr fallback
+    # ------------------------------------------------------------------ #
+    def _get_threshold_from_sysfs(self, attr_name):
+        """Read threshold from hwmon sysfs via PDDF attr_list mapping.
+
+        Works when the chip supports the PMBus warn/fault registers
+        (e.g. inN_max, inN_min, inN_crit, inN_lcrit) and the JSON
+        attr_list maps them via drv_attr_name.
+        """
+        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, attr_name)
+        if not output:
+            return None
+        if output['status'].isalpha():
+            return None
+        return float(output['status'])
+
+    def _get_threshold_from_json(self, key):
+        """Fallback: look up static threshold from dev_attr in JSON.
+
+        Used for chips that don't support warn limit registers
+        (e.g. TPS53659/TPS53622 lack VOUT_OV_WARN / VOUT_UV_WARN).
+        """
+        val = self._top_dev_attr.get(key)
+        if val is None:
+            val = self._i2c_dev_attr.get(key)
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except (ValueError, TypeError):
+            return None
 
     def get_low_threshold(self):
-        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_low_threshold")
-        if not output:
-            return None
-
-        if output['status'].isalpha():
-            attr_value = None
-        else:
-            attr_value = float(output['status'])
-
-        return attr_value
+        # Try sysfs first (chip hw warn limit)
+        val = self._get_threshold_from_sysfs("volt1_low_threshold")
+        if val is not None:
+            return val
+        # Fallback: static JSON threshold
+        return self._get_threshold_from_json('low_threshold')
 
     def get_high_threshold(self):
-        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_high_threshold")
-        if not output:
-            return None
+        val = self._get_threshold_from_sysfs("volt1_high_threshold")
+        if val is not None:
+            return val
+        return self._get_threshold_from_json('high_threshold')
 
-        if output['status'].isalpha():
-            attr_value = None
-        else:
-            attr_value = float(output['status'])
-
-        return attr_value
-    
     def get_high_critical_threshold(self):
-        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_crit_high_threshold")
-        if not output:
-            return None
+        val = self._get_threshold_from_sysfs("volt1_crit_high_threshold")
+        if val is not None:
+            return val
+        return self._get_threshold_from_json('crit_high_threshold')
 
-        if output['status'].isalpha():
-            attr_value = None
-        else:
-            attr_value = float(output['status'])
-
-        return attr_value
-    
     def get_low_critical_threshold(self):
-        output = self.pddf_obj.get_attr_name_output(self.sensor_obj_name, "volt1_crit_low_threshold")
-        if not output:
-            return None
-
-        if output['status'].isalpha():
-            attr_value = None
-        else:
-            attr_value = float(output['status'])
-
-        return attr_value
+        val = self._get_threshold_from_sysfs("volt1_crit_low_threshold")
+        if val is not None:
+            return val
+        return self._get_threshold_from_json('crit_low_threshold')

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -16,6 +16,8 @@ SONIC_CFGGEN_PATH = '/usr/local/bin/sonic-cfggen'
 LED_CTRL_LOCK_PATH = '/var/lock/pddf-locks/pddf-api-led.lock'
 HWSKU_KEY = 'DEVICE_METADATA.localhost.hwsku'
 PLATFORM_KEY = 'DEVICE_METADATA.localhost.platform'
+SENSOR_TYPE_HWMON = 'hwmon'
+SENSOR_TYPE_IIO = 'iio'
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 
@@ -242,6 +244,116 @@ class PddfApi():
         finally:
             self._release_led_ctrl_lock()
 
+    # ================================================================
+    # sysfs_led: sysfs file-based LED control
+    # ================================================================
+
+    def set_led_color_from_sysfs(self, led_device_name, color):
+        """
+        Set LED color by writing a value to a sysfs file.
+
+        Each attr_list entry maps a color name to a sysfs path and value:
+            {"attr_name": "green", "attr_devtype": "sysfs_led",
+             "sysfs_path": "/sys/class/leds/.../brightness",
+             "value": "0x1"}
+
+        The sysfs_path can be any writable sysfs file; the code does not
+        assume a specific filename or attribute name.
+
+        Supports two LED topologies based on the attr_list entries:
+        - Single-path: all color entries share the same sysfs_path with
+          different values (color is encoded in the written value).
+        - Multi-path: each color entry has a different sysfs_path. All
+          other paths are cleared to 0 before the target is written,
+          ensuring only one path is active at a time.
+        """
+        attr_list = self.data[led_device_name]['i2c']['attr_list']
+
+        # Find the matching color entry
+        target_attr = None
+        for attr in attr_list:
+            if attr['attr_name'].strip() == color.strip():
+                target_attr = attr
+                break
+
+        if target_attr is None:
+            return (False, "Invalid color '{}' for {}".format(color, led_device_name))
+
+        sysfs_path = target_attr.get('sysfs_path', '')
+        value = str(int(target_attr.get('value', '0x0'), 0))
+
+        if not sysfs_path:
+            return (False, "No sysfs_path for color '{}' in {}".format(
+                color, led_device_name))
+
+        # For multi-path LEDs: check if different colors use different
+        # sysfs paths. If so, write "0" to all other paths first to ensure
+        # only one path is active at a time (e.g. the Linux LED core caches
+        # brightness per led_classdev independently).
+        all_paths = set()
+        for attr in attr_list:
+            p = attr.get('sysfs_path', '')
+            if p and p != sysfs_path:
+                all_paths.add(p)
+
+        for other_path in all_paths:
+            try:
+                with open(other_path, 'w') as f:
+                    f.write("0")
+            except (IOError, OSError):
+                pass  # best-effort clear
+
+        # Write the target value
+        try:
+            with open(sysfs_path, 'w') as f:
+                f.write(value)
+            return (True, "Success")
+        except (IOError, OSError) as e:
+            return (False, "Failed to write {} to {}: {}".format(
+                value, sysfs_path, e))
+
+    def get_led_color_from_sysfs(self, led_device_name):
+        """
+        Get LED color by reading the current value from sysfs.
+
+        Reads the sysfs file and matches it against the value in each
+        color entry. For multi-path LEDs (different paths per color),
+        scans each path and returns the first one with a non-zero value.
+        """
+        attr_list = self.data[led_device_name]['i2c']['attr_list']
+
+        # Check if all entries share the same sysfs_path (single-path LED)
+        paths = set(attr.get('sysfs_path', '') for attr in attr_list)
+        paths.discard('')
+
+        if len(paths) == 1:
+            # Single-path LED: read value and match
+            sysfs_path = paths.pop()
+            try:
+                with open(sysfs_path, 'r') as f:
+                    current_val = int(f.read().strip())
+            except (IOError, OSError, ValueError):
+                return "off"
+
+            for attr in attr_list:
+                if int(attr.get('value', '0x0'), 0) == current_val:
+                    return attr['attr_name']
+            return "off"
+        else:
+            # Multi-path LED: find which path has a non-zero value
+            for attr in attr_list:
+                p = attr.get('sysfs_path', '')
+                if not p:
+                    continue
+                try:
+                    with open(p, 'r') as f:
+                        val = int(f.read().strip())
+                    if val > 0:
+                        return attr['attr_name']
+                except (IOError, OSError, ValueError):
+                    continue
+            return "off"
+
     def get_system_led_color(self, led_device_name):
         if led_device_name not in self.data.keys():
             msg = led_device_name + " is not configured"
@@ -253,6 +365,8 @@ class PddfApi():
             color = self.get_led_color_from_gpio(led_device_name)
         elif dtype == 'bmc':
             color = self.get_led_color_from_bmc(led_device_name)
+        elif dtype == 'sysfs_led':
+            color = self.get_led_color_from_sysfs(led_device_name)
         else:
             # This case takes care of CPLD as well as I2CFPGA
             color = self.get_led_color_from_cpld(led_device_name)
@@ -281,6 +395,8 @@ class PddfApi():
 
         if dtype == 'gpio':
             return (self.set_led_color_from_gpio(led_device_name, color))
+        elif dtype == 'sysfs_led':
+            return (self.set_led_color_from_sysfs(led_device_name, color))
         else:
             return (self.set_led_color_from_cpld(led_device_name, color))
 
@@ -358,44 +474,138 @@ class PddfApi():
 
         return ret
 
-    def show_attr_hwmon_device(self, dev, ops, data_sysfs_key):
-        def _path_expand(*path):
-            full_path = glob.glob(os.path.join(*path))
-            if not full_path:
-                return None
-            return full_path[0]
+    def _path_expand(self, *path):
+        full_path = glob.glob(os.path.join(*path))
+        if not full_path:
+            return None
+        return full_path[0]
 
+    def _get_i2c_backing_device(self, dev):
+        virt_parent = dev.get('dev_info', {}).get('virt_parent')
+        if virt_parent is None:
+            virt_parent = dev.get('i2c', {}).get('virt_parent')
+        return self.data.get(virt_parent, dev) if virt_parent else dev
+
+    def _get_attr_list(self, dev):
+        return dev.get('i2c', {}).get('attr_list', [])
+
+    def _get_sensor_attr_real_name(self, attr, dev_attr, default_attr_name):
+        if 'drv_attr_name' in attr:
+            return attr['drv_attr_name']
+        return default_attr_name.format(**dev_attr)
+
+    def _get_sensor_sysfs_path(self, i2c_dev, ops, real_name, sensor_type):
+        if 'topo_info' in i2c_dev.get('i2c', {}):
+            path = self.show_device_sysfs(i2c_dev, ops) + "/%d-00%02x/" % (
+                int(i2c_dev['i2c']['topo_info']['parent_bus'], 0),
+                int(i2c_dev['i2c']['topo_info']['dev_addr'], 0))
+            if sensor_type == SENSOR_TYPE_IIO:
+                sysfs_path = self._path_expand(path, 'iio:device*', real_name)
+            else:
+                sysfs_path = self._path_expand(path, 'hwmon', 'hwmon*', real_name)
+            if sysfs_path:
+                return sysfs_path
+
+        dynamic_path = self._get_dynamic_sensor_sysfs_path(i2c_dev, real_name, sensor_type)
+        if dynamic_path:
+            return dynamic_path
+
+        if 'path_info' in i2c_dev.get('i2c', {}):
+            path = i2c_dev['i2c']['path_info']['sysfs_base_path']
+            return self._path_expand(path, real_name)
+
+        return None
+
+    def _find_i2c_bus_by_adapter(self, adapter_name):
+        for bus_path in glob.glob('/sys/bus/i2c/devices/i2c-*'):
+            name_path = os.path.join(bus_path, 'name')
+            try:
+                with open(name_path, 'r') as fd:
+                    if fd.read().strip() == adapter_name:
+                        return int(os.path.basename(bus_path).split('-')[1])
+            except OSError:
+                continue
+        return None
+
+    def _find_mux_child_bus(self, parent_bus, chan_id, mux_addr=None):
+        parent_path = '/sys/bus/i2c/devices/i2c-%d' % parent_bus
+        expected_name = 'i2c-%d-mux (chan_id %s)' % (parent_bus, chan_id)
+        for bus_path in glob.glob(os.path.join(parent_path, 'i2c-*')):
+            name_path = os.path.join(bus_path, 'name')
+            try:
+                with open(name_path, 'r') as fd:
+                    if fd.read().strip() == expected_name:
+                        if mux_addr is not None:
+                            mux_path = os.path.realpath(os.path.join(bus_path, 'mux_device'))
+                            mux_name = '%d-00%02x' % (parent_bus, int(mux_addr, 0))
+                            if os.path.basename(mux_path) != mux_name:
+                                continue
+                        return int(os.path.basename(bus_path).split('-')[1])
+            except OSError:
+                continue
+        return None
+
+    def _get_dynamic_i2c_bus(self, dev_attr):
+        adapter_name = dev_attr.get('adapter_name')
+        if not adapter_name:
+            return None
+
+        bus = self._find_i2c_bus_by_adapter(adapter_name)
+        if bus is None:
+            return None
+
+        mux_layers = (
+            ('mux_chan', 'mux_addr'),
+            ('mux2_chan', 'mux2_addr'),
+        )
+        for mux_key, mux_addr_key in mux_layers:
+            if mux_key not in dev_attr:
+                continue
+            bus = self._find_mux_child_bus(bus, dev_attr[mux_key], dev_attr.get(mux_addr_key))
+            if bus is None:
+                return None
+
+        return bus
+
+    def _get_dynamic_sensor_sysfs_path(self, i2c_dev, real_name, sensor_type):
+        dev_attr = i2c_dev.get('i2c', {}).get('dev_attr', {})
+        bus = self._get_dynamic_i2c_bus(dev_attr)
+        if bus is None:
+            return None
+
+        topo_info = i2c_dev.get('i2c', {}).get('topo_info', {})
+        if 'dev_addr' not in topo_info:
+            return None
+
+        path = '/sys/bus/i2c/devices/%d-00%02x/' % (bus, int(topo_info['dev_addr'], 0))
+        if sensor_type == SENSOR_TYPE_IIO:
+            return self._path_expand(path, 'iio:device*', real_name)
+        return self._path_expand(path, 'hwmon', 'hwmon*', real_name)
+
+    def show_attr_sensor_device(self, dev, ops, data_sysfs_key, sensor_type=SENSOR_TYPE_HWMON):
         ret = []
         if 'i2c' not in dev.keys():
             return ret
         attr_name = ops['attr']
-        attr_list = dev['i2c']['attr_list'] if 'i2c' in dev else []
+        attr_list = self._get_attr_list(dev)
+        if not attr_list and sensor_type == SENSOR_TYPE_IIO:
+            attr_list = [{'attr_name': 'volt1_input'}]
         KEY = data_sysfs_key
         dsysfs_path = ""
 
         if KEY not in self.data_sysfs_obj:
             self.data_sysfs_obj[KEY] = []
 
-        # Current/Voltage sensors are oftentimes rails that are part of a DPM/DCDC
-        if "virt_parent" in dev['dev_info']:
-            i2c_dev = self.data[dev['dev_info']['virt_parent']]
-        else:
-            i2c_dev = dev
+        i2c_dev = self._get_i2c_backing_device(dev)
+        dev_attr = dict(dev.get('i2c', {}).get('dev_attr', {}))
+        default_attr_name = 'in_voltage{channel_id}_raw' if sensor_type == SENSOR_TYPE_IIO else '{attr_name}'
+        dev_attr.setdefault('channel_id', '0')
 
         for attr in attr_list:
             if attr_name == attr['attr_name'] or attr_name == 'all':
-                if 'drv_attr_name' in attr.keys():
-                    real_name = attr['drv_attr_name']
-                else:
-                    real_name = attr['attr_name']
-
-                if 'topo_info' in i2c_dev['i2c']:
-                    path = self.show_device_sysfs(i2c_dev, ops)+"/%d-00%02x/"%(int(i2c_dev['i2c']['topo_info']['parent_bus'], 0),
-                            int(i2c_dev['i2c']['topo_info']['dev_addr'], 0))
-                    full_path = _path_expand(path, 'hwmon', 'hwmon*', real_name)
-                elif 'path_info' in i2c_dev['i2c']:
-                    path = i2c_dev['i2c']['path_info']['sysfs_base_path']
-                    full_path = _path_expand(path, real_name)
+                real_name = self._get_sensor_attr_real_name(
+                    attr, dict(dev_attr, attr_name=attr['attr_name']), default_attr_name)
+                full_path = self._get_sensor_sysfs_path(i2c_dev, ops, real_name, sensor_type)
 
                 if full_path is None:
                     return []
@@ -407,8 +617,20 @@ class PddfApi():
 
         return ret
 
+    def show_attr_hwmon_device(self, dev, ops, data_sysfs_key):
+        return self.show_attr_sensor_device(dev, ops, data_sysfs_key, SENSOR_TYPE_HWMON)
+
     def show_attr_voltage_sensor_device(self, dev, ops):
+        sensor_type = dev.get('i2c', {}).get('dev_attr', {}).get('sensor_type', '')
+        if sensor_type == SENSOR_TYPE_IIO:
+            return self.show_attr_iio_device(dev, ops, "voltage-sensors")
         return self.show_attr_hwmon_device(dev, ops, "voltage-sensors")
+
+    def show_attr_iio_device(self, dev, ops, data_sysfs_key):
+        return self.show_attr_sensor_device(dev, ops, data_sysfs_key, SENSOR_TYPE_IIO)
+
+    def get_sensor_i2c_dev_attr(self, dev):
+        return dict(dev.get('i2c', {}).get('dev_attr', {}))
 
     def show_attr_current_sensor_device(self, dev, ops):
         return self.show_attr_hwmon_device(dev, ops, "current-sensors")

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
@@ -484,15 +484,20 @@ class PddfApi():
         virt_parent = dev.get('dev_info', {}).get('virt_parent')
         if virt_parent is None:
             virt_parent = dev.get('i2c', {}).get('virt_parent')
-        return self.data.get(virt_parent, dev) if virt_parent else dev
+        if virt_parent:
+            if virt_parent not in self.data:
+                print("PDDF: virt_parent '{}' not found in data".format(virt_parent))
+                return None
+            return self.data[virt_parent]
+        return dev
 
-    def _get_attr_list(self, dev):
+    def _get_i2c_attr_list(self, dev):
         return dev.get('i2c', {}).get('attr_list', [])
 
-    def _get_sensor_attr_real_name(self, attr, dev_attr, default_attr_name):
+    def _get_sensor_attr_real_name(self, attr):
         if 'drv_attr_name' in attr:
             return attr['drv_attr_name']
-        return default_attr_name.format(**dev_attr)
+        return attr['attr_name']
 
     def _get_sensor_sysfs_path(self, i2c_dev, ops, real_name, sensor_type):
         if 'topo_info' in i2c_dev.get('i2c', {}):
@@ -528,8 +533,13 @@ class PddfApi():
         return None
 
     def _find_mux_child_bus(self, parent_bus, chan_id, mux_addr=None):
+        try:
+            chan_id = int(chan_id, 0)
+        except (TypeError, ValueError):
+            return None
+
         parent_path = '/sys/bus/i2c/devices/i2c-%d' % parent_bus
-        expected_name = 'i2c-%d-mux (chan_id %s)' % (parent_bus, chan_id)
+        expected_name = 'i2c-%d-mux (chan_id %d)' % (parent_bus, chan_id)
         for bus_path in glob.glob(os.path.join(parent_path, 'i2c-*')):
             name_path = os.path.join(bus_path, 'name')
             try:
@@ -587,9 +597,7 @@ class PddfApi():
         if 'i2c' not in dev.keys():
             return ret
         attr_name = ops['attr']
-        attr_list = self._get_attr_list(dev)
-        if not attr_list and sensor_type == SENSOR_TYPE_IIO:
-            attr_list = [{'attr_name': 'volt1_input'}]
+        attr_list = self._get_i2c_attr_list(dev)
         KEY = data_sysfs_key
         dsysfs_path = ""
 
@@ -597,14 +605,12 @@ class PddfApi():
             self.data_sysfs_obj[KEY] = []
 
         i2c_dev = self._get_i2c_backing_device(dev)
-        dev_attr = dict(dev.get('i2c', {}).get('dev_attr', {}))
-        default_attr_name = 'in_voltage{channel_id}_raw' if sensor_type == SENSOR_TYPE_IIO else '{attr_name}'
-        dev_attr.setdefault('channel_id', '0')
+        if i2c_dev is None:
+            return ret
 
         for attr in attr_list:
             if attr_name == attr['attr_name'] or attr_name == 'all':
-                real_name = self._get_sensor_attr_real_name(
-                    attr, dict(dev_attr, attr_name=attr['attr_name']), default_attr_name)
+                real_name = self._get_sensor_attr_real_name(attr)
                 full_path = self._get_sensor_sysfs_path(i2c_dev, ops, real_name, sensor_type)
 
                 if full_path is None:


### PR DESCRIPTION
#### Why I did it

PDDF voltage sensors previously relied on the common base class to read hwmon attributes. Platforms that expose voltage rails through the Linux IIO subsystem, such as ADC-backed rails, could not use the common PddfVoltageSensor path without adding platform-specific Python code.

An earlier version of this change also added raw userspace SMBus/PMBus access to the generic PDDF voltage sensor path. Based on review feedback, that is the wrong abstraction boundary: generic PDDF should not perform board-specific I2C transactions, mux selection, or PMBus VOUT decoding. Those responsibilities belong in kernel drivers and platform init code, with PDDF consuming the resulting sysfs interfaces.

#### How I did it

Updated the generic PDDF voltage sensor flow so PddfVoltageSensor reads voltage values through PddfApi-resolved sysfs paths only:

- hwmon sensors continue to use the existing hwmon attribute path
- IIO sensors use sensor_type="iio" and channel_id metadata to read in_voltageN_raw
- scaling remains driven by multi_factor and decimate_factor in pddf-device.json
- threshold APIs continue to prefer hwmon sysfs limits and fall back to JSON thresholds

Extended PddfApi with generic sysfs resolution helpers for sensor devices:

- resolve static and dynamic sensor paths
- locate I2C devices and backing devices from topology metadata
- locate hwmon and IIO sysfs directories under the bound kernel device
- support dynamic mux child bus lookup for platform-described topologies
- synthesize the default IIO voltage attribute from channel_id when attr_list is empty

This keeps generic PDDF hardware-independent. Platform-specific code is expected to load/bind the appropriate kernel drivers so voltage rails appear through hwmon or IIO sysfs before PDDF reads them.

#### How to verify it

- python3 -m py_compile platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
- git diff --check -- platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_voltage_sensor.py platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddfapi.py
- Verified on Juniper PTX10002 hardware with platform init binding the required kernel drivers: MAX1139 IIO rails, PMBus/hwmon VRM rails, CPU rails, and hotswap rails all report through show platform voltage.

#### Which release branch to backport

N/A

#### Description for the changelog

Enhance the PDDF common voltage sensor path to support Linux IIO-backed voltage sensors through sysfs while preserving existing hwmon behavior. Raw SMBus/PMBus access is intentionally kept out of generic PDDF; platforms should expose such rails via kernel hwmon/IIO drivers.

#### Link to config_db schema for YANG module changes

N/A

Signed-off-by: Satish Gopalakrishnan <satishg@juniper.net>