### PR TITLE
[Mellanox] Fix BMC import issue

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -1229,9 +1229,9 @@ class Chassis(ChassisBase):
         return False
 
     def initialize_bmc(self):
-        from .bmc import BMC
         if self._bmc_initialized:
             return
+        from .bmc import BMC
         self._bmc = BMC.get_instance()
         if self._bmc is not None:
             try:

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -933,7 +933,6 @@ class Chassis(ChassisBase):
 
         # Initialize BMC and its components
         if DeviceDataManager.is_platform_with_bmc():
-            from .bmc import BMC
             self.initialize_bmc()
 
     def get_num_components(self):
@@ -1230,6 +1229,7 @@ class Chassis(ChassisBase):
         return False
 
     def initialize_bmc(self):
+        from .bmc import BMC
         if self._bmc_initialized:
             return
         self._bmc = BMC.get_instance()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it

After lazy BMC initialization (#26901), `from .bmc import BMC` lived only inside `initialize_components()`. `initialize_bmc()` still calls `BMC.get_instance()` in the chassis module scope, so `BMC` was never defined there. That breaks BMC CLIs on OpenBMC platforms, for example:

- `sudo show platform bmc summary` → `Error retrieving BMC information: name 'BMC' is not defined`
- `sudo show platform bmc eeprom` → `Error retrieving BMC EEPROM information: name 'BMC' is not defined`

The import must run in the function that uses `BMC`, while keeping lazy load so non-BMC platforms do not pull in BMC/Redfish at chassis import time.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Moved `from .bmc import BMC` from `initialize_components()` into `initialize_bmc()` in `platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py`.
- Left the `DeviceDataManager.is_platform_with_bmc()` gate in `initialize_components()` unchanged; only the import site moved.
- Lazy-load behavior is unchanged: `bmc.py` is still loaded only when BMC initialization runs on BMC-capable platforms.

#### How to verify it

1. **Unit tests** (from repo root):
   ```bash
   cd platform/mellanox/mlnx-platform-api
   pytest tests/test_chassis.py tests/test_bmc.py -v
  ```

2. **On a BMC-capable DUT** (e.g. SN6600 LD with bmc.json present):

  ```bash
  sudo show platform bmc summary
  sudo show platform bmc eeprom
  ```

Expect BMC fields (manufacturer, model, serial, etc.), not name 'BMC' is not defined.



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

