### PR TITLE
[multiasic][rsyslog] Restart the rsyslog.service for multiasic platform

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -68,6 +68,12 @@ if [ ! -f /etc/rsyslog.conf ] || ! cmp -s "$TMPFILE" /etc/rsyslog.conf; then
         exit 1
     fi
 else
-    # Config unchanged — just signal rsyslog to re-open log files
-    systemctl kill -s HUP rsyslog
+    if [[ ($NUM_ASIC -gt 1) ]]; then
+        # multi-asic, docker0 IP interface may not be present when rsyslog.service was started.
+        # restart the rsyslog for TCP port socket binding.
+        systemctl restart rsyslog
+    else
+        # Config unchanged — just signal rsyslog to re-open log files
+        systemctl kill -s HUP rsyslog
+    fi
 fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The rsyslogd listener ("tcp        0      0 240.127.1.1:2514        0.0.0.0:*               LISTEN")  is missing after system reboot on multiasic platform. All syslog from container will not be able to log to syslog server.   Restart the rsyslog.service on multiasic platform. Fixes https://github.com/sonic-net/sonic-buildimage/issues/27236

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
rsyslog.service starts in the early stage which docker0 IP interface may not be present in multiasic platform.  Added code to check if it is multiasic platform, restart the rsyslog.service instead of just reopen the syslog file. 

#### How to verify it
After system boot up, esxecute command "docker exec -it pmon logger "Testing 123".  The verify "Testing 123" is in the syslog file.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

