### PR TITLE
[Mellanox] [logging] mellanox-fw-manager: surface and parse mlxfwmanager errors from stdout when stderr is empty

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_fw_manager/spectrum_manager.py
+++ b/platform/mellanox/platform-utils/mellanox_fw_manager/spectrum_manager.py
@@ -22,6 +22,7 @@ Spectrum ASIC firmware manager implementation.
 Handles firmware operations specific to Spectrum ASICs using mlxfwmanager.
 """
 
+import re
 import subprocess
 from typing import Dict, Optional
 from .firmware_base import FirmwareManagerBase, FW_ALREADY_UPDATED_FAILURE
@@ -39,6 +40,16 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
         '15b3:cf82': 'SPC5',
     }
 
+    _ANSI_ESCAPE_RE = re.compile(r'\x1b\[[0-9;]*[A-Za-z]|[\x08\r]')
+    _MLXFW_ERR_RE = re.compile(
+        r'^\s*Fail\s*:|^\s*-[EW]-|MCC\s+(?:ERROR|FAIL)|\bFAIL(?:ED|URE|S)?\b|\bERROR\b',
+        re.IGNORECASE,
+    )
+    _MLXFW_NOISE_RE = re.compile(
+        r'^\s*(user/.*\.(?:cpp|c|h):\d+|\[FLASH_ACCESS_DEBUG\]|-D-|controlFsm\s*:)',
+        re.IGNORECASE,
+    )
+
     @classmethod
     def get_asic_type_map(cls) -> Dict[str, str]:
         """
@@ -52,6 +63,31 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
     def _get_mst_device_type(self) -> str:
         """Get MST device type for Spectrum ASICs."""
         return "Spectrum"
+
+    @classmethod
+    def _mlxfwmanager_detail(cls, result: subprocess.CompletedProcess, max_len: int = 1024) -> str:
+        """Extract a syslog-safe error string from an mlxfwmanager result."""
+        stderr = cls._ANSI_ESCAPE_RE.sub('', (result.stderr or "")).strip()
+        if stderr:
+            return stderr
+
+        stdout = cls._ANSI_ESCAPE_RE.sub('', (result.stdout or "")).strip()
+        if not stdout:
+            return ""
+
+        seen, picked = set(), []
+        for line in stdout.splitlines():
+            line = line.strip()
+            if not line or line in seen or cls._MLXFW_NOISE_RE.search(line):
+                continue
+            if cls._MLXFW_ERR_RE.search(line):
+                seen.add(line)
+                picked.append(line)
+
+        if picked:
+            detail = " | ".join(picked)
+            return detail if len(detail) <= max_len else detail[:max_len].rstrip() + " ...[truncated]"
+        return stdout if len(stdout) <= max_len else "...[truncated]" + stdout[-max_len:]
 
     def _get_available_firmware_version(self, psid: str) -> Optional[str]:
         """Get available firmware version for Spectrum ASICs using mlxfwmanager."""
@@ -93,7 +129,7 @@ class SpectrumFirmwareManager(FirmwareManagerBase):
                 result = self._run_command(cmd, env=env, capture_output=True, text=True)
 
             if result.returncode != 0:
-                self.logger.error(f"Failed to update firmware for Spectrum ASICs with return code {result.returncode}: {result.stderr}")
+                self.logger.error(f"Failed to update firmware for Spectrum ASICs with return code {result.returncode}: {self._mlxfwmanager_detail(result)}")
                 return False
 
             return True

--- a/platform/mellanox/platform-utils/tests/test_spectrum_manager.py
+++ b/platform/mellanox/platform-utils/tests/test_spectrum_manager.py
@@ -307,6 +307,132 @@ Device Info:
         self.assertIn('FLASH_ACCESS_DEBUG', env)
         self.assertIn('FW_COMPS_DEBUG', env)
 
+    @patch('mellanox_fw_manager.spectrum_manager.SpectrumFirmwareManager._run_command')
+    def test_run_firmware_update_failure_logs_parsed_detail(self, mock_run_cmd):
+        """Failure log should surface parsed stdout detail when stderr is empty"""
+        manager = self._create_manager()
+
+        mock_run_cmd.return_value = MagicMock(
+            returncode=2,
+            stdout=(
+                "-W- BME is not set, DMA access is not supported.\n"
+                "MCC ERROR: 0x5\n"
+                "Fail : Rejected authentication\n"
+            ),
+            stderr="",
+        )
+
+        with patch.object(manager, 'logger') as mock_logger:
+            result = manager.run_firmware_update()
+
+        self.assertFalse(result)
+        mock_logger.error.assert_called_once()
+        logged = mock_logger.error.call_args[0][0]
+        self.assertIn("return code 2", logged)
+        self.assertIn("BME is not set", logged)
+        self.assertIn("MCC ERROR: 0x5", logged)
+        self.assertIn("Rejected authentication", logged)
+
+
+class TestMlxfwmanagerDetail(unittest.TestCase):
+    """Test cases for SpectrumFirmwareManager._mlxfwmanager_detail parsing helper"""
+
+    @staticmethod
+    def _result(stdout="", stderr=""):
+        return MagicMock(stdout=stdout, stderr=stderr)
+
+    def _detail(self, stdout="", stderr="", **kwargs):
+        return SpectrumFirmwareManager._mlxfwmanager_detail(
+            self._result(stdout=stdout, stderr=stderr), **kwargs)
+
+    def test_prefers_stderr_when_present(self):
+        """Non-empty stderr is returned verbatim and stdout is ignored"""
+        detail = self._detail(stdout="-E- error on stdout", stderr="real stderr reason")
+        self.assertEqual(detail, "real stderr reason")
+
+    def test_stderr_is_stripped(self):
+        """Surrounding whitespace/newlines are stripped from stderr"""
+        detail = self._detail(stderr="  device busy\n")
+        self.assertEqual(detail, "device busy")
+
+    def test_strips_ansi_and_cursor_control_from_stderr(self):
+        """ANSI escapes, backspaces and carriage returns are removed from stderr"""
+        detail = self._detail(stderr="\x1b[31m\rdevice busy\x08\x1b[0m")
+        self.assertEqual(detail, "device busy")
+
+    def test_empty_stderr_and_stdout_returns_empty(self):
+        """Both streams empty (or None) yields an empty string"""
+        self.assertEqual(self._detail(stdout="", stderr=""), "")
+        self.assertEqual(self._detail(stdout=None, stderr=None), "")
+
+    def test_extracts_error_lines_from_stdout(self):
+        """Relevant error/warning lines are picked from stdout and joined with '|'"""
+        stdout = (
+            "Querying device ...\n"
+            "-W- BME is not set, DMA access is not supported.\n"
+            "MCC ERROR: 0x5\n"
+            "Fail : Rejected authentication\n"
+            "Done\n"
+        )
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(
+            detail,
+            "-W- BME is not set, DMA access is not supported. | "
+            "MCC ERROR: 0x5 | Fail : Rejected authentication",
+        )
+
+    def test_matches_generic_error_and_fail_keywords(self):
+        """Generic ERROR / FAIL* keywords are matched case-insensitively"""
+        stdout = "informational line\nSomething Failed badly\nan Error occurred\nok\n"
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(detail, "Something Failed badly | an Error occurred")
+
+    def test_suppresses_noise_lines(self):
+        """Debug/source-banner/flash-access noise is suppressed even if it matches errors"""
+        stdout = (
+            "-D- debug chatter\n"
+            "user/mlxfwmanager.cpp:123\n"
+            "[FLASH_ACCESS_DEBUG] error reading flash\n"
+            "controlFsm : ERROR state\n"
+            "-E- real error here\n"
+        )
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(detail, "-E- real error here")
+
+    def test_deduplicates_repeated_lines(self):
+        """Identical error lines appear only once, preserving first-seen order"""
+        stdout = "-E- same error\n-E- same error\n-E- other error\n-E- same error\n"
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(detail, "-E- same error | -E- other error")
+
+    def test_strips_ansi_from_stdout_before_matching(self):
+        """ANSI/cursor-control bytes in stdout are removed before line matching"""
+        stdout = "\x1b[2J\x1b[H-E- corrupt MFA file\x1b[0m\n\rprogress\x08\x08\n"
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(detail, "-E- corrupt MFA file")
+
+    def test_falls_back_to_full_stdout_when_no_error_line(self):
+        """With no recognizable error line, the full cleaned stdout is returned"""
+        stdout = "just some neutral progress output\nmore output\n"
+        detail = self._detail(stdout=stdout)
+        self.assertEqual(detail, "just some neutral progress output\nmore output")
+
+    def test_picked_detail_truncated_to_max_len(self):
+        """Joined error detail longer than max_len is truncated with a marker"""
+        stdout = "\n".join(f"-E- error number {i} with some padding text" for i in range(200))
+        detail = self._detail(stdout=stdout, max_len=128)
+        self.assertTrue(detail.endswith(" ...[truncated]"))
+        self.assertLessEqual(len(detail), 128 + len(" ...[truncated]"))
+        self.assertTrue(detail.startswith("-E- error number 0"))
+
+    def test_stdout_fallback_truncated_keeps_tail(self):
+        """Oversized fallback stdout is truncated keeping the tail with a leading marker"""
+        stdout = "x" * 5000  # no error markers -> fallback path
+        detail = self._detail(stdout=stdout, max_len=100)
+        self.assertTrue(detail.startswith("...[truncated]"))
+        self.assertEqual(len(detail), len("...[truncated]") + 100)
+        self.assertTrue(detail.endswith("x" * 100))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Why I did it

`mlxfwmanager` does not always write its failure reason to stderr; for several classes of error (corrupt MFA file, BME / DMA prerequisites missing, MCC authentication failures) the only diagnostic appears on stdout while stderr stays empty. As a result, when `SpectrumFirmwareManager.run_firmware_update` logged the failure as `... return code N: {result.stderr}`, syslog showed only the return code and an empty reason — operators had no actionable signal to distinguish a corrupt firmware blob from a missing kernel module.

### Work item tracking

* **Microsoft ADO (number only)**: N/A

## How I did it

* Added a `_mlxfwmanager_detail()` classmethod to `SpectrumFirmwareManager` that returns a syslog-safe error string: prefers a non-empty stderr; if stderr is empty, strips ANSI/cursor-control bytes from stdout and extracts only the relevant error/warning lines (`-E-`, `-W-`, `Fail :`, `MCC ERROR`, generic `ERROR`/`FAIL`) while suppressing known noise (`-D-`, source-file banners, `[FLASH_ACCESS_DEBUG]`, `controlFsm:`).
* Joined the picked lines with `|` and capped the output at 1024 chars to stay well under the syslog line limit, with truncation markers when needed.
* Replaced the `{result.stderr}` interpolation in the non-zero-return-code failure log with `{self._mlxfwmanager_detail(result)}`.
* No behavior change on the success path; only the failure log message is enriched.

## How to verify it

Run a firmware update on a Spectrum switch against a known-bad input and confirm the syslog line now contains the actionable error parsed from `mlxfwmanager` stdout.

Example: invoking the firmware update against a corrupt MFA file on a Spectrum switch (`<dut-hostname>`) previously produced an empty reason; with this change syslog now shows:

```
2026-05-28 04:04:56,283 - root - WARNING - FW reactivation failed with return code 1: -E- Failed to execute image reactivation on device 0000:02:00.0. Error: FW already reactivated.
2026-05-28 04:04:56,283 - root - INFO - Executing: mlxfwmanager -u -f -y -d 0000:02:00.0 -i /etc/mlnx/fw-SPC5.mfa
2026-05-28 04:06:32,297 - root - ERROR - Failed to update firmware for Spectrum ASICs with return code 2: -W- BME is not set, DMA access is not supported. please make sure mst driver and mlx5 driver are loaded | MCC ERROR: 0x5 | Fail : Rejected authentication
2026-05-28 04:06:32,301 - root - INFO - Upgrade results: 0 successful, 1 failed
```

No new unit tests were added (the change is a logging/parsing helper on top of the existing `_run_command` path; a follow-up unit test for `_mlxfwmanager_detail` is being considered separately).

## Which release branch to backport (provide reason below if selected)

* [ ] 202305
* [ ] 202311
* [ ] 202405
* [ ] 202411
* [ ] 202505
* [ ] 202511

## Tested branch (Please provide the tested image version)

* [ ] `<image-version>`

## Description for the changelog

[mellanox] mellanox-fw-manager: surface mlxfwmanager errors from stdout when stderr is empty

## A picture of a cute animal (not mandatory but encouraged)

```text
 (\_/)
 ( •_•)
 /> Asking nicely for that LGTM!

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update failure error messages by filtering unnecessary output and providing cleaner, more actionable error details for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nvidia-sonic/sonic-buildimage/pull/871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->