### PR TITLE
[Mellanox] Trigger FW upgrade when device is in prod_image_dev_capable state

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import os
 import logging
+import re
 import subprocess
 import time
 import xml.etree.ElementTree as ET
@@ -190,7 +191,48 @@ class FirmwareManagerBase(Process):
         Returns:
             True if upgrade is required, False otherwise
         """
-        return self.current_version != self.available_version
+        if self.current_version != self.available_version:
+            return True
+        return self._has_prod_image_dev_capable_device()
+
+    def _has_prod_image_dev_capable_device(self) -> bool:
+        """
+        Check whether the device exposes the 'prod_image_dev_capable_device'
+        security attribute via 'flint -d <pci_id> q full'. When this attribute
+        is set, the firmware must be re-burned to transition the device out of
+        the dev-capable state, even if versions already match.
+
+        Returns:
+            True if the attribute is present in the device's security
+            attributes, False otherwise (including on query failure).
+        """
+        try:
+            cmd = ['/usr/bin/flint', '-d', self.pci_id, 'q', 'full']
+            result = self._run_command(cmd, capture_output=True, text=True)
+            if result.returncode != 0:
+                self.logger.warning(
+                    f"flint query full failed for {self.pci_id} "
+                    f"(rc={result.returncode}): {result.stderr}"
+                )
+                return False
+
+            match = re.search(r'^Security Attributes:\s*(.+)$', result.stdout, re.MULTILINE)
+            if not match:
+                return False
+            tokens = {t.strip() for t in match.group(1).split(',')}
+            if 'prod_image_dev_capable_device' in tokens:
+                self.logger.info(
+                    f"ASIC {self.asic_index} ({self.pci_id}) has "
+                    f"'prod_image_dev_capable_device' security attribute; "
+                    f"firmware upgrade is required."
+                )
+                return True
+            return False
+        except Exception as e:
+            self.logger.warning(
+                f"Failed to query security attributes for {self.pci_id}: {e}"
+            )
+            return False
 
     def _report_status(self, status: UpgradeStatusType, message: str = ""):
         """Report status to parent process."""

--- a/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/firmware_base.py
@@ -190,21 +190,38 @@ class FirmwareManagerBase(Process):
 
         Returns:
             True if upgrade is required, False otherwise
+
+        Raises:
+            FirmwareManagerError: If the device's security state cannot be
+                determined (so the decision is surfaced to the caller rather
+                than silently defaulting to "no upgrade").
         """
         if self.current_version != self.available_version:
             return True
-        return self._has_prod_image_dev_capable_device()
+        is_prod_image_dev_capable = self._has_prod_image_dev_capable_device()
+        if is_prod_image_dev_capable is None:
+            raise FirmwareManagerError(
+                f"Unable to determine security attributes for {self.pci_id}; "
+                f"cannot decide whether firmware upgrade is required."
+            )
+        return is_prod_image_dev_capable
 
-    def _has_prod_image_dev_capable_device(self) -> bool:
+    def _has_prod_image_dev_capable_device(self) -> Optional[bool]:
         """
         Check whether the device exposes the 'prod_image_dev_capable_device'
         security attribute via 'flint -d <pci_id> q full'. When this attribute
         is set, the firmware must be re-burned to transition the device out of
         the dev-capable state, even if versions already match.
 
+        Devices that do not advertise security attributes at all (no
+        'Security Attributes:' line in flint output) are treated as normal
+        and return False.
+
         Returns:
-            True if the attribute is present in the device's security
-            attributes, False otherwise (including on query failure).
+            True if the attribute is present, False if it is not present
+            (including devices that do not expose security attributes at all),
+            None if the security state could not be determined due to a
+            flint query failure or unexpected exception.
         """
         try:
             cmd = ['/usr/bin/flint', '-d', self.pci_id, 'q', 'full']
@@ -214,7 +231,7 @@ class FirmwareManagerBase(Process):
                     f"flint query full failed for {self.pci_id} "
                     f"(rc={result.returncode}): {result.stderr}"
                 )
-                return False
+                return None
 
             match = re.search(r'^Security Attributes:\s*(.+)$', result.stdout, re.MULTILINE)
             if not match:
@@ -232,7 +249,7 @@ class FirmwareManagerBase(Process):
             self.logger.warning(
                 f"Failed to query security attributes for {self.pci_id}: {e}"
             )
-            return False
+            return None
 
     def _report_status(self, status: UpgradeStatusType, message: str = ""):
         """Report status to parent process."""

--- a/platform/mellanox/platform-utils/tests/test_firmware_base.py
+++ b/platform/mellanox/platform-utils/tests/test_firmware_base.py
@@ -391,7 +391,7 @@ class TestFirmwareManagerBase(unittest.TestCase):
         self.assertTrue(result)
 
     def test_is_upgrade_required_false(self):
-        """Test is_upgrade_required when no upgrade needed (line 189)"""
+        """Versions match and device does not advertise prod_image_dev_capable_device."""
         with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
             manager = ConcreteFirmwareManager(
                 asic_index=0,
@@ -402,8 +402,98 @@ class TestFirmwareManagerBase(unittest.TestCase):
         manager.current_version = "2.0.0"
         manager.available_version = "2.0.0"
 
-        result = manager.is_upgrade_required()
+        with patch.object(manager, '_has_prod_image_dev_capable_device', return_value=False):
+            result = manager.is_upgrade_required()
         self.assertFalse(result)
+
+    def test_is_upgrade_required_security_state_unknown_raises(self):
+        """When security state can't be determined, surface a FirmwareManagerError."""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        manager.current_version = "2.0.0"
+        manager.available_version = "2.0.0"
+
+        with patch.object(manager, '_has_prod_image_dev_capable_device', return_value=None):
+            with self.assertRaises(FirmwareManagerError):
+                manager.is_upgrade_required()
+
+    def test_has_prod_image_dev_capable_device_present(self):
+        """flint reports the attribute among Security Attributes -> True."""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = (
+            "FW Version:            39.2020.0248\n"
+            "PSID:                  MSF0000000068\n"
+            "Security Attributes:   secure-fw, prod_image_dev_capable_device\n"
+            "Default Update Method: fw_ctrl\n"
+        )
+        mock_result.stderr = ""
+
+        with patch.object(manager, '_run_command', return_value=mock_result):
+            self.assertTrue(manager._has_prod_image_dev_capable_device())
+
+    def test_has_prod_image_dev_capable_device_absent(self):
+        """flint reports Security Attributes without the token -> False."""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "Security Attributes:   secure-fw\n"
+        mock_result.stderr = ""
+
+        with patch.object(manager, '_run_command', return_value=mock_result):
+            self.assertFalse(manager._has_prod_image_dev_capable_device())
+
+    def test_has_prod_image_dev_capable_device_no_security_line(self):
+        """flint output without a Security Attributes line -> False (normal device)."""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "FW Version:            39.2020.0248\nPSID: MSF0000000068\n"
+        mock_result.stderr = ""
+
+        with patch.object(manager, '_run_command', return_value=mock_result):
+            self.assertFalse(manager._has_prod_image_dev_capable_device())
+
+    def test_has_prod_image_dev_capable_device_flint_failure_returns_none(self):
+        """flint returns non-zero -> None (unknown)."""
+        with patch.object(ConcreteFirmwareManager, '_initialize_asic'):
+            manager = ConcreteFirmwareManager(
+                asic_index=0,
+                pci_id="01:00.0",
+                asic_type="test"
+            )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "flint: device not found"
+
+        with patch.object(manager, '_run_command', return_value=mock_result):
+            self.assertIsNone(manager._has_prod_image_dev_capable_device())
 
     def test_report_status_with_queue(self):
         """Test _report_status with status queue (lines 193-202)"""


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
While the device is in prod_image_dev_capable_device state, the running firmware version may already match the bundled firmware version,
but a re-burn is required to transition the device out of the dev-capable state into the final state.

The previous `is_upgrade_required()` check only compared current vs. available firmware versions, so it would skip the upgrade in this scenario and leave the device stuck in the dev-capable state.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Extended `FirmwareManagerBase.is_upgrade_required()` to also return `True` when the device reports the `prod_image_dev_capable_device` security attribute, in addition to the existing version-mismatch check.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)