### PR TITLE
[docker-sonic-mgmt] Expose /opt/venv packages to system /usr/bin/python3 via .pth fallback

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -55,6 +55,18 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN uv venv --system-site-packages /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
+# Make the venv's site-packages visible to the *system* python (/usr/bin/python3).
+# `uv venv --system-site-packages` only lets the venv see system packages, not
+# the other way around. Many existing sonic-mgmt code paths (notably the
+# Ansible localhost connection which historically hardcodes
+# ansible_python_interpreter to /usr/bin/python3) invoke system python
+# directly. Without this .pth file those callers fail with ModuleNotFoundError
+# for yaml/ansible/etc.
+RUN py_ver=$(/usr/bin/python3 -c 'import sys; print("python%d.%d" % sys.version_info[:2])') \
+    && mkdir -p "/usr/local/lib/${py_ver}/dist-packages" \
+    && echo "/opt/venv/lib/${py_ver}/site-packages" \
+         > "/usr/local/lib/${py_ver}/dist-packages/venv-fallback.pth"
+
 # Configure system-wide PATH and sudo secure_path for /opt/venv/bin access
 # Without this change, running pip or python with sudo will not use the binaries from /opt/venv/bin
 RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \


### PR DESCRIPTION
<!--
Make sure all your commits include a signature generated with `git commit -s`.
-->

#### Why I did it

The recent change to `dockers/docker-sonic-mgmt/Dockerfile.j2` that moved Python dependencies into a uv-managed venv at `/opt/venv` broke any sonic-mgmt code path that invokes the *system* `/usr/bin/python3` directly. The most visible victim is the Ansible `localhost` connection, which historically hardcodes `ansible_python_interpreter = /usr/bin/python3` and is used by e.g. `.azure-pipelines/upgrade_image.py` → `conn_graph_facts`. Every nightly testbed prepare on the cisco-8000 `internal-202511` line failed with:

```
Module failed: No module named 'yaml'
```

`uv venv --system-site-packages /opt/venv` only makes the *venv* see system packages, not the reverse. So `/opt/venv/bin/python` works, but `/usr/bin/python3` is bare. This PR adds a one-line `.pth` file so the system interpreter also resolves packages from `/opt/venv`, restoring compatibility for any caller that invokes system python directly.

A companion PR in `sonic-net/sonic-mgmt` removes the hardcoded interpreter path so it auto-discovers `sys.executable`; this image-level fix is the belt-and-braces complement that protects every other tool / script that ever calls `/usr/bin/python3`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a `RUN` step right after `uv venv` is created that writes `venv-fallback.pth` into the system python's site-packages directory. The file contains a single line: the venv's `site-packages` path. Python's `site` module reads `.pth` files at startup and appends each non-comment line to `sys.path`, so the system interpreter then resolves all venv packages transparently.

The python version is detected at build time (`python3 -c 'sys.version_info'`) so the recipe survives Ubuntu base-image upgrades.

#### How to verify it

Inside a freshly built `docker-sonic-mgmt` container:
```
$ /usr/bin/python3 -c "import yaml, ansible; print(yaml.__version__, ansible.__version__)"
6.0.3 2.20.6
```
Before this change the same command prints `ModuleNotFoundError: No module named 'yaml'`.

End-to-end: nightly `PREPARE_TESTBED` previously failed 25+ retries on `conn_graph_facts`. After applying the equivalent of this change (writing the same `.pth` file into a running container on a lab server), `upgrade_image.py` proceeds past the failing step into the actual image upgrade flow.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

Reason: the `/opt/venv` migration landed in 202511 / master; older branches still install everything into system python and don't need this.

#### Tested branch (Please provide the tested image version)

- [x] master — verified inside `sonicdev-microsoft.azurecr.io:443/docker-sonic-mgmt:latest` (image ID `b3bd7b53c7e1`)

#### Description for the changelog
docker-sonic-mgmt: expose `/opt/venv` packages to system `/usr/bin/python3` via a `.pth` file so legacy callers that invoke system python directly (e.g. Ansible localhost connection) keep working.

#### Link to config_db schema for YANG module changes
N/A.

#### A picture of a cute animal (not mandatory but encouraged)
🦦

### Review update (2026-09-17)

Merged current master and resolved the line-ending conflict in 2275daccfed685a37a01e06ae7f5c52275131602. The diff against master is now only the 12-line compatibility fallback; current dependency pins, gNOI wheel support and image changes are preserved. The Jinja template parses successfully. A fresh container build/runtime check is pending; the earlier image result above is historical, not a result for this new head.
