### PR TITLE
[macsec] Extend container stop timeout to 60s

### DIFF
--- a/dockers/docker-macsec/supervisord.conf
+++ b/dockers/docker-macsec/supervisord.conf
@@ -35,6 +35,7 @@ command=/usr/bin/macsecmgrd
 priority=2
 autostart=false
 autorestart=false
+stopwaitsecs=60
 stdout_logfile=NONE
 stdout_syslog=true
 stderr_logfile=NONE

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -875,6 +875,12 @@ stop() {
     {%- elif docker_container_name == "teamd" %}
         # Longer timeout of 60 sec to wait for Portchannels to be cleaned.
         /usr/local/bin/container stop -t 60 $DOCKERNAME
+    {%- elif docker_container_name == "macsec" %}
+        # Longer timeout of 60 sec for macsecmgrd to disable MKA on every
+        # port and reap each per-port wpa_supplicant before SIGKILL. A
+        # short timeout leaves stale MACsec SAs in ASIC_DB whose SAK no
+        # longer matches APPL_DB.
+        /usr/local/bin/container stop -t 60 $DOCKERNAME
     {%- elif docker_container_name in ["swss", "syncd"] and enable_asan == "y" %}
         /usr/local/bin/container stop -t 60 $DOCKERNAME
     {%- else %}


### PR DESCRIPTION
#### Why I did it

When the macsec container is stopped, macsecmgrd needs to disable MKA on
every configured port and reap each per-port wpa_supplicant before
exiting. The default container stop timeout is too short and SIGKILLs
macsecmgrd mid-cleanup, leaving stale MACsec SAs programmed in ASIC_DB
whose SAK no longer matches what was last published to APPL_DB. On the
next container start MKA renegotiates fresh SAKs, but the dangling SAs
in ASIC_DB continue to decrypt incoming frames with the old key,
producing one-direction traffic loss until the SAs are manually cleared.

##### Work item tracking
- Microsoft ADO **(number only)**: n/a

#### How I did it

1. Set `stopwaitsecs=60` for the `macsecmgrd` program in
   `dockers/docker-macsec/supervisord.conf` so supervisord waits up to
   60 seconds for macsecmgrd to exit before sending SIGKILL.
2. Added a `macsec` case in the `stop()` block of
   `files/build_templates/docker_image_ctl.j2` to invoke
   `/usr/local/bin/container stop -t 60 $DOCKERNAME`, matching the
   pattern already used for `teamd` (and `swss`/`syncd` under ASAN).

#### How to verify it

1. Configure MACsec on one or more ports and confirm MKA reaches the
   secure channel state with bidirectional traffic flowing.
2. Stop the macsec container with `systemctl stop macsec`.
3. Confirm in syslog that macsecmgrd exits cleanly and is not SIGKILLed
   by supervisord/docker.
4. Restart the container and confirm there are no stale entries in
   `ASIC_DB` (`SAI_OBJECT_TYPE_MACSEC_SA`) whose SAK does not match the
   freshly negotiated SAK in `APPL_DB` (`MACSEC_SA_TABLE`).
5. Confirm bidirectional traffic resumes without any manual SA cleanup.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511

#### Tested branch (Please provide the tested image version)

- [x] 202511

#### Description for the changelog

[macsec] Extend macsec container stop timeout to 60s so macsecmgrd can
disable MKA and reap per-port wpa_supplicants cleanly, avoiding stale
MACsec SAs in ASIC_DB after a container restart.

#### Link to config_db schema for YANG module changes

n/a — no schema changes.
