### PR TITLE
[Mellanox][Smartswitch] Add blacklist for dpu kernel module to prevent race condition

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn4280-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn4280-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq ima_hash=sha384 amd_iommu=off cpufreq.default_governor=performance"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq ima_hash=sha384 amd_iommu=off cpufreq.default_governor=performance modprobe.blacklist=mlxreg_dpu"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On this Mellanox SmartSwitch platform, the `mlxreg_dpu` kernel module needs to be loaded only after the platform's I2C topology is in place, and is loaded explicitly later in boot. The current modprobe.d-based blacklist that gates early autoload is written by a userspace service and is subject to a race against udev-driven autoload on early boot, which intermittently causes `mlxreg_dpu` to attach too early. Adding the blacklist via the kernel command line in `installer.conf` makes the gate effective from PID 0, closing the race while still allowing the later explicit `modprobe` to load the module normally.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Append `modprobe.blacklist=mlxreg_dpu` to `ONIE_PLATFORM_EXTRA_CMDLINE_LINUX` in the platform `installer.conf`. ONIE bakes this into the GRUB `linux` line at install time, so the parameter is present on the kernel command line from the very first boot.

```1:1:device/mellanox/x86_64-nvidia_sn4280-r0/installer.conf
ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq ima_hash=sha384 amd_iommu=off cpufreq.default_governor=performance modprobe.blacklist=mlxreg_dpu"
```

The canonical module name `mlxreg_dpu` (underscore — as reported by `modinfo`'s `name:` field, even though the on-disk object is `mlxreg-dpu.ko`) is used so that `kmod` matches the autoload alias. Explicit `modprobe mlxreg-dpu` calls later in boot are unaffected, since `modprobe.blacklist=` only suppresses implicit/alias/dependency loads.

#### How to verify it

On a freshly installed image of the affected platform:

1. Confirm the kernel command line carries the blacklist:

    ```
    cat /proc/cmdline | tr ' ' '\n' | grep modprobe.blacklist
    # expect: modprobe.blacklist=mlxreg_dpu
    ```

2. Confirm the explicit modprobe path still loads the module during normal boot:

    ```
    lsmod | grep mlxreg_dpu
    # expect: mlxreg_dpu loaded (loaded later in boot via explicit modprobe)
    ```

3. Functional verification: run the SmartSwitch DPU bring-up sanity test across repeated cold boots and confirm the DPUs reach the expected operational state — the previous race manifested as intermittent failures in this scenario.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

[Mellanox] Blacklist `mlxreg_dpu` via kernel cmdline on SmartSwitch platform to prevent early udev autoload race.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A — no YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)
