### PR TITLE
Enable IEEE 800G autoneg for QuicksilverP512

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P28O72/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P28O72/th5-a7060x6-64pe.config.bcm
@@ -45,6 +45,7 @@ bcm_device:
             l3_ecmp_member_first_lkup_mem_size: 0
             l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
+            sai_phy_an_mode_c73: 1
 
 ---
 device:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -48,6 +48,7 @@ bcm_device:
             l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             sai_pfc_dlr_init_capability: 2
+            sai_phy_an_mode_c73: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
@@ -46,6 +46,7 @@ bcm_device:
             l3_ecmp_member_secondary_mem_size: 0
             stat_custom_receive0_management_mode: 1
             sai_pfc_dlr_init_capability: 2
+            sai_phy_an_mode_c73: 1
 ---
 device:
     0:

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -48,6 +48,7 @@ bcm_device:
             l3_ecmp_member_secondary_mem_size: 0
             sai_mmu_custom_config: 1
             sai_pfc_dlr_init_capability: 2
+            sai_phy_an_mode_c73: 1
 ---
 device:
     0:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Without this change, QuicksilverP512 will enable special BAM 800G autoneg mode other than the normal IEEE 800G autoneg mode and will fail to link up with a partner that is running IEEE 800G autoneg. We need this fix to make sure QuicksilverP512 can successfully link up with other devices at 800G speed when autoneg is enabled. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add the needed configuration as per Broadcom guide

#### How to verify it

Confirmed the 800G link can get up with IEEE partner with this change

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202605
- [x] 202505
- [x] 202511
- [x] msft-202503

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605
- [x] 202511
- [x] 202505
- [x] msft-202503 

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

