### PR TITLE
[Mellanox] integrate-mlnx-sdk: Update SDK tarball name and kernel backports path

### DIFF
--- a/platform/mellanox/integration-scripts.mk
+++ b/platform/mellanox/integration-scripts.mk
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2016-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2016-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/integration-scripts.mk
+++ b/platform/mellanox/integration-scripts.mk
@@ -193,11 +193,11 @@ endif
 
 integrate-mlnx-sdk:
 	$(FLUSH_LOG)
-	rm -rf $(MLNX_SDK_VERSION).zip sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz
+	rm -rf $(MLNX_SDK_VERSION).zip sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz
 
 ifeq ($(SDK_FROM_SRC),y)
-	wget $(MLNX_SDK_SOURCE_BASE_URL)/sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz $(LOG_SIMPLE)
-	tar -xf sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz --strip-components=1 -C $(SDK_TMPDIR) $(LOG_SIMPLE)
+	wget $(MLNX_SDK_SOURCE_BASE_URL)/sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz $(LOG_SIMPLE)
+	tar -xf sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz --strip-components=1 -C $(SDK_TMPDIR) $(LOG_SIMPLE)
 else ifeq ($(MLNX_SDK_SOURCE_BASE_URL),)
 	# Download from upstream repository (no source URL available)
 	wget $(MLNX_SDK_DRIVERS_GITHUB_URL)/archive/refs/heads/$(MLNX_SDK_VERSION).zip $(LOG_SIMPLE)
@@ -205,8 +205,8 @@ else ifeq ($(MLNX_SDK_SOURCE_BASE_URL),)
 	mv $(SDK_TMPDIR)/Spectrum-SDK-Drivers-$(MLNX_SDK_VERSION)/* $(SDK_TMPDIR) $(LOG_SIMPLE)
 else
 	# Use provided source URL
-	wget $(MLNX_SDK_SOURCE_BASE_URL)/sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz $(LOG_SIMPLE)
-	tar -xf sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz --strip-components=1 -C $(SDK_TMPDIR) $(LOG_SIMPLE)
+	wget $(MLNX_SDK_SOURCE_BASE_URL)/sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz $(LOG_SIMPLE)
+	tar -xf sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz --strip-components=1 -C $(SDK_TMPDIR) $(LOG_SIMPLE)
 endif
 
 	pushd $(BUILD_WORKDIR)/src/sonic-linux-kernel; git clean -f -- patch/; git stash -- patch/

--- a/platform/mellanox/integration-scripts/helper.py
+++ b/platform/mellanox/integration-scripts/helper.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/platform/mellanox/integration-scripts/helper.py
+++ b/platform/mellanox/integration-scripts/helper.py
@@ -34,7 +34,7 @@ SLK_SERIES = SLK_PATCH_LOC + "series"
 NON_UP_PATCH_DIR = "platform/mellanox/non-upstream-patches/"
 NON_UP_PATCH_LOC = NON_UP_PATCH_DIR + "patches"
 NON_UP_DIFF = NON_UP_PATCH_DIR + "external-changes.patch"
-KCFG_HDR_RE = "\[(.*)\]"
+KCFG_HDR_RE = r"\[(.*)\]"
 KERNEL_BACKPORTS = "kernel_backports"
  # kconfig_inclusion headers to consider
 HDRS = ["common", "amd64"]

--- a/platform/mellanox/integration-scripts/tests/test_sdkaction.py
+++ b/platform/mellanox/integration-scripts/tests/test_sdkaction.py
@@ -205,7 +205,7 @@ class TestSDKAction(TestCase):
         assert Data.old_patches[-1] == "0001-psample-Encapsulate-packet-metadata-in-a-struct.patch"
 
     def test_get_new_patches(self):
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         self.action.get_kernel_dir()
         print(Data.k_dir)
@@ -215,7 +215,7 @@ class TestSDKAction(TestCase):
         assert Data.new_patches[1] == "0002-psample-Add-additional-metadata-attributes.patch"
 
     def test_update_series(self):
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         Data.old_series = MOCK_SLK_SERIES.splitlines(True)
         self.action.refresh_markers()
@@ -229,7 +229,7 @@ class TestSDKAction(TestCase):
         assert "mellanox_sdk-end" in Data.old_series[Data.i_sdk_end]
 
     def test_update_series_1(self):
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         Data.old_series = MOCK_SLK_SERIES_1.splitlines(True)
         self.action.refresh_markers()
@@ -243,7 +243,7 @@ class TestSDKAction(TestCase):
         assert "mellanox_sdk-end" in Data.old_series[Data.i_sdk_end]
 
     def test_process_patches_1(self):
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         self.create_files(root_dir, EXT_PTCH_LIST)
         Data.old_series = MOCK_SLK_SERIES.splitlines(True)
@@ -257,7 +257,7 @@ class TestSDKAction(TestCase):
         assert check_lists(MOCK_FINAL_SLK_SERIES.splitlines(True), Data.new_series)
 
     def test_process_patches_2(self):
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         self.create_files(root_dir, EXT_PTCH_LIST)
         Data.old_series = MOCK_SLK_SERIES_1.splitlines(True)
@@ -286,7 +286,7 @@ class TestSDKAction(TestCase):
     def test_commit_msg(self, mock_read_strip_mock):
         global LINES_READ 
         LINES_READ = MOCK_README.splitlines()
-        root_dir = "/tmp/kernel_backports/5.10/5.10.27"
+        root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
         self.create_files(root_dir, ["0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch"])
         Data.old_series = MOCK_SLK_SERIES.splitlines(True)

--- a/platform/mellanox/integration-scripts/tests/test_sdkaction.py
+++ b/platform/mellanox/integration-scripts/tests/test_sdkaction.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,11 +16,11 @@
 # limitations under the License.
 #
 
+from sdk_kernel_patches import *
 import sys
 from unittest import mock, TestCase
 from pyfakefs.fake_filesystem_unittest import Patcher
 sys.path.append('../')
-from sdk_kernel_patches import *
 
 MOCK_SLK_SERIES = """\
 # Trtnetlink-catch-EOPNOTSUPP-errors.patch
@@ -85,12 +86,12 @@ MOCK_FINAL_SLK_SERIES = """\
 #####
 """
 
-PTCH_LIST = ["0001-psample-Encapsulate-packet-metadata-in-a-struct.patch", \
-              "0002-psample-Add-additional-metadata-attributes.patch"]
+PTCH_LIST = ["0001-psample-Encapsulate-packet-metadata-in-a-struct.patch",
+             "0002-psample-Add-additional-metadata-attributes.patch"]
 
-EXT_PTCH_LIST = ["0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch", \
-              "0004-new-sdk-driver-change-1.patch", \
-              "0005-new-sdk-driver-change-1.patch"]
+EXT_PTCH_LIST = ["0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch",
+                 "0004-new-sdk-driver-change-1.patch",
+                 "0005-new-sdk-driver-change-1.patch"]
 
 MOCK_SLK_VER = "5.10.104"
 
@@ -104,7 +105,7 @@ Patch                                                                      Upstr
 0002-psample-Add-additional-metadata-attributes.patch                      07e1a5809b595df6e125504dff6245cb2c8ed3de    5.13
 0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch               N/A                                         N/A
 wrong-patch-name                                                           Whatevrr                                    rqrwf     vwvwvrvrv
-==================================================  
+==================================================
 """
 
 TEST_SLK_COMMIT = """\
@@ -118,13 +119,14 @@ Integrate SDK 4.5.1000 Kernel Patches
 
 LINES_READ = ""
 
+
 def mock_sdk_args():
     with mock.patch("sys.argv", ["sdk_kernel_patches.py",
-                                "--sonic_kernel_ver", MOCK_SLK_VER,
-                                "--patches", "/tmp",
-                                "--sdk_ver", "4.5.1000",
-                                "--slk_msg", "/tmp/slk-commit-msg.hgsdhg",
-                                "--build_root", "/sonic"]):
+                                 "--sonic_kernel_ver", MOCK_SLK_VER,
+                                 "--patches", "/tmp",
+                                 "--sdk_ver", "4.5.1000",
+                                 "--slk_msg", "/tmp/slk-commit-msg.hgsdhg",
+                                 "--build_root", "/sonic"]):
         parser = create_parser()
         return parser.parse_args()
 
@@ -143,9 +145,11 @@ def check_lists(exp, rec):
             return False
     return True
 
+
 def read_strip_mock(path, as_string=False):
     global LINES_READ
     return LINES_READ
+
 
 class TestSDKAction(TestCase):
     def setUp(self):
@@ -164,7 +168,7 @@ class TestSDKAction(TestCase):
         Data.i_sdk_start = -1
         Data.i_sdk_end = -1
         self.patcher.tearDown()
-        global LINES_READ 
+        global LINES_READ
         LINES_READ = ""
 
     def create_files(self, root_dir, lis):
@@ -176,7 +180,7 @@ class TestSDKAction(TestCase):
         self.patcher.fs.create_dir(os.path.join("/tmp", dir_))
         self.action.get_kernel_dir()
         assert dir_ == Data.k_dir
-        
+
     def test_get_kernel_dir_2(self):
         dir_ = os.path.join(self.path_kernel, "5.10.99")
         self.patcher.fs.create_dir(os.path.join("/tmp", dir_))
@@ -272,7 +276,7 @@ class TestSDKAction(TestCase):
 
     @mock.patch('helper.FileHandler.read_strip', side_effect=read_strip_mock)
     def test_patch_table(self, mock_read_strip_mock):
-        global LINES_READ 
+        global LINES_READ
         LINES_READ = MOCK_README.splitlines()
         table = self.action.fetch_patch_table("")
         assert "0001-psample-Encapsulate-packet-metadata-in-a-struct.patch" in table
@@ -281,10 +285,10 @@ class TestSDKAction(TestCase):
         assert table["0001-psample-Encapsulate-packet-metadata-in-a-struct.patch"] == "a03e99d39f1943ec88f6fd3b0b9f34c20663d401"
         assert table["0002-psample-Add-additional-metadata-attributes.patch"] == "07e1a5809b595df6e125504dff6245cb2c8ed3de"
         assert table["0003-psample-define-the-macro-PSAMPLE_MD_EXTENDED_ATTR.patch"] == "N/A"
-    
+
     @mock.patch('helper.FileHandler.read_strip', side_effect=read_strip_mock)
     def test_commit_msg(self, mock_read_strip_mock):
-        global LINES_READ 
+        global LINES_READ
         LINES_READ = MOCK_README.splitlines()
         root_dir = os.path.join("/tmp", KERNEL_BACKPORTS, "5.10/5.10.27")
         self.create_files(root_dir, PTCH_LIST)
@@ -297,4 +301,4 @@ class TestSDKAction(TestCase):
         table = self.action.fetch_patch_table("")
         msg = self.action.create_commit_msg(table)
         print(msg)
-        assert check_lists(TEST_SLK_COMMIT.splitlines(True),  msg.splitlines(True))
+        assert check_lists(TEST_SLK_COMMIT.splitlines(True), msg.splitlines(True))


### PR DESCRIPTION
Switch to the new sys_sdk-* tarball and update the kernel backports path from kernel_backports/ to sxd_kernel/kernel_backports/.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The Mellanox SDK kernel patches are now distributed via `sys_sdk-*` with an updated internal
directory layout.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Replaced all references to `sx_kernel-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz` with `sys_sdk-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz` in `integration-scripts.mk`
- Updated the `KERNEL_BACKPORTS` constant in `helper.py` from `kernel_backports` to `sxd_kernel/kernel_backports` to reflect the new path inside the tarball

#### How to verify it
Run `make integrate-mlnx-sdk` with the new `sys_sdk-*` tarball and verify patches are correctly extracted and applied to `sonic-linux-kernel`


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

