### PR TITLE
[Arista] Add sai_switch_pcie_hotswap_disable: 1 to TH5 platforms

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/Arista-7060X6-16PE-384C-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-FANOUT/th5-a7060x6-16pe-384c.config.bcm
@@ -23,6 +23,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2-LAB/th5-a7060x6-16pe-384c.config.bcm
@@ -23,6 +23,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S2/th5-a7060x6-16pe-384c.config.bcm
@@ -23,6 +23,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S4/th5-a7060x6-16pe-384c.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/Arista-7060X6-16PE-384C-B-O128S4/th5-a7060x6-16pe-384c.config.bcm
@@ -23,6 +23,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_32pe/Arista-7060X6-32PE/th5-a7060x6-32pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_32pe/Arista-7060X6-32PE/th5-a7060x6-32pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-256x200G/th5-a7060x6-64pe.config.bcm
@@ -24,6 +24,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-64x400G/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C224O8/th5-a7060x6-64pe.config.bcm
@@ -24,6 +24,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-C256S2/th5-a7060x6-64pe.config.bcm
@@ -24,6 +24,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-O128S2/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32O64/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32V128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE-P32V128/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe/Arista-7060X6-64PE/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C448O16/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe-lt2.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe-lt2.config.bcm
@@ -22,6 +22,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe.config.bcm
@@ -22,6 +22,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128S2/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P28O72/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P28O72/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32O64/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P32V128/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-P64/th5-a7060x6-64pe.config.bcm
@@ -25,6 +25,7 @@ bcm_device:
     0:
         global:
             pktio_mode: 1
+            sai_switch_pcie_hotswap_disable: 1
             default_cpu_tx_queue: 7
             vlan_flooding_l2mc_num_reserved: 0
             ipv6_lpm_128b_enable: 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Under certain anomalous test conditions, the switch enters a reboot loop. Setting sai_switch_pcie_hotswap_disable to 1 mitigates the issue.

For more detail, the device can enter an unrecoverable state if there is an invalid access to a reserved memory space, and it will require a reset to recover. We can avoid this by disabling the hot-swap logic, which forces the entire device to reset whenever the PCIe link goes down.

Fixes: [28434](https://github.com/sonic-net/sonic-buildimage/issues/28434)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605 

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511: no regression from this change on kusto ID: de08085a-871a-4061-aa69-628f04aebe42
- [x] 202605: no regression from this change on kusto ID: 91d6de69-fb86-4836-8130-ad36acb51c22

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

