### PR TITLE
fix(dhcpservd): fix STATE_DB lease sync when Kea appends stale release after MAC move

### DIFF
--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
@@ -136,6 +136,16 @@ class KeaDhcp4LeaseHandler(LeaseHanlder):
 
             new_key = self._lease_key(subnet_id, mac_address)
             if new_key in new_lease:
+                existing = new_lease[new_key]
+                existing_is_release = existing["lease_start"] == existing["lease_end"]
+                current_is_valid = int(valid_lifetime) > 0
+                different_ip = existing["ip"] != ip_str
+                if existing_is_release and current_is_valid and different_ip:
+                    new_lease[new_key] = {
+                      "lease_start": str(int(lease_end) - int(valid_lifetime)),
+                      "lease_end": lease_end,
+                      "ip": ip_str
+                    }
                 continue
             new_lease[new_key] = {
                 "lease_start": str(int(lease_end) - int(valid_lifetime)),

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
@@ -142,9 +142,9 @@ class KeaDhcp4LeaseHandler(LeaseHanlder):
                 different_ip = existing["ip"] != ip_str
                 if existing_is_release and current_is_valid and different_ip:
                     new_lease[new_key] = {
-                      "lease_start": str(int(lease_end) - int(valid_lifetime)),
-                      "lease_end": lease_end,
-                      "ip": ip_str
+                        "lease_start": str(int(lease_end) - int(valid_lifetime)),
+                        "lease_end": lease_end,
+                        "ip": ip_str
                     }
                 continue
             new_lease[new_key] = {

--- a/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
+++ b/src/sonic-dhcp-utilities/dhcp_utilities/dhcpservd/dhcp_lease.py
@@ -140,7 +140,8 @@ class KeaDhcp4LeaseHandler(LeaseHanlder):
                 existing_is_release = existing["lease_start"] == existing["lease_end"]
                 current_is_valid = int(valid_lifetime) > 0
                 different_ip = existing["ip"] != ip_str
-                if existing_is_release and current_is_valid and different_ip:
+                current_is_newer = int(lease_end) >= int(existing["lease_end"])
+                if existing_is_release and current_is_valid and different_ip and current_is_newer:
                     new_lease[new_key] = {
                         "lease_start": str(int(lease_end) - int(valid_lifetime)),
                         "lease_end": lease_end,

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_lease.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_lease.py
@@ -53,6 +53,30 @@ def test_read_kea_lease(mock_swsscommon_dbconnector_init):
         assert lease == expected_lease
 
 
+def test_read_kea_lease_prefers_active_lease_over_newer_stale_release(
+        mock_swsscommon_dbconnector_init, tmp_path):
+    lease_file = tmp_path / "kea-lease.csv"
+    lease_file.write_text(
+        "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,"
+        "fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id\n"
+        "192.168.0.131,10:70:fd:b6:13:17,,3600,1694000915,1000,0,0,,0,,1\n"
+        "192.168.0.2,10:70:fd:b6:13:17,,0,1693997309,1000,0,0,,2,,1\n",
+        encoding="utf-8"
+    )
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table):
+        db_connector = DhcpDbConnector()
+        kea_lease_handler = KeaDhcp4LeaseHandler(db_connector, lease_file=lease_file)
+
+        assert kea_lease_handler._read() == {
+            "Vlan1000|10:70:fd:b6:13:17": {
+                "lease_start": "1693997315",
+                "lease_end": "1694000915",
+                "ip": "192.168.0.131"
+            }
+        }
+
+
 # Cannot mock built-in/extension type function(datetime.datetime.timestamp), need to free time
 @freeze_time("2023-09-08")
 def test_update_kea_lease(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init):

--- a/src/sonic-dhcp-utilities/tests/test_dhcp_lease.py
+++ b/src/sonic-dhcp-utilities/tests/test_dhcp_lease.py
@@ -77,6 +77,45 @@ def test_read_kea_lease_prefers_active_lease_over_newer_stale_release(
         }
 
 
+def test_read_kea_lease_does_not_resurrect_older_lease_when_newer_ip_is_legitimately_released(
+        mock_swsscommon_dbconnector_init, tmp_path):
+    """
+    Timeline:
+      1. Client holds IP_A (active, oldest row).
+      2. Client moves; receives IP_B (active, middle row).
+      3. Client legitimately releases IP_B (release, newest row).
+
+    _read() scans bottom-up, so the IP_B release is stored first.
+    When it reaches the IP_A active row (different IP, older timestamp), it must NOT
+    overwrite the legitimate IP_B release with the stale IP_A entry.
+    """
+    lease_file = tmp_path / "kea-lease.csv"
+    lease_file.write_text(
+        "address,hwaddr,client_id,valid_lifetime,expire,subnet_id,"
+        "fqdn_fwd,fqdn_rev,hostname,state,user_context,pool_id\n"
+        # IP_A active — oldest (expire=1694000000)
+        "192.168.0.10,10:70:fd:b6:13:17,,3600,1694000000,1000,0,0,,0,,1\n"
+        # IP_B active — client moved (expire=1694003600)
+        "192.168.0.20,10:70:fd:b6:13:17,,3600,1694003600,1000,0,0,,0,,1\n"
+        # IP_B release — newest, legitimate (expire=1694003700, valid_lifetime=0)
+        "192.168.0.20,10:70:fd:b6:13:17,,0,1694003700,1000,0,0,,2,,1\n",
+        encoding="utf-8"
+    )
+
+    with patch.object(DhcpDbConnector, "get_config_db_table", side_effect=mock_get_config_db_table):
+        db_connector = DhcpDbConnector()
+        kea_lease_handler = KeaDhcp4LeaseHandler(db_connector, lease_file=lease_file)
+
+        assert kea_lease_handler._read() == {
+            "Vlan1000|10:70:fd:b6:13:17": {
+                # lease_start == lease_end signals a release; IP_B must be preserved
+                "lease_start": "1694003700",
+                "lease_end": "1694003700",
+                "ip": "192.168.0.20"
+            }
+        }
+
+
 # Cannot mock built-in/extension type function(datetime.datetime.timestamp), need to free time
 @freeze_time("2023-09-08")
 def test_update_kea_lease(mock_swsscommon_dbconnector_init, mock_swsscommon_table_init):


### PR DESCRIPTION
Fixes missing or cleared DHCP_SERVER_IPV4_LEASE entries in STATE_DB after a successful DHCP ACK on Kea 2.6.x, when the memfile contains multiple rows per MAC and the newest row is a release for a previous IP while an older row holds the current active lease.

Bug id : https://github.com/sonic-net/sonic-mgmt/issues/24868

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
dhcpservd mirrors Kea memfile leases from /var/lib/kea/kea-lease.csv into STATE_DB (DHCP_SERVER_IPV4_LEASE). KeaDhcp4LeaseHandler._read() scans the CSV bottom-up and, on duplicate MAC keys, keeps the newest row.

On Kea 2.6.x (master), DHCP RELEASE with lease affinity often does not remove the lease from the memfile. After a MAC move (new ACK on a new IP), Kea can append a release row for the old IP at the end of the file (valid_lifetime=0, lease_start == lease_end). The parser then treats that stale release as canonical, update_lease() removes or never publishes the active lease, and sonic-mgmt verify_lease() fails with "state db doesnt have lease info" despite a valid DHCP ACK.

On 202511 / Kea 2.2.0, RELEASE usually deletes the row from the CSV, so this issue is mainly visible on master with Kea 2.6.3.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In _read(), when merging duplicate (subnet, MAC) rows during the bottom-up scan:

```
- Default: keep the newest row (continue unchanged).
- Exception: if the stored (newest) row is a release (lease_start == lease_end), the older CSV row has valid_lifetime > 0, and the IPs differ, use the older active lease (stale release for old IP after MAC move).
```

different_ip ensures normal same-IP releases still keep the newest release row (existing unit test semantics in test_read_kea_lease / tests/test_data/kea-lease.csv).
#### How to verify it
**Unit test**

cd src/sonic-dhcp-utilities
pytest tests/test_dhcp_lease.py::test_read_kea_lease -v
Expected: PASS

**On DUT (after MAC move / DHCP ACK)**

docker exec dhcp_server tail -20 /var/lib/kea/kea-lease.csv
sonic-db-cli STATE_DB HGETALL "DHCP_SERVER_IPV4_LEASE|Vlan1000|<mac>"
Expected: STATE_DB shows the correct active lease (new IP), not empty.

**sonic-mgmt**

pytest tests/dhcp_server/test_dhcp_server.py -k mac_move -v
pytest tests/dhcp_server/test_dhcp_server.py -v
Expected: no "state db doesnt have lease info" failures.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

Reason: the stale-release lease parsing bug reproduces on 202605 with Kea 2.6.3 and causes recurring dhcp_server STATE_DB lease failures.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20260510.02 (Nokia-7215, mx): unpatched 0/4 passed; patched 4/4 passed, followed by 20/20 passed.
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Fix DHCP server STATE_DB lease sync when Kea 2.6.x appends a stale release row after MAC move.
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

