### PR TITLE
[mux] write_standby.py: silent no-op on non-dualToR --shutdown bgp

### DIFF
--- a/files/scripts/write_standby.py
+++ b/files/scripts/write_standby.py
@@ -161,6 +161,14 @@ class MuxStateWriter(object):
         Writes standby mux state to APP DB for all mux interfaces
         """
         if not self.is_dualtor:
+            if self.shutdown_module == 'bgp':
+                # On non-dualToR, --shutdown bgp is a no-op (no MUX_CABLE_TABLE to update).
+                # Returning here lets bgp.service ExecStopPost succeed; exiting non-zero
+                # would mark bgp.service failed and burn the unit's StartLimitBurst.
+                # The mux startup path (no --shutdown arg) and the --shutdown mux path
+                # intentionally still exit 1 — refusing mux operations on non-dualToR
+                # is the intent of #23804.
+                return
             logger.log_warning("It is not a Dual-ToR system, do not start mux container")
             sys.exit(1)
 


### PR DESCRIPTION
#### Why I did it

**Fixes #27607.**

Regression introduced in #23804 (commit `bd28d51fba`): the non-dualToR early-out in `files/scripts/write_standby.py::apply_mux_config()` was changed from `return` to `sys.exit(1)`. That hardening is correct for the **mux startup** call site (`mux.service ExecStartPre=/usr/local/bin/write_standby.py`) — refuse to bring up the mux container when there is no dualToR. But the same script is also wired as `bgp.service ExecStopPost` with `--shutdown bgp`:

```
ExecStopPost=/usr/local/bin/write_standby.py --shutdown bgp
```

On a non-dualToR system there is no `MUX_CABLE_TABLE` to update — the previous `return` (in place since 2021, commit `17cbfc44e61`) quietly no-op'd. The new `sys.exit(1)` causes systemd to mark `bgp.service` `failed (Result: exit-code)` on every clean stop. With `Restart=always` from the `auto_restart` drop-in, repeated failed stops accumulate against `StartLimitBurst` and eventually trip `Start request repeated too quickly`, leaving `bgp.service` permanently in a failed state until manual `systemctl reset-failed bgp.service`.

#### How I did it

Early-return from `apply_mux_config()` on non-dualToR specifically when invoked as `--shutdown bgp`. The mux startup path (no `--shutdown` arg) and the `--shutdown mux` path are unchanged — both continue to log the warning and `sys.exit(1)`, preserving #23804's intent of refusing all mux operations on non-dualToR.

```diff
         if not self.is_dualtor:
+            if self.shutdown_module == 'bgp':
+                # On non-dualToR, --shutdown bgp is a no-op (no MUX_CABLE_TABLE to update).
+                # Returning here lets bgp.service ExecStopPost succeed; exiting non-zero
+                # would mark bgp.service failed and burn the unit's StartLimitBurst.
+                # The mux startup path (no --shutdown arg) and the --shutdown mux path
+                # intentionally still exit 1 — refusing mux operations on non-dualToR
+                # is the intent of #23804.
+                return
             logger.log_warning("It is not a Dual-ToR system, do not start mux container")
             sys.exit(1)
```

#### How to verify it

On any non-dualToR DUT (`DEVICE_METADATA.localhost.subtype` not set to `DualToR`):

**Before the fix:**

```
$ sudo systemctl stop bgp.service
$ systemctl status bgp.service
× bgp.service - BGP container
     Active: failed (Result: exit-code) since ...
    Process: ... ExecStop=/usr/local/bin/bgp.sh stop                         (code=exited, status=0/SUCCESS)
    Process: ... ExecStopPost=/usr/local/bin/write_standby.py --shutdown bgp (code=exited, status=1/FAILURE)

$ sudo journalctl -u bgp.service --no-pager -n 5
... write_standby[...]: It is not a Dual-ToR system, do not start mux container
... bgp.service: Control process exited, code=exited, status=1/FAILURE
... bgp.service: Failed with result 'exit-code'.
```

**After the fix:**

```
$ sudo systemctl stop bgp.service
$ systemctl status bgp.service
○ bgp.service - BGP container
     Active: inactive (dead) since ...
    Process: ... ExecStop=/usr/local/bin/bgp.sh stop                         (code=exited, status=0/SUCCESS)
    Process: ... ExecStopPost=/usr/local/bin/write_standby.py --shutdown bgp (code=exited, status=0/SUCCESS)

$ sudo journalctl -u bgp.service --no-pager -n 5
... bgp.service: Deactivated successfully.
... bgp.service: Stopped bgp.service - BGP container.
```

Mux-startup path is unaffected — still hard-fails on non-dualToR as #23804 requires:

#### Which release branch to backport (provide reason below if selected)

The regression in #23804 is present on `master`, `202511`, and `202505` (cherry-picked into 202505 as #24024). All three branches need this fix to recover `bgp.service` on non-dualToR DUTs.

- [x] 202505
- [x] 202511

#### Description for the changelog

Fix `bgp.service` entering permanently failed state after repeated stops on non-dualToR DUTs (regression from #23804).

#### Tested branch (Please provide the tested image version)

Verified on master with a non-dualToR DUT.
