### PR TITLE
Tell p4lang to use protobuf and grpcio installed via pip

### DIFF
--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -521,8 +521,6 @@ RUN eatmydata apt-get install -y \
         libprotoc-dev \
         protobuf-compiler-grpc \
         valgrind \
-        python3-protobuf \
-        python3-grpcio \
         thrift-compiler \
         gfortran \
         libopenmpi-dev \

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -10,6 +10,7 @@ $(addprefix $(DEST)/, $(P4LANG_TARGET)): $(DEST)/% :
 	dget -u p4lang-pi_$(P4LANG_PI_VERSION_FULL).dsc http://download.opensuse.org/repositories/home:/p4lang/Debian_11/p4lang-pi_$(P4LANG_PI_VERSION_FULL).dsc
 	pushd p4lang-pi-$(P4LANG_PI_VERSION)
 	patch -p1 -i ../p4lang-pi.patch/use-boost-1.83.patch
+	patch -p1 -i ../p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else
@@ -44,6 +45,7 @@ $(addprefix $(DEST)/, $(P4LANG_P4C_TARGET)): $(DEST)/% :
 	patch -p1 -i ../p4lang-p4c.patch/use-boost-1.83.patch
 	patch -p1 -i ../p4lang-p4c.patch/fix-build-for-boost-1.83.patch
 	patch -p1 -i ../p4lang-p4c.patch/update-thrift-dependency.patch
+	patch -p1 -i ../p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/p4lang/Makefile
+++ b/src/p4lang/Makefile
@@ -11,6 +11,7 @@ $(addprefix $(DEST)/, $(P4LANG_TARGET)): $(DEST)/% :
 	pushd p4lang-pi-$(P4LANG_PI_VERSION)
 	patch -p1 -i ../p4lang-pi.patch/use-boost-1.83.patch
 	patch -p1 -i ../p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
+	patch -p1 -i ../p4lang-pi.patch/remove-init-file.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -us -uc -b -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/p4lang/p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
+++ b/src/p4lang/p4lang-p4c.patch/remove-protobuf-from-debian-dependency.patch
@@ -1,0 +1,34 @@
+Don't depend on Debian's version of the Python 3 protobuf package. Instead,
+have it use the version that we install with pip. This is so that there's a
+single copy of the protobuf package present in the slave container and the
+installed environment.
+
+Index: p4lang-p4c-1.2.4.2/debian/control
+===================================================================
+--- p4lang-p4c-1.2.4.2.orig/debian/control
++++ p4lang-p4c-1.2.4.2/debian/control
+@@ -23,10 +23,8 @@ Build-Depends:
+     iproute2,
+     net-tools,
+     python3-all,
+-    python3-grpcio,
+     python3-pyroute2,
+     python3-ply,
+-    python3-protobuf,
+     python3-scapy,
+     python3-setuptools,
+     python3-thrift,
+@@ -64,13 +62,11 @@ Depends:
+     clang,
+     iproute2,
+     net-tools,
+-    python3-grpcio,
+     python3-pyroute2,
+     python3-ply,
+     python3-scapy,
+     python3-setuptools,
+     python3-thrift,
+-    python3-protobuf,
+     libprotobuf-dev,
+     libprotoc-dev,
+     protobuf-compiler,

--- a/src/p4lang/p4lang-pi.patch/remove-init-file.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-init-file.patch
@@ -1,0 +1,10 @@
+Index: p4lang-pi-0.1.0/debian/rules
+===================================================================
+--- p4lang-pi-0.1.0.orig/debian/rules
++++ p4lang-pi-0.1.0/debian/rules
+@@ -33,3 +33,5 @@ override_dh_auto_install:
+ 	dh_auto_install -- DESTDIR=$(CURDIR)/debian/p4lang-pi install
+ 	find $(CURDIR)/debian/p4lang-pi -name "*.pyc" | xargs rm -f
+ 	find $(CURDIR)/debian/p4lang-pi -name "*.pyo" | xargs rm -f
++	# Workaround to encourage/force the use of the pip-installed protobuf library
++	rm -f $(CURDIR)/debian/p4lang-pi/usr/lib/python3/dist-packages/google/__init__.py

--- a/src/p4lang/p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
+++ b/src/p4lang/p4lang-pi.patch/remove-protobuf-from-debian-dependency.patch
@@ -1,0 +1,22 @@
+Don't depend on Debian's version of the Python 3 protobuf package. Instead,
+have it use the version that we install with pip. This is so that there's a
+single copy of the protobuf package present in the slave container and the
+installed environment.
+
+Index: p4lang-pi-0.1.0/debian/control
+===================================================================
+--- p4lang-pi-0.1.0.orig/debian/control
++++ p4lang-pi-0.1.0/debian/control
+@@ -43,11 +43,9 @@ Depends:
+     libprotobuf-dev,
+     libprotoc-dev,
+     protobuf-compiler,
+-    python3-protobuf,
+     libgrpc++-dev,
+     libgrpc-dev,
+-    protobuf-compiler-grpc,
+-    python3-grpcio
++    protobuf-compiler-grpc
+ Description: Implementation framework of a P4Runtime server
+  Protocol Independent API (PI or P4 Runtime) defines a set of APIs that allow
+  interacting with entities defined in a P4 program.


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When building the KVM image, there is a chance that the ycabled tests fail because some protobuf import cannot be resolved. This is happening as a side effect of p4lang using the protobuf package installed from Debian (which is a different version than the one installed from pip) and also installing an `__init__.py` file into the system-wide `google` module namespace (as opposed to the one in `/usr/local/lib/python3/`), because it's installing some additional modules under that namespace.

Fixes #27737

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

To fix this, don't install python3-protobuf and python3-grpcio from Debian, so that only the version that we install via pip is available in the build environment. Additionally, modify the dependencies for the p4lang packages to not depend on these two packages.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

