### PR TITLE
[Mellanox] Fix ThermalUpdater ASIC temp read when STATE_DB has N/A

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/thermal_updater.py
@@ -150,9 +150,18 @@ class ThermalUpdater:
         utils.write_file('/run/hw-management/config/suspend', 1 if suspend else 0)
 
     def get_asic_temp(self, asic_name):
+        """
+        Read ASIC temperature from STATE_DB TEMPERATURE_INFO.
+
+        Returns temperature as int scaled by TEMPERATURE_SCALE, 0 if
+        missing or N/A, None on error.
+        """
+        temperature = None
         try:
             present, temperature = get_db_table_helper().get_temperature_info_table().hget(asic_name, 'temperature')
-            return int(float(temperature) * TEMPERATURE_SCALE) if present else 0
+            if not present or temperature == 'N/A':
+                return 0
+            return int(float(temperature) * TEMPERATURE_SCALE)
         except Exception as e:
             logger.log_error(f'Failed to read ASIC {asic_name} temperature - {temperature} - {e}')
             return None

--- a/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_thermal_updater.py
@@ -136,6 +136,9 @@ class TestThermalUpdater:
 
         mock_temp_table.hget.return_value = (False, None)
         assert updater.get_asic_temp('ASIC') == 0
+
+        mock_temp_table.hget.return_value = (True, 'N/A')
+        assert updater.get_asic_temp('ASIC') == 0
         assert updater.get_asic_temp_warning_threshold() == ASIC_DEFAULT_TEMP_WARNNING_THRESHOLD
         assert updater.get_asic_temp_critical_threshold() == ASIC_DEFAULT_TEMP_CRITICAL_THRESHOLD
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
After fast-reboot, `thermalctld` / `ThermalUpdater` can read ASIC temperature from `STATE_DB` `TEMPERATURE_INFO` before the value is populated. The field may be missing or set to `N/A`. `get_asic_temp()` called `float(temperature)` on `N/A`, which raised `ValueError` and produced error logs in platform monitoring. After system ready, values are correct.

#### How I did it
- In `thermal_updater.py`, treat missing entries and `temperature == 'N/A'` like absent data: return `0` instead of calling `float()`.
- Initialize `temperature = None` before the DB read so exception logging is safe.
- Add unit test in `test_thermal_updater.py` for `(True, 'N/A')` from `hget`.

#### How to verify it
Do fast-reboot in switch, and see if error still happen:
```bash
Failed to read ASIC ASIC temperature - N/A - could not convert string to float: 'N/A'
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)
- [x] master
- [x] 202605

#### Tested branch (Please provide the tested image version)
- [x] master
- [x] 202605

#### Test result
master: PASS
202605: PASS

Test evidence:
- Fast-reboot completed successfully.
- thermalctld remained running.
- No `could not convert string to float: 'N/A'` error was found.
- ASIC temperature was reported correctly after STATE_DB was populated.