### PR TITLE
add FT2 buffer profile for Arista-7060X6-64PE-B-O128

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers.json.j2
@@ -1,6 +1,8 @@
 {# set default_topo based on switch_role #}
 {%- if DEVICE_METADATA is defined and ('lowerspinerouter' in DEVICE_METADATA['localhost']['type'].lower() or 'fabricregionalhub' == DEVICE_METADATA['localhost']['type'].lower()) -%}
 {%-         set default_topo = 'lt2' %}
+{%- elif DEVICE_METADATA is defined and 'fabricspinerouter' in DEVICE_METADATA['localhost']['type'].lower() -%}
+{%-         set default_topo = 'ft2' %}
 {%- else %}
 {%-         set default_topo = 't1' %}
 {%- endif %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers_defaults_ft2.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/buffers_defaults_ft2.j2
@@ -1,0 +1,36 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "164075364",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "49418240"
+        },
+        "egress_lossless_pool": {
+            "size": "164075364",
+            "type": "egress",
+            "mode": "static"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "1778",
+            "dynamic_th": "0"
+        },
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        }
+    },
+{%- endmacro %}

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/qos.json.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/qos.json.j2
@@ -1,4 +1,4 @@
-{%- if DEVICE_METADATA is defined and ('lowerspinerouter' in DEVICE_METADATA['localhost']['type'].lower() or 'fabricregionalhub' == DEVICE_METADATA['localhost']['type'].lower()) -%}
+{%- if DEVICE_METADATA is defined and ('lowerspinerouter' in DEVICE_METADATA['localhost']['type'].lower() or 'fabricspinerouter' in DEVICE_METADATA['localhost']['type'].lower() or 'fabricregionalhub' == DEVICE_METADATA['localhost']['type'].lower()) -%}
 
 {# Do nothing for lt2 #}
 

--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/sai.profile.j2
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-O128/sai.profile.j2
@@ -1,7 +1,7 @@
 {# Get sai.profile based on switch_role #}
 {%- if DEVICE_METADATA is defined -%}
 {%-     set switch_role = DEVICE_METADATA['localhost']['type'] -%}
-{%-     if 'lowerspinerouter' in switch_role.lower() or 'fabricregionalhub' == switch_role.lower() %}
+{%-     if 'lowerspinerouter' in switch_role.lower() or 'fabricspinerouter' in switch_role.lower() or 'fabricregionalhub' == switch_role.lower() %}
 {%         set sai_profile_contents = 'SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe-lt2.config.bcm' -%}
 {%-     else %}
 {%-         set sai_profile_contents = 'SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/th5-a7060x6-64pe.config.bcm' -%}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Was asked to add support for FT2 role for this hwsku. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Reused LT2 buffer profile and other config settings.

#### How to verify it

Confirmed new buffer data is shown with 'show mmu' after setting DEVICE METADATA type to FabricSpineRouter then config reload, config qos reload.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)
202511: manually verified config after add-topo 202600728
202605: manually verified config after add-topo 202600728
master: manually verified config after add-topo 202600728
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added new config for hwsku
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

