### PR TITLE
Adding yang model changes

### DIFF
--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -198,6 +198,7 @@ yang_files = [
     'sonic-system-port.yang',
     'sonic-system-radius.yang',
     'sonic-system-tacacs.yang',
+    'sonic-tam.yang',
     'sonic-tc-dscp-map.yang',
     'sonic-tc-priority-group-map.yang',
     'sonic-tc-queue-map.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1156,12 +1156,6 @@
                 "policy_desc": "Test ACL Table for TCP_FLAGS validation",
                 "stage": "INGRESS",
                 "type": "CUSTOM_L3_L4_PORT"
-            },
-            "IFA": {
-                "policy_desc": "IFA Ingress Device Policy",
-                "stage": "INGRESS",
-                "type": "L3",
-                "ports": [ "Ethernet0" ]
             }
         },
         "PBH_HASH_FIELD": {
@@ -3216,8 +3210,8 @@
         },
         "TAM": {
             "device": {
-                "device-id": "12345",
-                "enterprise-id": "54321",
+                "device_id": "12345",
+                "enterprise_id": "54321",
                 "ifa": "true"
             }
         },

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1156,8 +1156,14 @@
                 "policy_desc": "Test ACL Table for TCP_FLAGS validation",
                 "stage": "INGRESS",
                 "type": "CUSTOM_L3_L4_PORT"
+            },
+            "IFA": {
+                "policy_desc": "IFA Ingress Device Policy",
+                "stage": "INGRESS",
+                "type": "L3",
+                "ports": [ "Ethernet0" ]
             }
-        }, 
+        },
         "PBH_HASH_FIELD": {
             "inner_ip_proto": {
                 "hash_field": "INNER_IP_PROTOCOL",
@@ -3207,6 +3213,46 @@
         "DEBUG_COUNTER_DROP_REASON": {
             "DEBUG_4|DIP_LINK_LOCAL": {},
             "DEBUG_4|SIP_LINK_LOCAL": {}
+        },
+        "TAM": {
+            "device": {
+                "device-id": "12345",
+                "enterprise-id": "54321",
+                "ifa": "true"
+            }
+        },
+        "TAM_COLLECTOR": {
+            "collector1": {
+                "src_ip": "1.1.1.1",
+                "dst_ip": "2.2.2.2",
+                "dst_port": "10000",
+                "dscp_value": "32"
+            }
+        },
+        "TAM_FLOW_GROUP": {
+            "flow1": {
+                "aging_interval": "1000",
+                "ports": [
+                    "Ethernet0"
+                ]
+            },
+            "flow1|rule1": {
+                "src_ip_prefix": "10.1.1.0/24",
+                "dst_ip_prefix": "20.2.2.0/24",
+                "ip_protocol": "6",
+                "l4_src_port": "1000",
+                "l4_dst_port": "80"
+            }
+        },
+        "TAM_SESSION": {
+            "SESSION1": {
+                "type": "drop-monitor",
+                "report_type": "ipfix",
+                "flow_group": "flow1",
+                "collector": [
+                    "collector1"
+                ]
+            }
         },
         "HIGH_FREQUENCY_TELEMETRY_PROFILE": {
             "dummy": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tam.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tam.json
@@ -1,0 +1,48 @@
+{
+    "TAM_DEVICE_VALID": {
+        "desc": "Configure valid transit device."
+    },
+    "TAM_DEVICE_VALID_NO_IFA": {
+        "desc": "Configure valid non-transit device."
+    },
+    "TAM_DEVICE_INVALID_DEVICE": {
+        "desc": "Invalid device name.",
+        "eStrKey": "Pattern"
+    },
+    "TAM_DEVICE_INVALID_DEVICEID_RANGE": {
+        "desc": "Invalid deviceid range.",
+        "eStrKey": "Range"
+    },
+   "TAM_DEVICE_INVALID_ENTERPRISEID_RANGE": {
+        "desc": "Invalid enterpriseid range.",
+        "eStrKey": "Range"
+    },
+    "TAM_COLLECTOR_VALID_IPV4": {
+        "desc": "Valid ipv4 collector table."
+    },
+    "TAM_COLLECTOR_VALID_IPV6": {
+        "desc": "Valid ipv6 collector table."
+    },
+    "TAM_COLLECTOR_VALID_MULTIPLE": {
+        "desc": "Valid multiple collectors."
+    },
+    "TAM_COLLECTOR_INVALID_PORT": {
+        "desc": "Invalid port range.",
+        "eStrKey": "Bounds"
+    },
+    "TAM_COLLECTOR_INVALID_PORT_MISSING": {
+        "desc": "Missing port",
+        "eStrKey": "Mandatory"
+    },
+    "TAM_COLLECTOR_INVALID_IPADDRESS": {
+        "desc": "Invalid IP Address",
+        "eStrKey": "InvalidValue"
+    },
+    "TAM_COLLECTOR_INVALID_MISSING_IPADDRESS": {
+        "desc": "Missing ip address",
+        "eStrKey": "Mandatory"
+    },
+    "TAM_FLOW_GROUP_VALID": {
+        "desc": "Configure valid flow group."
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tam.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tam.json
@@ -1,0 +1,203 @@
+{
+    "TAM_DEVICE_VALID": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM": {
+                "TAM_LIST": [
+                    {
+                        "device": "device",
+                        "device-id": 12345,
+                        "enterprise-id": 54321,
+                        "ifa": "true"
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_DEVICE_VALID_NO_IFA": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM": {
+                "TAM_LIST": [
+                    {
+                        "device": "device",
+                        "device-id": 12345,
+                        "enterprise-id": 54321
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_DEVICE_INVALID_DEVICE": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM": {
+                "TAM_LIST": [
+                    {
+                        "device": "badname",
+                        "device-id": 12345
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_DEVICE_INVALID_DEVICEID_RANGE": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM": {
+                "TAM_LIST": [
+                    {
+                        "device": "device",
+                        "device-id": 999999999
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_DEVICE_INVALID_ENTERPRISEID_RANGE": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM": {
+                "TAM_LIST": [
+                    {
+                        "device": "device",
+                        "enterprise-id": 999999999
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_VALID_IPV4": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "src_ip": "2.2.2.2",
+                        "dst_ip": "1.1.1.1",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_VALID_IPV6": {
+        "sonic-tam:sonic-tam": {
+           "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "src_ip": "2620:10::1",
+                        "dst_ip": "2620:10::2",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_VALID_MULTIPLE": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "src_ip": "2.2.2.2",
+                        "dst_ip": "1.1.1.1",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    },
+                    {
+                        "name": "collector2",
+                        "src_ip": "2620:10::1",
+                        "dst_ip": "2620:10::2",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_INVALID_PORT": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "src_ip": "2620:10::1",
+                        "dst_ip": "2620:10::2",
+                        "dst_port": 99999,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_INVALID_PORT_MISSING": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "src_ip": "2620:10::1",
+                        "dst_ip": "2620:10::2",
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_INVALID_IPADDRESS": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "dst_ip": "xxx.xxx.xxx.xxx",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_COLLECTOR_INVALID_MISSING_IPADDRESS": {
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_COLLECTOR": {
+                "TAM_COLLECTOR_LIST": [
+                    {
+                        "name": "collector1",
+                        "dst_port": 1234,
+                        "dscp_value": 32
+                    }
+                ]
+            }
+        }
+    },
+    "TAM_FLOW_GROUP_VALID": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "mtu": 9000,
+                        "name": "Ethernet0",
+                        "speed": 25000,
+                        "lanes": "1"
+                    }
+                ]
+            }
+        },
+        "sonic-tam:sonic-tam": {
+            "sonic-tam:TAM_FLOW_GROUP": {
+                "TAM_FLOW_GROUP_LIST": [
+                    {
+                        "name": "flow1",
+                        "aging_interval": 1000,
+                        "ports": [
+                            "Ethernet0"
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tam.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tam.json
@@ -5,8 +5,8 @@
                 "TAM_LIST": [
                     {
                         "device": "device",
-                        "device-id": 12345,
-                        "enterprise-id": 54321,
+                        "device_id": 12345,
+                        "enterprise_id": 54321,
                         "ifa": "true"
                     }
                 ]
@@ -19,8 +19,8 @@
                 "TAM_LIST": [
                     {
                         "device": "device",
-                        "device-id": 12345,
-                        "enterprise-id": 54321
+                        "device_id": 12345,
+                        "enterprise_id": 54321
                     }
                 ]
             }
@@ -32,7 +32,7 @@
                 "TAM_LIST": [
                     {
                         "device": "badname",
-                        "device-id": 12345
+                        "device_id": 12345
                     }
                 ]
             }
@@ -44,7 +44,7 @@
                 "TAM_LIST": [
                     {
                         "device": "device",
-                        "device-id": 999999999
+                        "device_id": 999999999
                     }
                 ]
             }
@@ -56,7 +56,7 @@
                 "TAM_LIST": [
                     {
                         "device": "device",
-                        "enterprise-id": 999999999
+                        "enterprise_id": 999999999
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-tam.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tam.yang
@@ -46,7 +46,7 @@ module sonic-tam {
                     }
                 }
 
-                leaf device-id {
+                leaf device_id {
                     description "Uniquely identifies this device in exported
                                  telemetry records. 28-bit value.
                                  Defaults to the last 16 bits of the
@@ -56,7 +56,7 @@ module sonic-tam {
                     }
                 }
 
-                leaf enterprise-id {
+                leaf enterprise_id {
                     description "Uniquely identifies the enterprise in exported
                                  telemetry records. 28-bit value.
                                  Defaults to the last 16 bits of the

--- a/src/sonic-yang-models/yang-models/sonic-tam.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tam.yang
@@ -23,7 +23,7 @@ module sonic-tam {
         prefix vrf;
     }
 
-    description "TAM YANG Module for SONiC OS";
+    description "Telemetry and Monitoring (TAM) configuration";
 
     revision 2025-09-24 {
         description "Initial Revision";
@@ -34,32 +34,41 @@ module sonic-tam {
             description "Defines TAM device configuration";
 
             list TAM_LIST {
+                description "Singleton table -- only one entry with key 'device'
+                             is meaningful.";
+
                 key "device";
 
                 leaf device {
-                    description "Only one instance and has a fixed key 'device'.";
+                    description "Fixed key 'device' (the table is a singleton).";
                     type string {
                         pattern "device";
                     }
                 }
 
                 leaf device-id {
-                    description "Uniquely identifies a device on the network to be analyzed. 28bits. Uses last 16bits of the Mac address if not defined.";
+                    description "Uniquely identifies this device in exported
+                                 telemetry records. 28-bit value.
+                                 Defaults to the last 16 bits of the
+                                 switch MAC address when not configured.";
                     type uint32 {
-                        range "1..134217727";
+                        range "1..268435455";
                     }
                 }
 
                 leaf enterprise-id {
-                    description "Uniquely identifies the enterprise.  28bits. Uses last 16bits of the Mac address if not defined.";
+                    description "Uniquely identifies the enterprise in exported
+                                 telemetry records. 28-bit value.
+                                 Defaults to the last 16 bits of the
+                                 switch MAC address when not configured.";
                     type uint32 {
-                        range "1..134217727";
+                        range "1..268435455";
                     }
                 }
 
                 leaf ifa {
-                    description "Optional parameter to specify device type as intermediate, value can be 'intermediate'
-                                 only.";
+                    description "When true, marks this device as an IFA
+                                 (In-band Flow Analyzer) intermediate node.";
                     type boolean;
                 }
             }
@@ -69,20 +78,26 @@ module sonic-tam {
 
 
         container TAM_FLOW_GROUP {
-            description "Defines TAM flow group configuration";
+            description "Flow-groups define what traffic a TAM session
+                         monitors. Each group is a named ACL (its rules in
+                         TAM_FLOW_GROUP_RULE_LIST) optionally bound to a
+                         set of ports for ingress drop-monitoring.";
 
             list TAM_FLOW_GROUP_LIST {
                 key "name";
 
                 leaf name {
-                    description "flow group name, should be unique.";
+                    description "Unique name of the flow-group.";
                     type string {
                         length 1..255;
                     }
                 }
 
                 leaf aging_interval {
-                    description "interval in seconds.";
+                    description "Flow-cache aging interval in seconds.
+                                 Inactive flows are evicted from the
+                                 per-session flow cache after this many
+                                 seconds without a hit.";
                     type uint32;
                 }
 
@@ -101,26 +116,31 @@ module sonic-tam {
             /* end of list TAM_FLOW_GROUP_LIST */
 
             list TAM_FLOW_GROUP_RULE_LIST {
-                description "rules associated with the TAM flow group";
+                description "ACL match rules for a flow-group. A flow matches
+                             the group if it matches any rule. Each rule
+                             supports 5-tuple matching: src/dst IP prefix,
+                             L4 ports, and IP protocol.";
 
                 key "name rule";
 
                 leaf name {
-                    description "name of flow group";
+                    description "Reference to the parent flow-group this
+                                 rule belongs to.";
                     type leafref {
                         path "/tam:sonic-tam/tam:TAM_FLOW_GROUP/tam:TAM_FLOW_GROUP_LIST/tam:name";
                     }
                 }
 
                 leaf rule {
-                    description "name of rule for flow group";
+                    description "Unique rule name within this flow-group.";
                     type string {
                         length 1..255;
                     }
                 }
 
                 leaf src_ip_prefix {
-                    description "source ipv4 or ipv6 prefix. Use 0.0.0.0/0 or ::/0 for any.";
+                    description "Source IPv4 or IPv6 prefix to match. Use
+                                 0.0.0.0/0 or ::/0 for any.";
                     type union {
                         type inet:ipv4-prefix;
                         type inet:ipv6-prefix;
@@ -129,7 +149,8 @@ module sonic-tam {
                 }
 
                 leaf dst_ip_prefix {
-                    description "dest ipv4 or ipv6 prefix. Use 0.0.0.0/0 or ::/0 for any.";
+                    description "Destination IPv4 or IPv6 prefix to match.
+                                 Use 0.0.0.0/0 or ::/0 for any.";
                     type union {
                         type inet:ipv4-prefix;
                         type inet:ipv6-prefix;
@@ -138,14 +159,20 @@ module sonic-tam {
                 }
 
                 leaf l4_src_port {
+                    description "Layer-4 source port to match (TCP/UDP).
+                                 Unset means any.";
                     type uint16;
                 }
 
                 leaf l4_dst_port {
+                    description "Layer-4 destination port to match (TCP/UDP).
+                                 Unset means any.";
                     type uint16;
                 }
 
                 leaf ip_protocol {
+                    description "IP protocol number to match (IANA-assigned,
+                                 e.g. 6=TCP, 17=UDP, 1=ICMP). Unset means any.";
                     type uint8 {
                         range 0..255;
                     }
@@ -157,19 +184,28 @@ module sonic-tam {
 
 
         container TAM_COLLECTOR {
-            description "Defines a TAM collector";
+            description "External telemetry collector endpoints. A TAM
+                         session references one or more collectors here as
+                         its export destinations.";
 
             list TAM_COLLECTOR_LIST {
+                description "Per-collector configuration: the destination
+                             IP/UDP port, optional source-IP override, DSCP
+                             marking, and the VRF the export packets are
+                             routed through.";
+
                 key "name";
 
                 leaf name {
-                    description "unique collector name";
+                    description "Unique collector name.";
                     type string {
                         length 1..255;
                     }
                 }
 
                 leaf src_ip {
+                    description "Source IPv4/IPv6 address used as the exporter source. When unset, the system
+                                 picks the egress interface address.";
                     type union {
                         type inet:ipv4-address;
                         type inet:ipv6-address;
@@ -177,6 +213,9 @@ module sonic-tam {
                 }
 
                 leaf dst_ip {
+                    description "IPv4 or IPv6 address of the external
+                                 collector endpoint that receives the telemetry
+                                 reports.";
                     mandatory true;
                     type union {
                         type inet:ipv4-address;
@@ -185,17 +224,21 @@ module sonic-tam {
                 }
 
                 leaf dst_port {
+                    description "UDP destination port on the collector.";
                     mandatory true;
                     type uint16;
                 }
 
                 leaf dscp_value {
+                    description "DSCP marking applied to IPFIX export packets
+                                 toward the collector. Defaults to 32 (CS4).";
                     type uint8;
                     default 32;
                 }
 
                 leaf vrf {
-                    description "VRF";
+                    description "VRF used to route export telemetry packets
+                                 toward dst_ip.";
                     type union {
                         type leafref {
                             path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
@@ -206,7 +249,9 @@ module sonic-tam {
                         }
                     }
                     must "(current() != 'mgmt')
-                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
+                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')" {
+                        error-message "VRF 'mgmt' requires MGMT_VRF_CONFIG.vrf_global.mgmtVrfEnabled = true.";
+                    }
                 }
             }
             /* end of list TAM_COLLECTOR_LIST */
@@ -214,19 +259,22 @@ module sonic-tam {
         /* end of container TAM_COLLECTOR */
 
         container TAM_SESSION {
-            description "Defines a TAM session";
+            description "Defines a TAM session. Each session ties relevant attributes of the
+                        session like type, collectors, report format, etc.";
 
             list TAM_SESSION_LIST {
                 key "name";
 
                 leaf name {
-                    description "unique session name";
+                    description "Unique session name.";
                     type string {
                         length 1..255;
                     }
                 }
 
                 leaf type {
+                    description "Session type: 'drop-monitor' reports packets
+                                 the data plane dropped.";
                     type enumeration {
                         enum drop-monitor;
                     }
@@ -234,6 +282,7 @@ module sonic-tam {
                 }
 
                 leaf report_type {
+                    description "Wire format for exported telemetry records.";
                     type enumeration {
                         enum ipfix;
                     }
@@ -241,12 +290,16 @@ module sonic-tam {
                 }
 
                 leaf flow_group {
+                    description "Flow-group whose matching traffic this
+                                 session monitors.";
                     type leafref {
                         path "/tam:sonic-tam/tam:TAM_FLOW_GROUP/tam:TAM_FLOW_GROUP_LIST/tam:name";
                     }
                 }
 
                 leaf-list collector {
+                    description "One or more collector references receiving
+                                 this session's telemetry reports.";
                     type leafref {
                         path "/tam:sonic-tam/tam:TAM_COLLECTOR/tam:TAM_COLLECTOR_LIST/tam:name";
                     }

--- a/src/sonic-yang-models/yang-models/sonic-tam.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tam.yang
@@ -1,0 +1,262 @@
+module sonic-tam {
+    yang-version 1.1;
+    namespace "http://github.com/sonic-net/sonic-tam";
+    prefix tam;
+
+    import ietf-inet-types {
+        prefix inet;
+    }
+
+    import sonic-port {
+        prefix port;
+    }
+
+    import sonic-portchannel {
+        prefix lag;
+    }
+
+    import sonic-mgmt_vrf {
+        prefix mvrf;
+    }
+
+    import sonic-vrf {
+        prefix vrf;
+    }
+
+    description "TAM YANG Module for SONiC OS";
+
+    revision 2025-09-24 {
+        description "Initial Revision";
+    }
+
+    container sonic-tam {
+        container TAM {
+            description "Defines TAM device configuration";
+
+            list TAM_LIST {
+                key "device";
+
+                leaf device {
+                    description "Only one instance and has a fixed key 'device'.";
+                    type string {
+                        pattern "device";
+                    }
+                }
+
+                leaf device-id {
+                    description "Uniquely identifies a device on the network to be analyzed. 28bits. Uses last 16bits of the Mac address if not defined.";
+                    type uint32 {
+                        range "1..134217727";
+                    }
+                }
+
+                leaf enterprise-id {
+                    description "Uniquely identifies the enterprise.  28bits. Uses last 16bits of the Mac address if not defined.";
+                    type uint32 {
+                        range "1..134217727";
+                    }
+                }
+
+                leaf ifa {
+                    description "Optional parameter to specify device type as intermediate, value can be 'intermediate'
+                                 only.";
+                    type boolean;
+                }
+            }
+            /* end of list TAM_LIST */
+        }
+        /* end of container TAM */
+
+
+        container TAM_FLOW_GROUP {
+            description "Defines TAM flow group configuration";
+
+            list TAM_FLOW_GROUP_LIST {
+                key "name";
+
+                leaf name {
+                    description "flow group name, should be unique.";
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf aging_interval {
+                    description "interval in seconds.";
+                    type uint32;
+                }
+
+                leaf-list ports {
+                    min-elements 1;
+                    type union {
+                        type leafref {
+                            path /port:sonic-port/port:PORT/port:PORT_LIST/port:name;
+                        }
+                        type leafref {
+                            path /lag:sonic-portchannel/lag:PORTCHANNEL/lag:PORTCHANNEL_LIST/lag:name;
+                        }
+                    }
+                }
+            }
+            /* end of list TAM_FLOW_GROUP_LIST */
+
+            list TAM_FLOW_GROUP_RULE_LIST {
+                description "rules associated with the TAM flow group";
+
+                key "name rule";
+
+                leaf name {
+                    description "name of flow group";
+                    type leafref {
+                        path "/tam:sonic-tam/tam:TAM_FLOW_GROUP/tam:TAM_FLOW_GROUP_LIST/tam:name";
+                    }
+                }
+
+                leaf rule {
+                    description "name of rule for flow group";
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf src_ip_prefix {
+                    description "source ipv4 or ipv6 prefix. Use 0.0.0.0/0 or ::/0 for any.";
+                    type union {
+                        type inet:ipv4-prefix;
+                        type inet:ipv6-prefix;
+                    }
+                    mandatory true;
+                }
+
+                leaf dst_ip_prefix {
+                    description "dest ipv4 or ipv6 prefix. Use 0.0.0.0/0 or ::/0 for any.";
+                    type union {
+                        type inet:ipv4-prefix;
+                        type inet:ipv6-prefix;
+                    }
+                    mandatory true;
+                }
+
+                leaf l4_src_port {
+                    type uint16;
+                }
+
+                leaf l4_dst_port {
+                    type uint16;
+                }
+
+                leaf ip_protocol {
+                    type uint8 {
+                        range 0..255;
+                    }
+                }
+            }
+            /* end of list TAM_FLOW_GROUP_RULE_LIST */
+        }
+        /* end of container TAM_FLOW_GROUP */
+
+
+        container TAM_COLLECTOR {
+            description "Defines a TAM collector";
+
+            list TAM_COLLECTOR_LIST {
+                key "name";
+
+                leaf name {
+                    description "unique collector name";
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf src_ip {
+                    type union {
+                        type inet:ipv4-address;
+                        type inet:ipv6-address;
+                    }
+                }
+
+                leaf dst_ip {
+                    mandatory true;
+                    type union {
+                        type inet:ipv4-address;
+                        type inet:ipv6-address;
+                    }
+                }
+
+                leaf dst_port {
+                    mandatory true;
+                    type uint16;
+                }
+
+                leaf dscp_value {
+                    type uint8;
+                    default 32;
+                }
+
+                leaf vrf {
+                    description "VRF";
+                    type union {
+                        type leafref {
+                            path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                        }
+                        type enumeration {
+                            enum default;
+                            enum mgmt;
+                        }
+                    }
+                    must "(current() != 'mgmt')
+                    or (/mvrf:sonic-mgmt_vrf/mvrf:MGMT_VRF_CONFIG/mvrf:vrf_global/mvrf:mgmtVrfEnabled = 'true')";
+                }
+            }
+            /* end of list TAM_COLLECTOR_LIST */
+        }
+        /* end of container TAM_COLLECTOR */
+
+        container TAM_SESSION {
+            description "Defines a TAM session";
+
+            list TAM_SESSION_LIST {
+                key "name";
+
+                leaf name {
+                    description "unique session name";
+                    type string {
+                        length 1..255;
+                    }
+                }
+
+                leaf type {
+                    type enumeration {
+                        enum drop-monitor;
+                    }
+                    mandatory true;
+                }
+
+                leaf report_type {
+                    type enumeration {
+                        enum ipfix;
+                    }
+                    default ipfix;
+                }
+
+                leaf flow_group {
+                    type leafref {
+                        path "/tam:sonic-tam/tam:TAM_FLOW_GROUP/tam:TAM_FLOW_GROUP_LIST/tam:name";
+                    }
+                }
+
+                leaf-list collector {
+                    type leafref {
+                        path "/tam:sonic-tam/tam:TAM_COLLECTOR/tam:TAM_COLLECTOR_LIST/tam:name";
+                    }
+                    min-elements 1;
+                }
+            }
+            /* end of list TAM_SESSION_LIST */
+        }
+        /* end of container TAM_SESSION */
+    }
+    /* end of top level container */
+}
+/* end of module sonic-tam */

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -211,7 +211,7 @@ module sonic-acl {
 				leaf IP_PROTOCOL {
 					description "IP protocol number to match";
 					type uint8 {
-						range 1..143;
+						range 0..255;
 					}
 				}
 
@@ -286,7 +286,7 @@ module sonic-acl {
 				leaf INNER_IP_PROTOCOL {
 					description "Inner packet IP protocol number to match for tunnel traffic";
 					type uint8 {
-						range 1..143;
+						range 0..255;
 					}
 				}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This is being tracked for 202605 release: https://github.com/orgs/sonic-net/projects/39
HLD : https://github.com/sonic-net/SONiC/pull/2094

Adds the YANG configuration schema for the new TAM (Telemetry and Monitoring)
  drop-monitor feature. This is the YANG counterpart to the orchagent and
  swss-common changes in:

  - sonic-net/sonic-swss#4370 — orchagent TAM Mirror-on-drop implementation
  - sonic-net/sonic-swss-common#1190 — adds the TAM drop-monitor STATE_DB table

  Without this PR, `TAM`, `TAM_FLOW_GROUP`, `TAM_FLOW_GROUP_RULE`, `TAM_COLLECTOR`,
  and `TAM_SESSION` config_db tables have no YANG model, so configuration cannot
  be validated or rendered by GCU / config-management tooling.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added `src/sonic-yang-models/yang-models/sonic-tam.yang` defining the
    following config_db containers:
    - `TAM` — singleton device-level config (device-id, enterprise-id, ifa flag)
    - `TAM_FLOW_GROUP` / `TAM_FLOW_GROUP_RULE` — flow-group ACL (5-tuple match
      rules + port bindings) for drop-monitor traffic selection
    - `TAM_COLLECTOR` — external IPFIX collector endpoints (dst_ip/port, DSCP,
      optional src_ip and VRF; `mgmt` VRF constrained by MGMT_VRF_CONFIG)
    - `TAM_SESSION` — ties a flow-group to one or more collectors with a
      `drop-monitor` session type and `ipfix` report format
  - Registered `sonic-tam.yang` in `setup.py`.
  - Widened the IP protocol range in `sonic-acl.yang.j2` (`IP_PROTOCOL` and
    `INNER_IP_PROTOCOL`) from `1..143` to `0..255` so the full IANA-assigned
    range is configurable. The prior cap rejected valid protocol numbers
    outside `1..143`.
  - Added `tests/yang_model_tests/tests/tam.json` and
    `tests_config/tam.json` covering positive/negative cases (required
    fields, leafref integrity, type/enum constraints, VRF must-clause).
  - Extended `tests/files/sample_config_db.json` with a representative
    IFA ACL table entry and TAM/TAM_COLLECTOR/TAM_FLOW_GROUP/TAM_SESSION
    configuration so existing config-DB round-trip tests exercise the
    new schema.

#### How to verify it
  The new `tam.json` tests under `tests/yang_model_tests/` exercise the
  schema; the updated `sample_config_db.json` is validated by the existing
  config-DB tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
  Add YANG model for TAM (Telemetry and Monitoring) drop-monitor feature.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

