### PR TITLE
[Nexthop] Add bus num to i2c driver error logs

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
@@ -316,8 +316,8 @@ static int xiic_poll_wait(struct fpgalogic_i2c *i2c)
 				val &=(~tmp);
 				xiic_setreg32(i2c, XIIC_CR_REG_OFFSET, val);
 				xiic_setreg32(i2c, XIIC_IISR_OFFSET, XIIC_INTR_ARB_LOST_MASK);
-				printk("%s: TRANSFER STATUS ERROR, ISR: bit 0x%x happens\n",
-					 __func__, XIIC_INTR_ARB_LOST_MASK);
+				printk("%s: TRANSFER STATUS ERROR on bus %d, ISR: bit 0x%x happens\n",
+					 __func__, i2c->adap->nr, XIIC_INTR_ARB_LOST_MASK);
 			} 
 			if (status & XIIC_INTR_TX_ERROR_MASK) {
 				int sta = 0;
@@ -326,8 +326,8 @@ static int xiic_poll_wait(struct fpgalogic_i2c *i2c)
 				cr = xiic_getreg32(i2c,XIIC_CR_REG_OFFSET);
 				xiic_setreg32(i2c, XIIC_IISR_OFFSET, XIIC_INTR_TX_ERROR_MASK);
 #ifdef DEBUG_KERN
-				printk("%s: TRANSFER STATUS ERROR, ISR: bit 0x%x happens; SR: bit 0x%x; CR: bit 0x%x\n",
-					 __func__, status, sta, cr);
+				printk("%s: TRANSFER STATUS ERROR on bus %d, ISR: bit 0x%x happens; SR: bit 0x%x; CR: bit 0x%x\n",
+					 __func__, i2c->adap->nr, status, sta, cr);
 #endif
 			}
 			/* Soft reset IIC controller. */
@@ -340,8 +340,8 @@ static int xiic_poll_wait(struct fpgalogic_i2c *i2c)
 	}
 #ifdef DEBUG_KERN
 	if (err)
-		printk("%s: STATUS timeout, bit 0x%x did not clear in 50ms\n",
-			 __func__, status);
+		printk("%s: STATUS timeout on bus %d, bit 0x%x did not clear in 50ms\n",
+			 __func__, i2c->adap->nr, status);
 #endif
 	return err;
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently on errors it is difficult to determine which bus is problematic.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Log the bus number in error message.

#### How to verify it
On a unit with problematic PSU (i2c), we see the error on the expected bus (19):
```
admin@gold107:~$ sudo dmesg | grep -i error
...
[  318.916643] xiic_poll_wait: TRANSFER STATUS ERROR on bus 19, ISR: bit 0x1 happens
[  318.992568] xiic_poll_wait: TRANSFER STATUS ERROR on bus 19, ISR: bit 0x1 happens
[  319.064435] xiic_poll_wait: TRANSFER STATUS ERROR on bus 19, ISR: bit 0x1 happens
[  322.140428] xiic_poll_wait: TRANSFER STATUS ERROR on bus 19, ISR: bit 0x1 happens
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

