### PR TITLE
stp: complete STP feature enablement (FEATURE entry, service dependency, CoPP trap)

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -77,6 +77,7 @@
 {%- if include_dhcp_server == "y" %}{% do features.append(("dhcp_server", "disabled", false, "enabled")) %}{% endif %}
 {%- if sonic_asic_platform == "vs" %}{% do features.append(("gbsyncd", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_iccpd == "y" %}{% do features.append(("iccpd", "disabled", false, "enabled")) %}{% endif %}
+{%- if include_stp == "y" %}{% do features.append(("stp", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_mgmt_framework == "y" %}{% do features.append(("mgmt-framework", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_mux == "y" %}{% do features.append(("mux", "{% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %}enabled{% else %}always_disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_nat == "y" %}{% do features.append(("nat", "disabled", false, "enabled")) %}{% endif %}

--- a/files/build_templates/stp.service.j2
+++ b/files/build_templates/stp.service.j2
@@ -1,7 +1,7 @@
 [Unit]
 Description=STP container
-Requires=updategraph.service swss.service
-After=updategraph.service swss.service syncd.service
+Requires=config-setup.service swss.service
+After=config-setup.service swss.service syncd.service
 Before=ntp-config.service
 BindsTo=sonic.target
 After=sonic.target

--- a/files/image_config/copp/copp_cfg.j2
+++ b/files/image_config/copp/copp_cfg.j2
@@ -106,6 +106,10 @@
 		    "trap_ids": "lldp",
 		    "trap_group": "queue4_group3"
 	    },
+	    "stp": {
+		    "trap_ids": "stp,pvrst",
+		    "trap_group": "queue4_group3"
+	    },
 	    "dhcp_relay": {
 		    "trap_ids": "dhcp,dhcpv6",
 		    "trap_group": "queue4_group3"


### PR DESCRIPTION
#### Why I did it

When building with `INCLUDE_STP=y`, the `docker-stp` image builds and `stpd`/`stpmgrd` run, but the STP feature cannot be brought up the supported way and received BPDUs never reach `stpd`. Three small gaps in the feature enablement remain:

- `FEATURE|stp` is never registered, so `featured` cannot manage the container. Fixes #27640
- `stp.service` depends on a non-existent `updategraph.service`, so the unit cannot start. Fixes #27641
- No `stp`/`pvrst` CoPP trap exists, so ingress BPDUs are never copied to the CPU. Fixes #27642

Related: the `INCLUDE_STP` build-flag propagation gap (#24768, fixed by #24769) is required before these are reachable.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `init_cfg.json.j2`: append an `stp` FEATURE entry gated on `include_stp` (mirrors `iccpd`, disabled by default).
- `stp.service.j2`: depend on `config-setup.service` instead of the non-existent `updategraph.service` (matches every other service template).
- `copp_cfg.j2`: add an `stp` `COPP_TRAP` (`trap_ids: "stp,pvrst"`), feature-gated like `lldp`/`bgp`. No SAI change — the trap-ids already exist in `copporch`.

#### How to verify it

Build with `INCLUDE_STP=y`, then:

```
config feature state stp enabled        # stp container auto-starts
config spanning-tree enable pvst
config spanning-tree interface bpdu-guard enable --shutdown Ethernet0
# send a BPDU into Ethernet0 from a neighbor:
show spanning-tree statistics vlan 100   # BPDU Rx increments
show spanning-tree bpdu_guard            # Ethernet0 -> Port Shut: Yes
```

Before this change: `FEATURE|stp` is absent, `systemctl start stp.service` fails on `updategraph.service`, and `BPDU Rx` stays at 0.

#### Which release branch to backport (provide reason below if selected)

- [x] 202511

#### Tested branch (Please provide the tested image version)

- 202511 

#### Description for the changelog

Enable the STP feature end-to-end when built with `INCLUDE_STP=y`: register the `stp` FEATURE entry, fix the `stp.service` dependency, and add the `stp`/`pvrst` CoPP trap so BPDUs reach `stpd`.

#### A picture of a cute animal (not mandatory but encouraged)

https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg
