### PR TITLE
Added yang model support to set loopback interface as agent id for sflow

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/sflow.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/sflow.json
@@ -51,6 +51,13 @@
     "SFLOW_TEST": {
         "desc": "Configure  sflow global entry in SFLOW table."
     },
+    "SFLOW_TEST_WITH_AGENT_ID_AS_LOOPBACK": {
+        "desc": "Configure sflow global entry in SFLOW table with agent id as loopback."
+    },
+    "SFLOW_TEST_WITH_NON_EXIST_LO_AGENT_ID": {
+        "desc": "Configure sflow global entry in SFLOW table with non existing loopback as agent-id.",
+        "eStrKey": "InvalidValue"
+    },
     "SFLOW_TEST_WITH_NON_EXIST_PORT": {
         "desc": "Configure Port in SFLOW table which does not exist in PORT table.",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/sflow.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/sflow.json
@@ -251,6 +251,41 @@
         }
     },
 
+    "SFLOW_TEST_WITH_AGENT_ID_AS_LOOPBACK": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "Loopback1"
+                    }
+                ]
+            }
+        },
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW": {
+                "global": {
+                    "agent_id": "Loopback1",
+                    "admin_state": "up",
+                    "sample_direction": "both",
+                    "polling_interval": "20"
+                }
+            }
+        }
+    },
+
+    "SFLOW_TEST_WITH_NON_EXIST_LO_AGENT_ID": {
+        "sonic-sflow:sonic-sflow": {
+            "sonic-sflow:SFLOW": {
+                "global": {
+                    "agent_id": "Loopback100",
+                    "admin_state": "up",
+                    "sample_direction": "both",
+                    "polling_interval": "20"
+                }
+            }
+        }
+    },
+
     "SFLOW_TEST_WITH_NON_EXIST_PORT": {
         "sonic-sflow:sonic-sflow": {
             "sonic-sflow:SFLOW": {

--- a/src/sonic-yang-models/yang-models/sonic-sflow.yang
+++ b/src/sonic-yang-models/yang-models/sonic-sflow.yang
@@ -28,6 +28,9 @@ module sonic-sflow{
     import sonic-mgmt_vrf {
         prefix mvrf;
     }
+    import sonic-loopback-interface {
+        prefix lo;
+    }
 
 
     description "SFLOW yang Module for SONiC OS";
@@ -169,6 +172,9 @@ module sonic-sflow{
                         }
                         type leafref {
                             path "/mgmt-port:sonic-mgmt_port/mgmt-port:MGMT_PORT/mgmt-port:MGMT_PORT_LIST/mgmt-port:name";
+                        }
+                        type leafref {
+                            path "/lo:sonic-loopback-interface/lo:LOOPBACK_INTERFACE/lo:LOOPBACK_INTERFACE_LIST/lo:name";
                         }
                         /*
                         type leafref {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added yang model support to set loopback interface as sflow agent id. CLI already had support for this.
Fixes : https://github.com/sonic-net/sonic-buildimage/issues/26512

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated sflow-yang to include loopback interfaces.

#### How to verify it

sudo config apply-patch -n sflow.json
Patch Applier: localhost: Patch application starting.
Patch Applier: localhost: Patch: [{"op": "add", "path": "/SFLOW", "value": {"global": {"admin_state": "up", "agent_id": "Loopback1"}}}, {"op"
: "add", "path": "/SFLOW_COLLECTOR", "value": {"sp1.58": {"collector_ip": "10.250.29.251", "collector_port": "6343", "collector_vrf": "defaul
t"}}}, {"op": "add", "path": "/SFLOW_SESSION", "value": {"Ethernet0": {"admin_state": "up", "sample_direction": "rx", "sample_rate": "131072"
}}}]
Patch Applier: localhost getting current config db.
Patch Applier: localhost: simulating the target full config after applying the patch.
Patch Applier: localhost: validating all JsonPatch operations are permitted on the specified fields
Patch Applier: localhost: validating target config does not have empty tables,
since they do not show up in ConfigDb.
Patch Applier: localhost: sorting patch updates.
Patch Applier: The localhost patch was converted into 3 changes:
Patch Applier: localhost: applying 3 changes in order:
Patch Applier: * [{"op": "add", "path": "/SFLOW", "value": {"global": {"admin_state": "up", "agent_id": "Loopback1"}}}]
Patch Applier: * [{"op": "add", "path": "/SFLOW_COLLECTOR", "value": {"sp1.58": {"collector_ip": "10.250.29.251", "collector_port": "6343",
"collector_vrf": "default"}}}]
Patch Applier: * [{"op": "add", "path": "/SFLOW_SESSION", "value": {"Ethernet0": {"admin_state": "up", "sample_direction": "rx", "sample_ra
te": "131072"}}}]
Patch Applier: localhost: verifying patch updates are reflected on ConfigDB.
Patch Applier: localhost patch application completed.

sflow.json:
[
{
"op": "add",
"path": "/SFLOW",
"value": {
"global": {
"admin_state": "up",
"agent_id": "Loopback1"
}
}
},
{
"op": "add",
"path": "/SFLOW_COLLECTOR",
"value": {
"sp1.58": {
"collector_ip": "10.250.29.251",
"collector_port": "6343",
"collector_vrf": "default"
}
}
},
{
"op": "add",
"path": "/SFLOW_SESSION",
"value": {
"Ethernet0": {
"admin_state": "up",
"sample_direction": "rx",
"sample_rate": "131072"
}
}
}
]


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

