### PR TITLE
Flexcounter support for policer stats

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -55,6 +55,9 @@
         },
         "PORT_BUFFER_DROP": {
             "FLEX_COUNTER_STATUS": "enable"
+        },
+        "COPP_STATS": {
+            "FLEX_COUNTER_STATUS": "enable"
         }
     },
     "BGP_DEVICE_GLOBAL": {

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -55,6 +55,9 @@
         },
         "PORT_BUFFER_DROP": {
             "FLEX_COUNTER_STATUS": "enable"
+        },
+        "COPP_STATS": {
+            "FLEX_COUNTER_STATUS": "enable"
         }
 {%- if sonic_asic_platform in ["nvidia-bluefield", "pensando"] %},
         "ENI": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -82,6 +82,10 @@
                 "SWITCH": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 1000
+                },
+                "COPP_STATS": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
                 }
             }
         }
@@ -147,6 +151,10 @@
                     "POLL_INTERVAL": 99
                 },
                 "WRED_ECN_PORT": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 99
+                },
+                "COPP_STATS": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 99
                 }
@@ -222,6 +230,10 @@
                 "WRED_ECN_PORT": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 1000
+                },
+                "COPP_STATS": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
                 }
             }
         }
@@ -294,6 +306,10 @@
                 "WRED_ECN_PORT": {
                     "FLEX_COUNTER_STATUS": "enable",
                     "POLL_INTERVAL": 1000
+                },
+                "COPP_STATS": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 10000
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -496,6 +496,18 @@ module sonic-flex_counter {
                 }
             }
 
+            container COPP_STATS {
+                /* COPP_STATS_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
         }
         /* end of container FLEX_COUNTER_TABLE */
 

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -516,6 +516,18 @@ module sonic-flex_counter {
                 }
             }
 
+            container COPP_STATS {
+                /* COPP_STATS_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    type flex_status;
+                }
+                leaf FLEX_COUNTER_DELAY_STATUS {
+                    type flex_delay_status;
+                }
+                leaf POLL_INTERVAL {
+                    type poll_interval;
+                }
+            }
         }
         /* end of container FLEX_COUNTER_TABLE */
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

There was no way to check the policer stats for COPP on SONiC at the queue level, only flowcnt-trap had statistics about packets hitting specific traps. This PR aims to add support to show copp stats.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Add support to leverage the existing `SAI` API to get policer stats using `brcm_sai_get_policer_stats` by using the SONiC level flexcounter architecture. This does not create any new flexcounters, it picks the statistics from hardware which is already implemented at the broadcom / sai level of things.

The CLI being proposed - 

For showing the stats - `show copp stats`


The flow is - 
```
┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│   CoppOrch      │────►│  FLEX_COUNTER_DB │────►│     Syncd       │────►│  Vendor SAI     │
│  (orchagent)    │     │     (Redis)      │     │  FlexCounter    │     │   Library       │
└─────────────────┘     └──────────────────┘     └─────────────────┘     └─────────────────┘
         │                                               │                       │
         ▼                                               ▼                       ▼
┌─────────────────┐                             ┌─────────────────┐     ┌─────────────────┐
│ COUNTERS_DB     │◄────────────────────────────│  VendorSai      │◄────│  Hardware       │
│ (Name Map)      │                             │  getStats()     │     │  Counters       │
└─────────────────┘                             └─────────────────┘     └─────────────────┘
```
We initialize the FLEX_COUNTER_ENABLE by default in init.cfg.j2 so that the policer stats are available from bootup. This is because these stats already have resources allocated on the hardware side and no new flexcounter needs to be attached.   


#### How to verify it

```bash
admin@gold221:~$ show copp stats
Trap Group       Total Pkts    Total Bytes    Green Pkts    Green Bytes    Yellow Pkts    Yellow Bytes    Red Pkts    Red Bytes
-------------  ------------  -------------  ------------  -------------  -------------  --------------  ----------  -----------
default                   5            438             5            438              0               0           0            0
queue1_group1             0              0             0              0              0               0           0            0
queue1_group3             0              0             0              0              0               0           0            0
queue4_group1           470         515344           470         515344              0               0           0            0
queue4_group2            16           1232            16           1232              0               0           0            0
queue4_group3             0              0             0              0              0               0           0            0
admin@gold221:~$
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
`copp queue counters` support for broadcom xgs platforms

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

[sonic-utilities CLI changes](https://github.com/sonic-net/sonic-utilities/pull/4490)
[sonic-mgmt test changes](https://github.com/sonic-net/sonic-mgmt/pull/24182)
[sonic-swss changes](https://github.com/sonic-net/sonic-swss/pull/4514)

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

