### PR TITLE
[Nexthop] refactor fan _DEFAULT_MAX_SPEED to be platform dependent

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/pddf/pd-plugin.json
+++ b/device/nexthop/x86_64-nexthop_4010-r0/pddf/pd-plugin.json
@@ -240,6 +240,7 @@
                 }
             }
         },
+        "default_max_speed": 75,
         "duty_cycle_to_pwm": "lambda dc: ((dc/100) * 255)",
         "pwm_to_duty_cycle": "lambda pwm: ((pwm/255) * 100)"
     },

--- a/device/nexthop/x86_64-nexthop_4220-r0/pddf/pd-plugin.json
+++ b/device/nexthop/x86_64-nexthop_4220-r0/pddf/pd-plugin.json
@@ -266,6 +266,7 @@
                 }
             }
         },
+        "default_max_speed": 75,
         "duty_cycle_to_pwm": "lambda dc: ((dc/100) * 255)",
         "pwm_to_duty_cycle": "lambda pwm: ((pwm/255) * 100)"
     },

--- a/device/nexthop/x86_64-nexthop_5010-r0/pddf/pd-plugin.json
+++ b/device/nexthop/x86_64-nexthop_5010-r0/pddf/pd-plugin.json
@@ -336,6 +336,7 @@
                 }
             }
         },
+        "default_max_speed": 100,
         "duty_cycle_to_pwm": "lambda dc: ((dc/100) * 255)",
         "pwm_to_duty_cycle": "lambda pwm: ((pwm/255) * 100)"
     },

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/fan.py
@@ -37,7 +37,7 @@ class Fan(PddfFan):
     """PDDF Platform-Specific Fan class"""
 
     # Default maximum speed if not specified in STATE_DB
-    _DEFAULT_MAX_SPEED = 75.0
+    default_max_speed = None
 
     def __init__(
         self,
@@ -53,6 +53,12 @@ class Fan(PddfFan):
             self, tray_idx, fan_idx, pddf_data, pddf_plugin_data, is_psu_fan, psu_index
         )
         self._state_fan_tbl = _try_get_state_db_table(_FAN_INFO_TABLE_NAME)
+        self.default_max_speed = float(pddf_plugin_data["FAN"]["default_max_speed"])
+        if self.default_max_speed < 0 or self.default_max_speed > 100:
+            raise ValueError(
+                "pddf_plugin_data fan default_max_speed not in valid range [0, 100], "
+                f"got {self.default_max_speed}"
+            )
 
     def get_model(self):
         if self.get_presence() and not self.is_psu_fan:
@@ -111,26 +117,26 @@ class Fan(PddfFan):
             if self._state_fan_tbl is None:
                 logger.log_error(
                     "Can't connect to 'STATE_DB:FAN_INFO' table; "
-                    f"fallback to default max_speed={self._DEFAULT_MAX_SPEED}%."
+                    f"fallback to default max_speed={self.default_max_speed}%."
                 )
-                return self._DEFAULT_MAX_SPEED
+                return self.default_max_speed
 
         fan_name = PddfFan.get_name(self)
         found, data = self._state_fan_tbl.get(fan_name)
         if not found:
             logger.log_error(
                 f"'STATE_DB:FAN_INFO|{fan_name}' not found; "
-                f"fallback to default max_speed={self._DEFAULT_MAX_SPEED}%"
+                f"fallback to default max_speed={self.default_max_speed}%"
             )
-            return self._DEFAULT_MAX_SPEED
+            return self.default_max_speed
 
         data_dict = dict(data)
         if _STATE_MAX_SPEED_KEY not in data_dict:
             logger.log_error(
                 f"max_speed not found in 'STATE_DB:FAN_INFO|{fan_name}'; "
-                f"fallback to default={self._DEFAULT_MAX_SPEED}%."
+                f"fallback to default={self.default_max_speed}%."
             )
-            return self._DEFAULT_MAX_SPEED
+            return self.default_max_speed
         return float(data_dict[_STATE_MAX_SPEED_KEY])
 
     def set_max_speed(self, max_speed):
@@ -150,7 +156,7 @@ class Fan(PddfFan):
             if self._state_fan_tbl is None:
                 logger.log_error(
                     "Can't connect to 'STATE_DB:FAN_INFO' table; "
-                    f"ignore writing max_speed={self._DEFAULT_MAX_SPEED}% "
+                    f"ignore writing max_speed={max_speed}% "
                     f"for {self.get_name()}."
                 )
                 return False

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_fan.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_fan.py
@@ -61,12 +61,18 @@ def fan_module(mock_pddf_fan):
     yield fan
 
 
+@pytest.fixture
+def pddf_plugin_data():
+    """Mock plugin data for Fan"""
+    yield {"FAN": {"default_max_speed": 75}}
+
+
 class TestFan:
     """Test class for Fan functionality."""
 
-    def test_get_presence(self, mock_pddf_fan, fan_module):
+    def test_get_presence(self, mock_pddf_fan, fan_module, pddf_plugin_data):
         """Test get_presence."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
 
         mock_pddf_fan.get_presence.return_value = True
         assert fan.get_presence() is True
@@ -74,38 +80,38 @@ class TestFan:
         mock_pddf_fan.get_presence.return_value = False
         assert fan.get_presence() is False
 
-    def test_get_model_for_present_non_psu_fan(self, mock_pddf_fan, fan_module):
+    def test_get_model_for_present_non_psu_fan(self, mock_pddf_fan, fan_module, pddf_plugin_data):
         """Test get_model for present non-PSU fan."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
 
         mock_pddf_fan.get_presence.return_value = True
         assert fan.get_model() == "FAN-80G1-F"
 
-    def test_get_model_for_non_present_fan(self, mock_pddf_fan, fan_module):
+    def test_get_model_for_non_present_fan(self, mock_pddf_fan, fan_module, pddf_plugin_data):
         """Test get_model for non-present non-PSU fan."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
 
         mock_pddf_fan.get_presence.return_value = False
         assert fan.get_model() == "N/A"
 
-    def test_fan_init_ok_when_db_conn_fails(self, fan_module):
+    def test_fan_init_ok_when_db_conn_fails(self, fan_module, pddf_plugin_data):
         """Test Fan initialization is ok when DB connection fails."""
         # Given
         DBConnector = sys.modules["swsscommon"].swsscommon.DBConnector
         with patch.object(DBConnector, "__init__", Mock(side_effect=RuntimeError)):
             # When
-            fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+            fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
             # Then
             assert fan._state_fan_tbl is None
 
-    def test_get_max_speed_default(self, fan_module):
+    def test_get_max_speed_default(self, fan_module, pddf_plugin_data):
         """Test get_max_speed when it hasn't been set."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
-        assert fan.get_max_speed() == fan._DEFAULT_MAX_SPEED
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
+        assert fan.get_max_speed() == fan.default_max_speed
 
-    def test_set_max_speed(self, fan_module):
+    def test_set_max_speed(self, fan_module, pddf_plugin_data):
         """Test set_max_speed writes data to STATE_DB."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
 
         fan.set_max_speed(60.99)
         assert (
@@ -113,17 +119,17 @@ class TestFan:
             == "60.99"
         )
 
-    def test_set_and_get_max_speed(self, fan_module):
+    def test_set_and_get_max_speed(self, fan_module, pddf_plugin_data):
         """Test setting and getting max speed."""
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
 
         fan.set_max_speed(60.99)
         assert fan.get_max_speed() == 60.99
 
-    def test_set_speed_is_clamped_by_max_speed(self, mock_pddf_fan, fan_module):
+    def test_set_speed_is_clamped_by_max_speed(self, mock_pddf_fan, fan_module, pddf_plugin_data):
         """Test set_speed is clamped by the previously set max_speed."""
         # Given
-        fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+        fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
         fan.set_max_speed(60)
 
         # When
@@ -145,22 +151,22 @@ class TestFan:
             any_order=False,
         )
 
-    def test_set_and_get_max_speed_when_db_conn_fails(self, fan_module):
+    def test_set_and_get_max_speed_when_db_conn_fails(self, fan_module, pddf_plugin_data):
         """Test set_max_speed and get_max_speed change nothing when DB connection fails."""
         # Given
         DBConnector = sys.modules["swsscommon"].swsscommon.DBConnector
         with patch.object(DBConnector, "__init__", Mock(side_effect=RuntimeError)):
-            fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+            fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
             # When/Then
             assert fan.set_max_speed(60.99) == False
-            assert fan.get_max_speed() == fan._DEFAULT_MAX_SPEED
+            assert fan.get_max_speed() == fan.default_max_speed
 
-    def test_set_and_get_max_speed_when_db_conn_resumes(self, fan_module):
+    def test_set_and_get_max_speed_when_db_conn_resumes(self, fan_module, pddf_plugin_data):
         """Test set_max_speed and get_max_speed working when DB connection resumes."""
         # Given - Inject a failed DB connection
         DBConnector = sys.modules["swsscommon"].swsscommon.DBConnector
         with patch.object(DBConnector, "__init__", Mock(side_effect=RuntimeError)):
-            fan = fan_module.Fan(tray_idx=0, fan_idx=0)
+            fan = fan_module.Fan(tray_idx=0, fan_idx=0, pddf_plugin_data=pddf_plugin_data)
             assert fan._state_fan_tbl is None
 
         # When - Revive the DB connector


### PR DESCRIPTION
#### Why I did it
Fixes #27152
Currently, fan `_DEFAULT_MAX_SPEED = 75` for all nexthop platforms. This value takes effect if thermalctld is stopped (at which point it will delete the STATE_DB FAN_INFO tables where the live max_speed is stored.
- Max speed is limited on a per-platform basis to avoid tripping power limits on specific platforms. The 75% default maximum is not correct to use for all platforms.
- In some cases where we want to manually override fan speeds by stopping thermalctld, current behaviour is confusing on platforms that don't require the 75% max speed. (eg. PSU load sharing test)

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Moved the default to a new field in `pd-plugin.json` at ["FAN"]["default_max_speed"] and read it in when sonic_platform.fan.Fan is initialized. Add the config for all current nexthop platforms.

#### How to verify it
On 1 DUT per platform, disable thermalctld and verify fan speed can be set and read back with the correct maximums:
```
docker exec pmon supervisorctl stop thermalctld
sudo pddf_fanutil setspeed 30
python3 -c "from sonic_platform import platform; print(f'Fan 1 speed: {platform.Platform().get_chassis().get_fan(1).get_speed()}%')"
sudo pddf_fanutil setspeed 100
python3 -c "from sonic_platform import platform; print(f'Fan 1 speed: {platform.Platform().get_chassis().get_fan(1).get_speed()}%')"
# Expect: nh4010: 75%, nh4220: 75%, nh5010: 100%

sudo pddf_fanutil setspeed 30
python3 -c "from sonic_platform import platform; print(f'Fan 1 speed: {platform.Platform().get_chassis().get_fan(1).get_speed()}%')"
```



#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch

- [x] master
- [x] 202605


#### Test result
- master - Nexthop internal build (2026 Aug 17)
- 202605 - Nexthop internal build (2026 Aug 17)

Tested on 202605 branch - image `SONiC.yifan.fan_max_speed_default.202605_test.Nexthop.152388`
```
# nh4010 platform, DUT gold218
Step                                     Expected              Actual
default_max_speed in pd-plugin.json      75%                   75%
setspeed 30 (thermalctld stopped)        30%                   30%
setspeed 100                             75% (capped)          75%
setspeed 30 again                        30%                   30%

# nh5010 platform, DUT humm167
Step                                     Expected              Actual
default_max_speed in pd-plugin.json      100%                  100%
setspeed 30 (thermalctld stopped)        30%                   30%
setspeed 100                             100% (no 75% cap)     100%
setspeed 30 again                        30%                   30%
```
Expected behaviour is verified - when thermalctld is down, the max fan speed should be set by the platform in pd-plugin.json. Without this change, nh5010 platform incorrectly takes the 75% hardcoded limit.

#### Description for the changelog
[Nexthop] refactor fan _DEFAULT_MAX_SPEED to be platform dependent

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

