### PR TITLE
Code changes to introduce bpf capabilities for Nexthop

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/feature_capabilities.json
+++ b/device/nexthop/x86_64-nexthop_4010-r0/feature_capabilities.json
@@ -1,0 +1,6 @@
+{
+    "mmu_capabilities": {
+        "bpf_dynamic_th_low": -7,
+        "bpf_dynamic_th_high": 3
+    }
+}

--- a/device/nexthop/x86_64-nexthop_4010-r1/feature_capabilities.json
+++ b/device/nexthop/x86_64-nexthop_4010-r1/feature_capabilities.json
@@ -1,0 +1,6 @@
+{
+    "mmu_capabilities": {
+        "bpf_dynamic_th_low": -7,
+        "bpf_dynamic_th_high": 3
+    }
+}

--- a/device/nexthop/x86_64-nexthop_4020-r0/feature_capabilities.json
+++ b/device/nexthop/x86_64-nexthop_4020-r0/feature_capabilities.json
@@ -1,0 +1,6 @@
+{
+    "mmu_capabilities": {
+        "bpf_dynamic_th_low": -7,
+        "bpf_dynamic_th_high": 3
+    }
+}

--- a/src/sonic-yang-models/platform-yang-templates/sonic-buffer-profile-capability.yang.j2
+++ b/src/sonic-yang-models/platform-yang-templates/sonic-buffer-profile-capability.yang.j2
@@ -1,0 +1,34 @@
+module sonic-buffer-profile-capability {
+    yang-version 1.1;
+    namespace "http://github.com/sonic-net/sonic-buffer-profile-capability";
+    prefix bpf-capability;
+
+    import sonic-buffer-profile {
+        prefix bpf;
+    }
+
+    description "SONIC buffer profile platform-specific YANG model - generated from feature_capabilities.json";
+
+    revision 2025-11-12 {
+        description "Initial revision Generated from feature_capabilities.json at installation time";
+    }
+
+    {% if mmu_capabilities is defined %}
+    {% set bpf_dynamic_th_low = mmu_capabilities.bpf_dynamic_th_low %}
+    {% set bpf_dynamic_th_high = mmu_capabilities.bpf_dynamic_th_high %}
+
+    // Platform-specific deviations - BUFFER_PROFILE uses bpf_dynamic_th range from mmu_capabilities
+    deviation "/bpf:sonic-buffer-profile/bpf:BUFFER_PROFILE/bpf:BUFFER_PROFILE_LIST/bpf:dynamic_th" {
+        deviate replace {
+            type int32 {
+                range "{{ bpf_dynamic_th_low }}..{{ bpf_dynamic_th_high }}" {
+                    error-message "Invalid dynamic_th for this platform. dynamic_th should be in the range [{{ bpf_dynamic_th_low }}, {{ bpf_dynamic_th_high }}]";
+                }
+            }
+        }
+        description "Platform-specific deviation for dynamic_th";
+    }
+    {% else %}
+    // No buffer profile capability data - skip validation.
+    {% endif %}
+}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The feature to add platform-specific YANG capabilities is being added into SONiC. This PR adds the first such capability for nexthop platforms - for `buffer_profile` `dynamic_thresholds` for Nexthop 4010 platforms.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add the required `feature_capabilities.json` file and the subsequent platform-specific j2 file to be used by the infra that will be added as a part of the PR [sonic-buildimage 26203](https://github.com/sonic-net/sonic-buildimage/pull/26203)

#### How to verify it
Platform-specific YANG validation must be hit in all YANG validation paths - `config reload`, `config apply-patch` and `gNMI` native write paths. No translib write paths hit YANG validation (they go through cvlyang).  

```bash
admin@gold221:~$ sudo config reload -y config_db_buffer.json
Acquired lock on /etc/sonic/reload.lock
libyang[0]: Value "5" does not satisfy the constraint "-7..3" (range, length, or pattern). (path: /sonic-buffer-profile:sonic-buffer-profile/BUFFER_PROFILE/BUFFER_PROFILE_LIST[name='test_platform_profile']/dynamic_th)
libyang[0]: Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3] (path: /sonic-buffer-profile:sonic-buffer-profile/BUFFER_PROFILE/BUFFER_PROFILE_LIST[name='test_platform_profile']/dynamic_th)
sonic_yang(3):Data Loading Failed:Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
config_db_buffer.json fails YANG validation! Error: Data Loading Failed
Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
Released lock on /etc/sonic/reload.lock
Aborted!
admin@gold221:~$
```

The `dynamic_th` value used was 5 - which is outside the values allowed `[-7, 3]`

3. `config apply-patch` - with an invalid value for `dynamic_th`:

```
admin@gold221:~$ sudo config apply-patch buffer_patch.json
libyang[0]: Value "5" does not satisfy the constraint "-7..3" (range, length, or pattern). (path: /sonic-buffer-profile:sonic-buffer-profile/BUFFER_PROFILE/BUFFER_PROFILE_LIST[name='test_platform_profile']/dynamic_th)
libyang[0]: Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3] (path: /sonic-buffer-profile:sonic-buffer-profile/BUFFER_PROFILE/BUFFER_PROFILE_LIST[name='test_platform_profile']/dynamic_th)
sonic_yang(3):Data Loading Failed:Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
Failed to apply patch due to: Validate json patch: [{'op': 'add', 'path': '/BUFFER_POOL/egress_lossy_pool', 'value': {'type': 'egress', 'mode': 'dynamic'}}, {'op': 'add', 'path': '/BUFFER_PROFILE/test_platform_profile', 'value': {'pool': '[BUFFER_POOL|egress_lossy_pool]', 'dynamic_th': '5', 'size': '0'}}] failed due to:Data Loading Failed
Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
Usage: config apply-patch [OPTIONS] PATCH_FILE_PATH
Try 'config apply-patch -h' for help.

Error: Validate json patch: [{'op': 'add', 'path': '/BUFFER_POOL/egress_lossy_pool', 'value': {'type': 'egress', 'mode': 'dynamic'}}, {'op': 'add', 'path': '/BUFFER_PROFILE/test_platform_profile', 'value': {'pool': '[BUFFER_POOL|egress_lossy_pool]', 'dynamic_th': '5', 'size': '0'}}] failed due to:Data Loading Failed
Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
admin@gold221:~$
```

Same value used as before - `dynamic_th` as 5.

4. gNMI case - 

```
admin@gold221:~$ docker exec gnmi gnmi_set -notls -target_addr 127.0.0.1:8080     -update "/sonic-db:CONFIG_DB/localhost/BUFFER_PROFILE:@/buffer_profile.json"
/sonic-db:CONFIG_DB/localhost/BUFFER_PROFILE
@/buffer_profile.json
== setRequest:
prefix: <
>
update: <
  path: <
    origin: "sonic-db"
    elem: <
      name: "CONFIG_DB"
    >
    elem: <
      name: "localhost"
    >
    elem: <
      name: "BUFFER_PROFILE"
    >
  >
  val: <
    json_ietf_val: "{\"test_platform_profile\": {\"pool\": \"egress_lossy_pool\", \"dynamic_th\": \"5\", \"size\": \"0\"}}"
  >
>

F0316 08:56:58.089437   81716 gnmi_set.go:203] Set failed: rpc error: code = Unknown desc = Error: Validate json patch: [{'op': 'add', 'path': '/BUFFER_PROFILE', 'value': {'test_platform_profile': {'dynamic_th': '5', 'pool': 'egress_lossy_pool', 'size': '0'}}}] failed
due to:Data Loading Failed
admin@gold221:~$ show logging | tail -n 10
2026 Mar 16 08:56:57.844955 gold221 INFO sonic_yang: xlateList keyList:name
2026 Mar 16 08:56:57.844973 gold221 INFO sonic_yang: xlateConfigDBtoYang sonic-versions:sonic-versions:sonic-versions:VERSIONS
2026 Mar 16 08:56:57.844992 gold221 INFO sonic_yang: xlateProcessListOfContainer: DATABASE
2026 Mar 16 08:56:57.845013 gold221 INFO sonic_yang: Try to load Data in the tree
2026 Mar 16 08:56:57.846554 gold221 ERR sonic_yang: Data Loading Failed:Invalid dynamic_th for this platform. dynamic_th should be in the range [-7, 3]
2026 Mar 16 08:56:58.059553 gold221 NOTICE GenericConfigUpdater: Config Rollbacker: Deleting checkpoint starting.
2026 Mar 16 08:56:58.059642 gold221 NOTICE GenericConfigUpdater: Config Rollbacker: Checkpoint name: /etc/sonic/config.
2026 Mar 16 08:56:58.059688 gold221 NOTICE GenericConfigUpdater: Config Rollbacker: Checking checkpoint exists.
2026 Mar 16 08:56:58.059729 gold221 NOTICE GenericConfigUpdater: Config Rollbacker: Deleting checkpoint.
2026 Mar 16 08:56:58.059772 gold221 NOTICE GenericConfigUpdater: Config Rollbacker: Deleting checkpoint completed.
admin@gold221:~$
```

gNMI fails with a syslog showing the invalid `dynamic_th` message. 


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] master
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Feature capabilities for `buffer_profile` for Nexthop platforms.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

