### PR TITLE
[mellanox] Remove force power off during ONIE upgrade

### DIFF
--- a/platform/mellanox/mlnx-onie-fw-update.sh
+++ b/platform/mellanox/mlnx-onie-fw-update.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2024 NVIDIA CORPORATION & AFFILIATES.
-# Apache-2.0
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 
 this_script="$(basename $(realpath ${0}))"
 lock_file="/var/run/${this_script%.*}.lock"
@@ -114,8 +114,15 @@ system_reboot() {
     # Give user some time to cancel the update
     sleep 5s
 
+    # The staged ONIE update is committed past this point. Clear the rollback
+    # trap so a SIGHUP/SIGTERM delivered during systemd's orderly shutdown
+    # (e.g. when serial-getty@ttyS0 is stopped) cannot race terminate_handler
+    # into running disable_onie_fw_update_mode and undoing the staging.
+    trap - SIGHUP SIGINT SIGQUIT SIGTERM
+    echo "INFO: Reboot is underway, the ONIE firmware update can no longer be cancelled"
+
     # Use SONiC reboot scenario
-    /usr/local/bin/reboot -f
+    /usr/local/bin/reboot
     exit $?
 }
 


### PR DESCRIPTION
#### Why I did it

On SmartSwitch platforms  running `fwutil install chassis component ONIE fw <url>` leaves the DPUs in a bad state during force reboot (driver init failures, PCI link errors).

The root cause is the `reboot -f` introduced in PR #19407: `-f` makes `/usr/local/bin/reboot` bypass systemd's orderly shutdown and call the kernel `reboot(2)` syscall directly. As a side effect, the SmartSwitch-aware shutdown logic in `reboot_smartswitch_helper` (PCI detach via `module_pre_shutdown`, DPU graceful reboot via `gnmi_reboot_dpu`) is skipped. The DPUs are killed mid-flight, producing the driver-side errors observed on next boot.

`-f` was originally added to mitigate an earlier issue on a switch where the staged ONIE update was undone after a graceful reboot. The leading hypothesis for that bug is a SIGHUP-driven race against `terminate_handler` while the script was still alive (e.g. when `serial-getty@ttyS0` was stopped during shutdown). Closing that window directly is sufficient and lets us drop the blunt `-f` workaround.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Two changes to `platform/mellanox/mlnx-onie-fw-update.sh::system_reboot()`:

1. **Clear the rollback signal traps before invoking the reboot.** After the 5 s cancel-grace `sleep`, the staged ONIE update is committed. From that point on, no signal should be allowed to run `terminate_handler` (which calls `disable_onie_fw_update_mode` and reverts `BootNext` / `onie_entry` / `onie_mode`). `trap - SIGHUP SIGINT SIGQUIT SIGTERM` restores default disposition for the four signals registered in `register_terminate_handler`. An informational log line is also emitted so anyone tailing the console understands the boundary.

2. **Drop `-f` from the reboot call.** `/usr/local/bin/reboot` now follows the normal SONiC reboot path. On SmartSwitches that goes through `reboot_smartswitch_helper`, allowing PCI detach and DPU gNMI reboot to run before the host reboot. On regular UEFI switches, the existing `efibootmgr -n <ONIE>` set in `enable_onie_fw_update_mode` (also from PR #19407) continues to point UEFI at ONIE on the next boot, so behavior is unchanged.

#### How to verify it

1. **SmartSwitch path** (the bug this PR fixes). On a SmartSwitch (DPU-bearing) testbed, run `fwutil install chassis component ONIE fw <onie-updater-url> -y`. Verify that:
   - DPU teardown messages (`module_pre_shutdown`, `gnmi_reboot_dpu`) appear in syslog before the host kernel reboot.
   - After reboot, DPUs come up clean — `show chassis modules status` reports the DPUs as Online and no PCI link errors are logged by `dmesg`.

2. **Regression check for the original `onie_entry` issue on UEFI switches.** On a testbed, run the existing negative ONIE-update test (`test_fwutil_install_onie_key_check_fail[key_mismatched_signed]`). Expected: switch boots into ONIE, ONIE rejects the key-mismatched firmware, switch is restored to SONiC by the recover fixture, test passes.

3. **Sanity check of trap clearing.** While `system_reboot` is in its 5 s `sleep`, `Ctrl+C` still triggers `terminate_handler` and rolls the staging back. Once the sleep elapses, sending `SIGHUP`/`SIGTERM` to the script is a no-op (default disposition) — the reboot continues uninterrupted.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
-->

- [ ] 202305
- [ ] 202311 
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version under test on master -->
- [ ] <!-- image version under test on 202311 -->

#### Description for the changelog

[Mellanox] Restore graceful reboot in `mlnx-onie-fw-update.sh` to fix SmartSwitch DPU driver issues; clear signal traps before reboot to prevent the previously-seen SIGHUP race that could undo a staged ONIE update on graceful shutdown.

#### Link to config_db schema for YANG module changes

N/A — no YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)

<!-- optional -->

