### PR TITLE
[agent][cfggen] Fix len() called with no arguments in PortChannel Fallback parsing

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -966,7 +966,7 @@ def parse_dpg(dpg, hname):
                 intfs_inpc.append(pcmbr_list[i])
                 pc_members[(pcintfname, pcmbr_list[i])] = {}
             if pcintf.find(str(QName(ns, "Fallback"))) != None:
-                pcs[pcintfname] = {'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'min_links': str(int(math.ceil(len() * 0.75))), 'lacp_key': 'auto'}
+                pcs[pcintfname] = {'fallback': pcintf.find(str(QName(ns, "Fallback"))).text, 'min_links': str(int(math.ceil(len(pcmbr_list) * 0.75))), 'lacp_key': 'auto'}
             else:
                 pcs[pcintfname] = {'min_links': str(int(math.ceil(len(pcmbr_list) * 0.75))), 'lacp_key': 'auto' }
         port_nhipv4_map = {}


### PR DESCRIPTION
#### What I did
Fix `len()` called with no arguments in `minigraph.py:969`, which crashes PortChannel Fallback parsing with `TypeError`.

#### How I did it
Changed `len()` to `len(pcmbr_list)`, matching the non-Fallback branch on line 971.

#### How to verify it
Parse a minigraph XML containing a PortChannel with a `<Fallback>` element — it should no longer crash.

#### Which release branch to backport
master

#### Description for the changelog
Fix TypeError crash in minigraph PortChannel Fallback parsing due to len() called with no arguments.

Fixes: #26399