### PR TITLE
[rsyslog] Prevent RELP backpressure from blocking containers

### DIFF
--- a/dockers/docker-base-bookworm/etc/rsyslog.conf
+++ b/dockers/docker-base-bookworm/etc/rsyslog.conf
@@ -32,9 +32,12 @@ module(load="imuxsock" SysSock.RateLimit.Interval="300" SysSock.RateLimit.Burst=
 set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 
 # Set remote syslog server
+# Keep container syslog writers non-blocking if host-side RELP backpressure fills
+# the action queue. Dropping at queue saturation is safer than stalling service
+# initialization in syslog()/sendto().
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-base-bullseye/etc/rsyslog.conf
+++ b/dockers/docker-base-bullseye/etc/rsyslog.conf
@@ -32,9 +32,12 @@ module(load="imuxsock" SysSock.RateLimit.Interval="300" SysSock.RateLimit.Burst=
 set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 
 # Set remote syslog server
+# Keep container syslog writers non-blocking if host-side RELP backpressure fills
+# the action queue. Dropping at queue saturation is safer than stalling service
+# initialization in syslog()/sendto().
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="-1" queue.type="LinkedList" queue.size="20000" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="-1" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-base-trixie/etc/rsyslog.conf
+++ b/dockers/docker-base-trixie/etc/rsyslog.conf
@@ -32,9 +32,12 @@ module(load="imuxsock" SysSock.RateLimit.Interval="300" SysSock.RateLimit.Burst=
 set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 
 # Set remote syslog server
+# Keep container syslog writers non-blocking if host-side RELP backpressure fills
+# the action queue. Dropping at queue saturation is safer than stalling service
+# initialization in syslog()/sendto().
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-platform-monitor/etc/rsyslog.conf
+++ b/dockers/docker-platform-monitor/etc/rsyslog.conf
@@ -42,9 +42,12 @@ if $programname contains "sensord" and $msg contains "Error getting sensor data:
 }
 
 # Set remote syslog server
+# Keep container syslog writers non-blocking if host-side RELP backpressure fills
+# the action queue. Dropping at queue saturation is safer than stalling service
+# initialization in syslog()/sendto().
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.


### PR DESCRIPTION
## Why

Fixes https://github.com/sonic-net/sonic-buildimage/issues/27359.

Container rsyslog forwards to the host with RELP. If host-side backpressure fills the RELP action queue, the default enqueue timeout can block rsyslog's imuxsock processing path and make service initialization callers stall in `syslog()`/`sendto()`.

## What

Set `queue.timeoutEnqueue="0"` on container RELP action queues so queue saturation drops immediately instead of blocking container syslog producers. This preserves RELP behavior while the queue has capacity, but restores the important pre-RELP property that syslog forwarding must not stall critical service startup paths under log storms.

Covered configs:

- `dockers/docker-base-bookworm/etc/rsyslog.conf`
- `dockers/docker-base-trixie/etc/rsyslog.conf`
- `dockers/docker-base-bullseye/etc/rsyslog.conf`
- `dockers/docker-platform-monitor/etc/rsyslog.conf`

## Test

- `git diff --check`
- `rsyslogd -N1` not run locally: `rsyslogd` is not installed on the worker host.
