### PR TITLE
[yang] [macsec topo] Portchannel MTU changes for macsec

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1570,6 +1570,7 @@ def parse_linkmeta(meta, hname):
         lower_tor_hostname = ''
         auto_negotiation = None
         macsec_enabled = False
+        macsec_profile_name = None
         tx_power = None
         laser_freq = None
         properties = linkmeta.find(str(QName(ns1, "Properties")))
@@ -1588,6 +1589,8 @@ def parse_linkmeta(meta, hname):
                 auto_negotiation = value
             elif name == "MacSecEnabled":
                 macsec_enabled = value
+            elif name == "MacSecProfileName":
+                macsec_profile_name = value
             elif name == "TxPower":
                 tx_power = value
             elif name == "Frequency":
@@ -1605,6 +1608,8 @@ def parse_linkmeta(meta, hname):
             linkmetas[port]["AutoNegotiation"] = auto_negotiation
         if macsec_enabled:
             linkmetas[port]["MacSecEnabled"] = macsec_enabled
+        if macsec_profile_name:
+            linkmetas[port]["MacSecProfileName"] = macsec_profile_name
         if tx_power:
             linkmetas[port]["tx_power"] = tx_power
         # Convert the freq in GHz
@@ -2437,9 +2442,12 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         if autoneg:
             port['autoneg'] = 'on' if autoneg.lower() == 'true' else 'off'
 
-        # If macsec is enabled on interface, and profile is valid, add the profile to port
+        # If macsec is enabled on interface, bind the named profile or fall back to legacy key material
         macsec_enabled = linkmetas.get(alias, {}).get('MacSecEnabled')
-        if macsec_enabled and 'PrimaryKey' in macsec_profile:
+        macsec_profile_name_lm = linkmetas.get(alias, {}).get('MacSecProfileName')
+        if macsec_profile_name_lm:
+            port['macsec'] = macsec_profile_name_lm
+        elif macsec_enabled and 'PrimaryKey' in macsec_profile:
             port['macsec'] = macsec_profile['PrimaryKey']
 
         tx_power = linkmetas.get(alias, {}).get('tx_power')
@@ -2742,6 +2750,32 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # Enable bgp-suppress-fib by default for leafrouter
     if current_device and current_device['type'] in leafrouter_device_types:
         results['DEVICE_METADATA']['localhost']['suppress-fib-pending'] = 'enabled'
+
+    # Generate MACSEC_PROFILE table entries for named profiles referenced in LinkMetadata
+    _macsec_profile_names = {
+        lm['MacSecProfileName']
+        for lm in linkmetas.values()
+        if 'MacSecProfileName' in lm
+    }
+    if _macsec_profile_names:
+        import json as _json, os as _os
+        _pfile = '/etc/sonic/macsec_profiles.json'
+        if _os.path.exists(_pfile):
+            with open(_pfile) as _f:
+                _all = _json.load(_f)
+            results['MACSEC_PROFILE'] = {
+                name: {
+                    'priority': str(_all[name]['priority']),
+                    'cipher_suite': _all[name]['cipher_suite'],
+                    'primary_cak': _all[name]['primary_cak'],
+                    'primary_ckn': _all[name]['primary_ckn'],
+                    'policy': _all[name].get('policy', 'security'),
+                    'send_sci': _all[name]['send_sci'],
+                    'rekey_period': str(_all[name].get('rekey_period', 0)),
+                }
+                for name in _macsec_profile_names
+                if name in _all
+            }
 
     return results
 

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1570,7 +1570,6 @@ def parse_linkmeta(meta, hname):
         lower_tor_hostname = ''
         auto_negotiation = None
         macsec_enabled = False
-        macsec_profile_name = None
         tx_power = None
         laser_freq = None
         properties = linkmeta.find(str(QName(ns1, "Properties")))
@@ -1589,8 +1588,6 @@ def parse_linkmeta(meta, hname):
                 auto_negotiation = value
             elif name == "MacSecEnabled":
                 macsec_enabled = value
-            elif name == "MacSecProfileName":
-                macsec_profile_name = value
             elif name == "TxPower":
                 tx_power = value
             elif name == "Frequency":
@@ -1608,8 +1605,6 @@ def parse_linkmeta(meta, hname):
             linkmetas[port]["AutoNegotiation"] = auto_negotiation
         if macsec_enabled:
             linkmetas[port]["MacSecEnabled"] = macsec_enabled
-        if macsec_profile_name:
-            linkmetas[port]["MacSecProfileName"] = macsec_profile_name
         if tx_power:
             linkmetas[port]["tx_power"] = tx_power
         # Convert the freq in GHz
@@ -2442,12 +2437,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
         if autoneg:
             port['autoneg'] = 'on' if autoneg.lower() == 'true' else 'off'
 
-        # If macsec is enabled on interface, bind the named profile or fall back to legacy key material
+        # If macsec is enabled on interface, and profile is valid, add the profile to port
         macsec_enabled = linkmetas.get(alias, {}).get('MacSecEnabled')
-        macsec_profile_name_lm = linkmetas.get(alias, {}).get('MacSecProfileName')
-        if macsec_profile_name_lm:
-            port['macsec'] = macsec_profile_name_lm
-        elif macsec_enabled and 'PrimaryKey' in macsec_profile:
+        if macsec_enabled and 'PrimaryKey' in macsec_profile:
             port['macsec'] = macsec_profile['PrimaryKey']
 
         tx_power = linkmetas.get(alias, {}).get('tx_power')
@@ -2750,32 +2742,6 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     # Enable bgp-suppress-fib by default for leafrouter
     if current_device and current_device['type'] in leafrouter_device_types:
         results['DEVICE_METADATA']['localhost']['suppress-fib-pending'] = 'enabled'
-
-    # Generate MACSEC_PROFILE table entries for named profiles referenced in LinkMetadata
-    _macsec_profile_names = {
-        lm['MacSecProfileName']
-        for lm in linkmetas.values()
-        if 'MacSecProfileName' in lm
-    }
-    if _macsec_profile_names:
-        import json as _json, os as _os
-        _pfile = '/etc/sonic/macsec_profiles.json'
-        if _os.path.exists(_pfile):
-            with open(_pfile) as _f:
-                _all = _json.load(_f)
-            results['MACSEC_PROFILE'] = {
-                name: {
-                    'priority': str(_all[name]['priority']),
-                    'cipher_suite': _all[name]['cipher_suite'],
-                    'primary_cak': _all[name]['primary_cak'],
-                    'primary_ckn': _all[name]['primary_ckn'],
-                    'policy': _all[name].get('policy', 'security'),
-                    'send_sci': _all[name]['send_sci'],
-                    'rekey_period': str(_all[name].get('rekey_period', 0)),
-                }
-                for name in _macsec_profile_names
-                if name in _all
-            }
 
     return results
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -93,5 +93,16 @@
     "PORTCHANNEL_INTERFACE_INVALID_MAC_ADDR": {
         "desc": "Set invalid interface mac address.",
         "eStrKey": "Pattern"
+    },
+    "PORTCHANNEL_MEMBER_VALID_MATCHING_MTU": {
+        "desc": "Add a member port whose MTU matches the PortChannel MTU."
+    },
+    "PORTCHANNEL_MEMBER_VALID_NO_PORT_MTU": {
+        "desc": "Add a member port that has no MTU configured (any PortChannel MTU is allowed)."
+    },
+    "PORTCHANNEL_MEMBER_INVALID_MTU_MISMATCH": {
+        "desc": "Reject a member port whose MTU differs from the PortChannel MTU.",
+        "eStrKey": "Must",
+        "eStr": ["Cannot add a port with MTU configured to a PortChannel unless it matches the PortChannel MTU."]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -103,5 +103,16 @@
     "PORTCHANNEL_SYSTEM_MAC_INVALID": {
         "desc": "Configure invalid LACP system MAC address.",
         "eStrKey": "Pattern"
+    },
+    "PORTCHANNEL_MEMBER_VALID_MATCHING_MTU": {
+        "desc": "Add a member port whose MTU matches the PortChannel MTU."
+    },
+    "PORTCHANNEL_MEMBER_VALID_NO_PORT_MTU": {
+        "desc": "Add a member port that has no MTU configured (any PortChannel MTU is allowed)."
+    },
+    "PORTCHANNEL_MEMBER_INVALID_MTU_MISMATCH": {
+        "desc": "Reject a member port whose MTU differs from the PortChannel MTU.",
+        "eStrKey": "Must",
+        "eStr": ["Cannot add a port with MTU configured to a PortChannel unless it matches the PortChannel MTU."]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -652,5 +652,118 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_MEMBER_VALID_MATCHING_MTU": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9100,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_MEMBER_VALID_NO_PORT_MTU": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_MEMBER_INVALID_MTU_MISMATCH": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -748,5 +748,118 @@
                 ]
             }
         }
+    },
+    "PORTCHANNEL_MEMBER_VALID_MATCHING_MTU": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9100,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_MEMBER_VALID_NO_PORT_MTU": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_MEMBER_INVALID_MTU_MISMATCH": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000
+                    }
+                ]
+            }
+        },
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "mode": "routed"
+                    }
+                ]
+            },
+            "sonic-portchannel:PORTCHANNEL_MEMBER": {
+                "PORTCHANNEL_MEMBER_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "port": "Ethernet0"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,6 +24,10 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
+    revision 2026-05-02 {
+        description "Allow member port MTU when it matches the PortChannel MTU (MACsec overhead adjustment)";
+    }
+
     revision 2021-06-13 {
         description "Change min-links valid range from 1-128 to 1-1024";
     }
@@ -136,6 +140,12 @@ module sonic-portchannel {
                 description "Association of a physical port as a member of a PortChannel";
 
                 key "name port";
+
+                must "not(/port:sonic-port/port:PORT/port:PORT_LIST[port:name=current()/port]/port:mtu) or " +
+                     "(/port:sonic-port/port:PORT/port:PORT_LIST[port:name=current()/port]/port:mtu = " +
+                     "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST[lag:name=current()/name]/lag:mtu)" {
+                    error-message "Cannot add a port with MTU configured to a PortChannel unless it matches the PortChannel MTU.";
+                }
 
                 leaf name {
                     description "Reference to the parent PortChannel interface";

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,6 +24,9 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
+    revision 2026-07-26 {
+        description "Allow member port MTU when it matches the PortChannel MTU (MACsec overhead adjustment)";
+
     revision 2025-06-24 {
         description "Add LACP System MAC address";
     }
@@ -150,6 +153,12 @@ module sonic-portchannel {
                 description "Association of a physical port as a member of a PortChannel";
 
                 key "name port";
+
+                must "not(/port:sonic-port/port:PORT/port:PORT_LIST[port:name=current()/port]/port:mtu) or " +
+                     "(/port:sonic-port/port:PORT/port:PORT_LIST[port:name=current()/port]/port:mtu = " +
+                     "/lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST[lag:name=current()/name]/lag:mtu)" {
+                    error-message "Cannot add a port with MTU configured to a PortChannel unless it matches the PortChannel MTU.";
+                }
 
                 leaf name {
                     description "Reference to the parent PortChannel interface";


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SONiC's `sonic-portchannel.yang` previously rejected any combination of a `PORTCHANNEL_MEMBER` row with an explicit `PORT.mtu` field on the member port. As soon as MACsec golden config sets both `PORT.<member>.mtu = 9068` and `PORTCHANNEL.<pc>.mtu = 9068` (9068 = 9100 − 32-byte MACsec frame overhead), `config load_minigraph --override_config` and `config override-config-table` fail YANG validation.

For MACsec to work on PortChannel-member ports, the member port MUST run at the reduced MTU — otherwise jumbo TCP segments exceed the ASIC MAX_FRAME after the MACsec SecTag/ICV is prepended, causing silent drops and BGP hold-timer expiry. This patch relaxes the YANG constraint to allow the `PORT.mtu` field on a member port as long as it matches the parent PortChannel's MTU.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a `must` constraint to `PORTCHANNEL_MEMBER_LIST` in `src/sonic-yang-models/yang-models/sonic-portchannel.yang`:

> A `PORTCHANNEL_MEMBER` may carry an explicit `PORT.mtu` only if that value equals the parent `PORTCHANNEL.mtu`. Otherwise YANG validation rejects the config with `"Cannot add a port with MTU configured to a PortChannel unless it matches the PortChannel MTU."`

The constraint is `must "not(...) or (... = ...)"`, so it's a no-op for the common case where `PORT.mtu` is absent (non-MACsec deployments).

#### How to verify it
1. Build the image with this patch applied; ensure it boots.
2. Generate a `golden_config_db.json` whose `PORT.<member>.mtu` matches `PORTCHANNEL.<pc>.mtu` (both `9068`) — e.g. via the MACsec ansible flow in [sonic-mgmt#24406](https://github.com/sonic-net/sonic-mgmt/pull/24406).
3. Run `config override-config-table /etc/sonic/golden_config_db.json` — YANG validation passes (no `Cannot add a port with MTU configured to a PortChannel ...` error).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

