### PR TITLE
Fix test_get_platform_info in sonic-py-common

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -57,6 +57,7 @@ DPU_NAME_PREFIX = "dpu"
 # Cacheable Objects
 sonic_ver_info = {}
 hw_info_dict = {}
+_platform_cache = None
 
 def get_localhost_info(field, config_db=None):
     try:
@@ -114,6 +115,8 @@ def get_platform(**kwargs):
         A string containing the device's platform identifier
     """
 
+    global _platform_cache
+
     # If we are running in a virtual switch Docker container, the environment
     # variable 'PLATFORM' will be defined and will contain the platform
     # identifier.
@@ -121,15 +124,21 @@ def get_platform(**kwargs):
     if platform_env:
         return platform_env
 
+    # Return cached platform value if already resolved from machine.conf
+    if _platform_cache is not None:
+        return _platform_cache
+
     # If 'PLATFORM' env variable is not defined, we try to read the platform
     # identifier from machine.conf. This is critical for sonic-config-engine,
     # because it is responsible for populating this value in Config DB.
     machine_info = get_machine_info()
     if machine_info:
         if 'onie_platform' in machine_info:
-            return machine_info['onie_platform']
+            _platform_cache = machine_info['onie_platform']
+            return _platform_cache
         elif 'aboot_platform' in machine_info:
-            return machine_info['aboot_platform']
+            _platform_cache = machine_info['aboot_platform']
+            return _platform_cache
 
     # If we fail to read from machine.conf, we may be running inside a Docker
     # container in SONiC, where the /host directory is not mounted. In this

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -87,6 +87,17 @@ class TestDeviceInfo(object):
         with mock.patch.dict(os.environ, {}, clear=True):
             yield
 
+    @pytest.fixture(autouse=True)
+    def reset_caches(self):
+        # Reset module-level caches before each test to prevent cross-test contamination
+        device_info.hw_info_dict.clear()
+        device_info.sonic_ver_info.clear()
+        device_info._platform_cache = None
+        yield
+        device_info.hw_info_dict.clear()
+        device_info.sonic_ver_info.clear()
+        device_info._platform_cache = None
+
     def test_get_machine_info(self):
         with mock.patch("os.path.isfile") as mock_isfile:
             mock_isfile.return_value = True
@@ -192,8 +203,7 @@ class TestDeviceInfo(object):
             assert hw_info_dict["hwsku"] == "Mellanox-SN2700"
             assert hw_info_dict["switch_type"] == "npu"
         mock_sonic_ver.assert_called_once()
-        # TODO(trixie): Figure out why this is failing
-        # mock_machine_info.assert_called_once()
+        mock_machine_info.assert_called_once()
         mock_hwsku.assert_called_once()
         mock_cfg_inst.get_table.assert_called_once_with("DEVICE_METADATA")
 


### PR DESCRIPTION
Fixes sonic-net/sonic-buildimage#23796

Was previously failing `mock_machine_info.assert_called_once()` because within a single get_platform_info() call, get_machine_info() was invoked 3 times

Fix by caching the platform string resolved from machine.conf in a module-level _platform_cache variable. Values from env var (PLATFORM) or ConfigDB are not cached to preserve existing semantics.

Also add a reset_caches test fixture to clear all module-level caches between tests, preventing cross-test contamination from _platform_cache, and uncomment the mock_machine_info.assert_called_once() assertion that had been disabled with a TODO(trixie) comment.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

