### PR TITLE
Adding sai_fec_stats_cumulative ppt to Arista-7280R4[K]-32QF-32DF-64O

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/template/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm.j2
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/Arista-7280R4-32QF-32DF-64O/template/q3d-a7280R4-32QFx400G-32DFx400G.config.bcm.j2
@@ -449,3 +449,4 @@ appl_param_active_links_thr_high=91
 appl_param_active_links_thr_low=1
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -373,3 +373,4 @@ port_priorities_sch
 sai_lag_default_crc_hash
 sai_ecmp_group_members_increment
 sai_instru_stat_accum_enable
+sai_fec_stats_cumulative


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This disables the read on clear behaviour for FEC stats on the platform. Without this property the FEC stats will be cleared every time we try to read it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a property to the bcm config file for this platform.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Verified that the counters do not clear when displayed using the CLI: `show interface counters fec-stats`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="736" height="736" alt="image" src="https://github.com/user-attachments/assets/fc0d78db-81a9-488d-984a-f69ecde0f2ef" />

