### PR TITLE
pddf_psu_driver_module: reduce i2c retries and wait time between retries

### DIFF
--- a/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
+++ b/platform/pddf/i2c/modules/psu/driver/pddf_psu_api.c
@@ -165,7 +165,7 @@ int psu_update_attr(struct device *dev, struct psu_attr_info *data, PSU_DATA_ATT
 
 static u8 psu_get_vout_mode(struct i2c_client *client)
 {
-    u8 status = 0, retry = 10;
+    u8 status = 0, retry = 2;
     uint8_t offset = PSU_REG_VOUT_MODE;
 
     while (retry)
@@ -173,7 +173,7 @@ static u8 psu_get_vout_mode(struct i2c_client *client)
         status = i2c_smbus_read_byte_data((struct i2c_client *)client, offset);
         if (unlikely(status < 0)) 
         {
-            msleep(60);
+            msleep(1);
             retry--;
             continue;
         }
@@ -513,7 +513,7 @@ ret:
 
 int sonic_i2c_get_psu_block_default(void *client, PSU_DATA_ATTR *adata, void *data)
 {
-    int status = 0, retry = 10;
+    int status = 0, retry = 2;
     struct psu_attr_info *padata = (struct psu_attr_info *)data;
     char buf[32]="";  //temporary placeholder for block data
     uint8_t offset = (uint8_t)adata->offset;
@@ -549,7 +549,7 @@ int sonic_i2c_get_psu_block_default(void *client, PSU_DATA_ATTR *adata, void *da
 
         if (unlikely(status<0))
         {
-            msleep(60);
+            msleep(1);
             retry--;
             continue;
         }
@@ -582,14 +582,14 @@ int sonic_i2c_get_psu_block_default(void *client, PSU_DATA_ATTR *adata, void *da
 int sonic_i2c_get_psu_word_default(void *client, PSU_DATA_ATTR *adata, void *data)
 {
 
-    int status = 0, retry = 10;
+    int status = 0, retry = 2;
     struct psu_attr_info *padata = (struct psu_attr_info *)data;
     uint8_t offset = (uint8_t)adata->offset;
 
     while (retry) {
         status = i2c_smbus_read_word_data((struct i2c_client *)client, offset);
         if (unlikely(status < 0)) {
-            msleep(60);
+            msleep(1);
             retry--;
             continue;
         }


### PR DESCRIPTION
#### Why I did it
Resolves #27784

There is an excessive number of retries and waits for NACK'ed PMBus transactions in pddf. This causes lm-sensors to take an additional ~35s per run for each missing PSU on the system. 

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it
Using DUT with 1 missing PSU, time the lm-sensors read command.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

- [x] master
- [x] 202605

#### Test result
- Nexthop internal master build
```
time sensors
# With changes from PR (image SONiC.main.Nexthop.85654-c601a70df7)
real    0m6.315s
user    0m0.012s
sys     0m0.005s

# Without changes from PR
real    0m36.931s
user    0m0.016s
sys     0m0.003s
```
- Nexthop internal 202605 build
```
# With changes from PR (image SONiC.202605.Nexthop.163921-dadc4131e1)
real    0m6.286s
user    0m0.009s
sys     0m0.006s

# Without changes from PR
real    0m39.391s
user    0m0.001s
sys     0m0.016s
```

#### Description for the changelog
pddf_psu_driver_module: reduce i2c retries and wait time between retries

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

