### PR TITLE
Fix service_checker ignoring group: entries in critical_processes

### DIFF
--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -177,20 +177,22 @@ class ServiceChecker(HealthChecker):
         return running_containers
 
     def get_critical_process_list_from_file(self, container, critical_processes_file):
-        """Read critical process name list from critical processes file
+        """Read critical process and group name lists from critical processes file
 
         Args:
             container (str): contianer name
             critical_processes_file (str): critical processes file path
 
         Returns:
-            critical_process_list: A list of critical process names
+            (critical_process_list, critical_group_list): Lists of critical process names
+            and supervisord group names respectively
         """
         critical_process_list = []
+        critical_group_list = []
 
         with open(critical_processes_file, 'r') as file:
             for line in file:
-                # Try to match a line like "program:<process_name>"
+                # Try to match a line like "program:<process_name>" or "group:<group_name>"
                 match = re.match(r"^\s*((.+):(.*))*\s*$", line)
                 if match is None:
                     if container not in self.bad_containers:
@@ -202,8 +204,10 @@ class ServiceChecker(HealthChecker):
                     identifier_value = match.group(3).strip()
                     if identifier_key == "program" and identifier_value:
                         critical_process_list.append(identifier_value)
+                    elif identifier_key == "group" and identifier_value:
+                        critical_group_list.append(identifier_value)
 
-        return critical_process_list
+        return critical_process_list, critical_group_list
 
     def fill_critical_process_by_container(self, container):
         """Get critical process for a given container
@@ -230,7 +234,31 @@ class ServiceChecker(HealthChecker):
             return
 
         # Get critical process list from critical_processes
-        critical_process_list = self.get_critical_process_list_from_file(container, critical_processes_file)
+        critical_process_list, critical_group_list = self.get_critical_process_list_from_file(container, critical_processes_file)
+
+        # Expand group: entries to individual "group:process" names via supervisorctl status.
+        if critical_group_list:
+            count_before_expansion = len(critical_process_list)
+            cmd = 'docker exec {} bash -c "supervisorctl status"'.format(container)
+            status_output = utils.run_command(cmd, timeout=15)
+            if status_output:
+                process_status = self._parse_supervisorctl_status(status_output.strip().splitlines())
+                for proc_name in process_status:
+                    if ':' in proc_name:
+                        group_name = proc_name.split(':')[0]
+                        if group_name in critical_group_list:
+                            critical_process_list.append(proc_name)
+            else:
+                logger.log_warning('Failed to get supervisorctl status for container {}, was container stopped?'.format(container))
+
+            # If group expansion produced no processes (e.g. supervisord still
+            # booting, docker exec failed), skip caching so the next check cycle
+            # retries. Without this, the empty result sticks for the rest of the
+            # daemon's lifetime via the not-in-dict gate in get_current_running_containers.
+            if len(critical_process_list) == count_before_expansion:
+                logger.log_warning('Group expansion produced no processes for container {}; will retry on next check'.format(container))
+                return
+
         self._update_container_critical_processes(container, critical_process_list)
 
     def _update_container_critical_processes(self, container, critical_process_list):

--- a/src/system-health/tests/dhcp_relay/etc/supervisor/critical_processes
+++ b/src/system-health/tests/dhcp_relay/etc/supervisor/critical_processes
@@ -1,0 +1,1 @@
+group:dhcp-relay

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -27,6 +27,7 @@ swsscommon.RestartWaiter = MagicMock()
 
 test_path = os.path.dirname(os.path.abspath(__file__))
 telemetry_path = os.path.join(test_path, 'telemetry')
+dhcp_relay_path = os.path.join(test_path, 'dhcp_relay')
 modules_path = os.path.dirname(test_path)
 scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
@@ -58,6 +59,21 @@ from healthd import HealthDaemon
 mock_supervisorctl_output = """
 snmpd                       RUNNING   pid 67, uptime 1:03:56
 snmp-subagent               EXITED    Oct 19 01:53 AM
+"""
+
+mock_dhcp_relay_supervisorctl_output = """
+dhcp-relay:dhcprelayd        RUNNING   pid 100, uptime 1:00:00
+dhcp-relay:dhcp6relay        RUNNING   pid 101, uptime 1:00:00
+"""
+
+mock_dhcp_relay_supervisorctl_output_dhcp6relay_down = """
+dhcp-relay:dhcprelayd        RUNNING   pid 100, uptime 1:00:00
+dhcp-relay:dhcp6relay        EXITED    Oct 19 01:53 AM
+"""
+
+mock_dhcp_relay_supervisorctl_output_no_group_members = """
+rsyslogd                     RUNNING   pid 50, uptime 0:00:01
+supervisor-proc-exit-listener RUNNING   pid 51, uptime 0:00:01
 """
 device_info.get_platform = MagicMock(return_value='unittest')
 
@@ -178,6 +194,98 @@ def test_service_checker_single_asic(mock_config_db, mock_run, mock_docker_clien
     checker.save_critical_process_cache()
     checker.load_critical_process_cache()
     assert origin_container_critical_processes == checker.container_critical_processes
+
+
+@patch('swsscommon.swsscommon.ConfigDBConnector.connect', MagicMock())
+@patch('health_checker.service_checker.ServiceChecker._get_container_folder', MagicMock(return_value=dhcp_relay_path))
+@patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=False))
+@patch('docker.DockerClient')
+@patch('health_checker.utils.run_command')
+@patch('swsscommon.swsscommon.ConfigDBConnector')
+def test_service_checker_group_expansion(mock_config_db, mock_run, mock_docker_client):
+    """Verify that group: entries in critical_processes are expanded to individual processes."""
+    setup()
+    mock_db_data = MagicMock()
+    mock_get_table = MagicMock()
+    mock_db_data.get_table = mock_get_table
+    mock_config_db.return_value = mock_db_data
+    mock_get_table.return_value = {
+        'dhcp_relay': {
+            'state': 'enabled',
+            'has_global_scope': 'True',
+            'has_per_asic_scope': 'False',
+        }
+    }
+    mock_containers = MagicMock()
+    mock_dhcp_relay_container = MagicMock()
+    mock_dhcp_relay_container.name = 'dhcp_relay'
+    mock_dhcp_relay_container.labels = {}
+    mock_containers.list = MagicMock(return_value=[mock_dhcp_relay_container])
+    mock_docker_client_object = MagicMock()
+    mock_docker_client.return_value = mock_docker_client_object
+    mock_docker_client_object.containers = mock_containers
+
+    # Both processes running: expect STATUS_OK for each
+    mock_run.return_value = mock_dhcp_relay_supervisorctl_output
+    checker = ServiceChecker()
+    config = Config()
+    checker.check(config)
+
+    assert 'dhcp_relay:dhcp-relay:dhcprelayd' in checker._info
+    assert checker._info['dhcp_relay:dhcp-relay:dhcprelayd'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+    assert 'dhcp_relay:dhcp-relay:dhcp6relay' in checker._info
+    assert checker._info['dhcp_relay:dhcp-relay:dhcp6relay'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+
+    # dhcp6relay exits: expect STATUS_NOT_OK for it
+    setup()
+    mock_run.return_value = mock_dhcp_relay_supervisorctl_output_dhcp6relay_down
+    checker = ServiceChecker()
+    checker.check(config)
+
+    assert 'dhcp_relay:dhcp-relay:dhcprelayd' in checker._info
+    assert checker._info['dhcp_relay:dhcp-relay:dhcprelayd'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_OK
+    assert 'dhcp_relay:dhcp-relay:dhcp6relay' in checker._info
+    assert checker._info['dhcp_relay:dhcp-relay:dhcp6relay'][HealthChecker.INFO_FIELD_OBJECT_STATUS] == HealthChecker.STATUS_NOT_OK
+
+
+@patch('swsscommon.swsscommon.ConfigDBConnector.connect', MagicMock())
+@patch('health_checker.service_checker.ServiceChecker._get_container_folder', MagicMock(return_value=dhcp_relay_path))
+@patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=False))
+@patch('docker.DockerClient')
+@patch('health_checker.utils.run_command')
+def test_service_checker_group_expansion_retries_on_empty(mock_run, mock_docker_client):
+    """If group expansion produces no members (e.g. supervisord still booting),
+    fill_critical_process_by_container must not cache the empty result, so the
+    next check cycle retries instead of latching the gap for the daemon lifetime."""
+    setup()
+    mock_containers = MagicMock()
+    mock_dhcp_relay_container = MagicMock()
+    mock_dhcp_relay_container.name = 'dhcp_relay'
+    mock_dhcp_relay_container.labels = {}
+    mock_containers.list = MagicMock(return_value=[mock_dhcp_relay_container])
+    mock_docker_client_object = MagicMock()
+    mock_docker_client.return_value = mock_docker_client_object
+    mock_docker_client_object.containers = mock_containers
+
+    checker = ServiceChecker()
+
+    # First fill: supervisorctl returns no group members (group still booting).
+    mock_run.return_value = mock_dhcp_relay_supervisorctl_output_no_group_members
+    checker.fill_critical_process_by_container('dhcp_relay')
+    assert 'dhcp_relay' not in checker.container_critical_processes
+
+    # docker exec failure (None) should also leave the container uncached.
+    mock_run.return_value = None
+    checker.fill_critical_process_by_container('dhcp_relay')
+    assert 'dhcp_relay' not in checker.container_critical_processes
+
+    # Subsequent fill once group members are up succeeds and caches all members.
+    mock_run.return_value = mock_dhcp_relay_supervisorctl_output
+    checker.fill_critical_process_by_container('dhcp_relay')
+    assert checker.container_critical_processes['dhcp_relay'] == [
+        'dhcp-relay:dhcprelayd',
+        'dhcp-relay:dhcp6relay',
+    ]
 
 
 @patch('swsscommon.swsscommon.ConfigDBConnector.connect', MagicMock())


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`service_checker.py` had one issues affecting containers that declare critical processes via `group:` syntax (e.g. `dhcp_relay` with `group:dhcp-relay`):

1. **`group:` entries silently dropped.** `get_critical_process_list_from_file` only matched `program:<name>` lines, leaving group-based containers with an empty monitored-process list. `SYSTEM_HEALTH_INFO` was never populated for any process in those containers, so a crashed process would not surface in system health output.

##### Work item tracking
- #27681 

#### How I did it

**`src/system-health/health_checker/service_checker.py`**
- `get_critical_process_list_from_file` returns `(process_list, group_list)` and collects `group:` entries alongside `program:` ones.
- `fill_critical_process_by_container` expands each `group:` entry by running `docker exec {container} supervisorctl status` and appending every member process in `group:process` format. Logs a warning if the command fails.
- When `critical_group_list` was non-empty but expansion produced zero members, `fill_critical_process_by_container` returns without caching so the next check cycle retries. Without this, a transient miss latches.

**`src/system-health/tests/`**
- New fixture `tests/dhcp_relay/etc/supervisor/critical_processes` (`group:dhcp-relay`).
- New test `test_service_checker_group_expansion` covers all-RUNNING and one-EXITED cases.
- New test `test_service_checker_group_expansion_retries_on_empty` verifies that a transient first-fill failure does not latch and that a subsequent fill succeeds.

#### How to verify it

1. Check the critical process list is populated after daemon start:
   ```
   python3 -c "import pickle; print(pickle.load(open('/tmp/critical_process_cache','rb')).get('dhcp_relay'))"
   # Expected: ['dhcp-relay:dhcp6relay', 'dhcp-relay:dhcprelayd', 'dhcp-relay:isc-dhcpv4-relay-unified']
   ```
2. Stop a process and verify the alarm fires within one check cycle:
   ```
   docker exec dhcp_relay supervisorctl stop dhcp-relay:dhcp6relay
   sleep 65
   redis-cli -n 6 HGETALL SYSTEM_HEALTH_INFO | grep dhcp_relay
   # Expected: dhcp_relay:dhcp-relay:dhcp6relay  Process '...' is not running
   ```
3. Restart the process — the alarm should clear on the next cycle:
   ```
   docker exec dhcp_relay supervisorctl start dhcp-relay:dhcp6relay
   ```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-buildimage/issues/27681 
Failure type: <!-- day-one issue / regression / other --> day-one issue

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

202605: `SONiC.202605.1179093-ee68f85f5` (upstream 202605 broadcom nightly, build 1179093)

Tested on a Broadcom-based switch running the upstream 202605 nightly, with this PR's `service_checker.py` installed over the in-image copy (`/usr/local/lib/python3.13/dist-packages/health_checker/service_checker.py`), followed by `rm -f /tmp/critical_process_cache && systemctl restart system-health`.

Test config: `Vlan1000` with IPv4/IPv6 addresses, `dhcp_servers` set on `VLAN|Vlan1000`, and `dhcpv6_servers` set on `DHCP_RELAY|Vlan1000`, so the container renders `[group:dhcp-relay]` with members `dhcp6relay` and `dhcprelayd`. (`isc-dhcpv4-relay-<vlan>` renders outside the group on 202605 unless `has_sonic_dhcpv4_relay=True`, so the expected member list differs from the master example in the PR description.)

1. Critical process list is populated from the `group:` entry:

```
$ python3 -c "import pickle; print(pickle.load(open('/tmp/critical_process_cache','rb')).get('dhcp_relay'))"
['dhcp-relay:dhcp6relay', 'dhcp-relay:dhcprelayd']
```
2. Retry-instead-of-latch verified: before DHCP relay config was applied, the container had no dhcp-relay group, and healthd retried every cycle instead of caching an empty result — then succeeded on the first cycle after the group appeared:

```
Jul 30 18:35:40 ... bmc_base[25453]: Group expansion produced no processes for container dhcp_relay; will retry on next check
Jul 30 18:36:40 ... bmc_base[25453]: Group expansion produced no processes for container dhcp_relay; will retry on next check
(next cycle: cache populated, see above)
```
3. Alarm fires within one check cycle after stopping a group member:

```
$ docker exec dhcp_relay supervisorctl stop dhcp-relay:dhcp6relay
dhcp-relay:dhcp6relay: stopped
$ redis-cli -n 6 HGETALL SYSTEM_HEALTH_INFO | grep -A1 dhcp
dhcp_relay:dhcp-relay:dhcp6relay
Process 'dhcp-relay:dhcp6relay' in container 'dhcp_relay' is not running
```
4. Alarm clears on the next cycle after restarting the process:

```
$ docker exec dhcp_relay supervisorctl start dhcp-relay:dhcp6relay
dhcp-relay:dhcp6relay: started
$ redis-cli -n 6 HGETALL SYSTEM_HEALTH_INFO | grep dhcp
(no output — alarm cleared)
$ redis-cli -n 6 HGET SYSTEM_HEALTH_INFO summary
OK
```
Caveat: this was verified by overlaying the patched service_checker.py onto an unmodified 202605 nightly image (the change is host-side Python only, shipped in the system_health wheel), not by building a full 202605 image from this branch.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix service_checker ignoring group: entries in critical_processes files; retry empty group expansion on next check cycle instead of latching for the daemon lifetime.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

