### PR TITLE
[docker-sonic-mgmt] enable SBOM vulnerability scan as a Publish gate

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -93,15 +93,16 @@ stages:
     value: $(Build.SourceBranchName)
   jobs:
   - job: sbom_vuln_scan
-    displayName: "[OPTIONAL] SBOM-based vulnerability scan (docker-sonic-mgmt)"
-    # Disabled for now; remove this `condition: false` (or change to
-    # `and(succeeded(), in(dependencies.Build.result, 'Succeeded'))`)
-    # to re-enable the docker-sonic-mgmt SBOM vulnerability scan.
-    # The SBOM itself is still produced by the Build stage above
-    # when ENABLE_SBOM=y; only the post-build scan is gated.
-    condition: false
+    displayName: "SBOM-based vulnerability scan (docker-sonic-mgmt)"
+    # Gate the build on unpatched MEDIUM+ severity CVEs found in the
+    # SBOM produced by ENABLE_SBOM=y in the Build stage above.
+    # VEX statements under vex/ suppress CVEs that SONiC patches fix.
+    # Without this gate, freshly-disclosed Ubuntu USNs (e.g. USN-8292-1
+    # for libarchive13t64) silently flow into docker-sonic-mgmt:latest
+    # until someone reports it from a downstream image scanner.
+    condition: and(succeeded(), in(dependencies.Build.result, 'Succeeded'))
     pool: sonic-ubuntu-1c
-    continueOnError: true
+    continueOnError: false
     timeoutInMinutes: 30
     steps:
     - checkout: self


### PR DESCRIPTION
### Why I did it

The `sbom_vuln_scan` job in `.azure-pipelines/docker-sonic-mgmt.yml` has been present but disabled (`condition: false`) since SBOM support landed. As a result, unpatched MEDIUM+ CVEs in the produced `docker-sonic-mgmt` image flow into `:latest` and only get caught later by downstream image scanners (Defender for Cloud).

Concrete example: USN-8292-1 (`libarchive13t64` 3.7.2-2ubuntu0.6 → 0.7) was published on 2026-05-21, but daily builds since then have kept publishing `sha256:ea549ff…` as `:latest`. With this gate disabled, nothing in the pipeline noticed.

The root cause of *why* the build keeps producing a vulnerable image needs further investigation (snapshot mirror pin, base image staleness, etc.), but that's a separate question. **This PR makes the pipeline self-aware**: whatever the underlying reason, an unpatched fixable CVE will stop the Publish stage from running.

### How I did it

In `.azure-pipelines/docker-sonic-mgmt.yml`:
- Merge current master and rely on the existing `Test` stage dependency on `Build`; do not use a cross-stage `dependencies.Build.result` expression at job scope.
- Drop the `[OPTIONAL]` prefix and `continueOnError: true` so the job is no longer best-effort and its failure correctly fails the `Test` stage, which in turn blocks the `Publish` stage.

No new scan logic — `scripts/sbom_vuln_scan.py --fail-on medium` and the VEX statements under `vex/` already exist and are exactly the policy used by `.azure-pipelines/build-template.yml` for the main `.bin` images.

### How to verify it

- Trigger pipeline 194 (`Azure.docker-sonic-mgmt`) on this branch. With the current vulnerable digest still being produced, the `sbom_vuln_scan` job should fail and report `USN-8292-1` / `libarchive13t64` (plus any other unsuppressed CVEs).
- Confirm the `Publish` stage does **not** run when `sbom_vuln_scan` fails.
- On a follow-up commit that addresses the underlying CVEs (e.g. forcing a fresh base image), the same scan should pass and Publish should resume.
- VEX suppressions under `vex/` continue to work as a controlled exception channel for CVEs that are known not exploitable in this image.

### Review update (2026-09-17)

Current master already runs the SBOM scan in informational mode. This PR now only makes that existing scan mandatory. The merge conflict and invalid job-level condition are fixed in 76c20445926050d5be3684ee87f9c5a95283852d. Static YAML/dependency checks passed; fresh pipeline results are pending. The original commit f931c6b still lacks DCO sign-off; history was preserved, so that check still needs contributor/maintainer resolution before merge.
