### PR TITLE
frrcfgd: create unnumbered BGP neighbors and peer-groups from CONFIG_DB

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2187,6 +2187,12 @@ class BGPConfigDaemon:
         self.bgp_peer_group = {}
         # VRF ==> set of interface neighbor
         self.bgp_intf_nbr = {}
+        # VRF ==> set of peer-groups / interface neighbors this frrcfgd
+        # instance has actually created in FRR. Used only to gate the
+        # one-time 'neighbor <name> peer-group' / 'neighbor <ifname>
+        # interface' create commands. NOT seeded from CONFIG_DB: CONFIG_DB
+        # is the desired config, not proof the object exists in FRR yet.
+        self.bgp_pg_created = {}
         nbr_table = self.config_db.get_table('BGP_NEIGHBOR')
         pg_table = self.config_db.get_table('BGP_PEER_GROUP')
         for key, entry in pg_table.items():
@@ -2203,8 +2209,12 @@ class BGPConfigDaemon:
                     self.bgp_peer_group[vrf][pg_name].ref_nbrs.add(peer)
                     syslog.syslog(syslog.LOG_DEBUG, 'Init Config DB Data: VRF %s Neighbor %s Peer_Group %s' %
                             (vrf, peer, pg_name))
-            if not self.__peer_is_ip(peer):
-                self.bgp_intf_nbr.setdefault(vrf, set()).add(peer)
+            # Do not pre-seed bgp_intf_nbr from CONFIG_DB here. On a from-
+            # scratch boot (empty FRR) that would make the apply path skip
+            # the 'neighbor <ifname> interface' create, so the following
+            # 'neighbor <ifname> remote-as ...' is rejected by FRR with
+            # '% Create the peer-group or interface first'. The apply path
+            # creates and records each interface neighbor instead.
         # map_name ==> seq_no ==> operation
         self.route_map = {}
         rtmap_table = self.config_db.get_table('ROUTE_MAP')
@@ -2796,14 +2806,17 @@ class BGPConfigDaemon:
                 if not del_table:
                     if is_peer_group:
                         # if peer group is not created, create it before setting other attributes
-                        if key not in self.bgp_peer_group.setdefault(vrf, {}):
+                        if key not in self.bgp_pg_created.setdefault(vrf, set()):
                             command = ['vtysh', '-c', 'configure terminal',
                                        '-c', 'router bgp {} vrf {}'.format(local_asn, vrf),
                                        '-c', 'neighbor {} peer-group'.format(key)]
                             if not self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_ERR, 'failed to create peer-group %s for VRF %s' % (key, vrf))
                                 continue
-                            self.bgp_peer_group[vrf][key] = BGPPeerGroup(vrf)
+                            self.bgp_pg_created[vrf].add(key)
+                            # keep any existing BGPPeerGroup (and its ref_nbrs);
+                            # only create a new model object if absent
+                            self.bgp_peer_group.setdefault(vrf, {}).setdefault(key, BGPPeerGroup(vrf))
                     elif not self.__peer_is_ip(key):
                         if key not in self.bgp_intf_nbr.setdefault(vrf, set()):
                             command = ['vtysh', '-c', 'configure terminal',

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2494,6 +2494,8 @@ class BGPConfigDaemon:
 
     def __delete_vrf_neighbor(self, vrf, peer, data, is_peer_grp):
         if is_peer_grp:
+            if vrf in self.bgp_pg_created:
+                self.bgp_pg_created[vrf].discard(peer)
             if vrf in self.bgp_peer_group and peer in self.bgp_peer_group[vrf]:
                 del(self.bgp_peer_group[vrf][peer])
         else:


### PR DESCRIPTION
#### Why I did it

In `frr_mgmt_framework` mode, `frrcfgd` does not create unnumbered (interface-based) BGP neighbors or their peer-groups from CONFIG_DB when FRR starts from an empty / freshly-provisioned state. The `BGP_NEIGHBOR` entries are present, but `router bgp` ends up with no working neighbors. Full root-cause analysis in #27723.

`frrcfgd.__init__` pre-seeds its "already created in FRR" trackers (`bgp_intf_nbr`, `bgp_peer_group`) from CONFIG_DB, so the one-time create commands are skipped on a cold boot and the following `neighbor <ifname> remote-as ...` is rejected by FRR with `% Create the peer-group or interface first`. It is masked on in-service switches because FRR loads its persisted config before frrcfgd starts.

Fixes #27723. Related to #26960 (same capability gap in `bgpcfgd`).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Do not treat "present in CONFIG_DB" as "already created in FRR":

- Do not pre-seed `bgp_intf_nbr` from CONFIG_DB; the apply path creates and records each interface neighbor.
- Gate peer-group creation on a new `bgp_pg_created` set (empty at init) instead of the `bgp_peer_group` model dict, so the create runs while the model dict and its `ref_nbrs` stay intact.

The create commands (`neighbor <ifname> interface`, `neighbor <name> peer-group`) are idempotent in FRR.

#### How to verify it

On a switch with `frr_mgmt_framework_config: true`, configure an unnumbered neighbor purely via CONFIG_DB (no pre-existing `frr.conf`):

```
sonic-db-cli CONFIG_DB hset 'BGP_PEER_GROUP|default|PG_V6' admin_status up
sonic-db-cli CONFIG_DB hset 'BGP_NEIGHBOR|default|PortChannel1' asn 64999 peer_group_name PG_V6
```

- Before: `show ip bgp summary` shows no working neighbor; syslog has `failed running FRR command: neighbor PortChannel1 remote-as ...`.
- After: bgpd running-config contains `neighbor PortChannel1 interface peer-group PG_V6` and the neighbor is programmed.

Regression checks performed:

- **Warm restart / no flap:** with established unnumbered sessions, restarting `frrcfgd` repeatedly (which now re-issues the idempotent create commands) did not reset peer uptime or change received-prefix counts. Re-creating existing interface peers / peer-groups does not flap sessions.
- **Create + delete:** creating and deleting an interface neighbor and a peer-group via CONFIG_DB both applied and removed cleanly (`neighbor ... interface` / `neighbor ... peer-group` created; `no neighbor ...` on delete).

#### Which release branch to backport

- [x] 202511

#### Tested branch (Please provide the tested image version)

- master (frrcfgd `frr_mgmt_framework` daemon)

#### Description for the changelog

frrcfgd: create unnumbered (interface) BGP neighbors and peer-groups from CONFIG_DB on a fresh boot

#### A picture of a cute animal (not mandatory but encouraged)

https://upload.wikimedia.org/wikipedia/commons/3/3a/Cat03.jpg
