### PR TITLE
Support compiling flag to re-use existing slave dockers

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -195,6 +195,7 @@ endif
 SLAVE_IMAGE = $(SLAVE_BASE_IMAGE)-$(USER_LC)
 
 # Optional per-BLDENV reuse of an existing sonic-slave-user image (see header comment).
+SONIC_SLAVE_REUSE_SLAVE :=
 SONIC_SLAVE_REUSE_KIND :=
 SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE :=
 SONIC_SLAVE_REUSE_EFFECTIVE_TAG :=
@@ -618,7 +619,7 @@ SONIC_SLAVE_USER_BUILD = \
 		docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null; \
 	} || \
 	{ \
-		echo "ERROR: Slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Build once without SONIC_SLAVE_REUSE_<release>_* (e.g. make sonic-slave-build), or set reuse vars for this BLDENV from output of make showtag."; \
+                echo "ERROR: Slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Build once without SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_* (e.g. make sonic-slave-build), or set SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE and SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG for this BLDENV from output of make showtag."; \
 		exit 1; \
 	}
 else

--- a/Makefile.work
+++ b/Makefile.work
@@ -550,6 +550,7 @@ DOCKER_USER_BUILD = docker build $(DOCKER_NO_CACHE_FLAG) \
 	       --build-arg guid=$(shell id -g) \
 	       --build-arg hostname=$(shell echo $$HOSTNAME) \
                --build-arg slave_base_tag_ref=$(SLAVE_BASE_TAG) \
+	       --label com.sonic.base-tag=$(SLAVE_BASE_TAG) \
 	       -t $(SLAVE_IMAGE):$(SLAVE_TAG) \
 	       -f $(SLAVE_DIR)/Dockerfile.user \
 	       $(SLAVE_DIR) $(SPLIT_LOG) $(DOCKER_LOG)
@@ -621,7 +622,16 @@ SONIC_SLAVE_USER_BUILD = \
 	{ \
                 echo "ERROR: Slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Build once without SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_* (e.g. make sonic-slave-build), or set SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE and SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG for this BLDENV from output of make showtag."; \
 		exit 1; \
-	}
+	}; \
+	slave_base_tag=$$(docker inspect --type image --format '{{if .Config.Labels}}{{index .Config.Labels "com.sonic.base-tag"}}{{end}}' $(SLAVE_IMAGE):$(SLAVE_TAG)); \
+	if [ -n "$$slave_base_tag" ] && [ "$$slave_base_tag" != "$(SLAVE_BASE_TAG)" ]; then \
+		if [ -n "$(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD) $(SONIC_DPKG_CACHE_METHOD_OVERRIDE))" ]; then \
+			echo "ERROR: Reused slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) was built from slave base tag $$slave_base_tag, but the current slave base tag is $(SLAVE_BASE_TAG). Refusing to use a stale image while DPKG cache writes are enabled."; \
+			exit 1; \
+		else \
+			echo "WARNING: Reused slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) was built from slave base tag $$slave_base_tag, but the current slave base tag is $(SLAVE_BASE_TAG)."; \
+		fi; \
+	fi
 else
 SONIC_SLAVE_USER_BUILD = \
 	{ \

--- a/Makefile.work
+++ b/Makefile.work
@@ -68,6 +68,14 @@
 #  * ENABLE_VRF_STRICT: Enable VRF strict mode.
 #  *                 Default: unset
 #  *                 Values: y
+#  * SONIC_SLAVE_REUSE_<release>_IMAGE / SONIC_SLAVE_REUSE_<release>_TAG (optional): Use
+#  *                 an existing local sonic-slave **user** image instead of building when
+#  *                 the computed tag changes. Supported keys for this tree: TRIXIE and
+#  *                 BOOKWORM only (other BLDENV values do not use reuse variables here).
+#  *                 Set both for the current BLDENV from `make showtag` before the change.
+#  *                 Skips slave-base and slave-user docker build; fails if the image is
+#  *                 missing. Must match BLDENV/arch; reuse at own risk if stale vs.
+#  *                 current slave Dockerfiles.
 ###############################################################################
 
 SHELL = /bin/bash
@@ -185,6 +193,38 @@ endif
 endif
 endif
 SLAVE_IMAGE = $(SLAVE_BASE_IMAGE)-$(USER_LC)
+
+# Optional per-BLDENV reuse of an existing sonic-slave-user image (see header comment).
+SONIC_SLAVE_REUSE_KIND :=
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE :=
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG :=
+ifeq ($(BLDENV),trixie)
+SONIC_SLAVE_REUSE_KIND := TRIXIE
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE := $(strip $(SONIC_SLAVE_REUSE_TRIXIE_IMAGE))
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG := $(strip $(SONIC_SLAVE_REUSE_TRIXIE_TAG))
+else ifeq ($(BLDENV),bookworm)
+SONIC_SLAVE_REUSE_KIND := BOOKWORM
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE := $(strip $(SONIC_SLAVE_REUSE_BOOKWORM_IMAGE))
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG := $(strip $(SONIC_SLAVE_REUSE_BOOKWORM_TAG))
+endif
+
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+ifeq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+$(error SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG must be set when SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE is set)
+endif
+endif
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+ifeq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+$(error SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE must be set when SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG is set)
+endif
+endif
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+override SLAVE_IMAGE := $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)
+SONIC_SLAVE_REUSE_SLAVE = y
+endif
+endif
+
 DOCKER_ROOT = $(PWD)/fsroot.docker.$(BLDENV)
 
 ifeq ($(INCLUDE_FIPS), n)
@@ -266,7 +306,10 @@ SLAVE_BASE_TAG = $(shell \
 	| sha1sum \
 	| awk '{print substr($$1,0,11);}')
 
-# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_PLATFORM) to get unique SHA ID
+# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_ARCH) to get unique SHA ID
+ifeq ($(SONIC_SLAVE_REUSE_SLAVE),y)
+SLAVE_TAG := $(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG))
+else
 SLAVE_TAG = $(shell \
 	(cat $(SLAVE_DIR)/Dockerfile.user \
 		 $(SLAVE_DIR)/Dockerfile \
@@ -275,6 +318,7 @@ SLAVE_TAG = $(shell \
 	&& echo $(USER)/$(PWD)/$(CONFIGURED_ARCH)) \
 	| sha1sum \
 	| awk '{print substr($$1,0,11);}')
+endif
 
 COLLECT_DOCKER=DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
 	SONIC_VERSION_CACHE=$(SONIC_VERSION_CACHE) \
@@ -529,6 +573,11 @@ DOCKER_SLAVE_BASE_PULL_REGISTRY = \
 		$(COLLECT_DOCKER); \
 	}\
 
+ifeq ($(SONIC_SLAVE_REUSE_SLAVE),y)
+SONIC_SLAVE_BASE_BUILD = \
+	echo "SONIC_SLAVE_REUSE_*: skipping sonic-slave-base build (using existing user image $(SLAVE_IMAGE):$(SLAVE_TAG))"; \
+	true
+else
 SONIC_SLAVE_BASE_BUILD = \
 	{ \
 		$(DOCKER_SLAVE_BASE_INSPECT); \
@@ -543,6 +592,7 @@ SONIC_SLAVE_BASE_BUILD = \
 		$(DOCKER_SLAVE_BASE_BUILD) ; \
 		$(COLLECT_DOCKER) ; \
 	}
+endif
 
 DOCKER_SLAVE_USER_INSPECT = \
 	{ \
@@ -561,6 +611,17 @@ DOCKER_SLAVE_USER_PULL_REGISTRY = \
 		$(COLLECT_DOCKER); \
 	}\
 
+ifeq ($(SONIC_SLAVE_REUSE_SLAVE),y)
+SONIC_SLAVE_USER_BUILD = \
+	{ \
+		echo Checking sonic-slave-user image \(reuse\): $(SLAVE_IMAGE):$(SLAVE_TAG); \
+		docker inspect --type image $(SLAVE_IMAGE):$(SLAVE_TAG) &> /dev/null; \
+	} || \
+	{ \
+		echo "ERROR: Slave user image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Build once without SONIC_SLAVE_REUSE_<release>_* (e.g. make sonic-slave-build), or set reuse vars for this BLDENV from output of make showtag."; \
+		exit 1; \
+	}
+else
 SONIC_SLAVE_USER_BUILD = \
 	{ \
 		$(DOCKER_SLAVE_USER_INSPECT); \
@@ -573,6 +634,7 @@ SONIC_SLAVE_USER_BUILD = \
 		echo Image $(SLAVE_IMAGE):$(SLAVE_TAG) not found. Building... ; \
 		$(DOCKER_USER_BUILD) ; \
 	}
+endif
 
 SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            -f slave.mk \

--- a/Makefile.work
+++ b/Makefile.work
@@ -68,6 +68,15 @@
 #  * ENABLE_VRF_STRICT: Enable VRF strict mode.
 #  *                 Default: unset
 #  *                 Values: y
+#  * SONIC_SLAVE_REUSE_<release>_IMAGE / SONIC_SLAVE_REUSE_<release>_TAG (optional): Use
+#  *                 an existing local sonic-slave **base** image instead of building when
+#  *                 the computed base tag changes. Supported keys for this tree: TRIXIE and
+#  *                 BOOKWORM only (other BLDENV values do not use reuse variables here).
+#  *                 Set both for the current BLDENV from `make showtag` before the change.
+#  *                 Skips slave-base docker build; fails if the image is missing. Must match
+#  *                 BLDENV/arch; reuse at own risk if stale vs. current slave Dockerfiles.
+#  *                 With DPKG cache write modes, a reused tag that differs from the computed
+#  *                 base tag is rejected.
 ###############################################################################
 
 SHELL = /bin/bash
@@ -181,6 +190,38 @@ endif
 endif
 endif
 SLAVE_IMAGE = $(SLAVE_BASE_IMAGE)-$(USER_LC)
+
+# Optional per-BLDENV reuse of an existing sonic-slave-base image (see header comment).
+SONIC_SLAVE_REUSE_SLAVE :=
+SONIC_SLAVE_REUSE_KIND :=
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE :=
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG :=
+ifeq ($(BLDENV),trixie)
+SONIC_SLAVE_REUSE_KIND := TRIXIE
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE := $(strip $(SONIC_SLAVE_REUSE_TRIXIE_IMAGE))
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG := $(strip $(SONIC_SLAVE_REUSE_TRIXIE_TAG))
+else ifeq ($(BLDENV),bookworm)
+SONIC_SLAVE_REUSE_KIND := BOOKWORM
+SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE := $(strip $(SONIC_SLAVE_REUSE_BOOKWORM_IMAGE))
+SONIC_SLAVE_REUSE_EFFECTIVE_TAG := $(strip $(SONIC_SLAVE_REUSE_BOOKWORM_TAG))
+endif
+
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+ifeq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+$(error SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG must be set when SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE is set)
+endif
+endif
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+ifeq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+$(error SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE must be set when SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG is set)
+endif
+endif
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)),)
+ifneq ($(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG)),)
+SONIC_SLAVE_REUSE_SLAVE = y
+endif
+endif
+
 DOCKER_ROOT = $(PWD)/fsroot.docker.$(BLDENV)
 
 ifeq ($(INCLUDE_FIPS), n)
@@ -250,14 +291,21 @@ PREPARE_DOCKER=BUILD_SLAVE=y \
 $(shell $(PREPARE_DOCKER) )
 
 # Add the versions in the tag, if the version change, need to rebuild the slave
-SLAVE_BASE_TAG = $(shell \
+SLAVE_BASE_TAG_COMPUTED := $(shell \
 	cat $(SLAVE_DIR)/Dockerfile \
 		$(SLAVE_DIR)/sources.list.* \
 		$(SLAVE_DIR)/buildinfo/versions/versions-* 2>/dev/null \
 	| sha1sum \
 	| awk '{print substr($$1,0,11);}')
 
-# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_PLATFORM) to get unique SHA ID
+ifeq ($(SONIC_SLAVE_REUSE_SLAVE),y)
+override SLAVE_BASE_IMAGE := $(SONIC_SLAVE_REUSE_EFFECTIVE_IMAGE)
+override SLAVE_BASE_TAG := $(strip $(SONIC_SLAVE_REUSE_EFFECTIVE_TAG))
+else
+SLAVE_BASE_TAG := $(SLAVE_BASE_TAG_COMPUTED)
+endif
+
+# Calculate the slave TAG based on $(USER)/$(PWD)/$(CONFIGURED_ARCH) to get unique SHA ID
 SLAVE_TAG = $(shell \
 	(cat $(SLAVE_DIR)/Dockerfile \
 		 $(SLAVE_DIR)/sources.list.* \
@@ -567,6 +615,25 @@ DOCKER_SLAVE_BASE_PULL_REGISTRY = \
 		$(COLLECT_DOCKER); \
 	}\
 
+ifeq ($(SONIC_SLAVE_REUSE_SLAVE),y)
+SONIC_SLAVE_BASE_BUILD = \
+	{ \
+		echo Checking sonic-slave-base image \(reuse\): $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG); \
+		docker inspect --type image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) &> /dev/null; \
+	} || \
+	{ \
+		echo "ERROR: Slave base image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) not found. Build once without SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_* (e.g. make sonic-slave-build), or set SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_IMAGE and SONIC_SLAVE_REUSE_$(SONIC_SLAVE_REUSE_KIND)_TAG for this BLDENV from output of make showtag."; \
+		exit 1; \
+	}; \
+	if [ "$(SLAVE_BASE_TAG)" != "$(SLAVE_BASE_TAG_COMPUTED)" ]; then \
+		if [ -n "$(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD) $(SONIC_DPKG_CACHE_METHOD_OVERRIDE))" ]; then \
+			echo "ERROR: Reused slave base image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) differs from the computed slave base tag $(SLAVE_BASE_TAG_COMPUTED). Refusing to use a stale image while DPKG cache writes are enabled."; \
+			exit 1; \
+		else \
+			echo "WARNING: Reused slave base image $(SLAVE_BASE_IMAGE):$(SLAVE_BASE_TAG) differs from the computed slave base tag $(SLAVE_BASE_TAG_COMPUTED)."; \
+		fi; \
+	fi
+else
 SONIC_SLAVE_BASE_BUILD = \
 	{ \
 		$(DOCKER_SLAVE_BASE_INSPECT); \
@@ -581,6 +648,7 @@ SONIC_SLAVE_BASE_BUILD = \
 		$(DOCKER_SLAVE_BASE_BUILD) ; \
 		$(COLLECT_DOCKER) ; \
 	}
+endif
 
 SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            -f slave.mk \

--- a/README.md
+++ b/README.md
@@ -370,9 +370,7 @@ reproducibility notes, and known limitations.
   `SONIC_SLAVE_REUSE_TRIXIE_IMAGE` / `SONIC_SLAVE_REUSE_TRIXIE_TAG` for
   `BLDENV=trixie`, on later make invocations to skip rebuilding the slave. You
   can export several pairs in your environment when switching between releases.
-  (Previously `SONIC_SLAVE_REUSE_IMAGE` / `SONIC_SLAVE_REUSE_TAG` were used
-  globally; use `SONIC_SLAVE_REUSE_TRIXIE_*` / `SONIC_SLAVE_REUSE_BOOKWORM_*` as
-  appropriate.) See `Makefile.work` for details.
+  See `Makefile.work` for details.
 * The root user account is disabled. However, the created user can `sudo`.
 * The target directory is `./target`, containing the NOS installer image
   and docker images.

--- a/README.md
+++ b/README.md
@@ -361,6 +361,18 @@ reproducibility notes, and known limitations.
 * If you are running make for the first time, a sonic-slave-${USER} docker image
   will be built automatically.
   This may take a while, but it is a one-time action, so please be patient.
+* If the slave image tag changes (e.g. checkout path, edits under `sonic-slave-*`)
+  but you want to keep using an image you already built, run
+  `BLDENV=<release> make showtag` (per release and per arch, as in real builds) to
+  record `sonic-slave-…-${USER}:<tag>`, then pass the matching **per-release**
+  pair, e.g. `SONIC_SLAVE_REUSE_BOOKWORM_IMAGE` / `SONIC_SLAVE_REUSE_BOOKWORM_TAG`
+  for `BLDENV=bookworm` and
+  `SONIC_SLAVE_REUSE_TRIXIE_IMAGE` / `SONIC_SLAVE_REUSE_TRIXIE_TAG` for
+  `BLDENV=trixie`, on later make invocations to skip rebuilding the slave. You
+  can export several pairs in your environment when switching between releases.
+  (Previously `SONIC_SLAVE_REUSE_IMAGE` / `SONIC_SLAVE_REUSE_TAG` were used
+  globally; use `SONIC_SLAVE_REUSE_TRIXIE_*` / `SONIC_SLAVE_REUSE_BOOKWORM_*` as
+  appropriate.) See `Makefile.work` for details.
 * The root user account is disabled. However, the created user can `sudo`.
 * The target directory is `./target`, containing the NOS installer image
   and docker images.

--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ reproducibility notes, and known limitations.
 * If you are running make for the first time, a sonic-slave-${USER} docker image
   will be built automatically.
   This may take a while, but it is a one-time action, so please be patient.
+* If the slave base image tag changes (e.g. edits under `sonic-slave-*`) but you
+  want to keep using a base image you already built, run
+  `BLDENV=<release> make showtag` (per release and per arch, as in real builds) to
+  record `sonic-slave-<release>:<tag>`, then pass the matching **per-release**
+  pair, e.g. `SONIC_SLAVE_REUSE_BOOKWORM_IMAGE` / `SONIC_SLAVE_REUSE_BOOKWORM_TAG`
+  for `BLDENV=bookworm` and
+  `SONIC_SLAVE_REUSE_TRIXIE_IMAGE` / `SONIC_SLAVE_REUSE_TRIXIE_TAG` for
+  `BLDENV=trixie`, on later make invocations to skip rebuilding the slave. You
+  can export several pairs in your environment when switching between releases.
+  See `Makefile.work` for details.
 * The root user account is disabled. However, the created user can `sudo`.
 * The target directory is `./target`, containing the NOS installer image
   and docker images.


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it

The SONiC build system pulls the base slave image `sonic-slave-<release>:<tag>` when a build starts, then builds the per-user image `sonic-slave-<release>-<username>:<tag>`. In some situations only the user-local image already exists (for example after path or Dockerfile inputs changed and the computed tag no longer matches). Rebuilding the slave images in that case is slow and unnecessary when the desired image is already present locally.

Optional Makefile variables allow reusing an existing local sonic-slave **user** image by overriding the computed repository name and tag, skipping slave-base and slave-user Docker builds when both sides are set for the active `BLDENV` (Bookworm / Trixie in this tree).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Extended `Makefile.work` with per-`BLDENV` reuse knobs (`SONIC_SLAVE_REUSE_BOOKWORM_*` / `SONIC_SLAVE_REUSE_TRIXIE_*`): when both image and tag are set for the current release, override `SLAVE_IMAGE` / `SLAVE_TAG`, skip slave-base and slave-user build steps, and verify the image exists with `docker inspect`.
- Documented usage in `README.md` (run `BLDENV=<release> make showtag`, export the matching pair for later builds).

#### How to verify it

1. Build or obtain a local `sonic-slave-<release>-<user>:<tag>` image (e.g. run a normal build once, or note output from `BLDENV=bookworm make showtag`).
2. Change something that would normally alter the computed slave tag (e.g. checkout path or edits under `sonic-slave-*`) so a plain build would rebuild the slave.
3. Invoke `make` with the documented `SONIC_SLAVE_REUSE_<RELEASE>_IMAGE` and `SONIC_SLAVE_REUSE_<RELEASE>_TAG` values taken from `make showtag` before the change.
4. Confirm the build proceeds without rebuilding the slave-base/slave-user images and that failure occurs with a clear error if the referenced image is missing.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

