### PR TITLE
[alpinevs] Enable p4rt by default for alpine

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -80,7 +80,7 @@
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_mux == "y" %}{% do features.append(("mux", "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_nat == "y" %}{% do features.append(("nat", "disabled", false, "enabled")) %}{% endif %}
-{%- if include_p4rt == "y" %}{% do features.append(("p4rt", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_p4rt == "y" %}{% do features.append(("p4rt", "enabled" if sonic_asic_platform == "alpinevs" else "disabled", false, "enabled")) %}{% endif %}
 {%- if include_restapi == "y" and BUILD_REDUCE_IMAGE_SIZE == "y" and sonic_asic_platform == "broadcom" %}
     {% do features.append(("restapi", "{% if (DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined and DEVICE_METADATA['localhost']['type'] is defined and DEVICE_METADATA['localhost']['type'] is not in ['LeafRouter', 'BackEndLeafRouter']) %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}
 {%- elif include_restapi == "y" %}


### PR DESCRIPTION
#### Why I did it

Enable p4rt by default for the AlpineVS platform. A design change in P4RT/P4Orch requires that the supporting platforms must enable p4rt at the time of system boot.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Enable p4rt only for Alpine in init_cfg.json.j2


#### How to verify it

```
root@sonic:/home/admin# show ver

SONiC Software Version: SONiC.master.0-dirty-20260430.025358
SONiC OS Version: 13
Distribution: Debian 13.4
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 0ed721643
Build date: Thu Apr 30 03:15:36 UTC 2026

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 03:38:13 up 3 min,  1 user,  load average: 1.41, 0.86, 0.36
Date: Thu 30 Apr 2026 03:38:13
```

Just after bootup : 
```
root@sonic:/home/admin# docker ps
CONTAINER ID   IMAGE                             COMMAND                  CREATED              STATUS              PORTS     NAMES
9b409ae46c62   docker-router-advertiser:latest   "/usr/bin/docker-ini…"   About a minute ago   Up About a minute             radv
0ded3ea1b035   docker-eventd:latest              "/usr/local/bin/supe…"   About a minute ago   Up About a minute             eventd
ea45c242728b   docker-fpm-frr:latest             "/usr/bin/docker_ini…"   About a minute ago   Up About a minute             bgp
57e43f0aad2f   docker-syncd-vs:latest            "/usr/local/bin/supe…"   About a minute ago   Up About a minute             syncd
c25787e61640   docker-teamd:latest               "/usr/local/bin/supe…"   About a minute ago   Up About a minute             teamd
======> 37d6a6c4999f   docker-sonic-p4rt:latest          "/usr/local/bin/supe…"   About a minute ago   Up About a minute             p4rt 
3c40370b1924   docker-sysmgr:latest              "/usr/local/bin/supe…"   About a minute ago   Up About a minute             sysmgr
ef9bf2686de8   docker-orchagent:latest           "/usr/bin/docker-ini…"   About a minute ago   Up About a minute             swss
d30a10939252   docker-database:latest            "/usr/local/bin/dock…"   About a minute ago   Up About a minute             database
```

After config db is processed

```
root@sonic:/home/admin# docker ps
CONTAINER ID   IMAGE                                COMMAND                  CREATED         STATUS                  PORTS     NAMES
362b34cbec8d   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   1 second ago    Up Less than a second             pmon
1f4be1570773   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 seconds ago   Up 2 seconds                      mgmt-framework
95cd75b9c701   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   5 seconds ago   Up 4 seconds                      gnmi
57e43f0aad2f   docker-syncd-vs:latest               "/usr/local/bin/supe…"   2 minutes ago   Up 2 minutes                      syncd
======> 37d6a6c4999f   docker-sonic-p4rt:latest             "/usr/local/bin/supe…"   2 minutes ago   Up 2 minutes                      p4rt
3c40370b1924   docker-sysmgr:latest                 "/usr/local/bin/supe…"   2 minutes ago   Up 2 minutes                      sysmgr
ef9bf2686de8   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 minutes ago   Up 2 minutes                      swss
d30a10939252   docker-database:latest               "/usr/local/bin/dock…"   2 minutes ago   Up 2 minutes                      database
root@sonic:/home/admin# 

```

```
==========] 14 tests from 1 test suite ran. (48022 ms total)
[  PASSED  ] 14 tests.
Target //tests/thinkit:arbitration_test up-to-date:
  bazel-bin/tests/thinkit/arbitration_test
INFO: Elapsed time: 64.028s, Critical Path: 55.47s
INFO: 2 processes: 1 internal, 1 local.
INFO: Build completed successfully, 2 total actions
//tests/thinkit:arbitration_test                                         PASSED in 48.2s
```

#### Description for the changelog

[alpinevs] Enable p4rt by default for alpine

