### PR TITLE
Fix system manager protocol buffer race under parallel make

### DIFF
--- a/src/sonic-sysmgr/Makefile.am
+++ b/src/sonic-sysmgr/Makefile.am
@@ -13,7 +13,9 @@ rebootbackend_protobuf_compilation:
 		gnoi/common/common.proto \
 		gnoi/system/system.proto
 
-rebootbackend_dbus_compilation: build/gen/librebootgnoi.la
+# protoc outputs are not inferred from rebootbackend_protobuf_compilation;
+# with -jN, libtool can start *.pb.lo before protoc runs without these deps.
+rebootbackend_dbus_compilation: rebootbackend_protobuf_compilation build/gen/librebootgnoi.la
 	/usr/bin/dbusxx-xml2cpp rebootbackend/reboot.xml \
 		--proxy=rebootbackend/reboot_dbus.h
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it

Parallel `make -jN` builds of `sonic-sysmgr` could fail intermittently because libtool started compiling generated protobuf sources (`*.pb.lo`) before `protoc` had produced them. Automake does not infer that dependency from the custom `rebootbackend_protobuf_compilation` target, so the build was racy under high job counts.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- In `src/sonic-sysmgr/Makefile.am`, declared that all `librebootgnoi` protobuf sources depend on `rebootbackend_protobuf_compilation`, so `protoc` always runs first.
- Made `rebootbackend_dbus_compilation` depend on `rebootbackend_protobuf_compilation` as well, so D-Bus code generation does not run ahead of protobuf generation.

#### How to verify it

- Build the sysmgr package with parallel jobs, e.g. from the sonic-buildimage tree:
  `make target/sysmgr_1.0.0_<arch>.deb -j$(nproc)`
- Repeat the build several times (or run `make clean` in `src/sonic-sysmgr` and rebuild with `-j$(nproc)`) to confirm protobuf outputs are always generated before `*.pb.lo` compilation and the race no longer occurs.
- Optionally verify the resulting `sysmgr` package installs and the reboot backend / gNOI path still works on a DUT after upgrade.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

