### PR TITLE
[snmp] Set v1trapaddress to avoid expensive get_myaddr() on every trap

### DIFF
--- a/dockers/docker-fpm-frr/snmp.conf
+++ b/dockers/docker-fpm-frr/snmp.conf
@@ -5,3 +5,7 @@
 # Check that a snmpwalk to 1.3.6.1.2.1.15 gives an output
 # Further verification: 1.3.6.1.2.1.15.2.0 = INTEGER: 65000 the returned value should be the confiugred ASN
 agentXSocket    tcp:localhost:3161
+# Set v1trapaddress to avoid the expensive net-snmp get_myaddr() ioctl
+# enumeration on every trap. The agent_addr field is only used in SNMPv1
+# TRAP PDUs and is discarded by AgentX before reaching the snmp container.
+v1trapaddress   169.254.0.1

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -141,6 +141,14 @@ load   12 10 5
 #
 # Note: disabled snmp traps due to side effect of causing snmpd to listen on all ports (0.0.0.0)
 #
+# Set v1trapaddress to avoid the expensive net-snmp get_myaddr() ioctl
+# enumeration on every trap. The agent_addr field is only used in SNMPv1
+# TRAP PDUs; v2c/v3 does not have this field.
+# When a v1 trap receiver is configured, let snmpd resolve the real address.
+{% if not (SNMP_TRAP_CONFIG and SNMP_TRAP_CONFIG['v1TrapDest']) %}
+v1trapaddress 169.254.0.1
+{% endif %}
+#
 #   send SNMPv1  traps
 {% if SNMP_TRAP_CONFIG and SNMP_TRAP_CONFIG['v1TrapDest'] %}
 {% set v1SnmpTrapIp = SNMP_TRAP_CONFIG['v1TrapDest']['DestIp'] %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During AZD testing on a device with 2K interfaces and 2K BGP peers, BGP was spending the majority of its CPU time sending SNMP traps.
<img width="1194" height="405" alt="image" src="https://github.com/user-attachments/assets/ddc71abf-9c2b-45ce-8634-b5234a5954aa" />

#### How I did it

When net-snmp lib sends a trap notification, it unconditionally discovers a local IP address to populate the agent_addr field in the SNMPv1 TRAP PDU. This calls [get_myaddr()](https://github.com/net-snmp/net-snmp/blob/e8a9e5232842b793c6ae51663f6bd3ebfac3fdf5/agent/agent_trap.c#L978
), which opens a socket and enumerates all network interfaces via multiple ioctl(SIOCGIFCONF/SIOCGIFFLAGS) on every trap. 
The agent_addr field only exists in SNMPv1 TRAP PDUs; v2c/v3 does not have this field.

This is a significant bottleneck when the router has thousands of interfaces.

Hardcoded  v1trapaddress to a link-local address (169.254.0.1) so net-snmp does not need to look up a local address on every trap.

- docker-fpm-frr/snmp.conf: unconditional, since AgentX discards the agent_addr field before forwarding to the snmp container.
- docker-snmp/snmpd.conf.j2: conditional, only when no v1 trap receiver is configured. When a v1 receiver exists, snmpd resolves the real address.

#### How to verify it
Configured a v1 trap receiver:
  config snmptrap modify 1 10.0.0.1
Started
  tcpdump -i any port 162 -v
Executed 
 clear ip bgp *
Verified that:
1) No change in the trap agent_addr field after changes to the FRR docker only.
2) No change in the trap agent_addr field after changes to both the FRR and SNMP dockers.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
AZD deployment 

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master

#### Description for the changelog
<!--
Hardcode v1trapaddress to avoid expensive per-trap IP address discovery in net-snmp get_myaddr() on routers with thousands of interfaces.
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### A picture of a cute animal (not mandatory but encouraged)

![bgp_interface_profile_lbr](https://github.com/user-attachments/assets/f55192a0-062a-4f08-9bb5-54edbb22c54f)
