### PR TITLE
[Nexthop] Service to use BMC idprom contents to determine eth0 MAC addr

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/eth0-mac-fixup.sh
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/eth0-mac-fixup.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# eth0 MAC Address Fixup Script for NextHop B27
+# Sets MAC address on eth0 from system EEPROM or U-boot environment
+
+set -e
+
+LOGGER_TAG="eth0-mac-fixup"
+
+log() {
+    local prio="$1"
+    local msg="$2"
+    logger -t "${LOGGER_TAG}" -p "$prio" "$msg"
+}
+
+log_info() {
+    local msg="$1"
+    log "user.info" "$msg"
+}
+
+log_error() {
+    local msg="$1"
+    log "user.error" "$msg"
+}
+
+# Strict MAC address validation to be XX:XX:XX:XX:XX:XX hex
+# Returns 0 (success) if valid, 1 (failure) if invalid
+# Validates format and rejects invalid patterns
+validate_mac() {
+    local mac="$1"
+
+    if ! echo "$mac" | grep -qE '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$'; then
+        return 1
+    fi
+
+    return 0
+}
+
+# Step 1: Get MAC from EEPROM + uboot with validation
+# Note: EEPROM device is created by kernel at24 driver from device tree
+# systemd dependencies ensure I2C drivers are loaded before this script runs
+EEPROM_MAC=$(decode-syseeprom -m 2>/dev/null || true)
+UBOOT_MAC=$(fw_printenv 2>/dev/null | grep '^ethaddr=' | cut -d'=' -f2 || true)
+
+MAC_TO_USE=""
+
+# Priority: Use EEPROM MAC if valid, otherwise fall back to U-boot MAC
+if validate_mac "$EEPROM_MAC"; then
+    MAC_TO_USE="$EEPROM_MAC"
+    log_info "Using EEPROM MAC: $EEPROM_MAC"
+
+    # Sync U-boot environment to match EEPROM (if different)
+    if [ -n "$UBOOT_MAC" ] && [ "$UBOOT_MAC" != "$EEPROM_MAC" ]; then
+        log_info "Updating U-boot ethaddr from $UBOOT_MAC to $EEPROM_MAC"
+        fw_setenv ethaddr "$EEPROM_MAC"
+    elif [ -z "$UBOOT_MAC" ]; then
+        log_info "Setting U-boot ethaddr to $EEPROM_MAC (was unset)"
+        fw_setenv ethaddr "$EEPROM_MAC"
+    fi
+elif validate_mac "$UBOOT_MAC"; then
+    MAC_TO_USE="$UBOOT_MAC"
+    log_info "EEPROM MAC invalid ('$EEPROM_MAC'), falling back to U-boot MAC: $UBOOT_MAC"
+else
+    # Both sources are invalid - cannot proceed
+    log_error "No valid MAC address available - EEPROM: '$EEPROM_MAC', U-boot: '$UBOOT_MAC'"
+    exit 1
+fi
+
+# Step 2: Verify eth0 interface exists
+# Note: systemd dependencies ensure network drivers are loaded before networking starts
+INTERFACE='eth0'
+if ! ip link show "$INTERFACE" &>/dev/null; then
+    log_error "Interface '$INTERFACE' not found"
+    exit 1
+fi
+
+CURRENT_ETH0_MAC=$(cat /sys/class/net/eth0/address)
+if [ "$(echo "$CURRENT_ETH0_MAC" | tr 'A-F' 'a-f')" = "$(echo "$MAC_TO_USE" | tr 'A-F' 'a-f')" ]; then
+    log_info "eth0 MAC already matches desired MAC, skipping update"
+    exit 0
+fi
+
+# Step 3: Update MAC address
+log_info "Updating MAC address on ${INTERFACE} to ${MAC_TO_USE}"
+
+# Bring interface down
+ip link set "${INTERFACE}" down 2>/dev/null || true
+
+# Flush all IP addresses to clear stale DHCP leases
+ip addr flush dev "${INTERFACE}" 2>/dev/null || true
+
+# Set MAC address
+if ! ip link set "${INTERFACE}" address "${MAC_TO_USE}"; then
+    log_error "Failed to set MAC address on ${INTERFACE}"
+    exit 1
+fi
+
+log_info "Successfully set MAC address ${MAC_TO_USE} on ${INTERFACE}"
+
+# Bring interface up
+ip link set "${INTERFACE}" up || true
+
+# If DHCP client is already running, restart it to get new lease with updated MAC
+# (This handles the case where networking.service started before this script ran on first boot)
+DHCLIENT_PID_FILE="/var/run/dhclient.${INTERFACE}.pid"
+if [ -f "$DHCLIENT_PID_FILE" ]; then
+    log_info "Restarting dhclient to obtain new DHCP lease with updated MAC"
+    dhclient -r "${INTERFACE}" 2>/dev/null || true
+    dhclient "${INTERFACE}" >/dev/null 2>&1
+fi
+
+log_info "eth0 MAC address updated to ${MAC_TO_USE}"
+exit 0

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/eth0-mac-fixup.service
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/eth0-mac-fixup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NextHop BMC eth0 MAC Address Fixup Service
+After=sonic-uboot-env-init.service
+Before=networking.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/eth0-mac-fixup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/aspeed/sonic-platform-modules-nexthop/debian/sonic-platform-aspeed-nexthop-common.postinst
+++ b/platform/aspeed/sonic-platform-modules-nexthop/debian/sonic-platform-aspeed-nexthop-common.postinst
@@ -31,6 +31,10 @@ case "$1" in
         # Enable USB network service
         echo "Enabling USB network service..."
         systemctl enable --now usb-network-init.service 2>/dev/null || true
+
+        # Enable eth0 MAC address fixup service
+        echo "Enabling eth0 MAC address service..."
+        systemctl enable --now eth0-mac-fixup.service 2>/dev/null || true
         ;;
 esac
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Want to use the MAC Addr programmed into the BMC idprom for the `eth0` interface.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added eth0-mac-fixup.service systemd unit and corresponding shell script that:

1. Reads MAC address sources in priority order:
   - Primary: System EEPROM via decode-syseeprom -m
   - Fallback: U-boot environment variable ethaddr via fw_printenv
2. Synchronizes U-boot environment to match EEPROM MAC (ensures bootloader consistency)
3. Updates eth0 MAC address if it differs from the desired value
4. Handles DHCP lease renewal when running after networking has already started (first boot after package install)

##### Note on systemd dependences:
```
After=sonic-uboot-env-init.service
Before=networking.service
```

U-boot environment is accessible (for both reading fallback MAC and writing EEPROM MAC)
MAC is set before ifupdown starts DHCP on eth0
Transitive dependencies provide filesystem and I2C driver availability

#### How to verify it

Manually installing the mac address after boot (mimic first boot behaviour where networking.service might have started)
```
root@sonic:/home/admin# systemctl enable --now eth0-mac-fixup.service
Created symlink '/etc/systemd/system/multi-user.target.wants/eth0-mac-fixup.service' → '/usr/lib/systemd/system/eth0-mac-fixup.service'.
[ 4934.498750] ftgmac100 14050000.ethernet eth0: Link is Up - 1Gbps/Full - flow control rx/tx
root@sonic:/home/admin# cat /var/log/syslog | egrep "eth0-mac"
2025 Sep  3 20:00:21.884615 sonic INFO systemd[1]: Starting eth0-mac-fixup.service - NextHop BMC eth0 MAC Address Fixup Service...
2025 Sep  3 20:00:24.780200 sonic INFO eth0-mac-fixup: Using EEPROM MAC: E8:E4:9D:12:C1:37
2025 Sep  3 20:00:24.793310 sonic INFO eth0-mac-fixup: Setting U-boot ethaddr to E8:E4:9D:12:C1:37 (was unset)
2025 Sep  3 20:00:25.669413 sonic INFO eth0-mac-fixup: Updating MAC address on eth0 to E8:E4:9D:12:C1:37
2025 Sep  3 20:00:25.715952 sonic INFO eth0-mac-fixup: Successfully set MAC address E8:E4:9D:12:C1:37 on eth0
2025 Sep  3 20:00:25.750853 sonic INFO eth0-mac-fixup: Restarting dhclient to obtain new DHCP lease with updated MAC
2025 Sep  3 20:00:26.260259 sonic INFO eth0-mac-fixup: eth0 MAC address update complete: E8:E4:9D:12:C1:37
2025 Sep  3 20:00:26.269997 sonic INFO systemd[1]: Finished eth0-mac-fixup.service - NextHop BMC eth0 MAC Address Fixup Service.
root@sonic:/home/admin# ip addr show eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether e8:e4:9d:12:c1:37 brd ff:ff:ff:ff:ff:ff
    inet 10.250.3.246/24 brd 10.250.3.255 scope global dynamic eth0
       valid_lft 3696sec preferred_lft 3696sec
    inet6 fe80::eae4:9dff:fe12:c137/64 scope link proto kernel_ll
       valid_lft forever preferred_lft forever
```

After reboot:
```
admin@sonic:~$ sudo cat /var/log/syslog | grep eth0-mac
2025 Sep  3 20:04:56.241880 sonic INFO systemd[1]: Starting eth0-mac-fixup.service - NextHop BMC eth0 MAC Address Fixup Service...
2025 Sep  3 20:05:00.669028 sonic INFO eth0-mac-fixup: Using EEPROM MAC: E8:E4:9D:12:C1:37
2025 Sep  3 20:05:00.800200 sonic INFO eth0-mac-fixup: eth0 MAC already matches desired MAC, skipping update
2025 Sep  3 20:05:00.815276 sonic INFO systemd[1]: Finished eth0-mac-fixup.service - NextHop BMC eth0 MAC Address Fixup Service.
```


#### Which release branch to backport (provide reason below if selected)

<!—
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [ ] 202006
—>

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!—
- Please provide tested image version
- e.g.
- [x] 20201231.100
—>

- [ ] <!-- image version 1 —>
- [ ] <!-- image version 2 —>

#### Description for the changelog
<!—
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
—>

<!—
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
—>

#### Link to config_db schema for YANG module changes
<!—
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
—>

#### A picture of a cute animal (not mandatory but encouraged)

