### PR TITLE
Remove 'nht resolve-via-default' from FRR zebra config

### DIFF
--- a/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
+++ b/dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2
@@ -11,9 +11,15 @@ exit
 {% endblock vrf %}
 !
 {% block interfaces %}
+{% if (DEVICE_METADATA is defined and 'localhost' in DEVICE_METADATA and (DEVICE_METADATA['localhost'].get('cloudtype') or '').lower() == 'public') %}
+! Disable nht through default route for public cloudtype devices
+no ip nht resolve-via-default
+{% else %}
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+{% endif %}
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 {% for (name, prefix) in INTERFACE|pfx_filter %}
 interface {{ name }}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/frr.conf.j2/all.conf
@@ -17,7 +17,8 @@ agentx
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.conf
@@ -1,6 +1,6 @@
 !
-! Enable nht through default route
-ip nht resolve-via-default
+! Disable nht through default route for public cloudtype devices
+no ip nht resolve-via-default
 ! Disable ipv6 nht through default route
 no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/interfaces_public.json
@@ -1,0 +1,15 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "cloudtype": "Public"
+        }
+    },
+    "INTERFACE": {
+        "Ethernet0|10.20.30.40/24": {},
+        "Ethernet4|20.20.30.40/24": {}
+    },
+    "PORTCHANNEL": {
+        "PortChannel10": {},
+        "PortChannel20": {}
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/zebra/zebra.conf
@@ -33,7 +33,8 @@ exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -129,6 +129,18 @@ def test_zebra_interfaces():
              "zebra/interfaces.json",
              "zebra/interfaces.conf")
 
+def test_zebra_interfaces_public_cloudtype():
+    """For cloudtype=Public, IPv4 NHT resolve-via-default is explicitly disabled
+    ('no ip nht resolve-via-default') rather than omitted, since FRR's zebra
+    defaults this to enabled (true) under the 'traditional' defaults profile
+    that SONiC's FRR is built with. IPv6 NHT resolve-via-default is also
+    explicitly disabled ('no ipv6 nht resolve-via-default') for the same
+    reason, for all cloudtypes."""
+    run_test("zebra.interfaces.conf.j2 (Public cloudtype)",
+             "zebra/zebra.interfaces.conf.j2",
+             "zebra/interfaces_public.json",
+             "zebra/interfaces_public.conf")
+
 def test_zebra_set_src():
     run_test("zebra.set_src.conf.j2",
              "zebra/zebra.set_src.conf.j2",

--- a/src/sonic-config-engine/tests/sample_output/py2/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/frr.conf
@@ -20,7 +20,8 @@ agentx
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel03
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-vni-zebra.conf
@@ -30,7 +30,8 @@ exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet8
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/t2-chassis-fe-zebra.conf
@@ -30,7 +30,8 @@ exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet8
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr.conf
@@ -26,7 +26,8 @@ log facility local4
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel03
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/zebra_frr_dualtor.conf
@@ -26,7 +26,8 @@ log facility local4
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel03
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/frr.conf
@@ -20,7 +20,8 @@ agentx
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel01
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-vni-zebra.conf
@@ -30,7 +30,8 @@ exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/t2-chassis-fe-zebra.conf
@@ -30,7 +30,8 @@ exit
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface Ethernet0
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr.conf
@@ -26,7 +26,8 @@ log facility local4
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel01
 link-detect

--- a/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/zebra_frr_dualtor.conf
@@ -26,7 +26,8 @@ log facility local4
 !
 ! Enable nht through default route
 ip nht resolve-via-default
-ipv6 nht resolve-via-default
+! Disable ipv6 nht through default route
+no ipv6 nht resolve-via-default
 ! Enable link-detect (default disabled)
 interface PortChannel01
 link-detect


### PR DESCRIPTION
## Problem

FRR's zebra was configured with:
```
ip nht resolve-via-default
ipv6 nht resolve-via-default
```

These settings were originally introduced via #5600 to support BGP MONITOR sessions. With `resolve-via-default` enabled, zebra reports the default route as a valid nexthop for _any_ peer address. As a result, **BGP active (outbound) peering sessions would be initiated even when the peer IP has no real reachability** — any host with a default route would satisfy the NHT check.

## Root Cause Analysis (FRR code)

FRR's NHT is the gate for outbound BGP connection initiation. In `bgp_fsm.c`, `bgp_start()` calls `bgp_peer_reg_with_nht()` and only proceeds with the TCP connect if a valid nexthop is found in the RIB. With `resolve-via-default` enabled, this reachability check is defeated entirely.

Key code path:
- `bgp_start()` (`bgp_fsm.c`) — NHT gate for outbound connections
- `evaluate_paths()` (`bgp_nht.c`) — translates RIB state → NHT valid/invalid
- `bgp_fsm_nht_update()` (`bgp_fsm.c`) — drives FSM events based on NHT result

### Passive (inbound) BGP behavior

**Passive BGP peering is unaffected by NHT** regardless of this setting. In `bgp_accept()` (`bgp_network.c`), FRR accepts any incoming TCP connection from a configured peer and immediately fires `TCP_connection_open` without consulting NHT/RIB. Passive BGP sessions (including BGP MONITOR) establish regardless of RIB state.

## Important correction: omitting the config line does NOT disable this feature

An earlier version of this PR simply *omitted* the `ip/ipv6 nht resolve-via-default` lines from the rendered config for `cloudtype=Public` devices, relying on FRR falling back to a "disabled" default. **This does not work**, and has been corrected in this PR.

Tracing FRR's zebra source (`zebra/zebra_vrf.h`, `zebra/zebra_vrf.c`):

```c
// zebra_vrf.h
FRR_CFG_DEFAULT_BOOL(ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT,
	{ .val_bool = true, .match_profile = "traditional", },
	{ .val_bool = false },
);

// zebra_vrf.c, zebra_vrf_alloc()
if (DFLT_ZEBRA_IP_NHT_RESOLVE_VIA_DEFAULT) {
	zvrf->zebra_rnh_ip_default_route = true;
	zvrf->zebra_rnh_ipv6_default_route = true;
}
```

`zebra_rnh_ip_default_route` / `zebra_rnh_ipv6_default_route` (the in-memory flags that actually gate NHT behavior, and that `show running-config` reflects) default to **`true`** whenever FRR is built against the `"traditional"` defaults profile — which is exactly what SONiC's FRR is compiled as (`--enable-datacenter` is not passed anywhere in `rules/frr.mk` or `src/sonic-frr/frr/debian/rules`, so `configure.ac` falls through to `DFLT_NAME="traditional"`). zebra is also launched with no `-F <profile>` override in `supervisord.conf.common.j2`, so this compiled-in default applies as-is.

**Consequence:** simply not emitting the config line leaves zebra at its compiled-in default of `true` (enabled) — the previous version of this PR did not actually change zebra's live NHT behavior for Public devices at all. To actually disable the feature, the rendered config must contain the **explicit negation**:
```
no ip nht resolve-via-default
no ipv6 nht resolve-via-default
```
which is what this version of the PR now emits.

(Note: flipping FRR's defaults profile to `"datacenter"` at compile time was considered and rejected — it would also flip ~10 unrelated BGP/OSPF/OSPF6 defaults, e.g. `BGP_KEEPALIVE` 60s→3s, `BGP_HOLDTIME` 180s→9s, `BGP_EBGP_REQUIRES_POLICY` true→false, `BGP_LOG_NEIGHBOR_CHANGES`/`OSPF_LOG_ADJACENCY_CHANGES` false→true, etc. Using the explicit per-setting `no` command is scoped to exactly this one behavior.)

## Changes

**`dockers/docker-fpm-frr/frr/zebra/zebra.interfaces.conf.j2`**:

| Setting | `cloudtype=Public` | All other cloudtypes (Fairfax / Sovereign / unset) |
|---|---|---|
| IPv4 (`ip nht resolve-via-default`) | `no ip nht resolve-via-default` (explicitly disabled) | `ip nht resolve-via-default` (unchanged, enabled) |
| IPv6 (`ipv6 nht resolve-via-default`) | `no ipv6 nht resolve-via-default` (explicitly disabled) | `no ipv6 nht resolve-via-default` (explicitly disabled — **by design, for all cloudtypes**) |

> **Note:** sonic-mgmt test cases will be updated accordingly to configure BGP MONITOR sessions in passive mode, so that BGPMON peers only accept inbound connections and are not impacted by the removal of `nht resolve-via-default` on Public devices.

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Active BGP, peer IP reachable via specific route | Establishes | Establishes |
| Active BGP, peer IP reachable via default route only (Public, IPv4) | Establishes | **Does NOT establish** |
| Active BGP, peer IP reachable via default route only (any cloudtype, IPv6) | Establishes | **Does NOT establish** |
| Active BGP, no route at all | Does NOT establish | Does NOT establish |
| Passive BGP / BGP MONITOR (any RIB state) | Establishes | Establishes (unaffected) |
| Non-Public cloudtype, IPv4 | Unchanged | Unchanged |

## Testing

- Added `interfaces_public.json` fixture (`cloudtype=Public`) and `interfaces_public.conf` expected output — now expects both `no ip nht resolve-via-default` and `no ipv6 nht resolve-via-default`.
- Added `test_zebra_interfaces_public_cloudtype()` — verifies both explicit `no` lines present when `cloudtype=Public`.
- Existing `test_zebra_interfaces()` (no cloudtype set, non-Public path) updated to expect `ip nht resolve-via-default` (unchanged) plus the new `no ipv6 nht resolve-via-default`.
- Fixed a duplicated-content mistake in several golden fixtures (`zebra.conf`, `frr.conf.j2/all.conf`, and the `sonic-config-engine` py2/py3 sample outputs) left over from the earlier version of this change, and updated `frr.conf.j2/all.conf` which the earlier version had missed entirely.
- Verified rendering directly against the Jinja2 template + `sonic-cfggen`'s filter/search-path setup, since the `sonic-cfggen` binary itself requires `sonic_py_common`/`swsscommon` (only available in the sonic-slave build container).
