### PR TITLE
Add HLD for ZMQ southbound SAI notification handling

### DIFF
--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -1,0 +1,516 @@
+# HLD: SAI Notification Handling with ZMQ Southbound
+
+## 1. Background
+
+SONiC recently added support for ZMQ southbound communication between `orchagent` and `syncd` for regular switches. This is controlled by:
+
+```text
+DEVICE_METADATA|localhost.orch_southbound_zmq_enabled = true
+```
+
+The current issue is tracked in sonic-buildimage issue #27541. An initial short-term implementation is proposed in sonic-swss PR #4619.
+
+In non-ZMQ mode, SAI notifications are published by `syncd` into Redis `ASIC_DB:NOTIFICATIONS`. `orchagent` consumes those notifications from Redis in its normal main loop and dispatches them to the appropriate Orch components.
+
+In ZMQ mode, `syncd` sends notifications to `orchagent` through ZMQ. These notifications arrive in `orchagent` callback functions. Some callbacks already forward notifications to Redis, such as `on_port_state_change()`, but several callbacks are currently empty or incomplete. As a result, some notifications are dropped when ZMQ southbound is enabled.
+
+## 2. Problem Statement
+
+When ZMQ southbound is enabled, the following SAI notifications may not reach their existing Orch consumers:
+
+- `fdb_event`
+- `bfd_session_state_change`
+- `port_host_tx_ready`
+- `icmp_echo_session_state_change`
+
+Additional notification types may also need review, depending on platform and feature coverage.
+
+Expected consumers include:
+
+- `FdbOrch`
+- `BfdOrch`
+- `PortsOrch`
+- `IcmpOrch`
+
+Without a fix:
+
+- Hardware-learned MAC entries may not propagate to `FdbOrch`.
+- BFD session state transitions may not reach `BfdOrch`.
+- Port host TX readiness may not reach `PortsOrch`.
+- ICMP echo session monitoring may not reach `IcmpOrch`.
+
+## 3. Existing Notification Flows
+
+### 3.1 Non-ZMQ Mode
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> RedisNotificationProducer
+  -> ASIC_DB:NOTIFICATIONS
+  -> orchagent Redis consumer
+  -> orchagent main loop
+  -> Orch handler
+```
+
+This is the existing proven notification path.
+
+### 3.2 ZMQ Mode Today
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> ZeroMQNotificationProducer
+  -> orchagent ZMQ notification callback
+  -> callback-specific logic
+```
+
+The issue is that some callback-specific logic is missing.
+
+Example:
+
+```text
+on_port_state_change()
+  -> forwards to ASIC_DB:NOTIFICATIONS
+  -> works today
+
+on_fdb_event()
+on_bfd_session_state_change()
+on_port_host_tx_ready()
+IcmpSaiSessionHandler::on_state_change()
+  -> empty or incomplete
+  -> notification may be dropped
+```
+
+## 4. Design Goals
+
+- Preserve existing non-ZMQ behavior.
+- Restore missing notifications in ZMQ mode.
+- Avoid duplicate notification delivery.
+- Preserve existing Orch handler behavior.
+- Avoid unsafe direct access to Orch state from callback context.
+- Keep the immediate fix low risk.
+- Identify a cleaner long-term architecture.
+
+## 5. Design Options
+
+## Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode
+
+### Description
+
+In this option, `syncd` would use `RedisNotificationProducer` for SAI notifications even when southbound ZMQ is enabled.
+
+Important clarification: `RedisNotificationProducer` already exists and is used in the non-ZMQ notification path. The new behavior would be to instantiate/use it in the ZMQ-mode notification path as well, instead of using the ZMQ notification producer path for SAI notifications.
+
+### Flow
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> RedisNotificationProducer
+  -> ASIC_DB:NOTIFICATIONS
+  -> orchagent Redis consumer
+  -> orchagent main loop
+  -> Orch handler
+```
+
+### Implementation Idea
+
+Option 1 would change the ZMQ-mode notification producer selection in `syncd` from:
+
+```cpp
+m_notifications = std::make_shared<ZeroMQNotificationProducer>(m_contextConfig->m_zmqNtfEndpoint);
+```
+
+to:
+
+```cpp
+m_notifications = std::make_shared<RedisNotificationProducer>(m_contextConfig->m_dbAsic);
+```
+
+The command/request channel would still use `ZeroMQSelectableChannel` when ZMQ mode is enabled.
+
+### Pros
+
+- Reuses the existing Redis notification path.
+- Existing Orch consumers continue unchanged.
+- Minimal `orchagent` callback changes.
+
+### Cons
+
+- Makes ZMQ mode asymmetric:
+  - requests/responses use ZMQ
+  - notifications use Redis
+- Changes `syncd` ZMQ notification semantics.
+- May introduce ordering differences between ZMQ command processing and Redis notifications.
+- Moves notification transport policy into `syncd`.
+- If both Redis and ZMQ notification producers are used, duplicate notifications must be avoided.
+
+## Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`
+
+### Description
+
+In this option, `syncd` continues to send notifications to `orchagent` through ZMQ. The ZMQ callback in `orchagent` receives the notification and re-publishes it into `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled.
+
+This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in sonic-swss PR #4619.
+
+### Flow
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> ZeroMQNotificationProducer
+  -> orchagent ZMQ callback
+  -> NotificationProducer in orchagent
+  -> ASIC_DB:NOTIFICATIONS
+  -> orchagent Redis consumer
+  -> orchagent main loop
+  -> Orch handler
+```
+
+### Pseudo-code
+
+```cpp
+void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
+{
+    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        return;
+    }
+
+    static thread_local swss::DBConnector db("ASIC_DB", 0);
+    static thread_local swss::NotificationProducer producer(&db, "NOTIFICATIONS");
+
+    std::string payload = sai_serialize_fdb_event_ntf(count, data);
+    std::vector<swss::FieldValueTuple> values;
+
+    producer.send(SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT, payload, values);
+}
+```
+
+### Pros
+
+- Lowest risk short-term fix.
+- No `syncd` change.
+- Keeps ZMQ transport between `syncd` and `orchagent`.
+- Reuses existing Orch Redis notification processing path.
+- Follows existing `on_port_state_change()` behavior.
+- Can be implemented and validated event-by-event.
+
+### Cons
+
+- Adds an extra Redis hop after ZMQ delivery.
+- Slightly higher latency than direct/in-process handling.
+- Still depends on Redis internally for notification dispatch.
+- Does not provide the cleanest long-term ZMQ notification model.
+
+## Option 3: Directly Invoke Orch Logic from Callback
+
+### Description
+
+In this option, the ZMQ callback directly invokes the relevant Orch handling logic instead of re-posting to Redis.
+
+### Flow
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> ZeroMQNotificationProducer
+  -> orchagent ZMQ callback
+  -> direct Orch handler call
+```
+
+### Pseudo-code
+
+```cpp
+void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
+{
+    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        return;
+    }
+
+    std::string payload = sai_serialize_fdb_event_ntf(count, data);
+
+    gFdbOrch->handleNotification(
+        SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT,
+        payload,
+        {});
+}
+```
+
+### Pros
+
+- Avoids Redis re-posting.
+- Lower theoretical latency.
+- Direct data path.
+- Can be optimized event-by-event.
+
+### Cons
+
+- Higher concurrency risk.
+- Notification handling runs in the sairedis/ZMQ channel notification thread instead of the normal `orchagent` main loop.
+- Existing Orch code may assume single-threaded main-loop execution.
+- Requires thread-safety validation per notification type.
+- More invasive and harder to prove safe.
+
+## Option 4: In-process Notification Queue Drained by Orch Main Loop
+
+### Description
+
+In this option, the ZMQ callback does not re-post to Redis and does not directly invoke Orch logic. Instead, the callback packages the notification and enqueues it into an internal `orchagent` notification queue. The normal `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
+
+### Flow
+
+```text
+Vendor SAI
+  -> syncd SAI callback
+  -> syncd NotificationProcessor
+  -> RID-to-VID translation
+  -> ZeroMQNotificationProducer
+  -> orchagent ZMQ callback
+  -> in-process notification queue
+  -> orchagent main loop
+  -> common notification dispatcher
+  -> Orch handler
+```
+
+### Relationship to Existing Redis Path
+
+```text
+Existing Redis path:
+ASIC_DB:NOTIFICATIONS
+  -> Redis consumer
+  -> common dispatcher
+  -> Orch handler
+
+New ZMQ path:
+ZMQ callback
+  -> in-process notification queue
+  -> common dispatcher
+  -> Orch handler
+```
+
+Both paths should converge into common dispatch logic.
+
+### Pseudo-code
+
+```cpp
+struct SaiNotification
+{
+    std::string name;
+    std::string payload;
+    std::vector<swss::FieldValueTuple> values;
+};
+```
+
+```cpp
+class SaiNotificationQueue
+{
+public:
+    void enqueue(SaiNotification notification)
+    {
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            m_queue.push(std::move(notification));
+        }
+
+        notifyMainLoop();
+    }
+
+    bool tryDequeue(SaiNotification &notification)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (m_queue.empty())
+        {
+            return false;
+        }
+
+        notification = std::move(m_queue.front());
+        m_queue.pop();
+        return true;
+    }
+
+private:
+    std::mutex m_mutex;
+    std::queue<SaiNotification> m_queue;
+    SelectableEvent m_wakeupEvent;
+
+    void notifyMainLoop()
+    {
+        m_wakeupEvent.notify();
+    }
+};
+```
+
+`notifyMainLoop()` represents a wakeup mechanism for the existing `orchagent` main loop. The implementation could use an `eventfd`, pipe, `SelectableEvent`, or an existing swss selectable wakeup primitive. The important requirement is that enqueueing a notification makes a selectable object readable so `OrchDaemon::start()` wakes immediately.
+
+Callback:
+
+```cpp
+void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
+{
+    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    {
+        return;
+    }
+
+    SaiNotification notification;
+    notification.name = SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT;
+    notification.payload = sai_serialize_fdb_event_ntf(count, data);
+
+    gSaiNotificationQueue.enqueue(std::move(notification));
+}
+```
+
+Main-loop integration:
+
+Option 4 should integrate with the existing `OrchDaemon::start()` `Select` loop through a new `Selectable`/`Executor`, not by directly calling Orch logic from the ZMQ callback.
+
+```text
+ZMQ notification thread
+  -> orchagent callback
+  -> enqueue notification into in-process queue
+  -> notifyMainLoop()
+  -> wake OrchDaemon select loop
+  -> queue executor execute()
+  -> drain queued notifications
+  -> common notification dispatcher
+  -> Orch handler
+```
+
+The existing main loop already waits on selectable executors:
+
+```cpp
+void OrchDaemon::start(long heartBeatInterval)
+{
+    for (Orch *o : m_orchList)
+    {
+        m_select->addSelectables(o->getSelectables());
+    }
+
+    while (true)
+    {
+        Selectable *s;
+        int ret = m_select->select(&s, SELECT_TIMEOUT);
+
+        if (ret == Select::OBJECT)
+        {
+            auto *executor = static_cast<Executor *>(s);
+            executor->execute();
+        }
+    }
+}
+```
+
+The queued ZMQ notification path would add a new executor to this same model:
+
+```cpp
+class SaiNotificationQueueExecutor : public Executor
+{
+public:
+    void execute() override
+    {
+        m_queue.clearWakeupEvent();
+
+        SaiNotification notification;
+        while (m_queue.tryDequeue(notification))
+        {
+            dispatchSaiNotification(notification);
+        }
+    }
+};
+```
+
+During `orchagent` initialization:
+
+```cpp
+Orch::addExecutor(new SaiNotificationQueueExecutor(...));
+```
+
+The conceptual equivalent is:
+
+```cpp
+void processQueuedZmqNotifications()
+{
+    SaiNotification notification;
+
+    while (gSaiNotificationQueue.tryDequeue(notification))
+    {
+        dispatchSaiNotification(notification);
+    }
+}
+```
+
+Common dispatcher:
+
+```cpp
+void OrchDaemon::dispatchSaiNotification(const SaiNotification &notification)
+{
+    if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
+    {
+        gFdbOrch->handleNotification(notification.name, notification.payload, notification.values);
+    }
+    else if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_PORT_STATE_CHANGE)
+    {
+        gPortsOrch->handleNotification(notification.name, notification.payload, notification.values);
+    }
+    else if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_BFD_SESSION_STATE_CHANGE)
+    {
+        gBfdOrch->handleNotification(notification.name, notification.payload, notification.values);
+    }
+}
+```
+
+### Note on `on_port_state_change()`
+
+If Option 4 becomes the long-term architecture, existing ZMQ callbacks that currently re-post to Redis, such as `on_port_state_change()`, should eventually be migrated to the queue-based model too.
+
+Short-term:
+
+```text
+on_port_state_change()
+  -> Redis re-post
+```
+
+Long-term:
+
+```text
+on_port_state_change()
+  -> in-process queue
+```
+
+### Pros
+
+- Avoids Redis re-posting.
+- Reduces Redis load.
+- Lower latency than Option 2.
+- Preserves Orch main-loop execution model.
+- Lower concurrency risk than direct callback handling.
+- Cleaner long-term architecture.
+- Can support event-by-event migration.
+
+### Cons
+
+- Requires new queue and wakeup infrastructure in `orchagent`.
+- Requires clear ordering and fairness rules between queued ZMQ notifications, Redis notifications, timers, and other Orch tasks.
+- Requires backpressure behavior.
+- Requires lifecycle handling for the shared queue and wakeup mechanism during startup, shutdown, and callback teardown.
+- More implementation and test effort than Option 2.
+- Larger design review scope.
+
+## 6. References
+
+- sonic-buildimage issue #27541: Missing notification forwarding for FDB/BFD when ZMQ southbound is enabled
+- sonic-swss PR #4619: Forward SAI notifications to Redis in ZMQ southbound mode

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -77,8 +77,7 @@ flowchart TD
             redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask() / handler"]
-            orchHandler["Target Orch handler"]
+            orchHandler["Target Orch<br/>notification handler"]
         end
     end
 
@@ -89,8 +88,7 @@ flowchart TD
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier --> redisDoTask
-    redisDoTask --> orchHandler
+    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
 ```
 
 The non-ZMQ notification path has three main execution hops:
@@ -128,8 +126,7 @@ flowchart TD
             redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask() / handler"]
-            orchHandler["Target Orch handler"]
+            orchHandler["Target Orch<br/>notification handler"]
         end
     end
 
@@ -145,8 +142,7 @@ flowchart TD
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier --> redisDoTask
-    redisDoTask --> orchHandler
+    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
 
     callbackLogic -->|"for switch shutdown or<br/>ASIC SDK health"| directHandler
     directHandler --> orchHandler
@@ -266,8 +262,7 @@ flowchart TD
             redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask() / handler"]
-            orchHandler["Target Orch handler"]
+            orchHandler["Target Orch<br/>notification handler"]
         end
     end
 
@@ -281,8 +276,7 @@ flowchart TD
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier --> redisDoTask
-    redisDoTask --> orchHandler
+    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
 ```
 
 In Option 2, the ZMQ notification reaches the `orchagent` libsairedis callback, and the callback re-posts the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled. After the re-post, the existing Redis notification path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
@@ -328,7 +322,7 @@ Note: The callback must check whether ZMQ mode is enabled before re-publishing t
 
 ### Description
 
-In this option, the `orchagent` libsairedis callback packages the notification and makes it available to the main loop through an in-process notification queue. The `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
+In this option, the `orchagent` libsairedis callback packages the notification as an operation name, serialized payload, and optional field-value list, then makes it available to the main loop through an in-process notification queue. The `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
 
 This model is similar in spirit to existing selectable-based processing such as `ZmqConsumerStateTable`, where data availability wakes the main loop and processing happens through an executor path.
 
@@ -351,8 +345,8 @@ flowchart TD
             selectableEvent["new SAI notification queue<br/>selectable"]
             mainLoop["orchagent main Select loop"]
             queueExecutor["SaiNotification<br/>QueueExecutor"]
-            dispatcher["dispatchSaiNotification()"]
-            orchHandler["Target Orch handler"]
+            dispatcher["SAI notification handler<br/>registry"]
+            orchHandler["Target Orch<br/>notification handler"]
         end
     end
 
@@ -367,7 +361,7 @@ flowchart TD
     selectableEvent -->|"queued notification<br/>available"| mainLoop
     mainLoop --> queueExecutor
     queueExecutor --> dispatcher
-    dispatcher --> orchHandler
+    dispatcher -->|"registered op handler"| orchHandler
 ```
 
 ### Option 3 Sequence
@@ -421,30 +415,30 @@ sequenceDiagram
         participant Wakeup as new SAI notification queue selectable
         participant MainLoop as OrchDaemon::start Select loop
         participant Executor as SaiNotificationQueueExecutor::execute()
-        participant Dispatcher as dispatchSaiNotification()
+        participant Dispatcher as SAI notification handler registry
         participant Orch as Target Orch handler
     end
 
-    Callback->>Queue: 1. enqueue SaiNotification
+    Callback->>Queue: 1. enqueue op, serialized data, values
     Callback->>Wakeup: 2. notify queue selectable
     Wakeup->>MainLoop: 3. queued notification available
     MainLoop->>Executor: 4. dispatch executor
     Executor->>Queue: 5. pops queued notifications
-    Executor->>Dispatcher: 6. dispatch notification
-    Dispatcher->>Orch: 7. invoke target Orch handler
+    Executor->>Dispatcher: 6. dispatch queued notification by op
+    Dispatcher->>Orch: 7. invoke registered target Orch handler
 ```
 
 The main-loop processing sequence is:
 
 - The `orchagent` libsairedis callback runs in the ZMQ notification thread.
 
-1. The callback serializes/packages the notification as a `SaiNotification` and enqueues it into the in-process notification queue.
+1. The callback serializes/packages the notification as a `KeyOpFieldsValuesTuple`-compatible entry and enqueues it into the in-process notification queue.
 2. The callback notifies the new SAI notification queue selectable.
 3. The current `OrchDaemon::start()` `Select` loop is notified that queued notifications are available.
 4. The main loop dispatches `SaiNotificationQueueExecutor::execute()`.
 5. `SaiNotificationQueueExecutor::execute()` pops queued notifications from the in-process notification queue.
-6. The executor calls `dispatchSaiNotification()`.
-7. `dispatchSaiNotification()` routes the notification to the target Orch handler on the `orchagent` main-loop path.
+6. The executor dispatches each queued entry by notification op through a handler registry.
+7. The registry invokes the target Orch handler registered for that notification op on the `orchagent` main-loop path.
 
 ### Dispatch Relationship During Phased Migration to Option 3
 
@@ -460,32 +454,30 @@ flowchart TD
         redisConsumerReady["NotificationConsumer<br/>selectable ready"]
         redisMainLoop["orchagent main Select loop"]
         notifier["Notifier / Executor"]
-        redisDoTask["Orch doTask() / handler"]
     end
 
     subgraph option3Path["Option 3 queue-based path"]
         libsairedisCallback["orchagent libsairedis<br/>callback"]
         notificationQueue[["in-process<br/>notification queue"]]
         queueExecutor["SaiNotification<br/>QueueExecutor"]
-        option3Dispatch["dispatchSaiNotification()"]
+        dispatcher["SAI notification handler<br/>registry"]
     end
 
-    targetHandler["Target Orch handler"]
+    targetHandler["Target Orch<br/>notification handler"]
 
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> redisMainLoop
     redisMainLoop --> notifier
-    notifier --> redisDoTask
-    redisDoTask --> targetHandler
+    notifier -->|"doTask(NotificationConsumer&)"| targetHandler
 
     libsairedisCallback --> notificationQueue
     notificationQueue --> queueExecutor
-    queueExecutor --> option3Dispatch
-    option3Dispatch --> targetHandler
+    queueExecutor --> dispatcher
+    dispatcher -->|"registered op handler"| targetHandler
 
 ```
 
-Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` flow, while Option 3 uses the new queue-based executor path for migrated ZMQ notification types.
+Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` flow, while Option 3 uses the new queue-based executor path and dispatches queued notifications by op to registered target Orch handlers. The Redis and queue paths should share the same notification-specific handler logic where practical.
 
 ### Existing Code References
 
@@ -507,29 +499,27 @@ Selectable/executor integration:
 
 ### Implementation Notes
 
-The following snippets are high-level pseudo-code to illustrate the queue-based design; exact class names and integration points may change during implementation.
+The following snippets are high-level pseudo-code aligned with the proposed implementation. The queue stores the same shape used by existing swss notification consumers: operation name, serialized data, and optional field-value list.
+
+The queue and executor pattern is generic. Migrated callbacks enqueue into one shared `SaiNotificationQueue`. A queue executor drains that queue and dispatches each entry by operation name to a registered target Orch handler. The examples below use `FdbOrch` and `fdb_event`, but the same registry pattern applies to `BfdOrch`, `PortsOrch`, `IcmpOrch`, or other notification owners.
 
 ```cpp
-struct SaiNotification
-{
-    std::string name;
-    std::string payload;
-    std::vector<swss::FieldValueTuple> values;
-};
-```
-
-```cpp
-class SaiNotificationQueue : public Selectable
+class SaiNotificationQueue : public swss::Selectable
 {
 public:
-    void enqueue(SaiNotification notification)
+    SaiNotificationQueue(int pri = 100,
+                         size_t popBatchSize = swss::DEFAULT_NC_POP_BATCH_SIZE);
+
+    void enqueue(const std::string &op,
+                 std::string data,
+                 std::vector<swss::FieldValueTuple> values)
     {
         {
             std::lock_guard<std::mutex> lock(m_mutex);
-            m_queue.push(std::move(notification));
+            m_queue.emplace(std::move(data), op, std::move(values));
         }
 
-        notifyMainLoop();
+        m_selectableEvent.notify();
     }
 
     int getFd() override
@@ -553,49 +543,89 @@ public:
         return hasData();
     }
 
-    void pops(std::deque<SaiNotification> &notifications)
+    void pops(std::deque<swss::KeyOpFieldsValuesTuple> &entries)
     {
-        std::lock_guard<std::mutex> lock(m_mutex);
+        entries.clear();
 
-        notifications.clear();
-        while (!m_queue.empty())
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // Limit each drain to preserve main-loop fairness across ready executors.
+        const auto count = std::min(m_queue.size(), m_popBatchSize);
+        for (size_t i = 0; i < count; ++i)
         {
-            notifications.push_back(std::move(m_queue.front()));
+            entries.push_back(std::move(m_queue.front()));
             m_queue.pop();
+        }
+
+        if (!m_queue.empty())
+        {
+            m_selectableEvent.notify();
         }
     }
 
 private:
     std::mutex m_mutex;
-    std::queue<SaiNotification> m_queue;
-    SelectableEvent m_selectableEvent;
-
-    void notifyMainLoop()
-    {
-        m_selectableEvent.notify();
-    }
+    std::queue<swss::KeyOpFieldsValuesTuple> m_queue;
+    swss::SelectableEvent m_selectableEvent;
+    size_t m_popBatchSize;
 };
 ```
 
-`notifyMainLoop()` represents notifying the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model where practical, similar to `ZmqConsumerStateTable`, rather than introducing a separate main-loop mechanism. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the queue executor like other selectable executors.
+`m_selectableEvent.notify()` wakes the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model rather than introducing a separate main-loop mechanism. `ZmqConsumerStateTable` is one existing example of this wake-up pattern: data availability is represented through a selectable, and the main `Select` loop later dispatches an executor. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the queue executor like other selectable executors.
+
+The queue is created lazily so early notifications that arrive before the target Orch constructor registers its executor can still be queued instead of being dropped or sent through a Redis fallback path.
+
+```cpp
+SaiNotificationQueue *getSaiNotificationQueue()
+{
+    static std::mutex queueMutex;
+
+    std::lock_guard<std::mutex> lock(queueMutex);
+    // Create on first use so early callbacks can enqueue before executor setup.
+    if (gSaiNotificationQueue == nullptr)
+    {
+        gSaiNotificationQueue = new SaiNotificationQueue(
+            100, // pri -- match swss-common NotificationConsumer default
+            swss::DEFAULT_NC_POP_BATCH_SIZE);
+    }
+
+    return gSaiNotificationQueue;
+}
+
+void enqueueSaiNotification(const std::string &op,
+                            std::string data,
+                            std::vector<swss::FieldValueTuple> values)
+{
+    getSaiNotificationQueue()->enqueue(op, std::move(data), std::move(values));
+}
+```
 
 Callback:
 
 ```cpp
-void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
+void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data)
 {
-    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+    if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
     {
-        return;
+        std::string sdata = sai_serialize_fdb_event_ntf(count, data);
+        std::vector<swss::FieldValueTuple> values;
+
+        enqueueSaiNotification("fdb_event", std::move(sdata), std::move(values));
     }
-
-    SaiNotification notification;
-    notification.name = SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT;
-    notification.payload = sai_serialize_fdb_event_ntf(count, data);
-
-    gSaiNotificationQueue.enqueue(std::move(notification));
 }
 ```
+
+`fdb_event` is used here as an example because it is one of the notification types with missing ZMQ callback forwarding and is owned by `FdbOrch`. Other migrated callbacks, such as `bfd_session_state_change`, `port_host_tx_ready`, and `icmp_echo_session_state_change`, would enqueue into the same shared queue with their own operation names.
+
+For a notification type migrated to Option 3, the ZMQ-mode callback should enqueue to the in-process queue and should not re-post the same notification to `ASIC_DB:NOTIFICATIONS` as a fallback. Non-ZMQ mode continues to use the existing Redis notification path.
+
+The initial Option 3 coverage can be added by registering one handler per missing or incomplete notification:
+
+- `fdb_event`: `on_fdb_event()` enqueues the serialized FDB payload with op `fdb_event`; `FdbOrch` registers that op and reuses its FDB event parsing/state-update helper.
+- `bfd_session_state_change`: `on_bfd_session_state_change()` enqueues the serialized BFD session-state payload with op `bfd_session_state_change`; `BfdOrch` registers that op and reuses its BFD notification helper.
+- `port_host_tx_ready`: `on_port_host_tx_ready()` enqueues the serialized port host TX readiness payload with op `port_host_tx_ready`; `PortsOrch` registers that op and reuses or adds the corresponding port host TX readiness helper.
+- `icmp_echo_session_state_change`: `IcmpSaiSessionHandler::on_state_change()` enqueues the serialized ICMP echo session-state payload with op `icmp_echo_session_state_change`; `IcmpOrch` registers that op and reuses its ICMP session-state helper.
+
+This same mechanism also provides a migration path for existing Option 2-style callbacks. For example, if `port_state_change` is later migrated from Redis re-posting to Option 3, `on_port_state_change()` can switch from Redis re-posting to enqueueing op `port_state_change` into the shared queue. In addition to the `port_host_tx_ready` handler, `PortsOrch` can register a second queue-path handler for `port_state_change` that calls the `handlePortStateChangeNotification()` helper used by the existing Redis `NotificationConsumer` path for non-ZMQ mode.
 
 #### Main-loop Integration
 
@@ -606,24 +636,24 @@ flowchart TD
     subgraph zmqThreadContext["ZMQ notification thread context"]
         saiCallback["orchagent libsairedis<br/>callback"]
         enqueue["enqueue notification"]
-        notifyMainLoop["notifyMainLoop"]
+        selectableNotify["SelectableEvent notify"]
     end
 
     subgraph orchMainThread["orchagent main thread"]
         selectLoop["OrchDaemon::start<br/>Select loop"]
         queueExecutor["SaiNotification<br/>QueueExecutor::execute"]
         queueDrain["pops queued notifications"]
-        dispatcher["dispatchSaiNotification()"]
-        orchHandler["Target Orch handler"]
+        dispatcher["SAI notification handler<br/>registry"]
+        orchHandler["Target Orch<br/>notification handler"]
     end
 
     saiCallback --> enqueue
-    enqueue --> notifyMainLoop
-    notifyMainLoop -->|"queued notification<br/>available"| selectLoop
+    enqueue --> selectableNotify
+    selectableNotify -->|"queued notification<br/>available"| selectLoop
     selectLoop --> queueExecutor
     queueExecutor --> queueDrain
     queueDrain --> dispatcher
-    dispatcher --> orchHandler
+    dispatcher -->|"registered op handler"| orchHandler
 ```
 
 The existing main loop already waits on selectable executors:
@@ -650,42 +680,144 @@ void OrchDaemon::start(long heartBeatInterval)
 }
 ```
 
-The queued ZMQ notification path would add a new executor to this same model:
+The queued ZMQ notification path adds a new executor to this same model. The real `SaiNotificationQueue` is shared and kept for the lifetime of the `orchagent` process. However, `Executor` owns and deletes the `Selectable` object passed to it. To avoid giving ownership of the shared queue to the executor, the design passes a small `Selectable` adapter, `SaiNotificationQueueSelectable`, to `Executor`. The adapter is owned by the executor and forwards readiness checks to the shared `SaiNotificationQueue`.
 
 ```cpp
+class SaiNotificationQueueSelectable : public swss::Selectable
+{
+public:
+    explicit SaiNotificationQueueSelectable(SaiNotificationQueue *queue)
+        : m_queue(queue)
+    {
+    }
+
+    int getFd() override
+    {
+        return m_queue->getFd();
+    }
+
+    uint64_t readData() override
+    {
+        return m_queue->readData();
+    }
+
+    bool hasData() override
+    {
+        return m_queue->hasData();
+    }
+
+    bool hasCachedData() override
+    {
+        return m_queue->hasCachedData();
+    }
+
+private:
+    SaiNotificationQueue *m_queue;
+};
+
+class SaiNotificationDispatcher
+{
+public:
+    using Handler = std::function<void(swss::KeyOpFieldsValuesTuple &)>;
+
+    void registerHandler(const std::string &op, Handler handler)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_handlers[op] = std::move(handler);
+    }
+
+    void dispatch(swss::KeyOpFieldsValuesTuple &entry)
+    {
+        Handler handler;
+        auto op = kfvOp(entry);
+
+        {
+            std::lock_guard<std::mutex> lock(m_mutex);
+            auto handlerIt = m_handlers.find(op);
+            if (handlerIt != m_handlers.end())
+            {
+                handler = handlerIt->second;
+            }
+        }
+
+        if (handler)
+        {
+            handler(entry);
+        }
+    }
+
+private:
+    std::mutex m_mutex;
+    std::unordered_map<std::string, Handler> m_handlers;
+};
+
 class SaiNotificationQueueExecutor : public Executor
 {
 public:
+    SaiNotificationQueueExecutor(SaiNotificationQueue *queue,
+                                 Orch *orch,
+                                 SaiNotificationDispatcher *dispatcher,
+                                 const std::string &name)
+        : Executor(new SaiNotificationQueueSelectable(queue), orch, name)
+        , m_queue(queue)
+        , m_dispatcher(dispatcher)
+    {
+    }
+
     void execute() override
     {
-        std::deque<SaiNotification> notifications;
-        m_queue.pops(notifications);
+        std::deque<swss::KeyOpFieldsValuesTuple> entries;
+        m_queue->pops(entries);
 
-        for (const auto &notification : notifications)
+        for (auto &entry : entries)
         {
-            dispatchSaiNotification(notification);
+            m_dispatcher->dispatch(entry);
         }
     }
+
+private:
+    SaiNotificationQueue *m_queue;
+    SaiNotificationDispatcher *m_dispatcher;
 };
 ```
 
-During `orchagent` initialization:
+During `orchagent` initialization, the shared queue executor is registered once:
 
 ```cpp
-Orch::addExecutor(new SaiNotificationQueueExecutor(...));
+Orch::addExecutor(new SaiNotificationQueueExecutor(
+    getSaiNotificationQueue(),
+    this,
+    getSaiNotificationDispatcher(),
+    "SAI_NOTIFICATION_QUEUE"));
 ```
 
-The conceptual equivalent is:
+Each target Orch registers handlers for the notification operations it owns. For example, an `FdbOrch` migration can register the `fdb_event` handler from the `FdbOrch` constructor:
 
 ```cpp
-void processQueuedZmqNotifications()
+FdbOrch::FdbOrch(...)
 {
-    std::deque<SaiNotification> notifications;
-    gSaiNotificationQueue.pops(notifications);
+    ...
 
-    for (const auto &notification : notifications)
+    getSaiNotificationDispatcher()->registerHandler(
+        "fdb_event",
+        [this](swss::KeyOpFieldsValuesTuple &entry)
+        {
+            handleNotification(entry);
+        });
+}
+```
+
+When the shared executor drains the queue, the registered handler routes the entry to the target Orch notification-specific helper:
+
+```cpp
+void FdbOrch::handleNotification(swss::KeyOpFieldsValuesTuple &entry)
+{
+    auto op = kfvOp(entry);
+    auto data = kfvKey(entry);
+
+    if (op == "fdb_event")
     {
-        dispatchSaiNotification(notification);
+        handleFdbEventNotification(data);
     }
 }
 ```
@@ -698,25 +830,34 @@ The flow diagram and pseudo-code above show the initial Option 3 design, where m
 
 If notification-level priority is required, notifications can be split across multiple selectable/executor instances, such as a high-priority executor for port state, port host TX ready, and BFD notifications, and a normal-priority executor for other notifications. Each executor would use the existing `Select` priority mechanism.
 
-Option 3 notification dispatch:
+Option 3 notification dispatch should be implemented by the target Orch that owns the existing notification handler. The existing Redis-consumer handler can be refactored so the Redis path and Option 3 registered handler call the same notification-specific helper.
 
 ```cpp
-void OrchDaemon::dispatchSaiNotification(const SaiNotification &notification)
+void FdbOrch::handleNotification(NotificationConsumer &consumer,
+                                 swss::KeyOpFieldsValuesTuple &entry)
 {
-    if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT)
+    auto op = kfvOp(entry);
+    auto data = kfvKey(entry);
+
+    if (&consumer == m_fdbNotificationConsumer && op == "fdb_event")
     {
-        gFdbOrch->handleNotification(notification.name, notification.payload, notification.values);
+        handleFdbEventNotification(data);
     }
-    else if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_PORT_STATE_CHANGE)
+}
+
+void FdbOrch::handleNotification(swss::KeyOpFieldsValuesTuple &entry)
+{
+    auto op = kfvOp(entry);
+    auto data = kfvKey(entry);
+
+    if (op == "fdb_event")
     {
-        gPortsOrch->handleNotification(notification.name, notification.payload, notification.values);
-    }
-    else if (notification.name == SAI_SWITCH_NOTIFICATION_NAME_BFD_SESSION_STATE_CHANGE)
-    {
-        gBfdOrch->handleNotification(notification.name, notification.payload, notification.values);
+        handleFdbEventNotification(data);
     }
 }
 ```
+
+Other notification types would follow the same pattern in their owning Orch: keep the existing Redis `NotificationConsumer` handler for non-ZMQ mode and Option 2, add an Option 3 queue handler for migrated ZMQ notifications, and share notification-specific parsing/state-update helpers where practical.
 
 ### Migration Note for Existing Option 2-style Callbacks
 
@@ -749,6 +890,18 @@ flowchart TD
     zmqNotification --> libsairedisCallback
     libsairedisCallback --> notificationQueue
 ```
+
+### Validation and Unit Test Coverage
+
+The implementation should include focused unit coverage for the new queue mechanics:
+
+- Queue tests should verify enqueue, cached-data visibility, batch-limited `pops()`, FIFO order, and empty-queue state.
+- Dispatcher tests should verify that a registered operation handler is invoked with the queued entry.
+- Callback tests should verify that a migrated ZMQ-mode callback enqueues the expected operation and preserves the serialized notification payload.
+
+Existing Redis-path tests should continue to cover the established `NotificationConsumer` handler behavior. If the first migrated notification changes during review, callback-specific Option 3 coverage should target the notification selected for queue-based migration, while the generic queue tests remain applicable.
+
+DUT validation for a migrated notification should confirm both expected Orch behavior and Redis bypass. For example, a `port_state_change` validation can flap a port in southbound ZMQ mode, confirm `PortsOrch` logs and operational state updates, and confirm `ASIC_DB:NOTIFICATIONS` does not receive a re-posted `port_state_change` notification.
 
 ### Pros
 

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -65,19 +65,19 @@ The diagrams below show notification delivery paths at a high level. Where threa
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
-        syncdCallback["syncd SAI callback"]
-        notificationProcessor["syncd NotificationProcessor"]
-        redisProducer["RedisNotificationProducer"]
+        syncdCallback["SAI callback"]
+        notificationProcessor["NotificationProcessor"]
+        redisProducer["Redis<br/>NotificationProducer"]
     end
 
-    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            redisConsumerReady["NotificationConsumer selectable ready"]
+            redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
+            redisDoTask["Orch doTask() / handler"]
             orchHandler["Target Orch handler"]
         end
     end
@@ -111,24 +111,24 @@ ZMQ mode has existing notification handling gaps today. Some notifications alrea
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
-        syncdCallback["syncd SAI callback"]
-        notificationProcessor["syncd NotificationProcessor"]
-        zmqProducer["ZeroMQNotificationProducer"]
+        syncdCallback["SAI callback"]
+        notificationProcessor["NotificationProcessor"]
+        zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
 
-    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            zmqThread["libsairedis ZMQ notification thread"]
-            saiCallback["orchagent libsairedis callback"]
+            zmqThread["libsairedis ZMQ<br/>notification thread"]
+            saiCallback["orchagent libsairedis<br/>callback"]
             callbackLogic["implemented callback logic"]
-            redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
-            directHandler["callback handles notification directly"]
-            redisConsumerReady["NotificationConsumer selectable ready"]
+            redisRepost["callback re-posts to<br/>ASIC_DB NOTIFICATIONS"]
+            directHandler["callback handles<br/>notification directly"]
+            redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
+            redisDoTask["Orch doTask() / handler"]
             orchHandler["Target Orch handler"]
         end
     end
@@ -140,7 +140,7 @@ flowchart TD
     zmqThread --> saiCallback
     saiCallback --> callbackLogic
 
-    callbackLogic -->|"for port_state_change, HA, flow bulk get"| redisRepost
+    callbackLogic -->|"for port_state_change,<br/>HA,<br/>flow bulk get"| redisRepost
     redisRepost --> redisNotifications
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
@@ -148,7 +148,7 @@ flowchart TD
     notifier --> redisDoTask
     redisDoTask --> orchHandler
 
-    callbackLogic -->|"for switch shutdown or ASIC SDK health"| directHandler
+    callbackLogic -->|"for switch shutdown or<br/>ASIC SDK health"| directHandler
     directHandler --> orchHandler
 ```
 
@@ -163,16 +163,16 @@ In ZMQ mode, notifications that already have callback handling follow one of the
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
-        syncdCallback["syncd SAI callback"]
-        notificationProcessor["syncd NotificationProcessor"]
-        zmqProducer["ZeroMQNotificationProducer"]
+        syncdCallback["SAI callback"]
+        notificationProcessor["NotificationProcessor"]
+        zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            zmqThread["libsairedis ZMQ notification thread"]
-            saiCallback["orchagent libsairedis callback"]
-            callbackLogic["empty / incomplete callback logic:<br/>no forwarding or dispatch to existing Orch notification handling path"]
+            zmqThread["libsairedis ZMQ<br/>notification thread"]
+            saiCallback["orchagent libsairedis<br/>callback"]
+            callbackLogic["empty / incomplete<br/>callback logic:<br/>no forwarding or dispatch<br/>to existing Orch<br/>notification handling path"]
             dropped["notification dropped"]
         end
     end
@@ -251,22 +251,22 @@ This follows the existing `on_port_state_change()` model and is the approach use
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
-        syncdCallback["syncd SAI callback"]
-        notificationProcessor["syncd NotificationProcessor"]
-        zmqProducer["ZeroMQNotificationProducer"]
+        syncdCallback["SAI callback"]
+        notificationProcessor["NotificationProcessor"]
+        zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
 
-    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            zmqThread["libsairedis ZMQ notification thread"]
-            saiCallback["orchagent libsairedis callback"]
-            redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
-            redisConsumerReady["NotificationConsumer selectable ready"]
+            zmqThread["libsairedis ZMQ<br/>notification thread"]
+            saiCallback["orchagent libsairedis<br/>callback"]
+            redisRepost["callback re-posts to<br/>ASIC_DB NOTIFICATIONS"]
+            redisConsumerReady["NotificationConsumer<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
             notifier["Notifier / Executor"]
-            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
+            redisDoTask["Orch doTask() / handler"]
             orchHandler["Target Orch handler"]
         end
     end
@@ -338,19 +338,19 @@ This model is similar in spirit to existing selectable-based processing such as 
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
-        syncdCallback["syncd SAI callback"]
-        notificationProcessor["syncd NotificationProcessor"]
-        zmqProducer["ZeroMQNotificationProducer"]
+        syncdCallback["SAI callback"]
+        notificationProcessor["NotificationProcessor"]
+        zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            zmqThread["libsairedis ZMQ notification thread"]
-            saiCallback["orchagent libsairedis callback"]
-            notificationQueue[["in-process notification queue"]]
-            selectableEvent["new SAI notification queue selectable"]
+            zmqThread["libsairedis ZMQ<br/>notification thread"]
+            saiCallback["orchagent libsairedis<br/>callback"]
+            notificationQueue[["in-process<br/>notification queue"]]
+            selectableEvent["new SAI notification queue<br/>selectable"]
             mainLoop["orchagent main Select loop"]
-            queueExecutor["SaiNotificationQueueExecutor"]
+            queueExecutor["SaiNotification<br/>QueueExecutor"]
             dispatcher["dispatchSaiNotification()"]
             orchHandler["Target Orch handler"]
         end
@@ -364,7 +364,7 @@ flowchart TD
 
     saiCallback --> notificationQueue
     notificationQueue --> selectableEvent
-    selectableEvent -->|"queued notification available"| mainLoop
+    selectableEvent -->|"queued notification<br/>available"| mainLoop
     mainLoop --> queueExecutor
     queueExecutor --> dispatcher
     dispatcher --> orchHandler
@@ -454,19 +454,19 @@ The existing Redis notification path remains unchanged for non-ZMQ mode and for 
 
 ```mermaid
 flowchart TD
-    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
     subgraph redisPath["Existing Redis notification path"]
-        redisConsumerReady["NotificationConsumer selectable ready"]
+        redisConsumerReady["NotificationConsumer<br/>selectable ready"]
         redisMainLoop["orchagent main Select loop"]
         notifier["Notifier / Executor"]
-        redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
+        redisDoTask["Orch doTask() / handler"]
     end
 
     subgraph option3Path["Option 3 queue-based path"]
-        libsairedisCallback["orchagent libsairedis callback"]
-        notificationQueue[["in-process notification queue"]]
-        queueExecutor["SaiNotificationQueueExecutor"]
+        libsairedisCallback["orchagent libsairedis<br/>callback"]
+        notificationQueue[["in-process<br/>notification queue"]]
+        queueExecutor["SaiNotification<br/>QueueExecutor"]
         option3Dispatch["dispatchSaiNotification()"]
     end
 
@@ -604,14 +604,14 @@ Option 3 should expose the notification queue through an existing-style selectab
 ```mermaid
 flowchart TD
     subgraph zmqThreadContext["ZMQ notification thread context"]
-        saiCallback["orchagent libsairedis callback"]
+        saiCallback["orchagent libsairedis<br/>callback"]
         enqueue["enqueue notification"]
         notifyMainLoop["notifyMainLoop"]
     end
 
     subgraph orchMainThread["orchagent main thread"]
-        selectLoop["OrchDaemon::start Select loop"]
-        queueExecutor["SaiNotificationQueueExecutor::execute"]
+        selectLoop["OrchDaemon::start<br/>Select loop"]
+        queueExecutor["SaiNotification<br/>QueueExecutor::execute"]
         queueDrain["pops queued notifications"]
         dispatcher["dispatchSaiNotification()"]
         orchHandler["Target Orch handler"]
@@ -619,7 +619,7 @@ flowchart TD
 
     saiCallback --> enqueue
     enqueue --> notifyMainLoop
-    notifyMainLoop -->|"queued notification available"| selectLoop
+    notifyMainLoop -->|"queued notification<br/>available"| selectLoop
     selectLoop --> queueExecutor
     queueExecutor --> queueDrain
     queueDrain --> dispatcher
@@ -728,10 +728,10 @@ Current short-term / Option 2-style path:
 
 ```mermaid
 flowchart TD
-    zmqNotification["syncd sends notification over ZMQ"]
-    libsairedisCallback["orchagent libsairedis callback"]
+    zmqNotification["syncd sends notification<br/>over ZMQ"]
+    libsairedisCallback["orchagent libsairedis<br/>callback"]
     redisRepost["Redis re-post"]
-    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
     zmqNotification --> libsairedisCallback
     libsairedisCallback --> redisRepost
@@ -742,9 +742,9 @@ Long-term / Option 3 queue-based path:
 
 ```mermaid
 flowchart TD
-    zmqNotification["syncd sends notification over ZMQ"]
-    libsairedisCallback["orchagent libsairedis callback"]
-    notificationQueue[["in-process notification queue"]]
+    zmqNotification["syncd sends notification<br/>over ZMQ"]
+    libsairedisCallback["orchagent libsairedis<br/>callback"]
+    notificationQueue[["in-process<br/>notification queue"]]
 
     zmqNotification --> libsairedisCallback
     libsairedisCallback --> notificationQueue

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -1,18 +1,32 @@
 # HLD: SAI Notification Handling with ZMQ Southbound
 
+## Table of Contents
+
+- [1. Background](#1-background)
+- [2. Problem Statement](#2-problem-statement)
+- [3. Existing Notification Flows](#3-existing-notification-flows)
+  - [3.1 Non-ZMQ Mode](#31-non-zmq-mode)
+  - [3.2 ZMQ Mode Today](#32-zmq-mode-today)
+- [4. Design Goals](#4-design-goals)
+- [5. Design Options](#5-design-options)
+  - [Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode](#option-1-syncd-publishes-notifications-via-redis-in-zmq-mode)
+  - [Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`](#option-2-orchagent-callback-re-posts-to-asic_dbnotifications)
+  - [Option 3: In-process Notification Queue Drained by Orch Main Loop](#option-3-in-process-notification-queue-drained-by-orch-main-loop)
+- [6. References](#6-references)
+
 ## 1. Background
 
-SONiC recently added support for ZMQ southbound communication between `orchagent` and `syncd` for regular switches. This is controlled by:
+SONiC recently added support for ZMQ southbound communication between `orchagent` and `syncd` for regular switches. This is controlled by the route-performance ZMQ setting:
 
 ```text
-DEVICE_METADATA|localhost.orch_southbound_zmq_enabled = true
+SYSTEM_DEFAULTS|swss_zmq.status = enabled
 ```
 
-The current issue is tracked in sonic-buildimage issue #27541. An initial short-term implementation is proposed in sonic-swss PR #4619.
+In non-ZMQ mode (Redis mode), SAI notifications are published by `syncd` into Redis `ASIC_DB:NOTIFICATIONS`. `orchagent` consumes those notifications from Redis in its normal main loop and dispatches them to the appropriate Orch components.
 
-In non-ZMQ mode, SAI notifications are published by `syncd` into Redis `ASIC_DB:NOTIFICATIONS`. `orchagent` consumes those notifications from Redis in its normal main loop and dispatches them to the appropriate Orch components.
+In ZMQ mode, `syncd` sends notifications to `orchagent` through ZMQ. These notifications arrive in `orchagent` libsairedis callback functions. Some callbacks already forward notifications to Redis, such as `on_port_state_change()`, but several callbacks are currently empty or incomplete. As a result, some notifications are dropped when ZMQ southbound is enabled.
 
-In ZMQ mode, `syncd` sends notifications to `orchagent` through ZMQ. These notifications arrive in `orchagent` callback functions. Some callbacks already forward notifications to Redis, such as `on_port_state_change()`, but several callbacks are currently empty or incomplete. As a result, some notifications are dropped when ZMQ southbound is enabled.
+This gap is tracked in [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541). An initial short-term implementation is proposed in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619).
 
 ## 2. Problem Statement
 
@@ -39,51 +53,145 @@ Without a fix:
 - Port host TX readiness may not reach `PortsOrch`.
 - ICMP echo session monitoring may not reach `IcmpOrch`.
 
+Notification prioritization and timely handling of high-priority notifications, such as port state changes and BFD session state changes, under high `orchagent` load is a broader concern for both ZMQ and non-ZMQ modes. This HLD considers that concern only in the context of the ZMQ notification handling [design options](#5-design-options); it does not propose changes to the existing non-ZMQ notification path.
+
 ## 3. Existing Notification Flows
+
+The diagrams below show notification delivery paths at a high level. Where thread context affects the design, the text calls out the relevant execution contexts, such as the libsairedis notification thread and the `orchagent` main loop.
 
 ### 3.1 Non-ZMQ Mode
 
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> RedisNotificationProducer
-  -> ASIC_DB:NOTIFICATIONS
-  -> orchagent Redis consumer
-  -> orchagent main loop
-  -> Orch handler
+```mermaid
+flowchart TD
+    subgraph vendorAsic["Vendor SAI / ASIC"]
+        vendorEvent["SAI notification event"]
+    end
+
+    subgraph syncdContainer["syncd container"]
+        syncdCallback["syncd SAI callback context"]
+        notificationProcessor["syncd NotificationProcessor"]
+        redisProducer["RedisNotificationProducer"]
+    end
+
+    subgraph redisDb["Redis ASIC_DB"]
+        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+    end
+
+    subgraph swssContainer["swss container"]
+        subgraph orchagentProcess["orchagent process"]
+            redisConsumer["NotificationConsumer"]
+            mainLoop["orchagent main Select loop"]
+            orchHandler["Target Orch handler"]
+        end
+    end
+
+    vendorEvent --> syncdCallback
+    syncdCallback --> notificationProcessor
+    notificationProcessor --> redisProducer
+    redisProducer --> redisNotifications
+    redisNotifications --> redisConsumer
+    redisConsumer --> mainLoop
+    mainLoop --> orchHandler
 ```
+
+The non-ZMQ notification path has three main execution hops:
+
+- Vendor SAI invokes the registered notification callback in `syncd`.
+- `syncd` notification processing publishes the notification to `ASIC_DB:NOTIFICATIONS`.
+- `orchagent` consumes the notification through `NotificationConsumer` in the main `Select` loop and dispatches it to the target Orch handler.
 
 This is the existing proven notification path.
 
 ### 3.2 ZMQ Mode Today
 
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> ZeroMQNotificationProducer
-  -> orchagent ZMQ notification callback
-  -> callback-specific logic
+ZMQ mode has existing notification handling gaps today. Some notifications already have callback handling logic, while the notifications covered by this HLD do not yet reach their existing Orch consumers.
+
+### 3.2.1 Notifications Already Handled
+
+```mermaid
+flowchart TD
+    subgraph vendorAsic["Vendor SAI / ASIC"]
+        vendorEvent["SAI notification event"]
+    end
+
+    subgraph syncdContainer["syncd container"]
+        syncdCallback["syncd SAI callback context"]
+        notificationProcessor["syncd NotificationProcessor"]
+        zmqProducer["ZeroMQNotificationProducer"]
+    end
+
+    subgraph redisDb["Redis ASIC_DB"]
+        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+    end
+
+    subgraph swssContainer["swss container"]
+        subgraph orchagentProcess["orchagent process"]
+            zmqThread["libsairedis ZMQ notification thread"]
+            saiCallback["orchagent libsairedis callback"]
+            callbackLogic["implemented callback logic"]
+            redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
+            directHandler["callback handles notification directly"]
+            redisConsumer["NotificationConsumer"]
+            mainLoop["orchagent main Select loop"]
+            orchHandler["Target Orch handler"]
+        end
+    end
+
+    vendorEvent --> syncdCallback
+    syncdCallback --> notificationProcessor
+    notificationProcessor --> zmqProducer
+    zmqProducer -->|"ZMQ notification channel"| zmqThread
+    zmqThread --> saiCallback
+    saiCallback --> callbackLogic
+
+    callbackLogic -->|"for port_state_change, HA, flow bulk get"| redisRepost
+    redisRepost --> redisNotifications
+    redisNotifications --> redisConsumer
+    redisConsumer --> mainLoop
+    mainLoop --> orchHandler
+
+    callbackLogic -->|"for switch shutdown or ASIC SDK health"| directHandler
+    directHandler --> orchHandler
 ```
 
-The issue is that some callback-specific logic is missing.
+### 3.2.2 Notifications With Missing Callback Handling
 
-Example:
+```mermaid
+flowchart TD
+    subgraph vendorAsic["Vendor SAI / ASIC"]
+        vendorEvent["SAI notification event"]
+    end
 
-```text
-on_port_state_change()
-  -> forwards to ASIC_DB:NOTIFICATIONS
-  -> works today
+    subgraph syncdContainer["syncd container"]
+        syncdCallback["syncd SAI callback context"]
+        notificationProcessor["syncd NotificationProcessor"]
+        zmqProducer["ZeroMQNotificationProducer"]
+    end
 
-on_fdb_event()
-on_bfd_session_state_change()
-on_port_host_tx_ready()
-IcmpSaiSessionHandler::on_state_change()
-  -> empty or incomplete
-  -> notification may be dropped
+    subgraph swssContainer["swss container"]
+        subgraph orchagentProcess["orchagent process"]
+            zmqThread["libsairedis ZMQ notification thread"]
+            saiCallback["orchagent libsairedis callback"]
+            callbackLogic["empty or incomplete callback logic"]
+            dropped["notification dropped"]
+        end
+    end
+
+    subgraph missingPath["Expected but missing path"]
+        mainLoop["orchagent main Select loop"]
+        targetConsumer["Target Orch consumer"]
+    end
+
+    vendorEvent --> syncdCallback
+    syncdCallback --> notificationProcessor
+    notificationProcessor --> zmqProducer
+    zmqProducer -->|"ZMQ notification channel"| zmqThread
+    zmqThread --> saiCallback
+    saiCallback --> callbackLogic
+    callbackLogic --> dropped
+
+    callbackLogic -.->|"missing forwarding or dispatch"| mainLoop
+    mainLoop -.->|"not reached"| targetConsumer
 ```
 
 ## 4. Design Goals
@@ -92,9 +200,7 @@ IcmpSaiSessionHandler::on_state_change()
 - Restore missing notifications in ZMQ mode.
 - Avoid duplicate notification delivery.
 - Preserve existing Orch handler behavior.
-- Avoid unsafe direct access to Orch state from callback context.
-- Keep the immediate fix low risk.
-- Identify a cleaner long-term architecture.
+- Keep Orch state updates on the `orchagent` main-loop path.
 
 ## 5. Design Options
 
@@ -102,25 +208,15 @@ IcmpSaiSessionHandler::on_state_change()
 
 ### Description
 
-In this option, `syncd` would use `RedisNotificationProducer` for SAI notifications even when southbound ZMQ is enabled.
+Under this option, when ZMQ southbound is enabled, regular SAI operations continue to use the existing ZMQ request/response channel between `orchagent` and `syncd` through `ZeroMQSelectableChannel`, while SAI notifications are published by `syncd` through Redis.
 
-Important clarification: `RedisNotificationProducer` already exists and is used in the non-ZMQ notification path. The new behavior would be to instantiate/use it in the ZMQ-mode notification path as well, instead of using the ZMQ notification producer path for SAI notifications.
+This option reuses the existing `RedisNotificationProducer` used in non-ZMQ mode; the change is only to select it for SAI notifications when ZMQ southbound is enabled.
 
-### Flow
+### Notification Path
 
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> RedisNotificationProducer
-  -> ASIC_DB:NOTIFICATIONS
-  -> orchagent Redis consumer
-  -> orchagent main loop
-  -> Orch handler
-```
+SAI notifications follow the same Redis notification path described in [Section 3.1](#31-non-zmq-mode). The difference is that this path is selected even when ZMQ southbound is enabled; regular SAI request/response operations still use ZMQ.
 
-### Implementation Idea
+### Implementation Notes
 
 Option 1 would change the ZMQ-mode notification producer selection in `syncd` from:
 
@@ -134,49 +230,71 @@ to:
 m_notifications = std::make_shared<RedisNotificationProducer>(m_contextConfig->m_dbAsic);
 ```
 
-The command/request channel would still use `ZeroMQSelectableChannel` when ZMQ mode is enabled.
+`orchagent` libsairedis notification callbacks remain no-op for these notifications in this option, because `syncd` publishes the notifications directly to Redis. If a callback re-publishes a Redis-delivered notification back to Redis, duplicate or looping notifications can occur.
 
 ### Pros
 
-- Reuses the existing Redis notification path.
+- Uses the existing Redis notification path.
 - Existing Orch consumers continue unchanged.
-- Minimal `orchagent` callback changes.
 
 ### Cons
 
 - Makes ZMQ mode asymmetric:
-  - requests/responses use ZMQ
-  - notifications use Redis
-- Changes `syncd` ZMQ notification semantics.
-- May introduce ordering differences between ZMQ command processing and Redis notifications.
-- Moves notification transport policy into `syncd`.
-- If both Redis and ZMQ notification producers are used, duplicate notifications must be avoided.
+  - request/response operations use ZMQ.
+  - SAI notifications use Redis.
 
 ## Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`
 
 ### Description
 
-In this option, `syncd` continues to send notifications to `orchagent` through ZMQ. The ZMQ callback in `orchagent` receives the notification and re-publishes it into `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled.
+In this option, `syncd` continues to send notifications to `orchagent` through ZMQ. The `libsairedis` ZMQ notification path invokes the registered SAI notification callback in `orchagent`, and that callback re-publishes the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled.
 
-This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in sonic-swss PR #4619.
+This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619). The same forwarding behavior would be added to each missing notification callback covered by this HLD.
 
 ### Flow
 
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> ZeroMQNotificationProducer
-  -> orchagent ZMQ callback
-  -> NotificationProducer in orchagent
-  -> ASIC_DB:NOTIFICATIONS
-  -> orchagent Redis consumer
-  -> orchagent main loop
-  -> Orch handler
+```mermaid
+flowchart TD
+    subgraph vendorAsic["Vendor SAI / ASIC"]
+        vendorEvent["SAI notification event"]
+    end
+
+    subgraph syncdContainer["syncd container"]
+        syncdCallback["syncd SAI callback context"]
+        notificationProcessor["syncd NotificationProcessor"]
+        zmqProducer["ZeroMQNotificationProducer"]
+    end
+
+    subgraph redisDb["Redis ASIC_DB"]
+        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+    end
+
+    subgraph swssContainer["swss container"]
+        subgraph orchagentProcess["orchagent process"]
+            zmqThread["libsairedis ZMQ notification thread"]
+            saiCallback["orchagent libsairedis callback"]
+            redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
+            redisConsumer["NotificationConsumer"]
+            mainLoop["orchagent main Select loop"]
+            orchHandler["Target Orch handler"]
+        end
+    end
+
+    vendorEvent --> syncdCallback
+    syncdCallback --> notificationProcessor
+    notificationProcessor --> zmqProducer
+    zmqProducer -->|"ZMQ notification channel"| zmqThread
+    zmqThread --> saiCallback
+    saiCallback --> redisRepost
+    redisRepost --> redisNotifications
+    redisNotifications --> redisConsumer
+    redisConsumer --> mainLoop
+    mainLoop --> orchHandler
 ```
 
-### Pseudo-code
+### Implementation Notes
+
+The following snippet is high-level pseudo-code for the callback re-post model.
 
 ```cpp
 void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
@@ -196,114 +314,123 @@ void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
 }
 ```
 
+Note: The callback must check whether ZMQ mode is enabled before re-publishing to Redis. In non-ZMQ mode, `syncd` already publishes the notification to `ASIC_DB:NOTIFICATIONS`, and the normal `orchagent` `NotificationConsumer` path handles it in the main loop. The libsairedis notification path can still deserialize Redis notifications and invoke the registered `orchagent` libsairedis callback in non-ZMQ mode. If the callback re-publishes the notification to Redis in that mode, duplicate or looping notifications can occur. Therefore, the callback only re-publishes when `gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC`.
+
 ### Pros
 
-- Lowest risk short-term fix.
+- Low-risk short-term fix.
 - No `syncd` change.
 - Keeps ZMQ transport between `syncd` and `orchagent`.
 - Reuses existing Orch Redis notification processing path.
-- Follows existing `on_port_state_change()` behavior.
 - Can be implemented and validated event-by-event.
 
 ### Cons
 
-- Adds an extra Redis hop after ZMQ delivery.
-- Slightly higher latency than direct/in-process handling.
-- Still depends on Redis internally for notification dispatch.
-- Does not provide the cleanest long-term ZMQ notification model.
+- Compared with Option 1, notifications first travel over ZMQ before being re-posted to Redis for Orch processing, which can add latency.
+- Uses Redis for final notification dispatch.
 
-## Option 3: Directly Invoke Orch Logic from Callback
+## Option 3: In-process Notification Queue Drained by Orch Main Loop
 
 ### Description
 
-In this option, the ZMQ callback directly invokes the relevant Orch handling logic instead of re-posting to Redis.
+In this option, the `orchagent` libsairedis callback packages the notification and makes it available to the main loop through an in-process notification queue. The `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
+
+This model is similar in spirit to existing selectable-based processing such as `ZmqConsumerStateTable`, where data availability wakes the main loop and processing happens through an executor path.
 
 ### Flow
 
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> ZeroMQNotificationProducer
-  -> orchagent ZMQ callback
-  -> direct Orch handler call
+```mermaid
+flowchart TD
+    subgraph vendorAsic["Vendor SAI / ASIC"]
+        vendorEvent["SAI notification event"]
+    end
+
+    subgraph syncdContainer["syncd container"]
+        syncdCallback["syncd SAI callback context"]
+        notificationProcessor["syncd NotificationProcessor"]
+        zmqProducer["ZeroMQNotificationProducer"]
+    end
+
+    subgraph swssContainer["swss container"]
+        subgraph orchagentProcess["orchagent process"]
+            zmqThread["libsairedis ZMQ notification thread"]
+            saiCallback["orchagent libsairedis callback"]
+            notificationQueue["in-process notification queue"]
+            selectableEvent["selectable event / wakeup"]
+            mainLoop["orchagent main Select loop"]
+            queueExecutor["SaiNotificationQueueExecutor"]
+            dispatcher["dispatchSaiNotification()"]
+            orchHandler["Target Orch handler"]
+        end
+    end
+
+    vendorEvent --> syncdCallback
+    syncdCallback --> notificationProcessor
+    notificationProcessor --> zmqProducer
+    zmqProducer -->|"ZMQ notification channel"| zmqThread
+    zmqThread --> saiCallback
+
+    saiCallback --> notificationQueue
+    notificationQueue --> selectableEvent
+    selectableEvent -->|"wake Select loop"| mainLoop
+    mainLoop --> queueExecutor
+    queueExecutor --> dispatcher
+    dispatcher --> orchHandler
 ```
 
-### Pseudo-code
+### Dispatch Relationship During Phased Migration to Option 3
 
-```cpp
-void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
-{
-    if (gRedisCommunicationMode != SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
-    {
-        return;
-    }
+Option 3 does not send migrated ZMQ notifications back through `ASIC_DB:NOTIFICATIONS`. For notification types moved to the Option 3 queue-based model, the `orchagent` libsairedis callback enqueues the notification, and the `orchagent` main loop drains the queue and dispatches it to the target Orch handler.
 
-    std::string payload = sai_serialize_fdb_event_ntf(count, data);
+The existing Redis notification path remains unchanged for non-ZMQ mode and for notification types that continue to use the Option 2 Redis re-post model during phased rollout. In those cases, notifications are consumed through the existing `NotificationConsumer` path and dispatched by the corresponding Orch consumer `doTask()` / handler logic.
 
-    gFdbOrch->handleNotification(
-        SAI_SWITCH_NOTIFICATION_NAME_FDB_EVENT,
-        payload,
-        {});
-}
+```mermaid
+flowchart TD
+    subgraph redisPath["Redis notification path"]
+        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+        redisConsumer["NotificationConsumer"]
+        redisMainLoop["orchagent main Select loop"]
+        redisDoTask["existing Orch consumer doTask / handler path"]
+    end
+
+    subgraph option3Path["Option 3 queue-based path"]
+        libsairedisCallback["orchagent libsairedis callback"]
+        notificationQueue["in-process notification queue"]
+        queueExecutor["SaiNotificationQueueExecutor"]
+        option3Dispatch["dispatchSaiNotification()"]
+    end
+
+    targetHandler["Target Orch handler"]
+
+    redisNotifications --> redisConsumer
+    redisConsumer --> redisMainLoop
+    redisMainLoop --> redisDoTask
+    redisDoTask --> targetHandler
+
+    libsairedisCallback --> notificationQueue
+    notificationQueue --> queueExecutor
+    queueExecutor --> option3Dispatch
+    option3Dispatch --> targetHandler
+
 ```
 
-### Pros
+Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` and Orch consumer `doTask()` / handler flow, while Option 3 uses the new queue-based executor path for migrated ZMQ notification types.
 
-- Avoids Redis re-posting.
-- Lower theoretical latency.
-- Direct data path.
-- Can be optimized event-by-event.
+### Existing Code References
 
-### Cons
+Option 3 is expected to build on the following existing infrastructure:
 
-- Higher concurrency risk.
-- Notification handling runs in the sairedis/ZMQ channel notification thread instead of the normal `orchagent` main loop.
-- Existing Orch code may assume single-threaded main-loop execution.
-- Requires thread-safety validation per notification type.
-- More invasive and harder to prove safe.
+- Callback implementations: some existing `orchagent` SAI notification callbacks are currently no-op or incomplete for ZMQ mode and need forwarding or queueing behavior. Examples include `on_fdb_event()`, `on_bfd_session_state_change()`, and `on_port_host_tx_ready()` in `src/sonic-swss/orchagent/notifications.cpp`, and `IcmpSaiSessionHandler::on_state_change()` in `src/sonic-swss/orchagent/icmporch.cpp`. Under Option 3, these callbacks would enqueue notifications for main-loop processing.
+- Callback registration: notification callbacks are registered through existing Orch initialization and feature-specific setup paths. Examples include switch notification setup in `src/sonic-swss/orchagent/main.cpp`, `src/sonic-swss/orchagent/portsorch.cpp`, and `src/sonic-swss/orchagent/bfdorch.cpp`, and ICMP offload-session callback registration through `SaiOffloadSessionHandler`.
+- Existing Orch notification consumers: in the existing non-ZMQ notification path, these notification types are consumed from `ASIC_DB:NOTIFICATIONS` by target Orch consumers such as `FdbOrch`, `BfdOrch`, `PortsOrch`, and `IcmpOrch`. Option 3 should preserve the same Orch handler behavior without sending migrated ZMQ notifications through Redis.
+- Existing Redis notification dispatch: Redis-delivered SAI notifications are consumed through `NotificationConsumer` instances wrapped by `Notifier`. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, preserving the existing per-Orch notification handling model for non-ZMQ mode and Option 2.
+- Selectable-based ZMQ consumers: `src/sonic-swss-common/common/zmqconsumerstatetable.h` defines `ZmqConsumerStateTable`, an existing selectable-based ZMQ consumer that wakes the main loop when data is available and processes data through the executor path. Option 3 can follow a similar integration pattern for SAI notifications.
+- Select priority: `swss::Selectable` carries a priority value used by `Select`; higher priority values are selected ahead of lower-priority ready selectables. Option 3 should use this existing priority model where practical.
+- Main-loop infrastructure: `src/sonic-swss/orchagent/orchdaemon.cpp` contains the main `OrchDaemon::start()` `Select` loop that waits on registered selectables and dispatches `Executor::execute()` when a selectable becomes ready. The Option 3 integration approach is described in [Main-loop Integration](#main-loop-integration).
 
-## Option 4: In-process Notification Queue Drained by Orch Main Loop
+### Implementation Notes
 
-### Description
-
-In this option, the ZMQ callback does not re-post to Redis and does not directly invoke Orch logic. Instead, the callback packages the notification and enqueues it into an internal `orchagent` notification queue. The normal `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
-
-### Flow
-
-```text
-Vendor SAI
-  -> syncd SAI callback
-  -> syncd NotificationProcessor
-  -> RID-to-VID translation
-  -> ZeroMQNotificationProducer
-  -> orchagent ZMQ callback
-  -> in-process notification queue
-  -> orchagent main loop
-  -> common notification dispatcher
-  -> Orch handler
-```
-
-### Relationship to Existing Redis Path
-
-```text
-Existing Redis path:
-ASIC_DB:NOTIFICATIONS
-  -> Redis consumer
-  -> common dispatcher
-  -> Orch handler
-
-New ZMQ path:
-ZMQ callback
-  -> in-process notification queue
-  -> common dispatcher
-  -> Orch handler
-```
-
-Both paths should converge into common dispatch logic.
-
-### Pseudo-code
+The following snippets are high-level pseudo-code to illustrate the queue-based design; exact class names and integration points may change during implementation.
 
 ```cpp
 struct SaiNotification
@@ -354,7 +481,7 @@ private:
 };
 ```
 
-`notifyMainLoop()` represents a wakeup mechanism for the existing `orchagent` main loop. The implementation could use an `eventfd`, pipe, `SelectableEvent`, or an existing swss selectable wakeup primitive. The important requirement is that enqueueing a notification makes a selectable object readable so `OrchDaemon::start()` wakes immediately.
+`notifyMainLoop()` represents a wakeup mechanism for the existing `orchagent` main loop. The implementation should reuse the existing swss selectable/executor model where practical, similar to `ZmqConsumerStateTable`, rather than introducing a separate main-loop mechanism. The important requirement is that enqueueing a notification makes a selectable object readable so the current `OrchDaemon::start()` loop can dispatch it like other selectables.
 
 Callback:
 
@@ -374,20 +501,33 @@ void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
 }
 ```
 
-Main-loop integration:
+#### Main-loop Integration
 
-Option 4 should integrate with the existing `OrchDaemon::start()` `Select` loop through a new `Selectable`/`Executor`, not by directly calling Orch logic from the ZMQ callback.
+Option 3 should expose the notification queue through an existing-style selectable/executor so the current `OrchDaemon::start()` `Select` loop can dispatch it like other selectables.
 
-```text
-ZMQ notification thread
-  -> orchagent callback
-  -> enqueue notification into in-process queue
-  -> notifyMainLoop()
-  -> wake OrchDaemon select loop
-  -> queue executor execute()
-  -> drain queued notifications
-  -> common notification dispatcher
-  -> Orch handler
+```mermaid
+flowchart TD
+    subgraph zmqThreadContext["ZMQ notification thread context"]
+        saiCallback["orchagent libsairedis callback"]
+        enqueue["enqueue notification"]
+        notifyMainLoop["notifyMainLoop"]
+    end
+
+    subgraph orchMainThread["orchagent main thread"]
+        selectLoop["OrchDaemon::start Select loop"]
+        queueExecutor["SaiNotificationQueueExecutor::execute"]
+        queueDrain["queue drain"]
+        dispatcher["dispatchSaiNotification()"]
+        orchHandler["Target Orch handler"]
+    end
+
+    saiCallback --> enqueue
+    enqueue --> notifyMainLoop
+    notifyMainLoop -->|"SelectableEvent notify"| selectLoop
+    selectLoop --> queueExecutor
+    queueExecutor --> queueDrain
+    queueDrain --> dispatcher
+    dispatcher --> orchHandler
 ```
 
 The existing main loop already waits on selectable executors:
@@ -455,15 +595,13 @@ void processQueuedZmqNotifications()
 
 ### Priority and Fairness
 
-The in-process notification queue should support priority-aware processing.
+Option 3 should use the existing `Select` priority mechanism where practical instead of introducing separate internal priority queues.
 
-Time-sensitive notifications such as port state, port host TX ready, and BFD session state change should be processed with higher priority than less time-sensitive notifications.
+The flow diagram and pseudo-code above show the initial Option 3 design, where migrated SAI notifications share one notification queue and one selectable/executor priority. That selectable/executor should use an appropriate priority so time-sensitive SAI notifications can be processed ahead of lower-priority regular `orchagent` work. This follows the existing `Select` behavior where ready selectables are dispatched according to priority.
 
-To avoid starvation, the main-loop executor should not drain one notification type indefinitely. It should use a bounded drain policy, such as processing up to N high-priority notifications per loop before checking lower-priority notifications and other Orch tasks.
+If notification-level priority is required, notifications can be split across multiple selectable/executor instances, such as a high-priority executor for port state, port host TX ready, and BFD notifications, and a normal-priority executor for other notifications. Each executor would use the existing `Select` priority mechanism.
 
-This keeps latency low for critical notifications while preventing one notification stream from starving others.
-
-Common dispatcher:
+Option 3 notification dispatch:
 
 ```cpp
 void OrchDaemon::dispatchSaiNotification(const SaiNotification &notification)
@@ -483,44 +621,54 @@ void OrchDaemon::dispatchSaiNotification(const SaiNotification &notification)
 }
 ```
 
-### Note on `on_port_state_change()`
+### Migration Note for Existing Option 2-style Callbacks
 
-If Option 4 becomes the long-term architecture, existing ZMQ callbacks that currently re-post to Redis, such as `on_port_state_change()`, should eventually be migrated to the queue-based model too.
+For phased rollout of the long-term Option 3 queue-based model, notification types can be migrated incrementally. Notifications not yet migrated can continue to use Option 2, where libsairedis callbacks re-post notifications to Redis and the existing `ASIC_DB:NOTIFICATIONS` subscription handles final Orch dispatch.
 
-Short-term:
+Existing Option 2-style callbacks can be migrated notification type by notification type.
 
-```text
-on_port_state_change()
-  -> Redis re-post
+Current short-term / Option 2-style path:
+
+```mermaid
+flowchart TD
+    zmqNotification["syncd sends notification over ZMQ"]
+    libsairedisCallback["orchagent libsairedis callback"]
+    redisRepost["Redis re-post"]
+    redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+
+    zmqNotification --> libsairedisCallback
+    libsairedisCallback --> redisRepost
+    redisRepost --> redisNotifications
 ```
 
-Long-term:
+Long-term / Option 3 queue-based path:
 
-```text
-on_port_state_change()
-  -> in-process queue
+```mermaid
+flowchart TD
+    zmqNotification["syncd sends notification over ZMQ"]
+    libsairedisCallback["orchagent libsairedis callback"]
+    notificationQueue["in-process notification queue"]
+
+    zmqNotification --> libsairedisCallback
+    libsairedisCallback --> notificationQueue
 ```
 
 ### Pros
 
-- Avoids Redis re-posting.
-- Reduces Redis load.
-- Lower latency than Option 2.
-- Preserves Orch main-loop execution model.
-- Lower concurrency risk than direct callback handling.
-- Cleaner long-term architecture.
-- Can support event-by-event migration.
+- Compared with Option 2, avoids the Redis re-post for migrated notifications and can reduce notification latency.
+- Keeps Orch state updates on the `orchagent` main-loop path.
+- Uses the existing selectable/executor model and `Select` priority mechanism where practical.
+- Supports incremental migration from Option 2 to Option 3 per notification type.
 
 ### Cons
 
-- Requires new queue and wakeup infrastructure in `orchagent`.
-- Requires clear ordering and fairness rules between queued ZMQ notifications, Redis notifications, timers, and other Orch tasks.
-- Requires backpressure behavior.
+- Requires implementation and validation of a new selectable/executor path for SAI notifications.
+- Requires backpressure behavior for the in-process notification queue.
 - Requires lifecycle handling for the shared queue and wakeup mechanism during startup, shutdown, and callback teardown.
 - More implementation and test effort than Option 2.
 - Larger design review scope.
 
 ## 6. References
 
-- sonic-buildimage issue #27541: Missing notification forwarding for FDB/BFD when ZMQ southbound is enabled
-- sonic-swss PR #4619: Forward SAI notifications to Redis in ZMQ southbound mode
+- [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541): Missing notification forwarding for FDB/BFD when ZMQ southbound is enabled
+- [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619): Forward SAI notifications to Redis in ZMQ southbound mode

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -63,42 +63,41 @@ The diagrams below show notification delivery paths at a high level. Where threa
 
 ```mermaid
 flowchart TD
-    subgraph vendorAsic["Vendor SAI / ASIC"]
-        vendorEvent["SAI notification event"]
-    end
-
     subgraph syncdContainer["syncd container"]
-        syncdCallback["syncd SAI callback context"]
+        saiApi["SAI API / ASIC SDK"]
+        syncdCallback["syncd SAI callback"]
         notificationProcessor["syncd NotificationProcessor"]
         redisProducer["RedisNotificationProducer"]
     end
 
-    subgraph redisDb["Redis ASIC_DB"]
-        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
-    end
+    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
-            redisConsumer["NotificationConsumer"]
+            redisConsumerReady["NotificationConsumer selectable ready"]
             mainLoop["orchagent main Select loop"]
+            notifier["Notifier / Executor"]
+            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
             orchHandler["Target Orch handler"]
         end
     end
 
-    vendorEvent --> syncdCallback
+    saiApi -->|"raise SAI notification"| syncdCallback
     syncdCallback --> notificationProcessor
     notificationProcessor --> redisProducer
     redisProducer --> redisNotifications
-    redisNotifications --> redisConsumer
-    redisConsumer --> mainLoop
-    mainLoop --> orchHandler
+    redisNotifications -->|"notification available"| redisConsumerReady
+    redisConsumerReady --> mainLoop
+    mainLoop --> notifier
+    notifier --> redisDoTask
+    redisDoTask --> orchHandler
 ```
 
 The non-ZMQ notification path has three main execution hops:
 
-- Vendor SAI invokes the registered notification callback in `syncd`.
+- `SAI API / ASIC SDK` invokes the registered notification callback in `syncd`.
 - `syncd` notification processing publishes the notification to `ASIC_DB:NOTIFICATIONS`.
-- `orchagent` consumes the notification through `NotificationConsumer` in the main `Select` loop and dispatches it to the target Orch handler.
+- `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 
 This is the existing proven notification path.
 
@@ -110,19 +109,14 @@ ZMQ mode has existing notification handling gaps today. Some notifications alrea
 
 ```mermaid
 flowchart TD
-    subgraph vendorAsic["Vendor SAI / ASIC"]
-        vendorEvent["SAI notification event"]
-    end
-
     subgraph syncdContainer["syncd container"]
-        syncdCallback["syncd SAI callback context"]
+        saiApi["SAI API / ASIC SDK"]
+        syncdCallback["syncd SAI callback"]
         notificationProcessor["syncd NotificationProcessor"]
         zmqProducer["ZeroMQNotificationProducer"]
     end
 
-    subgraph redisDb["Redis ASIC_DB"]
-        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
-    end
+    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
@@ -131,13 +125,15 @@ flowchart TD
             callbackLogic["implemented callback logic"]
             redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
             directHandler["callback handles notification directly"]
-            redisConsumer["NotificationConsumer"]
+            redisConsumerReady["NotificationConsumer selectable ready"]
             mainLoop["orchagent main Select loop"]
+            notifier["Notifier / Executor"]
+            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
             orchHandler["Target Orch handler"]
         end
     end
 
-    vendorEvent --> syncdCallback
+    saiApi -->|"raise SAI notification"| syncdCallback
     syncdCallback --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
@@ -146,24 +142,28 @@ flowchart TD
 
     callbackLogic -->|"for port_state_change, HA, flow bulk get"| redisRepost
     redisRepost --> redisNotifications
-    redisNotifications --> redisConsumer
-    redisConsumer --> mainLoop
-    mainLoop --> orchHandler
+    redisNotifications -->|"notification available"| redisConsumerReady
+    redisConsumerReady --> mainLoop
+    mainLoop --> notifier
+    notifier --> redisDoTask
+    redisDoTask --> orchHandler
 
     callbackLogic -->|"for switch shutdown or ASIC SDK health"| directHandler
     directHandler --> orchHandler
 ```
 
+In ZMQ mode, notifications that already have callback handling follow one of the existing callback-specific paths:
+
+- Some callbacks re-post the notification to `ASIC_DB:NOTIFICATIONS`. From there, the existing Redis notification path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
+- Other callbacks, such as switch shutdown or ASIC SDK health handling, are handled directly by callback-specific logic.
+
 ### 3.2.2 Notifications With Missing Callback Handling
 
 ```mermaid
 flowchart TD
-    subgraph vendorAsic["Vendor SAI / ASIC"]
-        vendorEvent["SAI notification event"]
-    end
-
     subgraph syncdContainer["syncd container"]
-        syncdCallback["syncd SAI callback context"]
+        saiApi["SAI API / ASIC SDK"]
+        syncdCallback["syncd SAI callback"]
         notificationProcessor["syncd NotificationProcessor"]
         zmqProducer["ZeroMQNotificationProducer"]
     end
@@ -172,27 +172,21 @@ flowchart TD
         subgraph orchagentProcess["orchagent process"]
             zmqThread["libsairedis ZMQ notification thread"]
             saiCallback["orchagent libsairedis callback"]
-            callbackLogic["empty or incomplete callback logic"]
+            callbackLogic["empty / incomplete callback logic:<br/>no forwarding or dispatch to existing Orch notification handling path"]
             dropped["notification dropped"]
         end
     end
 
-    subgraph missingPath["Expected but missing path"]
-        mainLoop["orchagent main Select loop"]
-        targetConsumer["Target Orch consumer"]
-    end
-
-    vendorEvent --> syncdCallback
+    saiApi -->|"raise SAI notification"| syncdCallback
     syncdCallback --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
     saiCallback --> callbackLogic
     callbackLogic --> dropped
-
-    callbackLogic -.->|"missing forwarding or dispatch"| mainLoop
-    mainLoop -.->|"not reached"| targetConsumer
 ```
+
+In this case, the ZMQ notification reaches the `orchagent` libsairedis callback, but the callback does not forward or dispatch the notification to the existing Orch notification handling path. Because that forwarding/dispatch is missing today, the notification is dropped.
 
 ## 4. Design Goals
 
@@ -251,46 +245,47 @@ In this option, `syncd` continues to send notifications to `orchagent` through Z
 
 This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619). The same forwarding behavior would be added to each missing notification callback covered by this HLD.
 
-### Flow
+### Option 2 Flow
 
 ```mermaid
 flowchart TD
-    subgraph vendorAsic["Vendor SAI / ASIC"]
-        vendorEvent["SAI notification event"]
-    end
-
     subgraph syncdContainer["syncd container"]
-        syncdCallback["syncd SAI callback context"]
+        saiApi["SAI API / ASIC SDK"]
+        syncdCallback["syncd SAI callback"]
         notificationProcessor["syncd NotificationProcessor"]
         zmqProducer["ZeroMQNotificationProducer"]
     end
 
-    subgraph redisDb["Redis ASIC_DB"]
-        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
-    end
+    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
 
     subgraph swssContainer["swss container"]
         subgraph orchagentProcess["orchagent process"]
             zmqThread["libsairedis ZMQ notification thread"]
             saiCallback["orchagent libsairedis callback"]
             redisRepost["callback re-posts to ASIC_DB NOTIFICATIONS"]
-            redisConsumer["NotificationConsumer"]
+            redisConsumerReady["NotificationConsumer selectable ready"]
             mainLoop["orchagent main Select loop"]
+            notifier["Notifier / Executor"]
+            redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
             orchHandler["Target Orch handler"]
         end
     end
 
-    vendorEvent --> syncdCallback
+    saiApi -->|"raise SAI notification"| syncdCallback
     syncdCallback --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
     saiCallback --> redisRepost
     redisRepost --> redisNotifications
-    redisNotifications --> redisConsumer
-    redisConsumer --> mainLoop
-    mainLoop --> orchHandler
+    redisNotifications -->|"notification available"| redisConsumerReady
+    redisConsumerReady --> mainLoop
+    mainLoop --> notifier
+    notifier --> redisDoTask
+    redisDoTask --> orchHandler
 ```
+
+In Option 2, the ZMQ notification reaches the `orchagent` libsairedis callback, and the callback re-posts the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled. After the re-post, the existing Redis notification path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 
 ### Implementation Notes
 
@@ -337,16 +332,13 @@ In this option, the `orchagent` libsairedis callback packages the notification a
 
 This model is similar in spirit to existing selectable-based processing such as `ZmqConsumerStateTable`, where data availability wakes the main loop and processing happens through an executor path.
 
-### Flow
+### Option 3 Flow
 
 ```mermaid
 flowchart TD
-    subgraph vendorAsic["Vendor SAI / ASIC"]
-        vendorEvent["SAI notification event"]
-    end
-
     subgraph syncdContainer["syncd container"]
-        syncdCallback["syncd SAI callback context"]
+        saiApi["SAI API / ASIC SDK"]
+        syncdCallback["syncd SAI callback"]
         notificationProcessor["syncd NotificationProcessor"]
         zmqProducer["ZeroMQNotificationProducer"]
     end
@@ -355,8 +347,8 @@ flowchart TD
         subgraph orchagentProcess["orchagent process"]
             zmqThread["libsairedis ZMQ notification thread"]
             saiCallback["orchagent libsairedis callback"]
-            notificationQueue["in-process notification queue"]
-            selectableEvent["selectable event / wakeup"]
+            notificationQueue[["in-process notification queue"]]
+            selectableEvent["new SAI notification queue selectable"]
             mainLoop["orchagent main Select loop"]
             queueExecutor["SaiNotificationQueueExecutor"]
             dispatcher["dispatchSaiNotification()"]
@@ -364,7 +356,7 @@ flowchart TD
         end
     end
 
-    vendorEvent --> syncdCallback
+    saiApi -->|"raise SAI notification"| syncdCallback
     syncdCallback --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
@@ -372,39 +364,118 @@ flowchart TD
 
     saiCallback --> notificationQueue
     notificationQueue --> selectableEvent
-    selectableEvent -->|"wake Select loop"| mainLoop
+    selectableEvent -->|"queued notification available"| mainLoop
     mainLoop --> queueExecutor
     queueExecutor --> dispatcher
     dispatcher --> orchHandler
 ```
 
+### Option 3 Sequence
+
+The flow diagram above shows the components involved. The sequence diagrams below show the expected ordering and execution-context handoff for Option 3.
+
+Option 3 does not change notification delivery up to the `orchagent` libsairedis callback; its changes start after the callback receives the notification.
+
+ZMQ notification delivery to `orchagent` callback:
+
+```mermaid
+sequenceDiagram
+    box syncd container
+        participant SaiApi as SAI API / ASIC SDK
+        participant SyncdCb as syncd SAI callback
+        participant Processor as syncd NotificationProcessor
+        participant ZmqProducer as ZeroMQNotificationProducer
+    end
+
+    participant ZMQ as ZMQ
+
+    box swss container / orchagent process
+        participant ZmqThread as libsairedis ZMQ notification thread
+        participant Callback as orchagent libsairedis callback
+    end
+
+    SaiApi->>SyncdCb: 1. raise SAI notification
+    SyncdCb->>Processor: 2. process notification
+    Processor->>ZmqProducer: 3. pass to producer
+    ZmqProducer->>ZMQ: 4. send notification
+    ZMQ->>ZmqThread: 5. deliver notification
+    ZmqThread->>Callback: 6. invoke SAI callback
+```
+
+The notification delivery sequence is:
+
+1. `SAI API / ASIC SDK` raises a notification and invokes the registered `syncd` SAI callback.
+2. The `syncd` SAI callback passes the notification to `syncd` notification processing.
+3. `syncd` notification processing passes the notification to `ZeroMQNotificationProducer`.
+4. `ZeroMQNotificationProducer` sends the notification to ZMQ.
+5. ZMQ delivers the notification to the libsairedis ZMQ notification thread in `orchagent`.
+6. The libsairedis ZMQ notification thread invokes the registered `orchagent` libsairedis callback.
+
+Option 3 callback to main-loop processing:
+
+```mermaid
+sequenceDiagram
+    box swss container / orchagent process
+        participant Callback as orchagent libsairedis callback
+        participant Queue as in-process notification queue
+        participant Wakeup as new SAI notification queue selectable
+        participant MainLoop as OrchDaemon::start Select loop
+        participant Executor as SaiNotificationQueueExecutor::execute()
+        participant Dispatcher as dispatchSaiNotification()
+        participant Orch as Target Orch handler
+    end
+
+    Callback->>Queue: 1. enqueue SaiNotification
+    Callback->>Wakeup: 2. notify queue selectable
+    Wakeup->>MainLoop: 3. queued notification available
+    MainLoop->>Executor: 4. dispatch executor
+    Executor->>Queue: 5. pops queued notifications
+    Executor->>Dispatcher: 6. dispatch notification
+    Dispatcher->>Orch: 7. invoke target Orch handler
+```
+
+The main-loop processing sequence is:
+
+- The `orchagent` libsairedis callback runs in the ZMQ notification thread.
+
+1. The callback serializes/packages the notification as a `SaiNotification` and enqueues it into the in-process notification queue.
+2. The callback notifies the new SAI notification queue selectable.
+3. The current `OrchDaemon::start()` `Select` loop is notified that queued notifications are available.
+4. The main loop dispatches `SaiNotificationQueueExecutor::execute()`.
+5. `SaiNotificationQueueExecutor::execute()` pops queued notifications from the in-process notification queue.
+6. The executor calls `dispatchSaiNotification()`.
+7. `dispatchSaiNotification()` routes the notification to the target Orch handler on the `orchagent` main-loop path.
+
 ### Dispatch Relationship During Phased Migration to Option 3
 
 Option 3 does not send migrated ZMQ notifications back through `ASIC_DB:NOTIFICATIONS`. For notification types moved to the Option 3 queue-based model, the `orchagent` libsairedis callback enqueues the notification, and the `orchagent` main loop drains the queue and dispatches it to the target Orch handler.
 
-The existing Redis notification path remains unchanged for non-ZMQ mode and for notification types that continue to use the Option 2 Redis re-post model during phased rollout. In those cases, notifications are consumed through the existing `NotificationConsumer` path and dispatched by the corresponding Orch consumer `doTask()` / handler logic.
+The existing Redis notification path remains unchanged for non-ZMQ mode and for notification types that continue to use the Option 2 Redis re-post model during phased rollout. In those cases, the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 
 ```mermaid
 flowchart TD
-    subgraph redisPath["Redis notification path"]
-        redisNotifications["ASIC_DB NOTIFICATIONS channel"]
-        redisConsumer["NotificationConsumer"]
+    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
+
+    subgraph redisPath["Existing Redis notification path"]
+        redisConsumerReady["NotificationConsumer selectable ready"]
         redisMainLoop["orchagent main Select loop"]
-        redisDoTask["existing Orch consumer doTask / handler path"]
+        notifier["Notifier / Executor"]
+        redisDoTask["Orch doTask(NotificationConsumer&) / handler"]
     end
 
     subgraph option3Path["Option 3 queue-based path"]
         libsairedisCallback["orchagent libsairedis callback"]
-        notificationQueue["in-process notification queue"]
+        notificationQueue[["in-process notification queue"]]
         queueExecutor["SaiNotificationQueueExecutor"]
         option3Dispatch["dispatchSaiNotification()"]
     end
 
     targetHandler["Target Orch handler"]
 
-    redisNotifications --> redisConsumer
-    redisConsumer --> redisMainLoop
-    redisMainLoop --> redisDoTask
+    redisNotifications -->|"notification available"| redisConsumerReady
+    redisConsumerReady --> redisMainLoop
+    redisMainLoop --> notifier
+    notifier --> redisDoTask
     redisDoTask --> targetHandler
 
     libsairedisCallback --> notificationQueue
@@ -414,17 +485,23 @@ flowchart TD
 
 ```
 
-Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` and Orch consumer `doTask()` / handler flow, while Option 3 uses the new queue-based executor path for migrated ZMQ notification types.
+Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` flow, while Option 3 uses the new queue-based executor path for migrated ZMQ notification types.
 
 ### Existing Code References
 
-Option 3 is expected to build on the following existing infrastructure:
+Option 3 is expected to build on the following existing infrastructure.
+
+Current notification callbacks and consumers:
 
 - Callback implementations: some existing `orchagent` SAI notification callbacks are currently no-op or incomplete for ZMQ mode and need forwarding or queueing behavior. Examples include `on_fdb_event()`, `on_bfd_session_state_change()`, and `on_port_host_tx_ready()` in `src/sonic-swss/orchagent/notifications.cpp`, and `IcmpSaiSessionHandler::on_state_change()` in `src/sonic-swss/orchagent/icmporch.cpp`. Under Option 3, these callbacks would enqueue notifications for main-loop processing.
 - Callback registration: notification callbacks are registered through existing Orch initialization and feature-specific setup paths. Examples include switch notification setup in `src/sonic-swss/orchagent/main.cpp`, `src/sonic-swss/orchagent/portsorch.cpp`, and `src/sonic-swss/orchagent/bfdorch.cpp`, and ICMP offload-session callback registration through `SaiOffloadSessionHandler`.
 - Existing Orch notification consumers: in the existing non-ZMQ notification path, these notification types are consumed from `ASIC_DB:NOTIFICATIONS` by target Orch consumers such as `FdbOrch`, `BfdOrch`, `PortsOrch`, and `IcmpOrch`. Option 3 should preserve the same Orch handler behavior without sending migrated ZMQ notifications through Redis.
 - Existing Redis notification dispatch: Redis-delivered SAI notifications are consumed through `NotificationConsumer` instances wrapped by `Notifier`. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, preserving the existing per-Orch notification handling model for non-ZMQ mode and Option 2.
+
+Selectable/executor integration:
+
 - Selectable-based ZMQ consumers: `src/sonic-swss-common/common/zmqconsumerstatetable.h` defines `ZmqConsumerStateTable`, an existing selectable-based ZMQ consumer that wakes the main loop when data is available and processes data through the executor path. Option 3 can follow a similar integration pattern for SAI notifications.
+- `ZmqConsumerStateTable` processing model: the referenced SONiC ZMQ producer/consumer state table design describes a receive-thread-to-main-loop pattern where `ZmqServer` receives and deserializes ZMQ messages, dispatches them to `ZmqConsumerStateTable`, `ZmqConsumerStateTable` notifies `Select`, and the main loop later pops operations through `ZmqConsumerStateTable::pops()`. Option 3 follows the same general pattern for SAI notifications: the `orchagent` libsairedis callback enqueues the notification, notifies the main loop, and processing happens through the executor path.
 - Select priority: `swss::Selectable` carries a priority value used by `Select`; higher priority values are selected ahead of lower-priority ready selectables. Option 3 should use this existing priority model where practical.
 - Main-loop infrastructure: `src/sonic-swss/orchagent/orchdaemon.cpp` contains the main `OrchDaemon::start()` `Select` loop that waits on registered selectables and dispatches `Executor::execute()` when a selectable becomes ready. The Option 3 integration approach is described in [Main-loop Integration](#main-loop-integration).
 
@@ -442,7 +519,7 @@ struct SaiNotification
 ```
 
 ```cpp
-class SaiNotificationQueue
+class SaiNotificationQueue : public Selectable
 {
 public:
     void enqueue(SaiNotification notification)
@@ -455,33 +532,52 @@ public:
         notifyMainLoop();
     }
 
-    bool tryDequeue(SaiNotification &notification)
+    int getFd() override
+    {
+        return m_selectableEvent.getFd();
+    }
+
+    uint64_t readData() override
+    {
+        return m_selectableEvent.readData();
+    }
+
+    bool hasData() override
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return !m_queue.empty();
+    }
+
+    bool hasCachedData() override
+    {
+        return hasData();
+    }
+
+    void pops(std::deque<SaiNotification> &notifications)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
 
-        if (m_queue.empty())
+        notifications.clear();
+        while (!m_queue.empty())
         {
-            return false;
+            notifications.push_back(std::move(m_queue.front()));
+            m_queue.pop();
         }
-
-        notification = std::move(m_queue.front());
-        m_queue.pop();
-        return true;
     }
 
 private:
     std::mutex m_mutex;
     std::queue<SaiNotification> m_queue;
-    SelectableEvent m_wakeupEvent;
+    SelectableEvent m_selectableEvent;
 
     void notifyMainLoop()
     {
-        m_wakeupEvent.notify();
+        m_selectableEvent.notify();
     }
 };
 ```
 
-`notifyMainLoop()` represents a wakeup mechanism for the existing `orchagent` main loop. The implementation should reuse the existing swss selectable/executor model where practical, similar to `ZmqConsumerStateTable`, rather than introducing a separate main-loop mechanism. The important requirement is that enqueueing a notification makes a selectable object readable so the current `OrchDaemon::start()` loop can dispatch it like other selectables.
+`notifyMainLoop()` represents notifying the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model where practical, similar to `ZmqConsumerStateTable`, rather than introducing a separate main-loop mechanism. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the queue executor like other selectable executors.
 
 Callback:
 
@@ -516,14 +612,14 @@ flowchart TD
     subgraph orchMainThread["orchagent main thread"]
         selectLoop["OrchDaemon::start Select loop"]
         queueExecutor["SaiNotificationQueueExecutor::execute"]
-        queueDrain["queue drain"]
+        queueDrain["pops queued notifications"]
         dispatcher["dispatchSaiNotification()"]
         orchHandler["Target Orch handler"]
     end
 
     saiCallback --> enqueue
     enqueue --> notifyMainLoop
-    notifyMainLoop -->|"SelectableEvent notify"| selectLoop
+    notifyMainLoop -->|"queued notification available"| selectLoop
     selectLoop --> queueExecutor
     queueExecutor --> queueDrain
     queueDrain --> dispatcher
@@ -562,10 +658,10 @@ class SaiNotificationQueueExecutor : public Executor
 public:
     void execute() override
     {
-        m_queue.clearWakeupEvent();
+        std::deque<SaiNotification> notifications;
+        m_queue.pops(notifications);
 
-        SaiNotification notification;
-        while (m_queue.tryDequeue(notification))
+        for (const auto &notification : notifications)
         {
             dispatchSaiNotification(notification);
         }
@@ -584,9 +680,10 @@ The conceptual equivalent is:
 ```cpp
 void processQueuedZmqNotifications()
 {
-    SaiNotification notification;
+    std::deque<SaiNotification> notifications;
+    gSaiNotificationQueue.pops(notifications);
 
-    while (gSaiNotificationQueue.tryDequeue(notification))
+    for (const auto &notification : notifications)
     {
         dispatchSaiNotification(notification);
     }
@@ -623,7 +720,7 @@ void OrchDaemon::dispatchSaiNotification(const SaiNotification &notification)
 
 ### Migration Note for Existing Option 2-style Callbacks
 
-For phased rollout of the long-term Option 3 queue-based model, notification types can be migrated incrementally. Notifications not yet migrated can continue to use Option 2, where libsairedis callbacks re-post notifications to Redis and the existing `ASIC_DB:NOTIFICATIONS` subscription handles final Orch dispatch.
+For phased rollout of the long-term Option 3 queue-based model, notification types can be migrated incrementally. Notifications not yet migrated can continue to use Option 2, where libsairedis callbacks re-post notifications to Redis and the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` path handles final Orch dispatch.
 
 Existing Option 2-style callbacks can be migrated notification type by notification type.
 
@@ -634,7 +731,7 @@ flowchart TD
     zmqNotification["syncd sends notification over ZMQ"]
     libsairedisCallback["orchagent libsairedis callback"]
     redisRepost["Redis re-post"]
-    redisNotifications["ASIC_DB NOTIFICATIONS channel"]
+    redisNotifications[("Redis ASIC_DB: NOTIFICATIONS channel")]
 
     zmqNotification --> libsairedisCallback
     libsairedisCallback --> redisRepost
@@ -647,7 +744,7 @@ Long-term / Option 3 queue-based path:
 flowchart TD
     zmqNotification["syncd sends notification over ZMQ"]
     libsairedisCallback["orchagent libsairedis callback"]
-    notificationQueue["in-process notification queue"]
+    notificationQueue[["in-process notification queue"]]
 
     zmqNotification --> libsairedisCallback
     libsairedisCallback --> notificationQueue
@@ -664,7 +761,7 @@ flowchart TD
 
 - Requires implementation and validation of a new selectable/executor path for SAI notifications.
 - Requires backpressure behavior for the in-process notification queue.
-- Requires lifecycle handling for the shared queue and wakeup mechanism during startup, shutdown, and callback teardown.
+- Requires lifecycle handling for the shared queue and SAI notification queue selectable during startup, shutdown, and callback teardown.
 - More implementation and test effort than Option 2.
 - Larger design review scope.
 

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -453,6 +453,16 @@ void processQueuedZmqNotifications()
 }
 ```
 
+### Priority and Fairness
+
+The in-process notification queue should support priority-aware processing.
+
+Time-sensitive notifications such as port state, port host TX ready, and BFD session state change should be processed with higher priority than less time-sensitive notifications.
+
+To avoid starvation, the main-loop executor should not drain one notification type indefinitely. It should use a bounded drain policy, such as processing up to N high-priority notifications per loop before checking lower-priority notifications and other Orch tasks.
+
+This keeps latency low for critical notifications while preventing one notification stream from starving others.
+
 Common dispatcher:
 
 ```cpp

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -37,7 +37,7 @@
       - [5.3.8.1 Readiness-gated boot-time sequence (example: port readiness)](#5381-readiness-gated-boot-time-sequence-example-port-readiness)
       - [5.3.8.2 Non-readiness-gated boot-time sequence](#5382-non-readiness-gated-boot-time-sequence)
     - [5.3.9 Notification inventory](#539-notification-inventory)
-    - [5.3.10 Priority, Fairness, and Shared Handler](#5310-priority-fairness-and-shared-handler)
+    - [5.3.10 Priority, Fairness, Queue Policy, and Shared Handler](#5310-priority-fairness-queue-policy-and-shared-handler)
     - [5.3.11 Validation and Unit Test Coverage](#5311-validation-and-unit-test-coverage)
     - [5.3.12 Pros](#5312-pros)
     - [5.3.13 Cons](#5313-cons)
@@ -220,10 +220,11 @@ In this case, ZMQ transport delivers the notification to the `orchagent` libsair
 ## 4. Design Goals
 
 - Preserve existing non-ZMQ behavior.
-- Restore missing notifications in ZMQ mode for every `ASIC_DB:NOTIFICATIONS` type listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** ops.
+- Restore missing notifications in ZMQ mode for the covered `ASIC_DB:NOTIFICATIONS` SAI notification types, while leaving notifications that already use direct callback handling unchanged.
 - Avoid duplicate notification delivery.
 - Preserve existing Orch handler behavior, including per-orch readiness rules in `doTask(NotificationConsumer&)`.
 - Keep Orch state updates on the `orchagent` main-loop path.
+- Preserve Redis `NotificationConsumer` behavior where notification dispatch is reused or replaced: consumer isolation, coalescing policy (LruDedup vs FIFO), Select scheduling semantics, `hasCachedData()` behavior, and `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` field schema.
 
 ## 5. Design Options
 
@@ -235,7 +236,7 @@ The existing **non-ZMQ** notification path ([Section 3.1](#31-non-zmq-mode)) is 
 |--------|---------|
 | **Option 1** | `syncd` publishes notifications to Redis while request/response stays on ZMQ |
 | **Option 2** | ZMQ transport + `orchagent` callback re-post to Redis ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)) |
-| **Option 3** | ZMQ transport + `orchagent` callback enqueue to in-process queue (main-loop drain) |
+| **Option 3** | ZMQ transport + `orchagent` callback enqueue to in-process notification queues (main-loop drain) |
 
 See [Section 5.4](#54-recommendation) for the proposed path.
 
@@ -369,7 +370,12 @@ Note: The callback must check whether ZMQ mode is enabled before re-publishing t
 
 #### 5.3.1 Description
 
-In this option, the `orchagent` libsairedis callback packages the notification as an operation name, serialized payload, and optional field-value list, then makes it available to the main loop through an in-process notification queue. The `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
+In this option, the `orchagent` libsairedis callback packages the notification as an operation name, serialized payload, and optional field-value list, then enqueues it on an **in-process per-consumer notification queue**. Notification queue topology matches today's Redis `NotificationConsumer` layout on `ASIC_DB:NOTIFICATIONS`: one in-process notification queue and one `SaiNotificationQueueExecutor` per existing consumer (typically one op per consumer; `MACsecOrch` keeps a single shared notification queue for both POST-status ops). The `orchagent` main `Select` loop drains each ready notification queue and dispatches to the owning orch's existing `handleNotification()` path.
+
+Each queue uses the same coalescing policy as its Redis twin:
+
+- **LruDedup** for `fdb_event`, `port_state_change`, and `port_host_tx_ready` (end-state-idempotent; last-seen unique payload wins).
+- **FIFO** for the remaining migrated ops (`bfd_session_state_change`, `icmp_echo_session_state_change`, `twamp_session_event`, MACsec POST-status, HA/flow-bulk, `tam_tel_type_config_change`).
 
 This model is similar in spirit to existing selectable-based processing such as `ZmqConsumerStateTable`, where data availability wakes the main loop and processing happens through an executor path.
 
@@ -391,16 +397,16 @@ flowchart TD
         subgraph orchagentProcess["orchagent process"]
             zmqThread["libsairedis ZMQ<br/>notification thread"]
             saiCallback["orchagent libsairedis<br/>callback"]
-            notificationQueue[["in-process<br/>notification queue"]]
-            queueSelectableReady["SAI notification queue<br/>selectable ready"]
+            notificationQueue[["per-consumer<br/>in-process notification queues"]]
+            queueSelectableReady["per-consumer notification queue<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
-            saiNotificationOrch["SaiNotificationOrch<br/>(shared consumer host)"]
-            queueExecutor["SaiNotification<br/>QueueExecutor"]
-            headPredicate["check notification<br/>processing readiness<br/>for queue head"]
+            saiNotificationOrch["SaiNotificationOrch<br/>(consumer host)"]
+            queueExecutor["per-consumer notification<br/>QueueExecutor"]
+            headPredicate["check this notification queue's<br/>readiness predicate"]
             queueDrain["pops when readiness<br/>predicate passes"]
-            stayQueued["return without pop.<br/>Notification stays queued"]
+            stayQueued["return without pop.<br/>Notifications stay queued"]
             dispatcher["SaiNotificationDispatcher"]
-            orchHandler["Target Orch<br/>notification handler"]
+            orchHandler["Target Orch<br/>handleNotification()"]
         end
     end
 
@@ -483,44 +489,44 @@ sequenceDiagram
     end
 
     box rgb(219, 234, 254) New Option 3 components in swss/orchagent
-        participant Queue as in-process notification queue
-        participant Wakeup as new SAI notification queue selectable
+        participant Queue as per-consumer in-process notification queue
+        participant Wakeup as per-consumer notification queue selectable
         participant SaiNotificationOrch as SaiNotificationOrch
-        participant Executor as SaiNotificationQueueExecutor::execute()
+        participant Executor as per-consumer notification QueueExecutor::execute()
         participant Dispatcher as SaiNotificationDispatcher
     end
 
     box swss container / orchagent process
         participant MainLoop as OrchDaemon::start Select loop
-        participant Orch as Target Orch handler
+        participant Orch as Target Orch handleNotification()
     end
 
-    Callback->>Queue: 1. enqueue op, serialized data, values
-    Callback->>Wakeup: 2. notify queue selectable
-    Wakeup->>MainLoop: 3. queued notification available
-    MainLoop->>SaiNotificationOrch: 4. dispatch executor
+    Callback->>Queue: 1. enqueue onto that op's consumer notification queue
+    Callback->>Wakeup: 2. notify that notification queue's selectable
+    Wakeup->>MainLoop: 3. that notification queue is ready
+    MainLoop->>SaiNotificationOrch: 4. dispatch that consumer's notification executor
     SaiNotificationOrch->>Executor: 5. execute()
-    Executor->>Executor: 6. check per-operation readiness predicate
+    Executor->>Executor: 6. check this notification queue's readiness predicate
     alt 7. readiness predicate fails
-        Note over Executor,Queue: return without pop
-        Note over Queue: notification stays queued
+        Note over Executor,Queue: hasCachedData() is false, return without pop
+        Note over Queue: this consumer's notifications stay queued
     else 8-10. readiness predicate passes
-        Executor->>Queue: 8. pops
-        Executor->>Dispatcher: 9. dispatch by op
-        Dispatcher->>Orch: 10. invoke registered handler
+        Executor->>Queue: 8. pops (same-consumer batch)
+        Executor->>Dispatcher: 9. dispatch
+        Dispatcher->>Orch: 10. handleNotification(entry)
     end
 ```
 
-1. The callback serializes/packages the notification as a `KeyOpFieldsValuesTuple`-compatible entry and enqueues it into the in-process notification queue.
-2. The callback notifies the new SAI notification queue selectable.
-3. The current `OrchDaemon::start()` `Select` loop is notified that queued notifications are available.
-4. The main loop dispatches the executor owned by `SaiNotificationOrch`.
-5. `SaiNotificationQueueExecutor::execute()` is invoked on the main-loop path.
-6. The executor checks the **per-operation readiness predicate** for the notification queue head entry — a per-op function that returns true when the owning orch is ready to process that notification type (for example `gPortsOrch->allPortsReady()` for ops that gate on port readiness, or always true when no predicate is registered, such as `bfd_session_state_change`). See [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) for readiness predicate registration, boot-time behavior, and head-of-line blocking.
-7. If the readiness predicate fails, the executor returns without popping; queued notifications are preserved for a later main-loop iteration.
-8. If the readiness predicate passes, the executor pops queued notifications from the in-process notification message queue. Each `execute()` call is batch-limited via `DEFAULT_NC_POP_BATCH_SIZE` (see [Section 5.3.6](#536-implementation-notes)); if more entries remain, the queue selectable is re-notified so later main-loop iterations can drain them.
-9. The executor dispatches each popped entry by notification op through `SaiNotificationDispatcher` (the handler registry; see [Section 5.3.7](#537-main-loop-integration)).
-10. The dispatcher invokes the target Orch handler registered for that notification op on the `orchagent` main-loop path.
+1. The callback serializes/packages the notification as a `KeyOpFieldsValuesTuple`-compatible entry and enqueues it onto the **per-consumer** in-process notification queue for that op (same consumer layout as Redis `NotificationConsumer` on `ASIC_DB:NOTIFICATIONS`).
+2. The callback notifies that notification queue's selectable.
+3. The current `OrchDaemon::start()` `Select` loop is notified that this consumer's queued notifications are available.
+4. The main loop dispatches the notification executor owned by `SaiNotificationOrch` for that consumer.
+5. That `SaiNotificationQueueExecutor::execute()` is invoked on the main-loop path.
+6. The executor checks the **readiness predicate registered for this consumer/op**. See [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) for the per-consumer isolation rules that prevent mixed-readiness batch pops.
+7. If the readiness predicate fails, the executor returns without popping and this consumer's notifications stay queued; `hasCachedData()` is false to avoid main-loop spin. Retry behavior is described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
+8. If the readiness predicate passes, the executor pops a batch from **this** queue (`DEFAULT_NC_POP_BATCH_SIZE`). If more entries remain, `hasCachedData()` follows Redis (`size() > 1`) so the next drain happens on a later Select iteration. Remaining depth of 1 waits for the next fd-ready `select()`.
+9. The executor dispatches each popped entry through `SaiNotificationDispatcher`.
+10. The dispatcher invokes the target Orch `handleNotification(entry)` registered for that op on the `orchagent` main-loop path.
 
 #### 5.3.4 Notification Dispatch Path Comparison (Non-ZMQ, Option 2, and Option 3)
 
@@ -530,9 +536,9 @@ The diagram below shows three entry paths:
 
 - **Non-ZMQ mode** — `syncd` SAI callback enqueues on the internal notification queue; `NotificationProcessor` publishes to `ASIC_DB:NOTIFICATIONS`. The `orchagent` libsairedis callback is not part of notification delivery. The Redis consumer leg ([Section 3.1](#31-non-zmq-mode)) dispatches to the target Orch handler.
 - **Option 2** — ZMQ-mode interim fix ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)): the callback re-posts to `ASIC_DB:NOTIFICATIONS`, then uses the same Redis consumer leg as non-ZMQ mode.
-- **Option 3** — ZMQ-mode target design: the callback enqueues to the in-process notification message queue; the main loop drains through the shared queue executor and `SaiNotificationDispatcher`. Option 3 does not send notifications back through `ASIC_DB:NOTIFICATIONS`.
+- **Option 3** — ZMQ-mode target design: the callback enqueues to the **per-consumer** in-process notification queue for that op; the main loop drains each consumer through its own notification queue executor and `SaiNotificationDispatcher`. Option 3 does not send notifications back through `ASIC_DB:NOTIFICATIONS`.
 
-**Option 3 scope.** In ZMQ mode, Option 3 migrates every notification op listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** to the in-process queue. There is **no hybrid Option 2 + Option 3 coexistence** for the same notification type: queue-path ops enqueue only; they do not also re-post to Redis. Non-ZMQ mode continues to use the existing Redis notification path ([Section 3.1](#31-non-zmq-mode)).
+**Option 3 scope.** In ZMQ mode, Option 3 migrates every notification op listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** to the in-process notification queue path. There is **no hybrid Option 2 + Option 3 coexistence** for the same notification type: notification queue-path ops enqueue only; they do not also re-post to Redis. Non-ZMQ mode continues to use the existing Redis notification path ([Section 3.1](#31-non-zmq-mode)).
 
 ```mermaid
 flowchart TD
@@ -549,15 +555,15 @@ flowchart TD
     end
 
     subgraph option3Path["Option 3 queue-based path"]
-        enqueueNotify["enqueue and notify<br/>queue selectable"]
-        notificationQueue[["in-process<br/>notification message queue"]]
-        queueSelectableReady["SAI notification queue<br/>selectable ready"]
+        enqueueNotify["enqueue onto that op's<br/>per-consumer notification queue"]
+        notificationQueue[["per-consumer<br/>in-process notification queues"]]
+        queueSelectableReady["that consumer's notification queue<br/>selectable ready"]
         option3MainLoop["orchagent main Select loop"]
-        saiNotificationOrch["SaiNotificationOrch<br/>(shared consumer host)"]
-        queueExecutor["SaiNotification<br/>QueueExecutor"]
-        headPredicate["check notification<br/>processing readiness<br/>for queue head"]
+        saiNotificationOrch["SaiNotificationOrch<br/>(consumer host)"]
+        queueExecutor["per-consumer notification<br/>QueueExecutor"]
+        headPredicate["check this notification queue's<br/>readiness predicate"]
         queueDrain["pops when readiness<br/>predicate passes"]
-        stayQueued["return without pop.<br/>Notification stays queued"]
+        stayQueued["return without pop.<br/>Notifications stay queued"]
         dispatcher["SaiNotificationDispatcher"]
     end
 
@@ -589,7 +595,7 @@ flowchart TD
     class enqueueNotify,notificationQueue,queueSelectableReady,saiNotificationOrch,queueExecutor,headPredicate,queueDrain,stayQueued,dispatcher option3New
 ```
 
-All three paths preserve the same target Orch handler behavior. In non-ZMQ mode, `syncd` publishes directly to `ASIC_DB:NOTIFICATIONS` and the `orchagent` libsairedis callback is not part of notification delivery; the Redis consumer leg (`NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)`) handles it. Option 2 reuses that same Redis consumer leg, but reaches it by re-posting from the ZMQ-mode callback. Option 3 replaces the Redis leg with the queue-based executor path and dispatches queued notifications by op through `SaiNotificationDispatcher` to registered target Orch handlers. The Redis and queue paths should share the same notification-specific handler logic where practical.
+All three paths preserve the same target Orch handler behavior. In non-ZMQ mode, `syncd` publishes directly to `ASIC_DB:NOTIFICATIONS` and the `orchagent` libsairedis callback is not part of notification delivery; the Redis consumer leg (`NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)`) handles it. Option 2 reuses that same Redis consumer leg, but reaches it by re-posting from the ZMQ-mode callback. Option 3 replaces the Redis leg with **per-consumer in-process notification queues** (same consumer layout and LruDedup/FIFO policy as Redis) and dispatches to registered target Orch `handleNotification()` handlers. The Redis and notification queue paths share the same notification-specific handler logic.
 
 #### 5.3.5 Existing Code References
 
@@ -608,52 +614,96 @@ Selectable/executor integration:
 - `ZmqConsumerStateTable` processing model: the referenced SONiC ZMQ producer/consumer state table design describes a receive-thread-to-main-loop pattern where `ZmqServer` receives and deserializes ZMQ messages, dispatches them to `ZmqConsumerStateTable`, `ZmqConsumerStateTable` notifies `Select`, and the main loop later pops operations through `ZmqConsumerStateTable::pops()`. Option 3 follows the same general pattern for SAI notifications: the `orchagent` libsairedis callback enqueues the notification, notifies the main loop, and processing happens through the executor path.
 - Select priority: `swss::Selectable` carries a priority value used by `Select`; higher priority values are selected ahead of lower-priority ready selectables. Option 3 should use this existing priority model where practical.
 - Main-loop infrastructure: `src/sonic-swss/orchagent/orchdaemon.cpp` contains the main `OrchDaemon::start()` `Select` loop that waits on registered selectables and dispatches `Executor::execute()` when a selectable becomes ready. The Option 3 integration approach is described in [Section 5.3.7](#537-main-loop-integration).
-- `SaiNotificationOrch`: shared SAI notification queue consumer host; see [Section 5.3.7](#537-main-loop-integration) for construction order, ZMQ vs non-ZMQ registration, executor ownership, and `SaiNotificationDispatcher` handler registry.
+- `SaiNotificationOrch`: SAI notification consumer host; see [Section 5.3.7](#537-main-loop-integration) for construction order, per-consumer notification queue/executor ownership, ZMQ vs non-ZMQ registration, and `SaiNotificationDispatcher` handler registry.
+- `NotificationConsumerStatsOrch`: `src/sonic-swss/orchagent/notificationconsumerstatsorch.cpp` periodically publishes registered non-ZMQ `NotificationConsumer` stats to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS`. Option 3 extends this path for per-consumer in-process notification queues in ZMQ mode (see [Section 5.3.6](#536-implementation-notes)).
 
 #### 5.3.6 Implementation Notes
 
 The following snippets are high-level pseudo-code aligned with the proposed implementation. The queue stores the same shape used by existing swss notification consumers: operation name, serialized data, and optional field-value list.
 
-The queue and executor pattern is generic. Migrated callbacks enqueue into one shared `SaiNotificationQueue`. A queue executor drains that queue and dispatches each entry by operation name to a registered target Orch handler. The examples below use `FdbOrch` and `fdb_event`, but the same registry pattern applies to `BfdOrch`, `PortsOrch`, `IcmpOrch`, or other notification owners.
+The notification queue and executor pattern is generic and **per-consumer**. Migrated callbacks enqueue onto the in-process notification queue that corresponds to the Redis `NotificationConsumer` for that op. `SaiNotificationOrch` owns one `SaiNotificationQueue` plus one `SaiNotificationQueueExecutor` per consumer. Each executor drains only that notification queue and dispatches to the registered `handleNotification()` handler. Per-consumer isolation and multi-op readiness rules are described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
+
+**Queue policy (Redis parity).** Each in-process notification queue uses the same `NotificationQueuePolicy` as its Redis twin:
+
+| Queue policy | Ops |
+|---|---|
+| `LruDedup` | `fdb_event`, `port_state_change`, `port_host_tx_ready` |
+| `Fifo` | `bfd_session_state_change`, `icmp_echo_session_state_change`, `twamp_session_event`, `switch_macsec_post_status` + `macsec_post_status` (one MACsec consumer), `ha_set_event`, `ha_scope_event`, `flow_bulk_get_session_event`, `tam_tel_type_config_change` |
+
+`LruDedup` is byte-identical payload coalescing (last-seen unique payload at the tail), as in `swss-common` `LruDedupNotificationQueue`. It is used only for consumers already audited as end-state-idempotent on Redis. FIFO consumers keep strict arrival order.
+
+Option 3 intentionally keeps notification-message queue semantics rather than replacing the queue with a per-key last-value cache. The existing Redis path delivers serialized notification messages, not state-table updates. Some notification types represent ordered transitions, and different notifications for the same object can carry different event state or fields that the owning orch must observe. A per-key last-writer-wins structure would introduce new coalescing semantics and could drop distinct transitions. Option 3 therefore matches Redis behavior: FIFO consumers preserve every admitted notification in arrival order, while LruDedup consumers collapse only byte-identical payloads for the audited idempotent cases listed above.
+
+The examples below use `FdbOrch` / `fdb_event`, but the same registry pattern applies to every migrated consumer.
 
 ```cpp
-class SaiNotificationQueue : public swss::Selectable
+// Pseudo-type representing the selected FIFO or LruDedup queue backend.
+class NotificationQueueBackend;
+
+class SaiNotificationQueue
 {
 public:
-    SaiNotificationQueue(int pri = 100,
-                         size_t popBatchSize = swss::DEFAULT_NC_POP_BATCH_SIZE);
+    using ReadinessPredicate = std::function<bool()>;
 
-    void enqueue(const std::string &op,
-                 std::string data,
-                 std::vector<swss::FieldValueTuple> values)
+    SaiNotificationQueue(const std::string &consumerName,
+                         int pri = 100,
+                         size_t popBatchSize = swss::DEFAULT_NC_POP_BATCH_SIZE,
+                         swss::NotificationQueuePolicy policy = swss::NotificationQueuePolicy::Fifo)
+        : m_queue(consumerName, policy)
+        , m_pri(pri)
+        , m_popBatchSize(popBatchSize)
     {
-        {
-            std::lock_guard<std::mutex> lock(m_mutex);
-            m_queue.emplace(std::move(data), op, std::move(values));
-        }
-
-        m_selectableEvent.notify();
     }
 
-    int getFd() override
+    // ... enqueue routes into m_queue using Fifo or LruDedup, then notifies
+    // m_selectableEvent so the main Select loop sees queued work ...
+
+    int getPri() const
+    {
+        return m_pri;
+    }
+
+    int getFd()
     {
         return m_selectableEvent.getFd();
     }
 
-    uint64_t readData() override
+    uint64_t readData()
     {
         return m_selectableEvent.readData();
     }
 
-    bool hasData() override
+    void registerReadiness(ReadinessPredicate ready = nullptr)
+    {
+        m_ready = std::move(ready);
+        m_handlerRegistered = true;
+    }
+
+    bool isReady() const
+    {
+        return m_handlerRegistered && (!m_ready || m_ready());
+    }
+
+    bool hasData()
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         return !m_queue.empty();
     }
 
-    bool hasCachedData() override
+    // Redis NotificationConsumer::hasCachedData() is size() > 1, not "any
+    // non-empty". Returning hasData() here would reinsert the selectable
+    // immediately from Select::select() and can busy-spin when the
+    // consumer is not ready (queue non-empty, execute() returns).
+    // A single ready entry is still processed by the current execute();
+    // hasCachedData() only controls immediate reinsertion for another pass.
+    bool hasCachedData()
     {
-        return hasData();
+        if (!isReady())
+        {
+            return false;
+        }
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_queue.size() > 1;
     }
 
     bool peekFrontOp(std::string &op) const
@@ -680,48 +730,94 @@ public:
             m_queue.pop();
         }
 
-        if (!m_queue.empty())
-        {
-            m_selectableEvent.notify();
-        }
+        // Do not notify here. Cached-work reinsertion is controlled by
+        // hasCachedData() so Option 3 matches Redis NotificationConsumer.
     }
 
 private:
     std::mutex m_mutex;
-    std::queue<swss::KeyOpFieldsValuesTuple> m_queue;
+    NotificationQueueBackend m_queue;  // FIFO or LruDedup, selected by policy
     swss::SelectableEvent m_selectableEvent;
+    int m_pri;
     size_t m_popBatchSize;
+    ReadinessPredicate m_ready;
+    bool m_handlerRegistered = false;
 };
 ```
 
-`m_selectableEvent.notify()` wakes the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model rather than introducing a separate main-loop mechanism. `ZmqConsumerStateTable` is one existing example of this wake-up pattern: data availability is represented through a selectable, and the main `Select` loop later dispatches an executor. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the queue executor like other selectable executors.
+`m_selectableEvent.notify()` wakes the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model rather than introducing a separate main-loop mechanism. `ZmqConsumerStateTable` is one existing example of this wake-up pattern: data availability is represented through a selectable, and the main `Select` loop later dispatches an executor. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the notification queue executor like other selectable executors.
 
-The queue is created lazily so early notifications that arrive before the target Orch registers its queue-path handler with `gSaiNotificationOrch` can still be enqueued instead of being dropped. The shared `SaiNotificationQueueExecutor` is owned by `SaiNotificationOrch` (see [Section 5.3.7](#537-main-loop-integration)); feature orchs register per-op handlers, not separate executors.
+`SaiNotificationOrch` owns the static metadata for the [Section 5.3.9](#539-notification-inventory) notification queue-path ops: operation name, consumer/stats name, queue policy, and default readiness behavior. A notification queue is created when `SaiNotificationOrch` registers the consumer (or lazily on first enqueue for that op) using this metadata, so early notifications that arrive before the target Orch registers its notification queue-path handler can still be enqueued with the correct policy instead of being dropped. A notification queue that has not yet registered its handler must not pop entries; `dispatch()` warning on a missing handler is a last-resort guard, not the normal early-registration path. Each `SaiNotificationQueueExecutor` is owned by `SaiNotificationOrch`; feature orchs register per-op handlers, not separate executors.
 
-**Backpressure.** The in-process queue is not expected to grow without bound under normal operation: SAI/SDK notification rates are finite, and batch-limited `pops()` preserve main-loop fairness across ready executors.
+**Select priority.** Each per-consumer notification queue and its `SaiNotificationQueueSelectable` wrapper use Select priority **100**, matching `NotificationConsumer(..., pri = 100)`. The wrapper must forward that priority into `swss::Selectable` (the default constructor is `pri = 0`). Option 3 does **not** assign different priorities per notification op: Redis `NotificationConsumer`s on `ASIC_DB:NOTIFICATIONS` are all priority 100. Changing relative scheduling among SAI notification types would be new behavior, not Redis parity.
+
+**Backpressure and watermarks.**
+
+- **LruDedup** queues are bounded by count of distinct in-flight payloads (same as Redis). Reuse `LruDedupNotificationQueue` high-watermark logging (`SWSS_LOG_NOTICE` on a new max, rate-limited stats).
+- **FIFO** queues must not grow without bound. Each FIFO consumer has a maximum depth and an explicit overflow policy, plus a rate-limited `SWSS_LOG_WARN` when depth crosses the watermark, a new high-watermark is reached, or overflow occurs. A notification burst against a not-ready consumer must not be allowed to grow the FIFO without limit.
+
+Any FIFO overflow is notification loss and is not correctness-preserving, whether the implementation drops the newest entry, drops the oldest entry, or rejects admission in another way. The bound exists as a last-resort memory-protection guard under stall or fault conditions, not as normal flow control. The implementation must account for overflow with counters/logs so operators can distinguish overflow loss from normal LruDedup coalescing. If a consumer can safely keep only the latest state, it should use an audited coalescing policy such as LruDedup instead of FIFO.
+
+Implementation note: unless a consumer-specific design decision chooses otherwise, FIFO overflow should reject the new admission: keep already-admitted entries in FIFO order, do not enqueue the incoming notification, increment an overflow/drop counter, and emit a rate-limited log. This avoids blocking the libsairedis callback thread and preserves ordering for admitted entries, but it is still notification loss and must be treated as an operational fault.
+
+**COUNTERS_DB telemetry (Redis parity).** Registered non-ZMQ notification consumers publish stats through `NotificationConsumerStatsOrch` to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` (approximately every 10 seconds). Each registered consumer gets one hash key (for example `PortsOrch:port_state_change`). Option 3 must publish the **same field schema** for each per-consumer in-process notification queue when ZMQ mode is enabled:
+
+| Field group | LruDedup consumers | FIFO consumers |
+|---|---|---|
+| Admission | `channel`, `received`, `dropped_allowlist`, `admitted`, `admit_ratio_pct` | Same |
+| Queue policy | `queue_policy=LruDedup` | `queue_policy=Fifo` |
+| LruDedup queue depth | `lru_pushed`, `lru_dedup_hits`, `lru_dedup_ratio_pct`, `lru_current_depth`, `lru_high_watermark` | Not published (non-ZMQ FIFO has no equivalent today) |
+
+Registration happens when a feature orch calls `gSaiNotificationOrch->registerHandler()` (or when `SaiNotificationOrch` creates the per-consumer notification queue): each notification queue is registered with `NotificationConsumerStatsOrch` under the stable consumer name from the Option 3 metadata table. Where the corresponding Redis consumer already has a stats label (for example `FdbOrch:fdb_event`), Option 3 uses the same name. Where the corresponding Redis consumer has not opted into stats yet, the implementation should add the matching non-ZMQ `NotificationConsumerStatsOrch` registration with the same stable name and field schema as part of the same telemetry-parity work. Option 3 should not introduce ZMQ-only `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` coverage for a consumer unless the Redis path gets the same registration. The publish loop reuses the existing `NotificationConsumerStatsOrch` timer and table; Option 3 notification queues expose a `getStats()` surface compatible with that orch (LruDedup stats from the underlying `LruDedupNotificationQueue`; FIFO consumers publish admission counters and `queue_policy=Fifo` only, matching non-ZMQ).
+
+FIFO notification queue depth / high-watermark in `COUNTERS_DB` is **not** part of this HLD. Non-ZMQ FIFO `NotificationConsumer`s do not publish depth or HWM to `COUNTERS_DB` today (only `queue_policy=Fifo` plus admission counters). Adding FIFO depth/HWM fields would be new telemetry for **both** non-ZMQ and Option 3; see [Section 5.3.14](#5314-follow-on-work).
 
 ```cpp
-SaiNotificationQueue *getSaiNotificationQueue()
+SaiNotificationQueue *SaiNotificationOrch::getSaiNotificationQueue(const std::string &op)
 {
-    static std::mutex queueMutex;
+    const auto &meta = m_metadataByOp.at(op);
+    auto &entry = m_consumersByName[meta.consumerName];
 
-    std::lock_guard<std::mutex> lock(queueMutex);
-    // Create on first use so early callbacks can enqueue before executor setup.
-    if (gSaiNotificationQueue == nullptr)
+    if (!entry.queue)
     {
-        gSaiNotificationQueue = new SaiNotificationQueue(
-            100, // pri -- match swss-common NotificationConsumer default
-            swss::DEFAULT_NC_POP_BATCH_SIZE);
+        entry.queue = std::make_unique<SaiNotificationQueue>(
+            meta.consumerName,
+            100,
+            swss::DEFAULT_NC_POP_BATCH_SIZE,
+            meta.policy);
+
+        entry.executor = std::make_unique<SaiNotificationQueueExecutor>(
+            entry.queue.get(), this, &m_dispatcher, meta.consumerName);
+
+        Orch::addExecutor(entry.executor.get());
+
+        if (gNotifConsumerStatsOrch)
+        {
+            gNotifConsumerStatsOrch->registerConsumer(
+                meta.consumerName, entry.queue.get());
+        }
     }
 
-    return gSaiNotificationQueue;
+    return entry.queue.get();
+}
+
+void SaiNotificationOrch::registerHandler(
+        const std::string &op,
+        SaiNotificationDispatcher::Handler handler,
+        SaiNotificationQueue::ReadinessPredicate ready)
+{
+    auto *queue = getSaiNotificationQueue(op);
+
+    m_dispatcher.registerHandler(op, std::move(handler));
+    queue->registerReadiness(std::move(ready));
 }
 
 void enqueueSaiNotification(const std::string &op,
                             std::string data,
                             std::vector<swss::FieldValueTuple> values)
 {
-    getSaiNotificationQueue()->enqueue(op, std::move(data), std::move(values));
+    gSaiNotificationOrch->getSaiNotificationQueue(op)
+        ->enqueue(op, std::move(data), std::move(values));
 }
 ```
 
@@ -740,9 +836,9 @@ void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data)
 }
 ```
 
-`fdb_event` is used here as an example because it is one of the notification types with missing ZMQ callback handling and is owned by `FdbOrch`. Other migrated callbacks enqueue into the same shared queue with their own operation names. See [Section 5.3.9](#539-notification-inventory) for the full set.
+`fdb_event` is used here as an example because it is one of the notification types with missing ZMQ callback handling and is owned by `FdbOrch`. Other migrated callbacks enqueue onto **their own** per-consumer notification queue with their own operation names. See [Section 5.3.9](#539-notification-inventory) for the full set.
 
-For a notification type migrated to Option 3, the ZMQ-mode callback should enqueue to the in-process queue and should not re-post the same notification to `ASIC_DB:NOTIFICATIONS` as a fallback. Non-ZMQ mode continues to use the existing Redis notification path.
+For a notification type migrated to Option 3, the ZMQ-mode callback should enqueue to the in-process notification queue and should not re-post the same notification to `ASIC_DB:NOTIFICATIONS` as a fallback. Non-ZMQ mode continues to use the existing Redis notification path.
 
 #### 5.3.7 Main-loop Integration
 
@@ -750,17 +846,17 @@ Option 3 should expose the notification queue through an existing-style selectab
 
 For end-to-end flow and diagrams, see [Section 5.3.2](#532-option-3-flow), [Section 5.3.3](#533-option-3-sequence), and [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3). This section focuses on how Option 3 wires into the existing main loop and the implementation details behind that wiring.
 
-**Thread handoff.** In ZMQ mode, the `orchagent` libsairedis callback runs on the libsairedis ZMQ notification thread. That callback must not call Orch handler logic directly. Instead, it enqueues the notification into the shared `SaiNotificationQueue` and calls `SelectableEvent::notify()` so the main loop can process the entry later. The enqueue path is defined in [Section 5.3.6](#536-implementation-notes) (`SaiNotificationQueue::enqueue()`). After enqueue, predicate gating, queue pop, and handler dispatch all run on the `orchagent` main thread.
+**Thread handoff.** In ZMQ mode, the `orchagent` libsairedis callback runs on the libsairedis ZMQ notification thread. That callback must not call Orch handler logic directly. Instead, it enqueues the notification into the **per-consumer notification** `SaiNotificationQueue` for that op and calls `SelectableEvent::notify()` so the main loop can process the entry later. The enqueue path is defined in [Section 5.3.6](#536-implementation-notes). After enqueue, predicate gating, notification queue pop, and handler dispatch all run on the `orchagent` main thread.
 
-**Main-loop wiring.** `SaiNotificationOrch` is a thin **infrastructure** orch — a shared SAI notification queue consumer host, not a feature orch. This pattern plugs into the existing `Orch` / `Executor` / `Orch::addExecutor()` model (the same consumer + executor pattern used elsewhere in orchagent, for example `ZmqConsumerStateTable` with its executor on an existing orch). `SaiNotificationOrch` does not own feature state, has no `APP_DB` tables, and does not implement `doTask(Consumer&)`. Functionally it acts as a notification consumer: it owns the shared `SaiNotificationQueueExecutor` and exposes `registerHandler()` so feature orchs attach per-op callbacks through `SaiNotificationDispatcher`.
+**Main-loop wiring.** `SaiNotificationOrch` is a thin **infrastructure** orch — a SAI notification consumer host, not a feature orch. This pattern plugs into the existing `Orch` / `Executor` / `Orch::addExecutor()` model. `SaiNotificationOrch` does not own feature state, has no `APP_DB` tables, and does not implement `doTask(Consumer&)`. This remains true even though it owns multiple notification queue executors: those executors represent Redis `NotificationConsumer` twins, not new feature consumers. Functionally it acts as the host for **one executor per Redis `NotificationConsumer` twin**: it owns those `SaiNotificationQueueExecutor`s and exposes `registerHandler()` so feature orchs attach per-op callbacks through `SaiNotificationDispatcher`.
 
-`SaiNotificationOrch` is created by `OrchDaemon` in ZMQ mode before orchs that register queue-path handlers, similar to how `NotificationConsumerStatsOrch` is constructed before orchs that register `NotificationConsumer` stats. When ZMQ mode is enabled, feature orchs such as `FdbOrch` and `PortsOrch` register per-operation handlers and optional readiness predicates for the notification operations they own through `gSaiNotificationOrch->registerHandler()` once `gSaiNotificationOrch` is constructed. In non-ZMQ mode, notifications continue to use the existing Redis `NotificationConsumer` path and no queue handlers are registered.
+`SaiNotificationOrch` is created by `OrchDaemon` in ZMQ mode before orchs that register notification queue-path handlers, similar to how `NotificationConsumerStatsOrch` is constructed before orchs that register `NotificationConsumer` stats. When ZMQ mode is enabled, feature orchs such as `FdbOrch` and `PortsOrch` register per-operation handlers and optional readiness predicates for the notification operations they own through `gSaiNotificationOrch->registerHandler()` once `gSaiNotificationOrch` is constructed. Each registered per-consumer notification queue is also registered with `gNotifConsumerStatsOrch` so ZMQ-mode notification queue stats appear in `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` using the field schema described in [Section 5.3.6](#536-implementation-notes). In non-ZMQ mode, notifications continue to use the existing Redis `NotificationConsumer` path, Redis consumers that opt into stats register with `NotificationConsumerStatsOrch`, and no queue handlers are registered on `SaiNotificationOrch`.
 
-When the queue selectable becomes ready, the existing `OrchDaemon::start()` `Select` loop dispatches `SaiNotificationQueueExecutor::execute()` like any other executor. Head-of-line readiness, pop, and dispatch behavior are described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
+When a consumer's notification queue selectable becomes ready, the existing `OrchDaemon::start()` `Select` loop dispatches that consumer's `SaiNotificationQueueExecutor::execute()` like any other executor. Per-notification-queue readiness, pop, and dispatch behavior are described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
 
-**Lifecycle.** The shared `SaiNotificationQueue` and `gSaiNotificationOrch` live for the `orchagent` process lifetime, consistent with other global orch infrastructure. `SaiNotificationQueueSelectable` is owned by `SaiNotificationQueueExecutor` and destroyed with the executor; the shared queue outlives the adapter. Once graceful shutdown begins, libsairedis ZMQ callbacks must not enqueue new notifications (for example by checking the same `gOrchShutdownRequested` flag used by `OrchDaemon::start()`), because the main loop will no longer dispatch the queue executor.
+**Lifecycle.** Per-consumer `SaiNotificationQueue`s and `gSaiNotificationOrch` live for the `orchagent` process lifetime, consistent with other global orch infrastructure. Each `SaiNotificationQueueSelectable` is owned by its executor and destroyed with the executor; the notification queue objects outlive the adapters. Once graceful shutdown begins, libsairedis ZMQ callbacks must not enqueue new notifications (for example by checking the same `gOrchShutdownRequested` flag used by `OrchDaemon::start()`), because the main loop will no longer dispatch the notification queue executors. Drops at shutdown should increment a counter and log at notice/warning so they are not silent.
 
-**Selectable ownership.** The real `SaiNotificationQueue` is shared and kept for the lifetime of the `orchagent` process. However, `Executor` owns and deletes the `Selectable` object passed to it. To avoid giving ownership of the shared queue to the executor, the design passes a small `Selectable` adapter, `SaiNotificationQueueSelectable`, to `Executor`. The adapter is owned by the executor and forwards readiness checks to the shared `SaiNotificationQueue`.
+**Selectable ownership.** Each real `SaiNotificationQueue` is process-lifetime. `Executor` owns and deletes the `Selectable` object passed to it. To avoid giving ownership of the notification queue to the executor, the design passes a small `Selectable` adapter, `SaiNotificationQueueSelectable`, to `Executor`. The adapter is owned by the executor, **forwards Select priority 100**, and forwards readiness checks (`hasData` / `hasCachedData`) to the notification queue.
 
 The existing main loop already waits on selectable executors:
 
@@ -786,14 +882,15 @@ void OrchDaemon::start(long heartBeatInterval)
 }
 ```
 
-**Executor and dispatcher pseudo-code.** The snippets below show how the queue executor plugs into the existing `Executor` model, how `SaiNotificationDispatcher` handler registration and per-op readiness predicates work, and how `SaiNotificationOrch` is constructed and wired into `OrchDaemon`. Predicate evaluation, pop, and dispatch semantics are covered in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
+**Executor and dispatcher pseudo-code.** The snippets below show how the notification queue executor plugs into the existing `Executor` model, how `SaiNotificationDispatcher` handler registration and per-op readiness predicates work, and how `SaiNotificationOrch` is constructed and wired into `OrchDaemon`. Predicate evaluation, pop, and dispatch semantics are covered in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
 
 ```cpp
 class SaiNotificationQueueSelectable : public swss::Selectable
 {
 public:
     explicit SaiNotificationQueueSelectable(SaiNotificationQueue *queue)
-        : m_queue(queue)
+        : Selectable(queue->getPri())  // forward pri 100; default Selectable() is 0
+        , m_queue(queue)
     {
     }
 
@@ -825,25 +922,19 @@ class SaiNotificationDispatcher
 {
 public:
     using Handler = std::function<void(swss::KeyOpFieldsValuesTuple &)>;
-    using ReadinessPredicate = std::function<bool()>;
 
-    void registerHandler(const std::string &op, Handler handler,
-                         ReadinessPredicate ready = nullptr)
+    // Readiness is owned by SaiNotificationQueue because hasCachedData()
+    // must evaluate readiness before dispatch runs. The dispatcher only
+    // owns op-to-handler lookup.
+    void registerHandler(const std::string &op, Handler handler)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_handlers[op] = std::move(handler);
-        m_readiness[op] = std::move(ready);
-    }
-
-    bool isReady(const std::string &op) const
-    {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        auto readyIt = m_readiness.find(op);
-        if (readyIt == m_readiness.end() || !readyIt->second)
+        if (m_handlers.find(op) != m_handlers.end())
         {
-            return true;
+            SWSS_LOG_WARN("Replacing SAI notification handler for op %s",
+                          op.c_str());
         }
-        return readyIt->second();
+        m_handlers[op] = std::move(handler);
     }
 
     void dispatch(swss::KeyOpFieldsValuesTuple &entry)
@@ -864,12 +955,16 @@ public:
         {
             handler(entry);
         }
+        else
+        {
+            SWSS_LOG_WARN("No SAI notification handler registered for op %s",
+                          op.c_str());
+        }
     }
 
 private:
     std::mutex m_mutex;
     std::unordered_map<std::string, Handler> m_handlers;
-    std::unordered_map<std::string, ReadinessPredicate> m_readiness;
 };
 
 class SaiNotificationQueueExecutor : public Executor
@@ -887,9 +982,9 @@ public:
 
     void execute() override
     {
-        // Head-of-line readiness: do not pop if the front entry's op is not ready.
-        std::string frontOp;
-        if (!m_queue->peekFrontOp(frontOp) || !m_dispatcher->isReady(frontOp))
+        // Per-consumer queue: every entry is this consumer's op(s).
+        // Do not pop while this consumer is not ready.
+        if (!m_queue->isReady() || !m_queue->hasData())
         {
             return;
         }
@@ -909,9 +1004,7 @@ private:
 };
 ```
 
-`SaiNotificationQueue::peekFrontOp()` is a small helper used only by the executor to evaluate the readiness predicate for the notification queue head without dequeuing.
-
-`SaiNotificationOrch` registers the shared queue executor once during construction:
+`SaiNotificationOrch` registers **one notification queue executor per consumer** during handler registration (or construction):
 
 ```cpp
 class SaiNotificationOrch : public Orch
@@ -921,17 +1014,32 @@ public:
 
     void registerHandler(const std::string &op,
                          SaiNotificationDispatcher::Handler handler,
-                         SaiNotificationDispatcher::ReadinessPredicate ready = nullptr);
+                         SaiNotificationQueue::ReadinessPredicate ready = nullptr);
+
+    SaiNotificationQueue *getSaiNotificationQueue(const std::string &op);
 
 private:
-    SaiNotificationQueue *m_queue;
-    SaiNotificationDispatcher *m_dispatcher;
+    struct ConsumerMetadata
+    {
+        std::string consumerName;
+        swss::NotificationQueuePolicy policy;
+    };
+
+    struct ConsumerEntry
+    {
+        std::unique_ptr<SaiNotificationQueue> queue;
+        std::unique_ptr<SaiNotificationQueueExecutor> executor;
+    };
+
+    std::unordered_map<std::string, ConsumerEntry> m_consumersByName;
+    std::unordered_map<std::string, ConsumerMetadata> m_metadataByOp;
+    SaiNotificationDispatcher m_dispatcher;
 };
 
 extern SaiNotificationOrch *gSaiNotificationOrch;
 ```
 
-`OrchDaemon` constructs `SaiNotificationOrch` in ZMQ mode before orchs that register queue-path handlers:
+`OrchDaemon` constructs `SaiNotificationOrch` in ZMQ mode before orchs that register notification queue-path handlers:
 
 ```cpp
 if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
@@ -946,65 +1054,67 @@ gFdbOrch = new FdbOrch(...);
 
 #### 5.3.8 Readiness predicates and boot-time behavior
 
-**Why this is needed.** Option 3 must preserve the same boot-time behavior as the existing Redis `NotificationConsumer` path. In Redis, many orchs return from `doTask(NotificationConsumer&)` before `pop()` or `pops()` until their readiness conditions are met, so notifications stay in the consumer queue instead of being dropped. Option 3 uses the same model: the queue executor checks a per-operation readiness predicate for the notification queue head before `pops()`. If the head entry is not ready, the executor returns without popping.
+**Why this is needed.** Option 3 must preserve the same boot-time behavior as the existing Redis `NotificationConsumer` path. In Redis, many orchs return from `doTask(NotificationConsumer&)` before `pop()` or `pops()` until their readiness conditions are met, so notifications stay in **that consumer's** notification queue instead of being dropped. Option 3 uses the same model **per consumer**: the notification queue executor checks that consumer's readiness predicate before `pops()`. If the consumer is not ready, the executor returns without popping.
 
-The predicate is evaluated on each `SaiNotificationQueueExecutor::execute()` call. `SaiNotificationOrch` does not receive a separate event when readiness changes (for example when `PortsOrch::allPortsReady()` becomes true). The orchagent main loop keeps invoking the queue executor while notifications remain queued, so the head readiness predicate is re-checked on later iterations until it passes.
+**No main-loop spin.** Redis `NotificationConsumer::hasCachedData()` returns `size() > 1`, not "queue non-empty". `Select::select()` reinserts a selectable immediately only when `hasCachedData()` is true. Option 3 must match that:
 
-**How readiness is registered.** Each queue-path handler registers an optional readiness predicate alongside its handler through `SaiNotificationDispatcher::registerHandler()` (see the [Section 5.3.9](#539-notification-inventory) table). Do not use one shared `allPortsReady()` gate on `SaiNotificationOrch` for all notification types. The predicate must match the owning orch's Redis `doTask(NotificationConsumer&)` behavior for that op.
+- If this consumer is **not ready**, `hasCachedData()` is **false** even if the notification queue is non-empty. `execute()` returns without popping. The selectable is not immediately reinserted; if no other selectable is ready, the main loop waits normally. The notification queue is retried only after a later wake-up, such as a new notification enqueue or an explicit re-notify when the readiness-owning orch transitions to ready. This avoids a tight reinsert loop at boot when `allPortsReady()` is false.
+- If this consumer **is ready**, `hasCachedData()` is `size() > 1`, same as Redis.
 
-**Early enqueue and handler registration.** Notifications can be enqueued before the owning orch calls `registerHandler()` (see [Section 5.3.6](#536-implementation-notes)). The `OrchDaemon` construction order in [Section 5.3.7](#537-main-loop-integration) creates `gSaiNotificationOrch` before feature orchs so handlers are registered during orch construction. A readiness-gated head-of-line predicate (for example port readiness) may keep entries queued until the predicate passes.
+**How readiness is registered.** Each notification queue-path handler registers an optional readiness predicate alongside its handler through `gSaiNotificationOrch->registerHandler()` (see the [Section 5.3.9](#539-notification-inventory) table). `SaiNotificationOrch` installs that predicate on the corresponding per-consumer notification queue so both `execute()` and `hasCachedData()` use the same readiness decision. Do not use one shared `allPortsReady()` gate on `SaiNotificationOrch` for all notification types. The predicate must match the owning orch's Redis `doTask(NotificationConsumer&)` behavior for that consumer.
 
-**Missing handler at dispatch.** If `dispatch()` finds no registered handler for a popped entry, the implementation should log a warning rather than silently dropping the notification. By the time `dispatch()` runs, the executor has already popped the entry from the in-process queue, so a silent drop would lose the notification with no visible signal that handler logic never ran. The warning makes the gap visible when this condition occurs, instead of dropping the notification silently.
+**Early enqueue and handler registration.** Notifications can be enqueued before the owning orch calls `registerHandler()` (see [Section 5.3.6](#536-implementation-notes)). The `OrchDaemon` construction order in [Section 5.3.7](#537-main-loop-integration) creates `gSaiNotificationOrch` before feature orchs so handlers are registered during orch construction. A not-ready consumer keeps its own entries queued until its predicate passes and the notification queue is retried by a later wake-up; other consumers drain independently.
 
-**Readiness-gated notifications (example: port readiness).** Some ops register `gPortsOrch->allPortsReady()` as their readiness predicate — for example `port_state_change`, `fdb_event`, `port_host_tx_ready`, and `twamp_session_event`:
+**Missing handler at dispatch.** If `dispatch()` finds no registered handler for a popped entry, the implementation should log a warning rather than silently dropping the notification. `registerHandler()` should also warn on accidental double-registration for the same op.
+
+**Readiness-gated notifications (example: port readiness).** Some consumers register `gPortsOrch->allPortsReady()` — for example `port_state_change`, `fdb_event`, `port_host_tx_ready`, and `twamp_session_event`:
 
 - On boot, `PortsOrch::allPortsReady()` is false until `PortInitDone` is received and no ports remain in `m_pendingPortSet`.
-- If a readiness-gated op is at the queue head and its predicate is false, the executor returns without calling `pops()`; the notification stays in the queue.
-- After `allPortsReady()` becomes true, a later `execute()` sees the predicate pass, pops, and dispatches to the registered handler.
+- If that consumer is not ready, its executor returns without calling `pops()`; **only that consumer's** notifications stay queued. Other consumers (for example `bfd_session_state_change`) continue to drain.
+- After `allPortsReady()` becomes true, a later wake-up and `execute()` for that consumer sees the predicate pass, pops, and dispatches to the registered handler.
 
-**Non-readiness-gated notifications** (no readiness predicate registered — for example `bfd_session_state_change`, `icmp_echo_session_state_change`, MACsec post-status):
+**Non-readiness-gated notifications** (no readiness predicate — for example `bfd_session_state_change`, `icmp_echo_session_state_change`, MACsec post-status):
 
 - No `allPortsReady()` predicate is registered; the predicate is treated as always true.
-- When such an op is at the queue head, the executor may pop and dispatch on the next `execute()` without waiting for port initialization.
+- That consumer's executor may pop and dispatch on the next `execute()` without waiting for port initialization.
 - This matches Redis, where orchs such as `BfdOrch` call `consumer.pop()` without an `allPortsReady()` gate.
 
-**Shared queue caveat (head-of-line blocking).** Option 3 uses one shared notification message queue. Enqueue order is preserved, but dequeue is gated on the **queue head entry's** per-op readiness predicate. If a readiness-gated notification is at the head and its predicate is false, later entries — including those with no readiness predicate — remain queued behind it (head-of-line blocking). In the **Redis consumer path** (non-ZMQ mode and Option 2), separate `NotificationConsumer` instances give each orch its own admission queue on the shared `NOTIFICATIONS` channel. This behavioral difference from the Redis consumer path is documented in [Section 5.3.13](#5313-cons); follow-on mitigation options are in [Section 5.3.14](#5314-follow-on-work).
+**Per-consumer isolation (no cross-op head-of-line blocking).** Each in-process notification queue is isolated the same way Redis isolates `NotificationConsumer` instances. A not-ready `fdb_event` notification queue cannot block `bfd_session_state_change`. `PortsOrch` `port_state_change` and `port_host_tx_ready` remain separate notification queues, matching their separate Redis consumers. A batch `pops()` on a consumer notification queue cannot dispatch a mixed-op set with different readiness behavior. `MACsecOrch` is the explicit multi-op exception that matches Redis: one consumer (one notification queue) for both POST-status ops, both with no readiness predicate.
 
 ##### 5.3.8.1 Readiness-gated boot-time sequence (example: port readiness)
 
-The diagram below shows a **readiness-gated** case where the registered predicate is `gPortsOrch->allPortsReady()`. In general, the executor tests whether the readiness predicate for the notification queue head op passes before `pops()`; other ops may register different predicates or none at all.
+The diagram below shows a **readiness-gated** `fdb_event` consumer. Other consumers (for example BFD) are not blocked by this predicate.
 
 ```mermaid
 sequenceDiagram
     participant syncd
     participant Callback as ZMQ callback thread
-    participant Queue as SaiNotificationQueue
-    participant Executor as Queue executor
+    participant FdbQueue as fdb_event queue
+    participant FdbExec as fdb_event executor
     participant PortsOrch
     participant FdbOrch
 
-    syncd->>Callback: port_state / fdb_event
-    Callback->>Queue: enqueue
-    Executor->>Executor: check head predicate
-    Note over Executor: allPortsReady() is false
-    Note over Queue: do not pop, stay queued
+    syncd->>Callback: fdb_event
+    Callback->>FdbQueue: enqueue onto fdb consumer queue
+    FdbExec->>FdbExec: check fdb consumer readiness
+    Note over FdbExec: allPortsReady() is false
+    Note over FdbQueue: hasCachedData() false, do not pop
 
     Note over PortsOrch: PortInitDone received
     Note over PortsOrch: pending ports cleared
     Note over PortsOrch: allPortsReady() is true
 
-    Executor->>Executor: check head predicate
-    Note over Executor: allPortsReady() is true
-    Executor->>Queue: pops
-    Executor->>FdbOrch: dispatch fdb_event
-    Executor->>PortsOrch: dispatch port_state_change
+    FdbExec->>FdbExec: check fdb consumer readiness
+    Note over FdbExec: allPortsReady() is true
+    FdbExec->>FdbQueue: pops (fdb_event only)
+    FdbExec->>FdbOrch: handleNotification(fdb_event)
 ```
 
-The final `pops()` step may drain multiple queued entries in one batch (`DEFAULT_NC_POP_BATCH_SIZE`). Dispatches to `FdbOrch` and `PortsOrch` illustrate two entries popped together, not one notification routed to both orchs.
+The final `pops()` step drains a batch from **this consumer's** queue (`DEFAULT_NC_POP_BATCH_SIZE`). It does not pop mixed ops from a shared FIFO.
 
 ##### 5.3.8.2 Non-readiness-gated boot-time sequence
 
-The diagram below shows the case when the head entry has **no** readiness predicate (for example `bfd_session_state_change` at the queue head):
+The diagram below shows a consumer with **no** readiness predicate (for example `bfd_session_state_change`). That consumer drains even while `allPortsReady()` is still false:
 
 ```mermaid
 sequenceDiagram
@@ -1016,7 +1126,7 @@ sequenceDiagram
 
     syncd->>Callback: bfd_session_state_change
     Callback->>Queue: enqueue
-    Executor->>Executor: check head predicate
+    Executor->>Executor: check consumer readiness
     Note over Executor: no readiness predicate
     Executor->>Queue: pops
     Executor->>BfdOrch: dispatch bfd_session_state_change
@@ -1050,38 +1160,38 @@ gSaiNotificationOrch->registerHandler(
     });
 ```
 
-For the shared handler pattern, see [Section 5.3.10](#5310-priority-fairness-and-shared-handler).
+For the `handleNotification()` shared-handler pattern, see [Section 5.3.10](#5310-priority-fairness-queue-policy-and-shared-handler).
 
 #### 5.3.9 Notification inventory
 
 The [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) readiness model and registration examples above define the queue-path pattern; this section lists every notification op and how it maps to that pattern.
 
-Option 3 targets parity with the existing non-ZMQ `ASIC_DB:NOTIFICATIONS` path. The table below lists notification operations, their ZMQ delivery path today, the Option 3 plan for each, and the readiness predicate queue-path handlers register. The readiness predicate column uses the per-op predicates described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior); each value matches the owning orch's Redis `doTask(NotificationConsumer&)` behavior where a queue path applies.
+Option 3 targets parity with the existing non-ZMQ `ASIC_DB:NOTIFICATIONS` path. The table below lists notification operations, their ZMQ delivery path today, the Option 3 plan, the in-process notification queue policy (matching Redis), and the readiness predicate. Each notification queue-path handler matches the owning orch's Redis `NotificationConsumer` / `doTask(NotificationConsumer&)` behavior.
 
 **Option 3 plan** values:
 
 | Value | Meaning |
 |---|---|
-| **Enqueue (required)** | ZMQ callback is no-op or incomplete today. A queue path is required to restore non-ZMQ parity. |
-| **Migrate to queue** | Already delivered via Option 2 Redis re-post today. Change to the in-process queue (latency benefit, no Redis re-post). |
-| **Unchanged** | ZMQ callback already handles the notification outside the queue/Redis-consumer path. Option 3 does not apply. |
+| **Enqueue (required)** | ZMQ callback is no-op or incomplete today. A notification queue path is required to restore non-ZMQ parity. |
+| **Migrate to notification queue** | Already delivered via Option 2 Redis re-post today. Change to the in-process notification queue path (latency benefit, no Redis re-post). |
+| **Unchanged** | ZMQ callback already handles the notification outside the notification queue / Redis-consumer path. Option 3 does not apply. |
 
-| Notification op | Owning orch | ZMQ path today | Option 3 plan | Option 3 readiness predicate |
-|---|---|---|---|---|
-| `port_state_change` | `PortsOrch` | Option 2 Redis re-post | Migrate to queue | `gPortsOrch->allPortsReady()` |
-| `port_host_tx_ready` | `PortsOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
-| `fdb_event` | `FdbOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
-| `bfd_session_state_change` | `BfdOrch` | No-op / incomplete callback | Enqueue (required) | None |
-| `icmp_echo_session_state_change` | `IcmpOrch` | No-op / incomplete callback | Enqueue (required) | None |
-| `twamp_session_event` | `TwampOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
-| `switch_macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to queue | None |
-| `macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to queue | None |
-| `ha_set_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to queue | None |
-| `ha_scope_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to queue | None |
-| `flow_bulk_get_session_event` | `DashHaFlowOrch` | Option 2 Redis re-post | Migrate to queue | None |
-| `tam_tel_type_config_change` | `HFTelOrch` | No-op / incomplete callback | Enqueue (required) | None |
-| `switch_shutdown_request` | `SwitchOrch` | Direct callback handling | Unchanged | N/A |
-| `switch_asic_sdk_health_event` | `SwitchOrch` | Direct callback handling | Unchanged | N/A |
+| Notification op | Owning orch | ZMQ path today | Option 3 plan | Queue policy | Option 3 readiness predicate |
+|---|---|---|---|---|---|
+| `port_state_change` | `PortsOrch` | Option 2 Redis re-post | Migrate to notification queue | LruDedup | `gPortsOrch->allPortsReady()` |
+| `port_host_tx_ready` | `PortsOrch` | No-op / incomplete callback | Enqueue (required) | LruDedup | `gPortsOrch->allPortsReady()` |
+| `fdb_event` | `FdbOrch` | No-op / incomplete callback | Enqueue (required) | LruDedup | `gPortsOrch->allPortsReady()` |
+| `bfd_session_state_change` | `BfdOrch` | No-op / incomplete callback | Enqueue (required) | FIFO | None |
+| `icmp_echo_session_state_change` | `IcmpOrch` | No-op / incomplete callback | Enqueue (required) | FIFO | None |
+| `twamp_session_event` | `TwampOrch` | No-op / incomplete callback | Enqueue (required) | FIFO | `gPortsOrch->allPortsReady()` |
+| `switch_macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to notification queue | FIFO (shared MACsec consumer) | None |
+| `macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to notification queue | FIFO (shared MACsec consumer) | None |
+| `ha_set_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to notification queue | FIFO | None |
+| `ha_scope_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to notification queue | FIFO | None |
+| `flow_bulk_get_session_event` | `DashHaFlowOrch` | Option 2 Redis re-post | Migrate to notification queue | FIFO | None |
+| `tam_tel_type_config_change` | `HFTelOrch` | No-op / incomplete callback | Enqueue (required) | FIFO | None |
+| `switch_shutdown_request` | `SwitchOrch` | Direct callback handling | Unchanged | N/A | N/A |
+| `switch_asic_sdk_health_event` | `SwitchOrch` | Direct callback handling | Unchanged | N/A | N/A |
 
 Out of scope for the Option 3 SAI notification queue (not `ASIC_DB:NOTIFICATIONS` SAI delivery over ZMQ):
 
@@ -1091,7 +1201,7 @@ Out of scope for the Option 3 SAI notification queue (not `ASIC_DB:NOTIFICATIONS
 | `WATERMARK_CLEAR_REQUEST` | `WatermarkOrch` | `APPL_DB` request, not a syncd SAI callback |
 | `FLUSHFDBREQUEST` | `FdbOrch` | `APPL_DB` request |
 
-Option 3 coverage is added by registering one handler (and optional readiness predicate) per **Migrate to queue** / **Enqueue** row. Each follows the same pattern: ZMQ callback enqueues (or already enqueues), owning orch `registerHandler()` calling `handleNotification(entry)`, and notification-specific helpers shared with the Redis consumer path. Rollout is summarized in [Section 5.4](#54-recommendation).
+Option 3 coverage is added by registering one handler (and optional readiness predicate) per **Migrate to notification queue** / **Enqueue** row. Each follows the same pattern: ZMQ callback enqueues (or already enqueues), owning orch `registerHandler()` calling `handleNotification(entry)`, and notification-specific helpers shared with the Redis consumer path. Rollout is summarized in [Section 5.4](#54-recommendation).
 
 - `fdb_event`: `on_fdb_event()` enqueues the serialized FDB payload; `FdbOrch` registers the op, a readiness predicate that matches its Redis `doTask(NotificationConsumer&)` gate, and reuses its FDB event parsing/state-update helper.
 - `bfd_session_state_change`: `on_bfd_session_state_change()` enqueues the serialized BFD session-state payload; `BfdOrch` registers the op with no port-readiness predicate and reuses its BFD notification helper.
@@ -1104,17 +1214,19 @@ Option 3 coverage is added by registering one handler (and optional readiness pr
 - `flow_bulk_get_session_event`: migrate `on_flow_bulk_get_session_event()` from Redis re-post to enqueue; `DashHaFlowOrch` registers the op and reuses existing notification handling.
 - `tam_tel_type_config_change`: `on_tam_tel_type_config_change()` enqueues the serialized TAM telemetry-type payload; `HFTelOrch` registers the op with no readiness predicate and reuses `handleTamTelTypeConfigChangeNotification()`, the same helper used by the Redis `NotificationConsumer` path.
 
-#### 5.3.10 Priority, Fairness, and Shared Handler
+#### 5.3.10 Priority, Fairness, Queue Policy, and Shared Handler
 
-**Executor model.** Migrated SAI notifications use one shared `SaiNotificationQueue` and one `SaiNotificationQueueExecutor` selectable priority, as illustrated in [Section 5.3.2](#532-option-3-flow) and [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3), with implementation detail in [Sections 5.3.6](#536-implementation-notes) and [5.3.7](#537-main-loop-integration). That executor should use an appropriate priority so time-sensitive SAI notifications can be processed ahead of lower-priority regular `orchagent` work, following the existing `Select` behavior where ready selectables are dispatched according to priority.
+**Executor model.** Migrated SAI notifications use **one in-process notification queue and one executor per Redis `NotificationConsumer` twin**, as illustrated in [Section 5.3.2](#532-option-3-flow) and [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3), with implementation detail in [Sections 5.3.6](#536-implementation-notes) and [5.3.7](#537-main-loop-integration). `SaiNotificationOrch` hosts those executors; feature orchs do not register extra executors.
 
-**Priority.** Option 3 should use the existing `Select` priority mechanism where practical instead of introducing separate internal priority queues. "Internal priority queues" means priority lanes that reorder messages within a single queue; it does not prohibit multiple per-orch queues, each drained by its own executor, with scheduling priority expressed via Select `m_priority` as described in [Section 5.3.14](#5314-follow-on-work).
+**Priority.** Every notification queue selectable uses Select priority **100**, matching the existing `NotificationConsumer` default on `ASIC_DB:NOTIFICATIONS`. The `SaiNotificationQueueSelectable` wrapper **must forward** that 100 into `swss::Selectable` (see [Section 5.3.7](#537-main-loop-integration)). Priority 100 ranks notification executors ahead of route consumers (priority 5), not ahead of other notification types. Per-consumer selectables could use different priorities (for example `port_state_change` above `fdb_event`), but Option 3 does not: Redis does not rank SAI notification consumers that way. Isolation and coalescing come from per-consumer notification queues and LruDedup/FIFO policy, not from different `m_priority` values. Per-op priority tiers are follow-on work ([Section 5.3.14](#5314-follow-on-work) item 1).
 
-**Fairness.** Each `SaiNotificationQueueExecutor::execute()` drains at most `DEFAULT_NC_POP_BATCH_SIZE` entries per main-loop iteration. If more notifications remain, the queue re-notifies so other ready executors (including lower-priority orch consumers) can run before the next drain. This avoids the route-consumer pattern of draining an entire backlog in one `execute()` call (see `ZmqRouteConsumer`). **Priority** (Select `m_priority`) determines which ready executor runs first; **fairness** (batch-limited drain + re-notify) limits how long one executor holds the main loop once selected.
+**Fairness.** Each per-consumer `SaiNotificationQueueExecutor::execute()` drains at most `DEFAULT_NC_POP_BATCH_SIZE` entries per main-loop iteration. If more notifications remain **and the consumer is ready**, `hasCachedData()` is true only when `size() > 1`, matching Redis, so other ready executors can run. This avoids the route-consumer pattern of draining an entire backlog in one `execute()` call (see `ZmqRouteConsumer`). **Priority** (Select `m_priority` = 100 vs route consumers at 5) determines which ready executor runs first among different orch classes; **fairness** (batch-limited drain + Redis-style `hasCachedData`) limits how long one notification consumer holds the main loop once selected. Among ready selectables with the same priority, `Select` uses `last_used_time`, so notification consumers at priority 100 are scheduled fairly with the same tie-breaker as Redis `NotificationConsumer` executors.
 
-**Interaction with route consumers.** The notification executor uses a higher Select priority than route table consumers (for example priority 100 for the Option 3 notification queue or Redis `NotificationConsumer` executors vs priority 5 for `RouteOrch`). When both are ready, the notification executor is scheduled first. However, an in-progress `ZmqRouteConsumer::execute()` that drains route updates until empty can still delay notification processing on the main loop until that `execute()` completes. This is not specific to Option 3: it applies equally to the Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post), because all executors share the same `orchagent` main loop and Select priority does not preempt an executor already running.
+**Interaction with route consumers.** Notification executors use a higher Select priority than route table consumers (priority 100 vs priority 5 for `RouteOrch`). When both are ready, a notification executor is scheduled first. However, an in-progress `ZmqRouteConsumer::execute()` that drains route updates until empty can still delay notification processing on the main loop until that `execute()` completes. This is not specific to Option 3: it applies equally to the Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post), because all executors share the same `orchagent` main loop and Select priority does not preempt an executor already running.
 
-**Shared handler.** Each target Orch owns its notification handler logic. The Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post) and the Option 3 `gSaiNotificationOrch->registerHandler()` queue-path callback both call the same **`handleNotification(swss::KeyOpFieldsValuesTuple &entry)`** entry point. That function extracts `op`/`data` from the tuple and delegates to the notification-specific helper (for example `handleFdbEventNotification()`). `doTask(NotificationConsumer&)` retains consumer-specific routing (flush vs FDB notification, readiness gates) and prepares the tuple after `pop()`; `registerHandler()` passes the queued tuple directly.
+**Queue policy.** See [Section 5.3.6](#536-implementation-notes) and the [Section 5.3.9](#539-notification-inventory) table. LruDedup is used for `fdb_event` / `port_state_change` / `port_host_tx_ready`; FIFO is used for the rest. The policy follows Redis behavior: coalesce only where the Redis consumer already coalesces, and preserve arrival order where Redis uses FIFO.
+
+**Shared handler.** Each target Orch owns its notification handler logic. The Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post) and the Option 3 `gSaiNotificationOrch->registerHandler()` queue-path callback both call the same **`handleNotification(swss::KeyOpFieldsValuesTuple &entry)`** entry point. That function extracts `op`/`data` from the tuple and delegates to the notification-specific helper (for example `handleFdbEventNotification()`). `doTask(NotificationConsumer&)` retains consumer-specific routing (flush vs FDB notification, readiness gates) and prepares the tuple after `pop()`; `registerHandler()` passes the queued tuple directly. Handlers are not re-implemented for Option 3.
 
 ```cpp
 void FdbOrch::doTask(NotificationConsumer &consumer)
@@ -1133,7 +1245,7 @@ void FdbOrch::doTask(NotificationConsumer &consumer)
     if (&consumer == m_fdbNotificationConsumer)
     {
         KeyOpFieldsValuesTuple entry;
-        // populate entry from consumer.pop() — same op/key layout as queue path
+        // populate entry from consumer.pop() — same op/key layout as notification queue path
         handleNotification(entry);
     }
 }
@@ -1162,11 +1274,13 @@ The Redis path calls `handleNotification(entry)` from `doTask(NotificationConsum
 
 The implementation should include focused unit coverage for the new queue mechanics:
 
-- Queue tests should verify enqueue, cached-data visibility, batch-limited `pops()`, notification message queue order, and empty-queue state.
-- Executor and dispatcher tests should verify that a registered operation handler is invoked with the queued entry, that per-operation readiness predicates are honored before `pops()`, and that `dispatch()` logs a warning when no handler is registered for a popped op. Mock tests in `notifications_ut.cpp` include `SaiNotificationQueueExecutor` and `SaiNotificationQueueExecutorHeadOfLineBlocksUntilReady` for the executor readiness and head-of-line blocking behavior.
-- Callback tests should verify that each migrated ZMQ-mode callback enqueues the expected operation and preserves the serialized notification payload.
+- Queue tests should verify per-consumer enqueue routing, LruDedup coalescing vs FIFO order, `hasCachedData()` (`false` when not ready; `size() > 1` when ready), batch-limited `pops()`, watermark / max-depth drop on FIFO, and empty-queue state.
+- Executor and dispatcher tests should verify that a registered operation handler is invoked with the queued entry, that a not-ready consumer does not spin (`hasCachedData()` false), that queued notifications are retried after a later wake-up when readiness becomes true, that a not-ready consumer does not block a different ready consumer, and that `dispatch()` logs a warning when no handler is registered. Mock tests in `notifications_ut.cpp` should cover per-consumer isolation (not shared-FIFO head-of-line blocking).
+- Callback tests should verify that each migrated ZMQ-mode callback enqueues the expected operation onto the correct consumer queue and preserves the serialized notification payload.
+- Selectable tests should verify the wrapper forwards priority 100.
+- `COUNTERS_DB` tests should verify that registered Option 3 per-consumer notification queues publish to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` with the same fields as their Redis twins: admission counters for all consumers; LruDedup depth/HWM fields for `fdb_event`, `port_state_change`, and `port_host_tx_ready`; `queue_policy=Fifo` only (no depth/HWM) for FIFO consumers.
 
-Existing Redis-path tests should continue to cover the established `NotificationConsumer` handler behavior. Callback-specific Option 3 coverage should target each notification type selected for queue-based migration, while the generic queue and readiness-predicate tests remain applicable. Multi-executor and per-op queue notification tests are deferred follow-on work ([Section 5.3.14](#5314-follow-on-work)).
+Existing Redis-path tests should continue to cover the established `NotificationConsumer` handler behavior and `NotificationConsumerStatsOrch` publish for non-ZMQ consumers. Callback-specific Option 3 coverage should target each notification type selected for queue-based migration.
 
 DUT validation for a migrated notification should confirm both expected Orch behavior and Redis bypass. For example, a `port_state_change` validation can flap a port in southbound ZMQ mode, confirm `PortsOrch` logs and operational state updates, and confirm `ASIC_DB:NOTIFICATIONS` does not receive a re-posted `port_state_change` notification.
 
@@ -1174,28 +1288,29 @@ DUT validation for a migrated notification should confirm both expected Orch beh
 
 - Compared with Option 2, avoids the Redis re-post for migrated notifications and can reduce notification latency.
 - Keeps Orch state updates on the `orchagent` main-loop path.
-- Uses the existing selectable/executor model and `Select` priority mechanism where practical.
-- Supports consolidating all notification types listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** on one in-process queue under Option 3.
+- Uses the existing selectable/executor model and `Select` priority 100, matching Redis `NotificationConsumer`.
+- Matches Redis consumer topology (per-consumer notification queues) and coalescing policy (LruDedup vs FIFO).
+- Reuses existing `handleNotification()` handlers; no handler-layer rewrite.
 
 #### 5.3.13 Cons
 
 - Requires implementation and validation of a new selectable/executor path for SAI notifications.
 - More implementation and test effort than Option 2.
-- **Cross-op head-of-line blocking:** Option 3 uses one shared queue with front-of-queue dequeue. When a readiness-gated entry is at the queue head and its readiness predicate is false, later entries behind it — including ops with no readiness predicate — remain queued. The Redis consumer path (non-ZMQ mode and Option 2) avoids this across orchs via separate per-orch `NotificationConsumer` queues (see [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior)).
+- FIFO in-process notification queues need an explicit max-depth / drop policy; Redis had implicit pub/sub backpressure. LruDedup remains bounded by distinct in-flight payloads.
 
 #### 5.3.14 Follow-on work
 
 The following items are **out of scope** for this HLD and left for follow-on work:
 
-1. **Multi-executor with per-op or per-orch queues.** If the single shared queue design proves insufficient, follow-on work should split notifications across separate queues and executors per notification op or per owning orch, restoring the same isolation as the Redis consumer path (non-ZMQ mode and Option 2) and eliminating cross-op head-of-line blocking ([Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior)). Enqueue routing selects the queue by `op`; each queue applies its own head readiness predicate independently. Executors can use the existing `Select` priority mechanism so time-sensitive notification ops are scheduled ahead of lower-priority orch work. A priority-tier split that groups multiple ops in one queue does not fully address cross-op head-of-line blocking and is not sufficient on its own.
-
-2. **Queue-depth monitoring and alarms.** Expose queue-depth metrics and raise an alarm when depth exceeds a configurable threshold under sustained load, so operators can detect main-loop stall or handler regressions.
+1. **Per-op Select priority tiers.** Notification consumers stay at priority 100. Ranking `port_state_change` ahead of `fdb_event` (or similar) would be new behavior, not Redis parity.
+2. **FIFO notification queue depth / HWM in `COUNTERS_DB` (both paths).** Non-ZMQ FIFO `NotificationConsumer`s publish only `queue_policy=Fifo` and admission counters to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS`; LruDedup consumers publish depth and HWM. Option 3 matches that split in this HLD ([Section 5.3.6](#536-implementation-notes)). Publishing FIFO `current_depth` / `high_watermark` to `COUNTERS_DB` would be **new** telemetry—not present on the non-ZMQ path today—and would be a future enhancement for **both** non-ZMQ and Option 3, not Option-3-only observability.
+3. **Operator alarms on notification queue depth / drops.** High-watermark and max-depth **syslog** for in-process notification queues is in scope ([Section 5.3.6](#536-implementation-notes)). Threshold-based operator alarms (distinct from periodic `COUNTERS_DB` stats and syslog) are follow-on.
 
 ### 5.4 Recommendation
 
 - **Near-term:** Use **Option 2** ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)) to restore missing ZMQ-mode notification delivery quickly with minimal risk. Callbacks re-post to `ASIC_DB:NOTIFICATIONS` and existing Orch `NotificationConsumer` handlers remain unchanged.
-- **Long-term:** Adopt **Option 3** as the target design for migrated `ASIC_DB:NOTIFICATIONS` types: enqueue on the libsairedis ZMQ callback thread, drain through the shared SAI notification queue consumer (`SaiNotificationOrch`), and preserve per-op readiness predicates and handler behavior.
-- **Option 3 rollout:** Migrate every [Section 5.3.9](#539-notification-inventory) op to the in-process queue except **Unchanged** (`switch_shutdown_request`, `switch_asic_sdk_health_event`). Follow-on work is listed in [Section 5.3.14](#5314-follow-on-work).
+- **Long-term:** Adopt **Option 3** as the target design for migrated `ASIC_DB:NOTIFICATIONS` types: enqueue on the libsairedis ZMQ callback thread onto **per-consumer in-process notification queues** (LruDedup/FIFO matching Redis), drain through `SaiNotificationOrch`, and preserve per-consumer readiness predicates and `handleNotification()` behavior.
+- **Option 3 rollout:** Migrate every [Section 5.3.9](#539-notification-inventory) op to the in-process per-consumer notification queues except **Unchanged** (`switch_shutdown_request`, `switch_asic_sdk_health_event`). Notification-queue-layer Redis parity (topology, coalescing, `hasCachedData`, Select priority 100, syslog watermarks, `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` with the same fields as non-ZMQ) is in this HLD, not a later phase. Follow-on work is listed in [Section 5.3.14](#5314-follow-on-work).
 - **Not recommended:** **Option 1** (Redis notification producer in `syncd` while request/response stays on ZMQ) is not proposed because it makes ZMQ mode asymmetric and reintroduces duplicate-delivery risk if callbacks also re-post.
 
 ## 6. References

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -36,6 +36,7 @@
     - [5.3.8 Readiness predicates and boot-time behavior](#538-readiness-predicates-and-boot-time-behavior)
       - [5.3.8.1 Readiness-gated boot-time sequence (example: port readiness)](#5381-readiness-gated-boot-time-sequence-example-port-readiness)
       - [5.3.8.2 Non-readiness-gated boot-time sequence](#5382-non-readiness-gated-boot-time-sequence)
+      - [5.3.8.3 Readiness transition wake-up](#5383-readiness-transition-wake-up)
     - [5.3.9 Notification inventory](#539-notification-inventory)
     - [5.3.10 Priority, Fairness, Queue Policy, and Shared Handler](#5310-priority-fairness-queue-policy-and-shared-handler)
     - [5.3.11 Validation and Unit Test Coverage](#5311-validation-and-unit-test-coverage)
@@ -524,7 +525,7 @@ sequenceDiagram
 5. That `SaiNotificationQueueExecutor::execute()` is invoked on the main-loop path.
 6. The executor checks the **readiness predicate registered for this consumer/op**. See [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) for the per-consumer isolation rules that prevent mixed-readiness batch pops.
 7. If the readiness predicate fails, the executor returns without popping and this consumer's notifications stay queued; `hasCachedData()` is false to avoid main-loop spin. Retry behavior is described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
-8. If the readiness predicate passes, the executor pops a batch from **this** queue (`DEFAULT_NC_POP_BATCH_SIZE`). If more entries remain, `hasCachedData()` follows Redis (`size() > 1`) so the next drain happens on a later Select iteration. Remaining depth of 1 waits for the next fd-ready `select()`.
+8. If the readiness predicate passes, the executor pops a batch from **this** queue (`DEFAULT_NC_POP_BATCH_SIZE`). If more entries remain, `hasCachedData()` follows Redis (`size() > 1`) so the next drain happens on a later Select iteration. Remaining depth of 1 waits for the next fd-ready `select()` or an explicit readiness-transition wake-up ([Section 5.3.8.3](#5383-readiness-transition-wake-up)).
 9. The executor dispatches each popped entry through `SaiNotificationDispatcher`.
 10. The dispatcher invokes the target Orch `handleNotification(entry)` registered for that op on the `orchagent` main-loop path.
 
@@ -1018,6 +1019,9 @@ public:
 
     SaiNotificationQueue *getSaiNotificationQueue(const std::string &op);
 
+    // Re-arm queue executors when readiness predicates start passing.
+    void wakeReadyQueues();
+
 private:
     struct ConsumerMetadata
     {
@@ -1052,6 +1056,32 @@ gFdbOrch = new FdbOrch(...);
 // other orchs register handlers from their constructors
 ```
 
+When `PortsOrch::allPortsReady()` becomes true, `PortsOrch` calls `maybeWakeSaiNotificationQueues()` so readiness-gated queues with pending entries are explicitly re-notified ([Section 5.3.8.3](#5383-readiness-transition-wake-up)):
+
+```cpp
+void PortsOrch::maybeWakeSaiNotificationQueues()
+{
+    if (gSaiNotificationOrch && allPortsReady())
+    {
+        gSaiNotificationOrch->wakeReadyQueues();
+    }
+}
+
+void SaiNotificationOrch::wakeReadyQueues()
+{
+    for (const auto &entry : m_consumersByName)
+    {
+        auto *queue = entry.second.queue.get();
+        if (queue && queue->hasData() && queue->isReady())
+        {
+            queue->notifyPending();
+        }
+    }
+}
+```
+
+`maybeWakeSaiNotificationQueues()` is invoked from `PortsOrch::doPortTask()` when `PortInitDone` is processed and whenever a port is removed from `m_pendingPortSet` (including skipped/invalid port paths), matching the points where `allPortsReady()` may transition from false to true.
+
 #### 5.3.8 Readiness predicates and boot-time behavior
 
 **Why this is needed.** Option 3 must preserve the same boot-time behavior as the existing Redis `NotificationConsumer` path. In Redis, many orchs return from `doTask(NotificationConsumer&)` before `pop()` or `pops()` until their readiness conditions are met, so notifications stay in **that consumer's** notification queue instead of being dropped. Option 3 uses the same model **per consumer**: the notification queue executor checks that consumer's readiness predicate before `pops()`. If the consumer is not ready, the executor returns without popping.
@@ -1071,7 +1101,7 @@ gFdbOrch = new FdbOrch(...);
 
 - On boot, `PortsOrch::allPortsReady()` is false until `PortInitDone` is received and no ports remain in `m_pendingPortSet`.
 - If that consumer is not ready, its executor returns without calling `pops()`; **only that consumer's** notifications stay queued. Other consumers (for example `bfd_session_state_change`) continue to drain.
-- After `allPortsReady()` becomes true, a later wake-up and `execute()` for that consumer sees the predicate pass, pops, and dispatches to the registered handler.
+- After `allPortsReady()` becomes true, `PortsOrch` calls `maybeWakeSaiNotificationQueues()` ([Section 5.3.8.3](#5383-readiness-transition-wake-up)). A later `execute()` for that consumer sees the predicate pass, pops, and dispatches to the registered handler.
 
 **Non-readiness-gated notifications** (no readiness predicate — for example `bfd_session_state_change`, `icmp_echo_session_state_change`, MACsec post-status):
 
@@ -1092,6 +1122,7 @@ sequenceDiagram
     participant FdbQueue as fdb_event queue
     participant FdbExec as fdb_event executor
     participant PortsOrch
+    participant SaiNotifOrch as SaiNotificationOrch
     participant FdbOrch
 
     syncd->>Callback: fdb_event
@@ -1103,6 +1134,8 @@ sequenceDiagram
     Note over PortsOrch: PortInitDone received
     Note over PortsOrch: pending ports cleared
     Note over PortsOrch: allPortsReady() is true
+    PortsOrch->>SaiNotifOrch: maybeWakeSaiNotificationQueues()
+    SaiNotifOrch->>FdbQueue: notifyPending() (hasData && isReady)
 
     FdbExec->>FdbExec: check fdb consumer readiness
     Note over FdbExec: allPortsReady() is true
@@ -1131,6 +1164,18 @@ sequenceDiagram
     Executor->>Queue: pops
     Executor->>BfdOrch: dispatch bfd_session_state_change
 ```
+
+##### 5.3.8.3 Readiness transition wake-up
+
+Redis parity requires `hasCachedData()` to stay **false** while a consumer is not ready, even when its queue is non-empty ([Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior)). That prevents the Select loop from immediately reinserting the executor and spinning at boot. The trade-off is that a notification enqueued **before** readiness may remain at queue depth **1** after the predicate starts passing: `hasCachedData()` is still false (`size() > 1` is false), and the executor is not reselected until another wake-up.
+
+Option 3 therefore requires an **explicit readiness-transition wake-up** when the owning readiness condition becomes true:
+
+- `PortsOrch::maybeWakeSaiNotificationQueues()` runs when `allPortsReady()` may have just become true (`PortInitDone` and each `m_pendingPortSet.erase()` path in `doPortTask()`).
+- `SaiNotificationOrch::wakeReadyQueues()` walks registered per-consumer queues and calls `notifyPending()` on each queue with `hasData() && isReady()`.
+- That re-arms the queue's Selectable so the main loop runs `execute()` again and drains the previously blocked entry.
+
+Without this wake-up, readiness-gated notifications can stall indefinitely after boot even though `allPortsReady()` is true. New enqueues still work because `enqueue()` also calls `notifyPending()`.
 
 For example, an `FdbOrch` migration can register the `fdb_event` handler and a port-readiness predicate from the `FdbOrch` constructor:
 
@@ -1275,7 +1320,7 @@ The Redis path calls `handleNotification(entry)` from `doTask(NotificationConsum
 The implementation should include focused unit coverage for the new queue mechanics:
 
 - Queue tests should verify per-consumer enqueue routing, LruDedup coalescing vs FIFO order, `hasCachedData()` (`false` when not ready; `size() > 1` when ready), batch-limited `pops()`, watermark / max-depth drop on FIFO, and empty-queue state.
-- Executor and dispatcher tests should verify that a registered operation handler is invoked with the queued entry, that a not-ready consumer does not spin (`hasCachedData()` false), that queued notifications are retried after a later wake-up when readiness becomes true, that a not-ready consumer does not block a different ready consumer, and that `dispatch()` logs a warning when no handler is registered. Mock tests in `notifications_ut.cpp` should cover per-consumer isolation (not shared-FIFO head-of-line blocking).
+- Executor and dispatcher tests should verify that a registered operation handler is invoked with the queued entry, that a not-ready consumer does not spin (`hasCachedData()` false), that queued notifications are retried after a later wake-up when readiness becomes true (including explicit `notifyPending()` on the readiness transition — see `WakeOnReadinessTransition` in `notifications_ut.cpp`), that a not-ready consumer does not block a different ready consumer, and that `dispatch()` logs a warning when no handler is registered. Mock tests in `notifications_ut.cpp` should cover per-consumer isolation (not shared-FIFO head-of-line blocking).
 - Callback tests should verify that each migrated ZMQ-mode callback enqueues the expected operation onto the correct consumer queue and preserves the serialized notification payload.
 - Selectable tests should verify the wrapper forwards priority 100.
 - `COUNTERS_DB` tests should verify that registered Option 3 per-consumer notification queues publish to `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` with the same fields as their Redis twins: admission counters for all consumers; LruDedup depth/HWM fields for `fdb_event`, `port_state_change`, and `port_host_tx_ready`; `queue_policy=Fifo` only (no depth/HWM) for FIFO consumers.

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -1354,7 +1354,7 @@ The following items are **out of scope** for this HLD and left for follow-on wor
 ### 5.4 Recommendation
 
 - **Near-term:** Use **Option 2** ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)) to restore missing ZMQ-mode notification delivery quickly with minimal risk. Callbacks re-post to `ASIC_DB:NOTIFICATIONS` and existing Orch `NotificationConsumer` handlers remain unchanged.
-- **Long-term:** Adopt **Option 3** as the target design for migrated `ASIC_DB:NOTIFICATIONS` types: enqueue on the libsairedis ZMQ callback thread onto **per-consumer in-process notification queues** (LruDedup/FIFO matching Redis), drain through `SaiNotificationOrch`, and preserve per-consumer readiness predicates and `handleNotification()` behavior.
+- **Long-term:** Adopt **Option 3** as the target design for migrated `ASIC_DB:NOTIFICATIONS` types: enqueue on the libsairedis ZMQ callback thread onto **per-consumer in-process notification queues** (LruDedup/FIFO matching Redis), drain through `SaiNotificationOrch`, and preserve per-consumer readiness predicates and `handleNotification()` behavior. Implementation: [sonic-swss PR #4806](https://github.com/sonic-net/sonic-swss/pull/4806).
 - **Option 3 rollout:** Migrate every [Section 5.3.9](#539-notification-inventory) op to the in-process per-consumer notification queues except **Unchanged** (`switch_shutdown_request`, `switch_asic_sdk_health_event`). Notification-queue-layer Redis parity (topology, coalescing, `hasCachedData`, Select priority 100, syslog watermarks, `COUNTERS_DB:NOTIFICATION_CONSUMER_STATS` with the same fields as non-ZMQ) is in this HLD, not a later phase. Follow-on work is listed in [Section 5.3.14](#5314-follow-on-work).
 - **Not recommended:** **Option 1** (Redis notification producer in `syncd` while request/response stays on ZMQ) is not proposed because it makes ZMQ mode asymmetric and reintroduces duplicate-delivery risk if callbacks also re-post.
 
@@ -1362,3 +1362,4 @@ The following items are **out of scope** for this HLD and left for follow-on wor
 
 - [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541): Missing notification delivery for FDB/BFD when ZMQ southbound is enabled (GitHub issue title uses "forwarding"; this HLD uses re-post terminology in [Section 5.2](#52-option-2-orchagent-callback-re-posts-to-asic_dbnotifications))
 - [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619): Forward SAI notifications to Redis in ZMQ southbound mode
+- [sonic-swss PR #4806](https://github.com/sonic-net/sonic-swss/pull/4806): In-process SAI notification queue for ZMQ mode (Option 3)

--- a/hld/zmq-southbound-sai-notification-handling.md
+++ b/hld/zmq-southbound-sai-notification-handling.md
@@ -7,11 +7,42 @@
 - [3. Existing Notification Flows](#3-existing-notification-flows)
   - [3.1 Non-ZMQ Mode](#31-non-zmq-mode)
   - [3.2 ZMQ Mode Today](#32-zmq-mode-today)
+    - [3.2.1 Notifications Already Handled](#321-notifications-already-handled)
+    - [3.2.2 Notifications With Missing Callback Handling](#322-notifications-with-missing-callback-handling)
 - [4. Design Goals](#4-design-goals)
 - [5. Design Options](#5-design-options)
-  - [Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode](#option-1-syncd-publishes-notifications-via-redis-in-zmq-mode)
-  - [Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`](#option-2-orchagent-callback-re-posts-to-asic_dbnotifications)
-  - [Option 3: In-process Notification Queue Drained by Orch Main Loop](#option-3-in-process-notification-queue-drained-by-orch-main-loop)
+  - [5.1 Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode](#51-option-1-syncd-publishes-notifications-via-redis-in-zmq-mode)
+    - [5.1.1 Description](#511-description)
+    - [5.1.2 Notification Path](#512-notification-path)
+    - [5.1.3 Implementation Notes](#513-implementation-notes)
+    - [5.1.4 Pros](#514-pros)
+    - [5.1.5 Cons](#515-cons)
+  - [5.2 Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`](#52-option-2-orchagent-callback-re-posts-to-asic_dbnotifications)
+    - [5.2.1 Description](#521-description)
+    - [5.2.2 Option 2 Flow](#522-option-2-flow)
+    - [5.2.3 Implementation Notes](#523-implementation-notes)
+    - [5.2.4 Pros](#524-pros)
+    - [5.2.5 Cons](#525-cons)
+  - [5.3 Option 3: In-process Notification Queue Drained by Orch Main Loop](#53-option-3-in-process-notification-queue-drained-by-orch-main-loop)
+    - [5.3.1 Description](#531-description)
+    - [5.3.2 Option 3 Flow](#532-option-3-flow)
+    - [5.3.3 Option 3 Sequence](#533-option-3-sequence)
+      - [5.3.3.1 ZMQ notification delivery to `orchagent` callback](#5331-zmq-notification-delivery-to-orchagent-callback)
+      - [5.3.3.2 Callback to main-loop processing](#5332-callback-to-main-loop-processing)
+    - [5.3.4 Notification Dispatch Path Comparison (Non-ZMQ, Option 2, and Option 3)](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3)
+    - [5.3.5 Existing Code References](#535-existing-code-references)
+    - [5.3.6 Implementation Notes](#536-implementation-notes)
+    - [5.3.7 Main-loop Integration](#537-main-loop-integration)
+    - [5.3.8 Readiness predicates and boot-time behavior](#538-readiness-predicates-and-boot-time-behavior)
+      - [5.3.8.1 Readiness-gated boot-time sequence (example: port readiness)](#5381-readiness-gated-boot-time-sequence-example-port-readiness)
+      - [5.3.8.2 Non-readiness-gated boot-time sequence](#5382-non-readiness-gated-boot-time-sequence)
+    - [5.3.9 Notification inventory](#539-notification-inventory)
+    - [5.3.10 Priority, Fairness, and Shared Handler](#5310-priority-fairness-and-shared-handler)
+    - [5.3.11 Validation and Unit Test Coverage](#5311-validation-and-unit-test-coverage)
+    - [5.3.12 Pros](#5312-pros)
+    - [5.3.13 Cons](#5313-cons)
+    - [5.3.14 Follow-on work](#5314-follow-on-work)
+  - [5.4 Recommendation](#54-recommendation)
 - [6. References](#6-references)
 
 ## 1. Background
@@ -24,27 +55,22 @@ SYSTEM_DEFAULTS|swss_zmq.status = enabled
 
 In non-ZMQ mode (Redis mode), SAI notifications are published by `syncd` into Redis `ASIC_DB:NOTIFICATIONS`. `orchagent` consumes those notifications from Redis in its normal main loop and dispatches them to the appropriate Orch components.
 
-In ZMQ mode, `syncd` sends notifications to `orchagent` through ZMQ. These notifications arrive in `orchagent` libsairedis callback functions. Some callbacks already forward notifications to Redis, such as `on_port_state_change()`, but several callbacks are currently empty or incomplete. As a result, some notifications are dropped when ZMQ southbound is enabled.
+In ZMQ mode, `syncd` sends notifications to `orchagent` through ZMQ. These notifications arrive in `orchagent` libsairedis callback functions. Some callbacks already re-post notifications to Redis, such as `on_port_state_change()`, but several callbacks are currently empty or incomplete. As a result, some notifications are dropped when ZMQ southbound is enabled.
 
 This gap is tracked in [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541). An initial short-term implementation is proposed in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619).
 
 ## 2. Problem Statement
 
-When ZMQ southbound is enabled, the following SAI notifications may not reach their existing Orch consumers:
+When ZMQ southbound is enabled, SAI notifications delivered over ZMQ may not reach their existing Orch consumers. The primary gaps called out in [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541) are:
 
 - `fdb_event`
 - `bfd_session_state_change`
 - `port_host_tx_ready`
 - `icmp_echo_session_state_change`
 
-Additional notification types may also need review, depending on platform and feature coverage.
+Additional `ASIC_DB:NOTIFICATIONS` types should be reviewed for ZMQ-mode parity with the existing non-ZMQ Redis path, including `port_state_change` (currently re-posted to Redis in ZMQ mode), `twamp_session_event`, and MACsec post-status notifications.
 
-Expected consumers include:
-
-- `FdbOrch`
-- `BfdOrch`
-- `PortsOrch`
-- `IcmpOrch`
+Expected consumers include `FdbOrch`, `BfdOrch`, `PortsOrch`, `IcmpOrch`, `TwampOrch`, and `MACsecOrch`, depending on platform and feature coverage.
 
 Without a fix:
 
@@ -52,6 +78,9 @@ Without a fix:
 - BFD session state transitions may not reach `BfdOrch`.
 - Port host TX readiness may not reach `PortsOrch`.
 - ICMP echo session monitoring may not reach `IcmpOrch`.
+- Other `ASIC_DB:NOTIFICATIONS` types covered by this HLD (for example `twamp_session_event`, MACsec post-status, and HA/flow-bulk events; see [Section 5.3.9](#539-notification-inventory) for the full set) may be dropped or may not reach their owning orchs when ZMQ southbound is enabled.
+
+This HLD does not change notification channels outside `ASIC_DB:NOTIFICATIONS` SAI delivery, such as `RESTARTCHECK` (`SwitchOrch`) or `APPL_DB` requests such as `WATERMARK_CLEAR_REQUEST` (`WatermarkOrch`). These are out of scope because they are not delivered via syncd SAI notifications over ZMQ; they continue to use their existing Redis consumers unchanged in ZMQ mode.
 
 Notification prioritization and timely handling of high-priority notifications, such as port state changes and BFD session state changes, under high `orchagent` load is a broader concern for both ZMQ and non-ZMQ modes. This HLD considers that concern only in the context of the ZMQ notification handling [design options](#5-design-options); it does not propose changes to the existing non-ZMQ notification path.
 
@@ -66,6 +95,7 @@ flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
         syncdCallback["SAI callback"]
+        ntfQueue[["syncd notification<br/>queue"]]
         notificationProcessor["NotificationProcessor"]
         redisProducer["Redis<br/>NotificationProducer"]
     end
@@ -82,19 +112,20 @@ flowchart TD
     end
 
     saiApi -->|"raise SAI notification"| syncdCallback
-    syncdCallback --> notificationProcessor
+    syncdCallback --> ntfQueue
+    ntfQueue --> notificationProcessor
     notificationProcessor --> redisProducer
     redisProducer --> redisNotifications
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
+    notifier -->|"doTask<br/>(NotificationConsumer&)"| orchHandler
 ```
 
 The non-ZMQ notification path has three main execution hops:
 
 - `SAI API / ASIC SDK` invokes the registered notification callback in `syncd`.
-- `syncd` notification processing publishes the notification to `ASIC_DB:NOTIFICATIONS`.
+- The `syncd` SAI callback enqueues the notification on the internal `syncd` notification queue; `NotificationProcessor` dequeues and publishes the notification to `ASIC_DB:NOTIFICATIONS`.
 - `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 
 This is the existing proven notification path.
@@ -110,6 +141,7 @@ flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
         syncdCallback["SAI callback"]
+        ntfQueue[["syncd notification<br/>queue"]]
         notificationProcessor["NotificationProcessor"]
         zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
@@ -131,7 +163,8 @@ flowchart TD
     end
 
     saiApi -->|"raise SAI notification"| syncdCallback
-    syncdCallback --> notificationProcessor
+    syncdCallback --> ntfQueue
+    ntfQueue --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
@@ -142,7 +175,7 @@ flowchart TD
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
+    notifier -->|"doTask<br/>(NotificationConsumer&)"| orchHandler
 
     callbackLogic -->|"for switch shutdown or<br/>ASIC SDK health"| directHandler
     directHandler --> orchHandler
@@ -150,7 +183,7 @@ flowchart TD
 
 In ZMQ mode, notifications that already have callback handling follow one of the existing callback-specific paths:
 
-- Some callbacks re-post the notification to `ASIC_DB:NOTIFICATIONS`. From there, the existing Redis notification path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
+- Some callbacks re-post the notification to `ASIC_DB:NOTIFICATIONS`. From there, the existing Redis notification consumer path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 - Other callbacks, such as switch shutdown or ASIC SDK health handling, are handled directly by callback-specific logic.
 
 ### 3.2.2 Notifications With Missing Callback Handling
@@ -160,6 +193,7 @@ flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
         syncdCallback["SAI callback"]
+        ntfQueue[["syncd notification<br/>queue"]]
         notificationProcessor["NotificationProcessor"]
         zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
@@ -168,45 +202,56 @@ flowchart TD
         subgraph orchagentProcess["orchagent process"]
             zmqThread["libsairedis ZMQ<br/>notification thread"]
             saiCallback["orchagent libsairedis<br/>callback"]
-            callbackLogic["empty / incomplete<br/>callback logic:<br/>no forwarding or dispatch<br/>to existing Orch<br/>notification handling path"]
-            dropped["notification dropped"]
+            callbackLogic["empty / incomplete<br/>callback logic:<br/>no re-post or dispatch<br/>to existing Orch<br/>notification handling path"]
         end
     end
 
     saiApi -->|"raise SAI notification"| syncdCallback
-    syncdCallback --> notificationProcessor
+    syncdCallback --> ntfQueue
+    ntfQueue --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
     saiCallback --> callbackLogic
-    callbackLogic --> dropped
 ```
 
-In this case, the ZMQ notification reaches the `orchagent` libsairedis callback, but the callback does not forward or dispatch the notification to the existing Orch notification handling path. Because that forwarding/dispatch is missing today, the notification is dropped.
+In this case, ZMQ transport delivers the notification to the `orchagent` libsairedis notification thread, which invokes the registered `orchagent` libsairedis callback. The callback does not re-post or dispatch the notification to the existing Orch notification handling path. Because that re-post/dispatch is missing today, the notification is dropped.
 
 ## 4. Design Goals
 
 - Preserve existing non-ZMQ behavior.
-- Restore missing notifications in ZMQ mode.
+- Restore missing notifications in ZMQ mode for every `ASIC_DB:NOTIFICATIONS` type listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** ops.
 - Avoid duplicate notification delivery.
-- Preserve existing Orch handler behavior.
+- Preserve existing Orch handler behavior, including per-orch readiness rules in `doTask(NotificationConsumer&)`.
 - Keep Orch state updates on the `orchagent` main-loop path.
 
 ## 5. Design Options
 
-## Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode
+This section compares three alternative ways to deliver `ASIC_DB:NOTIFICATIONS` SAI notifications when **ZMQ southbound is enabled** (`swss_zmq.status = enabled`). Throughout this document, **Option 1**, **Option 2**, and **Option 3** mean these ZMQ-mode notification delivery alternatives only.
 
-### Description
+The existing **non-ZMQ** notification path ([Section 3.1](#31-non-zmq-mode)) is unchanged by this HLD and is not an Option in this comparison. [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3) shows how non-ZMQ delivery relates to Option 2 and Option 3.
+
+| Option | Summary |
+|--------|---------|
+| **Option 1** | `syncd` publishes notifications to Redis while request/response stays on ZMQ |
+| **Option 2** | ZMQ transport + `orchagent` callback re-post to Redis ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)) |
+| **Option 3** | ZMQ transport + `orchagent` callback enqueue to in-process queue (main-loop drain) |
+
+See [Section 5.4](#54-recommendation) for the proposed path.
+
+### 5.1 Option 1: `syncd` Publishes Notifications via Redis in ZMQ Mode
+
+#### 5.1.1 Description
 
 Under this option, when ZMQ southbound is enabled, regular SAI operations continue to use the existing ZMQ request/response channel between `orchagent` and `syncd` through `ZeroMQSelectableChannel`, while SAI notifications are published by `syncd` through Redis.
 
 This option reuses the existing `RedisNotificationProducer` used in non-ZMQ mode; the change is only to select it for SAI notifications when ZMQ southbound is enabled.
 
-### Notification Path
+#### 5.1.2 Notification Path
 
 SAI notifications follow the same Redis notification path described in [Section 3.1](#31-non-zmq-mode). The difference is that this path is selected even when ZMQ southbound is enabled; regular SAI request/response operations still use ZMQ.
 
-### Implementation Notes
+#### 5.1.3 Implementation Notes
 
 Option 1 would change the ZMQ-mode notification producer selection in `syncd` from:
 
@@ -222,32 +267,33 @@ m_notifications = std::make_shared<RedisNotificationProducer>(m_contextConfig->m
 
 `orchagent` libsairedis notification callbacks remain no-op for these notifications in this option, because `syncd` publishes the notifications directly to Redis. If a callback re-publishes a Redis-delivered notification back to Redis, duplicate or looping notifications can occur.
 
-### Pros
+#### 5.1.4 Pros
 
 - Uses the existing Redis notification path.
 - Existing Orch consumers continue unchanged.
 
-### Cons
+#### 5.1.5 Cons
 
 - Makes ZMQ mode asymmetric:
   - request/response operations use ZMQ.
   - SAI notifications use Redis.
 
-## Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`
+### 5.2 Option 2: `orchagent` Callback Re-posts to `ASIC_DB:NOTIFICATIONS`
 
-### Description
+#### 5.2.1 Description
 
 In this option, `syncd` continues to send notifications to `orchagent` through ZMQ. The `libsairedis` ZMQ notification path invokes the registered SAI notification callback in `orchagent`, and that callback re-publishes the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled.
 
-This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619). The same forwarding behavior would be added to each missing notification callback covered by this HLD.
+This follows the existing `on_port_state_change()` model and is the approach used by the initial fix in [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619). The same re-post behavior would be added to each missing notification callback covered by this HLD.
 
-### Option 2 Flow
+#### 5.2.2 Option 2 Flow
 
 ```mermaid
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
         syncdCallback["SAI callback"]
+        ntfQueue[["syncd notification<br/>queue"]]
         notificationProcessor["NotificationProcessor"]
         zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
@@ -267,7 +313,8 @@ flowchart TD
     end
 
     saiApi -->|"raise SAI notification"| syncdCallback
-    syncdCallback --> notificationProcessor
+    syncdCallback --> ntfQueue
+    ntfQueue --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
@@ -276,12 +323,12 @@ flowchart TD
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> mainLoop
     mainLoop --> notifier
-    notifier -->|"doTask(NotificationConsumer&)"| orchHandler
+    notifier -->|"doTask<br/>(NotificationConsumer&)"| orchHandler
 ```
 
-In Option 2, the ZMQ notification reaches the `orchagent` libsairedis callback, and the callback re-posts the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled. After the re-post, the existing Redis notification path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
+In Option 2, ZMQ transport delivers the notification to the `orchagent` libsairedis notification thread, which invokes the registered `orchagent` libsairedis callback. The callback re-posts the notification to `ASIC_DB:NOTIFICATIONS` only when ZMQ mode is enabled. After the re-post, the existing Redis notification consumer path is used: the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
 
-### Implementation Notes
+#### 5.2.3 Implementation Notes
 
 The following snippet is high-level pseudo-code for the callback re-post model.
 
@@ -305,7 +352,7 @@ void on_fdb_event(uint32_t count, const sai_fdb_event_notification_data_t *data)
 
 Note: The callback must check whether ZMQ mode is enabled before re-publishing to Redis. In non-ZMQ mode, `syncd` already publishes the notification to `ASIC_DB:NOTIFICATIONS`, and the normal `orchagent` `NotificationConsumer` path handles it in the main loop. The libsairedis notification path can still deserialize Redis notifications and invoke the registered `orchagent` libsairedis callback in non-ZMQ mode. If the callback re-publishes the notification to Redis in that mode, duplicate or looping notifications can occur. Therefore, the callback only re-publishes when `gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC`.
 
-### Pros
+#### 5.2.4 Pros
 
 - Low-risk short-term fix.
 - No `syncd` change.
@@ -313,26 +360,29 @@ Note: The callback must check whether ZMQ mode is enabled before re-publishing t
 - Reuses existing Orch Redis notification processing path.
 - Can be implemented and validated event-by-event.
 
-### Cons
+#### 5.2.5 Cons
 
 - Compared with Option 1, notifications first travel over ZMQ before being re-posted to Redis for Orch processing, which can add latency.
 - Uses Redis for final notification dispatch.
 
-## Option 3: In-process Notification Queue Drained by Orch Main Loop
+### 5.3 Option 3: In-process Notification Queue Drained by Orch Main Loop
 
-### Description
+#### 5.3.1 Description
 
 In this option, the `orchagent` libsairedis callback packages the notification as an operation name, serialized payload, and optional field-value list, then makes it available to the main loop through an in-process notification queue. The `orchagent` main loop drains the queue and dispatches the event to the appropriate Orch handler.
 
 This model is similar in spirit to existing selectable-based processing such as `ZmqConsumerStateTable`, where data availability wakes the main loop and processing happens through an executor path.
 
-### Option 3 Flow
+#### 5.3.2 Option 3 Flow
+
+Note: Blue-highlighted boxes identify new Option 3 components and executor processing steps introduced by this design.
 
 ```mermaid
 flowchart TD
     subgraph syncdContainer["syncd container"]
         saiApi["SAI API / ASIC SDK"]
         syncdCallback["SAI callback"]
+        ntfQueue[["syncd notification<br/>queue"]]
         notificationProcessor["NotificationProcessor"]
         zmqProducer["ZeroMQ<br/>NotificationProducer"]
     end
@@ -342,41 +392,54 @@ flowchart TD
             zmqThread["libsairedis ZMQ<br/>notification thread"]
             saiCallback["orchagent libsairedis<br/>callback"]
             notificationQueue[["in-process<br/>notification queue"]]
-            selectableEvent["new SAI notification queue<br/>selectable"]
+            queueSelectableReady["SAI notification queue<br/>selectable ready"]
             mainLoop["orchagent main Select loop"]
+            saiNotificationOrch["SaiNotificationOrch<br/>(shared consumer host)"]
             queueExecutor["SaiNotification<br/>QueueExecutor"]
-            dispatcher["SAI notification handler<br/>registry"]
+            headPredicate["check notification<br/>processing readiness<br/>for queue head"]
+            queueDrain["pops when readiness<br/>predicate passes"]
+            stayQueued["return without pop.<br/>Notification stays queued"]
+            dispatcher["SaiNotificationDispatcher"]
             orchHandler["Target Orch<br/>notification handler"]
         end
     end
 
     saiApi -->|"raise SAI notification"| syncdCallback
-    syncdCallback --> notificationProcessor
+    syncdCallback --> ntfQueue
+    ntfQueue --> notificationProcessor
     notificationProcessor --> zmqProducer
     zmqProducer -->|"ZMQ notification channel"| zmqThread
     zmqThread --> saiCallback
 
     saiCallback --> notificationQueue
-    notificationQueue --> selectableEvent
-    selectableEvent -->|"queued notification<br/>available"| mainLoop
-    mainLoop --> queueExecutor
-    queueExecutor --> dispatcher
+    notificationQueue --> queueSelectableReady
+    queueSelectableReady -->|"queued notification<br/>available"| mainLoop
+    mainLoop --> saiNotificationOrch
+    saiNotificationOrch --> queueExecutor
+    queueExecutor --> headPredicate
+    headPredicate -->|"readiness passes"| queueDrain
+    headPredicate -->|"readiness fails"| stayQueued
+    queueDrain --> dispatcher
     dispatcher -->|"registered op handler"| orchHandler
+
+    classDef option3New fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#111827
+    class notificationQueue,queueSelectableReady,saiNotificationOrch,queueExecutor,headPredicate,queueDrain,stayQueued,dispatcher option3New
 ```
 
-### Option 3 Sequence
+#### 5.3.3 Option 3 Sequence
 
 The flow diagram above shows the components involved. The sequence diagrams below show the expected ordering and execution-context handoff for Option 3.
 
 Option 3 does not change notification delivery up to the `orchagent` libsairedis callback; its changes start after the callback receives the notification.
 
-ZMQ notification delivery to `orchagent` callback:
+##### 5.3.3.1 ZMQ notification delivery to `orchagent` callback
 
 ```mermaid
 sequenceDiagram
     box syncd container
         participant SaiApi as SAI API / ASIC SDK
         participant SyncdCb as syncd SAI callback
+        participant NtfQueue as syncd notification queue
         participant Processor as syncd NotificationProcessor
         participant ZmqProducer as ZeroMQNotificationProducer
     end
@@ -389,103 +452,152 @@ sequenceDiagram
     end
 
     SaiApi->>SyncdCb: 1. raise SAI notification
-    SyncdCb->>Processor: 2. process notification
-    Processor->>ZmqProducer: 3. pass to producer
-    ZmqProducer->>ZMQ: 4. send notification
-    ZMQ->>ZmqThread: 5. deliver notification
-    ZmqThread->>Callback: 6. invoke SAI callback
+    SyncdCb->>NtfQueue: 2. enqueue
+    NtfQueue->>Processor: 3. dequeue
+    Processor->>ZmqProducer: 4. send via ZeroMQNotificationProducer
+    ZmqProducer->>ZMQ: 5. send notification to orchagent via ZMQ
+    ZMQ->>ZmqThread: 6. libsairedis notification thread receives via ZMQ
+    ZmqThread->>Callback: 7. invoke registered SAI callback
 ```
 
 The notification delivery sequence is:
 
 1. `SAI API / ASIC SDK` raises a notification and invokes the registered `syncd` SAI callback.
-2. The `syncd` SAI callback passes the notification to `syncd` notification processing.
-3. `syncd` notification processing passes the notification to `ZeroMQNotificationProducer`.
-4. `ZeroMQNotificationProducer` sends the notification to ZMQ.
-5. ZMQ delivers the notification to the libsairedis ZMQ notification thread in `orchagent`.
-6. The libsairedis ZMQ notification thread invokes the registered `orchagent` libsairedis callback.
+2. The `syncd` SAI callback performs minimal work and enqueues the notification on the internal `syncd` notification queue (same pattern as non-ZMQ mode).
+3. The `syncd` `NotificationProcessor` thread dequeues the notification from the queue.
+4. `NotificationProcessor` sends the notification through `ZeroMQNotificationProducer`.
+5. `ZeroMQNotificationProducer` sends the notification to `orchagent` via ZMQ.
+6. The libsairedis ZMQ notification thread in `orchagent` receives the notification via ZMQ.
+7. The libsairedis ZMQ notification thread invokes the registered `orchagent` libsairedis callback.
 
-Option 3 callback to main-loop processing:
+Steps 1–2 run on the SAI callback thread; steps 3–4 run on the `NotificationProcessor` thread; steps 5–7 run on the libsairedis ZMQ notification thread.
+
+##### 5.3.3.2 Callback to main-loop processing
+
+The main-loop processing sequence is: steps 1–2 run on the libsairedis ZMQ notification thread; steps 3–10 run on the `orchagent` main-loop thread.
 
 ```mermaid
 sequenceDiagram
     box swss container / orchagent process
         participant Callback as orchagent libsairedis callback
+    end
+
+    box rgb(219, 234, 254) New Option 3 components in swss/orchagent
         participant Queue as in-process notification queue
         participant Wakeup as new SAI notification queue selectable
-        participant MainLoop as OrchDaemon::start Select loop
+        participant SaiNotificationOrch as SaiNotificationOrch
         participant Executor as SaiNotificationQueueExecutor::execute()
-        participant Dispatcher as SAI notification handler registry
+        participant Dispatcher as SaiNotificationDispatcher
+    end
+
+    box swss container / orchagent process
+        participant MainLoop as OrchDaemon::start Select loop
         participant Orch as Target Orch handler
     end
 
     Callback->>Queue: 1. enqueue op, serialized data, values
     Callback->>Wakeup: 2. notify queue selectable
     Wakeup->>MainLoop: 3. queued notification available
-    MainLoop->>Executor: 4. dispatch executor
-    Executor->>Queue: 5. pops queued notifications
-    Executor->>Dispatcher: 6. dispatch queued notification by op
-    Dispatcher->>Orch: 7. invoke registered target Orch handler
+    MainLoop->>SaiNotificationOrch: 4. dispatch executor
+    SaiNotificationOrch->>Executor: 5. execute()
+    Executor->>Executor: 6. check per-operation readiness predicate
+    alt 7. readiness predicate fails
+        Note over Executor,Queue: return without pop
+        Note over Queue: notification stays queued
+    else 8-10. readiness predicate passes
+        Executor->>Queue: 8. pops
+        Executor->>Dispatcher: 9. dispatch by op
+        Dispatcher->>Orch: 10. invoke registered handler
+    end
 ```
-
-The main-loop processing sequence is:
-
-- The `orchagent` libsairedis callback runs in the ZMQ notification thread.
 
 1. The callback serializes/packages the notification as a `KeyOpFieldsValuesTuple`-compatible entry and enqueues it into the in-process notification queue.
 2. The callback notifies the new SAI notification queue selectable.
 3. The current `OrchDaemon::start()` `Select` loop is notified that queued notifications are available.
-4. The main loop dispatches `SaiNotificationQueueExecutor::execute()`.
-5. `SaiNotificationQueueExecutor::execute()` pops queued notifications from the in-process notification queue.
-6. The executor dispatches each queued entry by notification op through a handler registry.
-7. The registry invokes the target Orch handler registered for that notification op on the `orchagent` main-loop path.
+4. The main loop dispatches the executor owned by `SaiNotificationOrch`.
+5. `SaiNotificationQueueExecutor::execute()` is invoked on the main-loop path.
+6. The executor checks the **per-operation readiness predicate** for the notification queue head entry — a per-op function that returns true when the owning orch is ready to process that notification type (for example `gPortsOrch->allPortsReady()` for ops that gate on port readiness, or always true when no predicate is registered, such as `bfd_session_state_change`). See [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) for readiness predicate registration, boot-time behavior, and head-of-line blocking.
+7. If the readiness predicate fails, the executor returns without popping; queued notifications are preserved for a later main-loop iteration.
+8. If the readiness predicate passes, the executor pops queued notifications from the in-process notification message queue. Each `execute()` call is batch-limited via `DEFAULT_NC_POP_BATCH_SIZE` (see [Section 5.3.6](#536-implementation-notes)); if more entries remain, the queue selectable is re-notified so later main-loop iterations can drain them.
+9. The executor dispatches each popped entry by notification op through `SaiNotificationDispatcher` (the handler registry; see [Section 5.3.7](#537-main-loop-integration)).
+10. The dispatcher invokes the target Orch handler registered for that notification op on the `orchagent` main-loop path.
 
-### Dispatch Relationship During Phased Migration to Option 3
+#### 5.3.4 Notification Dispatch Path Comparison (Non-ZMQ, Option 2, and Option 3)
 
-Option 3 does not send migrated ZMQ notifications back through `ASIC_DB:NOTIFICATIONS`. For notification types moved to the Option 3 queue-based model, the `orchagent` libsairedis callback enqueues the notification, and the `orchagent` main loop drains the queue and dispatches it to the target Orch handler.
+This section compares how `ASIC_DB:NOTIFICATIONS` SAI notifications reach target Orch handlers under non-ZMQ mode, ZMQ Option 2, and ZMQ Option 3.
 
-The existing Redis notification path remains unchanged for non-ZMQ mode and for notification types that continue to use the Option 2 Redis re-post model during phased rollout. In those cases, the `orchagent` main `Select` loop detects the ready `NotificationConsumer` selectable and dispatches the corresponding `Notifier` / executor. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, which handles the notification through the existing Orch handler logic.
+The diagram below shows three entry paths:
+
+- **Non-ZMQ mode** — `syncd` SAI callback enqueues on the internal notification queue; `NotificationProcessor` publishes to `ASIC_DB:NOTIFICATIONS`. The `orchagent` libsairedis callback is not part of notification delivery. The Redis consumer leg ([Section 3.1](#31-non-zmq-mode)) dispatches to the target Orch handler.
+- **Option 2** — ZMQ-mode interim fix ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)): the callback re-posts to `ASIC_DB:NOTIFICATIONS`, then uses the same Redis consumer leg as non-ZMQ mode.
+- **Option 3** — ZMQ-mode target design: the callback enqueues to the in-process notification message queue; the main loop drains through the shared queue executor and `SaiNotificationDispatcher`. Option 3 does not send notifications back through `ASIC_DB:NOTIFICATIONS`.
+
+**Option 3 scope.** In ZMQ mode, Option 3 migrates every notification op listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** to the in-process queue. There is **no hybrid Option 2 + Option 3 coexistence** for the same notification type: queue-path ops enqueue only; they do not also re-post to Redis. Non-ZMQ mode continues to use the existing Redis notification path ([Section 3.1](#31-non-zmq-mode)).
 
 ```mermaid
 flowchart TD
+    syncd["syncd notification processing<br/>(internal queue + NotificationProcessor)"]
+    zmq{{"ZMQ notification<br/>channel"}}
+    libsairedisCallback["orchagent libsairedis<br/>callback"]
+
     redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
 
-    subgraph redisPath["Existing Redis notification path"]
+    subgraph redisPath["Redis consumer leg"]
         redisConsumerReady["NotificationConsumer<br/>selectable ready"]
         redisMainLoop["orchagent main Select loop"]
         notifier["Notifier / Executor"]
     end
 
     subgraph option3Path["Option 3 queue-based path"]
-        libsairedisCallback["orchagent libsairedis<br/>callback"]
-        notificationQueue[["in-process<br/>notification queue"]]
+        enqueueNotify["enqueue and notify<br/>queue selectable"]
+        notificationQueue[["in-process<br/>notification message queue"]]
+        queueSelectableReady["SAI notification queue<br/>selectable ready"]
+        option3MainLoop["orchagent main Select loop"]
+        saiNotificationOrch["SaiNotificationOrch<br/>(shared consumer host)"]
         queueExecutor["SaiNotification<br/>QueueExecutor"]
-        dispatcher["SAI notification handler<br/>registry"]
+        headPredicate["check notification<br/>processing readiness<br/>for queue head"]
+        queueDrain["pops when readiness<br/>predicate passes"]
+        stayQueued["return without pop.<br/>Notification stays queued"]
+        dispatcher["SaiNotificationDispatcher"]
     end
 
     targetHandler["Target Orch<br/>notification handler"]
 
+    syncd -->|"Non-ZMQ:<br/>syncd publishes to Redis"| redisNotifications
+    syncd -->|"ZMQ mode:<br/>send via ZMQ"| zmq
+    zmq --> libsairedisCallback
+    libsairedisCallback -->|"Option 2:<br/>re-post to Redis"| redisNotifications
+    libsairedisCallback -->|"Option 3:<br/>enqueue"| enqueueNotify
+
     redisNotifications -->|"notification available"| redisConsumerReady
     redisConsumerReady --> redisMainLoop
     redisMainLoop --> notifier
-    notifier -->|"doTask(NotificationConsumer&)"| targetHandler
+    notifier -->|"doTask<br/>(NotificationConsumer&)"| targetHandler
 
-    libsairedisCallback --> notificationQueue
-    notificationQueue --> queueExecutor
-    queueExecutor --> dispatcher
+    enqueueNotify --> notificationQueue
+    notificationQueue --> queueSelectableReady
+    queueSelectableReady -->|"queued notification<br/>available"| option3MainLoop
+    option3MainLoop --> saiNotificationOrch
+    saiNotificationOrch --> queueExecutor
+    queueExecutor --> headPredicate
+    headPredicate -->|"readiness passes"| queueDrain
+    headPredicate -->|"readiness fails"| stayQueued
+    queueDrain --> dispatcher
     dispatcher -->|"registered op handler"| targetHandler
 
+    classDef option3New fill:#dbeafe,stroke:#2563eb,stroke-width:2px,color:#111827
+    class enqueueNotify,notificationQueue,queueSelectableReady,saiNotificationOrch,queueExecutor,headPredicate,queueDrain,stayQueued,dispatcher option3New
 ```
 
-Both paths should preserve the same Orch handler behavior. The non-ZMQ mode and Option 2 paths continue to use the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` flow, while Option 3 uses the new queue-based executor path and dispatches queued notifications by op to registered target Orch handlers. The Redis and queue paths should share the same notification-specific handler logic where practical.
+All three paths preserve the same target Orch handler behavior. In non-ZMQ mode, `syncd` publishes directly to `ASIC_DB:NOTIFICATIONS` and the `orchagent` libsairedis callback is not part of notification delivery; the Redis consumer leg (`NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)`) handles it. Option 2 reuses that same Redis consumer leg, but reaches it by re-posting from the ZMQ-mode callback. Option 3 replaces the Redis leg with the queue-based executor path and dispatches queued notifications by op through `SaiNotificationDispatcher` to registered target Orch handlers. The Redis and queue paths should share the same notification-specific handler logic where practical.
 
-### Existing Code References
+#### 5.3.5 Existing Code References
 
 Option 3 is expected to build on the following existing infrastructure.
 
 Current notification callbacks and consumers:
 
-- Callback implementations: some existing `orchagent` SAI notification callbacks are currently no-op or incomplete for ZMQ mode and need forwarding or queueing behavior. Examples include `on_fdb_event()`, `on_bfd_session_state_change()`, and `on_port_host_tx_ready()` in `src/sonic-swss/orchagent/notifications.cpp`, and `IcmpSaiSessionHandler::on_state_change()` in `src/sonic-swss/orchagent/icmporch.cpp`. Under Option 3, these callbacks would enqueue notifications for main-loop processing.
+- Callback implementations: some existing `orchagent` SAI notification callbacks are currently no-op or incomplete for ZMQ mode and need re-post (Option 2) or enqueue (Option 3) behavior. Examples include `on_fdb_event()`, `on_bfd_session_state_change()`, and `on_port_host_tx_ready()` in `src/sonic-swss/orchagent/notifications.cpp`, and `IcmpSaiSessionHandler::on_state_change()` in `src/sonic-swss/orchagent/icmporch.cpp`. Under Option 3, these callbacks enqueue notifications for main-loop processing.
 - Callback registration: notification callbacks are registered through existing Orch initialization and feature-specific setup paths. Examples include switch notification setup in `src/sonic-swss/orchagent/main.cpp`, `src/sonic-swss/orchagent/portsorch.cpp`, and `src/sonic-swss/orchagent/bfdorch.cpp`, and ICMP offload-session callback registration through `SaiOffloadSessionHandler`.
 - Existing Orch notification consumers: in the existing non-ZMQ notification path, these notification types are consumed from `ASIC_DB:NOTIFICATIONS` by target Orch consumers such as `FdbOrch`, `BfdOrch`, `PortsOrch`, and `IcmpOrch`. Option 3 should preserve the same Orch handler behavior without sending migrated ZMQ notifications through Redis.
 - Existing Redis notification dispatch: Redis-delivered SAI notifications are consumed through `NotificationConsumer` instances wrapped by `Notifier`. `Notifier::execute()` calls the corresponding Orch `doTask(NotificationConsumer&)`, preserving the existing per-Orch notification handling model for non-ZMQ mode and Option 2.
@@ -495,9 +607,10 @@ Selectable/executor integration:
 - Selectable-based ZMQ consumers: `src/sonic-swss-common/common/zmqconsumerstatetable.h` defines `ZmqConsumerStateTable`, an existing selectable-based ZMQ consumer that wakes the main loop when data is available and processes data through the executor path. Option 3 can follow a similar integration pattern for SAI notifications.
 - `ZmqConsumerStateTable` processing model: the referenced SONiC ZMQ producer/consumer state table design describes a receive-thread-to-main-loop pattern where `ZmqServer` receives and deserializes ZMQ messages, dispatches them to `ZmqConsumerStateTable`, `ZmqConsumerStateTable` notifies `Select`, and the main loop later pops operations through `ZmqConsumerStateTable::pops()`. Option 3 follows the same general pattern for SAI notifications: the `orchagent` libsairedis callback enqueues the notification, notifies the main loop, and processing happens through the executor path.
 - Select priority: `swss::Selectable` carries a priority value used by `Select`; higher priority values are selected ahead of lower-priority ready selectables. Option 3 should use this existing priority model where practical.
-- Main-loop infrastructure: `src/sonic-swss/orchagent/orchdaemon.cpp` contains the main `OrchDaemon::start()` `Select` loop that waits on registered selectables and dispatches `Executor::execute()` when a selectable becomes ready. The Option 3 integration approach is described in [Main-loop Integration](#main-loop-integration).
+- Main-loop infrastructure: `src/sonic-swss/orchagent/orchdaemon.cpp` contains the main `OrchDaemon::start()` `Select` loop that waits on registered selectables and dispatches `Executor::execute()` when a selectable becomes ready. The Option 3 integration approach is described in [Section 5.3.7](#537-main-loop-integration).
+- `SaiNotificationOrch`: shared SAI notification queue consumer host; see [Section 5.3.7](#537-main-loop-integration) for construction order, ZMQ vs non-ZMQ registration, executor ownership, and `SaiNotificationDispatcher` handler registry.
 
-### Implementation Notes
+#### 5.3.6 Implementation Notes
 
 The following snippets are high-level pseudo-code aligned with the proposed implementation. The queue stores the same shape used by existing swss notification consumers: operation name, serialized data, and optional field-value list.
 
@@ -543,6 +656,17 @@ public:
         return hasData();
     }
 
+    bool peekFrontOp(std::string &op) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_queue.empty())
+        {
+            return false;
+        }
+        op = kfvOp(m_queue.front());
+        return true;
+    }
+
     void pops(std::deque<swss::KeyOpFieldsValuesTuple> &entries)
     {
         entries.clear();
@@ -572,7 +696,9 @@ private:
 
 `m_selectableEvent.notify()` wakes the new SAI notification queue selectable. The implementation should reuse the existing swss selectable/executor model rather than introducing a separate main-loop mechanism. `ZmqConsumerStateTable` is one existing example of this wake-up pattern: data availability is represented through a selectable, and the main `Select` loop later dispatches an executor. The important requirement is that enqueueing a notification makes queued notification work visible to the current `OrchDaemon::start()` loop so it can dispatch the queue executor like other selectable executors.
 
-The queue is created lazily so early notifications that arrive before the target Orch constructor registers its executor can still be queued instead of being dropped or sent through a Redis fallback path.
+The queue is created lazily so early notifications that arrive before the target Orch registers its queue-path handler with `gSaiNotificationOrch` can still be enqueued instead of being dropped. The shared `SaiNotificationQueueExecutor` is owned by `SaiNotificationOrch` (see [Section 5.3.7](#537-main-loop-integration)); feature orchs register per-op handlers, not separate executors.
+
+**Backpressure.** The in-process queue is not expected to grow without bound under normal operation: SAI/SDK notification rates are finite, and batch-limited `pops()` preserve main-loop fairness across ready executors.
 
 ```cpp
 SaiNotificationQueue *getSaiNotificationQueue()
@@ -614,47 +740,27 @@ void on_fdb_event(uint32_t count, sai_fdb_event_notification_data_t *data)
 }
 ```
 
-`fdb_event` is used here as an example because it is one of the notification types with missing ZMQ callback forwarding and is owned by `FdbOrch`. Other migrated callbacks, such as `bfd_session_state_change`, `port_host_tx_ready`, and `icmp_echo_session_state_change`, would enqueue into the same shared queue with their own operation names.
+`fdb_event` is used here as an example because it is one of the notification types with missing ZMQ callback handling and is owned by `FdbOrch`. Other migrated callbacks enqueue into the same shared queue with their own operation names. See [Section 5.3.9](#539-notification-inventory) for the full set.
 
 For a notification type migrated to Option 3, the ZMQ-mode callback should enqueue to the in-process queue and should not re-post the same notification to `ASIC_DB:NOTIFICATIONS` as a fallback. Non-ZMQ mode continues to use the existing Redis notification path.
 
-The initial Option 3 coverage can be added by registering one handler per missing or incomplete notification:
-
-- `fdb_event`: `on_fdb_event()` enqueues the serialized FDB payload with op `fdb_event`; `FdbOrch` registers that op and reuses its FDB event parsing/state-update helper.
-- `bfd_session_state_change`: `on_bfd_session_state_change()` enqueues the serialized BFD session-state payload with op `bfd_session_state_change`; `BfdOrch` registers that op and reuses its BFD notification helper.
-- `port_host_tx_ready`: `on_port_host_tx_ready()` enqueues the serialized port host TX readiness payload with op `port_host_tx_ready`; `PortsOrch` registers that op and reuses or adds the corresponding port host TX readiness helper.
-- `icmp_echo_session_state_change`: `IcmpSaiSessionHandler::on_state_change()` enqueues the serialized ICMP echo session-state payload with op `icmp_echo_session_state_change`; `IcmpOrch` registers that op and reuses its ICMP session-state helper.
-
-This same mechanism also provides a migration path for existing Option 2-style callbacks. For example, if `port_state_change` is later migrated from Redis re-posting to Option 3, `on_port_state_change()` can switch from Redis re-posting to enqueueing op `port_state_change` into the shared queue. In addition to the `port_host_tx_ready` handler, `PortsOrch` can register a second queue-path handler for `port_state_change` that calls the `handlePortStateChangeNotification()` helper used by the existing Redis `NotificationConsumer` path for non-ZMQ mode.
-
-#### Main-loop Integration
+#### 5.3.7 Main-loop Integration
 
 Option 3 should expose the notification queue through an existing-style selectable/executor so the current `OrchDaemon::start()` `Select` loop can dispatch it like other selectables.
 
-```mermaid
-flowchart TD
-    subgraph zmqThreadContext["ZMQ notification thread context"]
-        saiCallback["orchagent libsairedis<br/>callback"]
-        enqueue["enqueue notification"]
-        selectableNotify["SelectableEvent notify"]
-    end
+For end-to-end flow and diagrams, see [Section 5.3.2](#532-option-3-flow), [Section 5.3.3](#533-option-3-sequence), and [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3). This section focuses on how Option 3 wires into the existing main loop and the implementation details behind that wiring.
 
-    subgraph orchMainThread["orchagent main thread"]
-        selectLoop["OrchDaemon::start<br/>Select loop"]
-        queueExecutor["SaiNotification<br/>QueueExecutor::execute"]
-        queueDrain["pops queued notifications"]
-        dispatcher["SAI notification handler<br/>registry"]
-        orchHandler["Target Orch<br/>notification handler"]
-    end
+**Thread handoff.** In ZMQ mode, the `orchagent` libsairedis callback runs on the libsairedis ZMQ notification thread. That callback must not call Orch handler logic directly. Instead, it enqueues the notification into the shared `SaiNotificationQueue` and calls `SelectableEvent::notify()` so the main loop can process the entry later. The enqueue path is defined in [Section 5.3.6](#536-implementation-notes) (`SaiNotificationQueue::enqueue()`). After enqueue, predicate gating, queue pop, and handler dispatch all run on the `orchagent` main thread.
 
-    saiCallback --> enqueue
-    enqueue --> selectableNotify
-    selectableNotify -->|"queued notification<br/>available"| selectLoop
-    selectLoop --> queueExecutor
-    queueExecutor --> queueDrain
-    queueDrain --> dispatcher
-    dispatcher -->|"registered op handler"| orchHandler
-```
+**Main-loop wiring.** `SaiNotificationOrch` is a thin **infrastructure** orch — a shared SAI notification queue consumer host, not a feature orch. This pattern plugs into the existing `Orch` / `Executor` / `Orch::addExecutor()` model (the same consumer + executor pattern used elsewhere in orchagent, for example `ZmqConsumerStateTable` with its executor on an existing orch). `SaiNotificationOrch` does not own feature state, has no `APP_DB` tables, and does not implement `doTask(Consumer&)`. Functionally it acts as a notification consumer: it owns the shared `SaiNotificationQueueExecutor` and exposes `registerHandler()` so feature orchs attach per-op callbacks through `SaiNotificationDispatcher`.
+
+`SaiNotificationOrch` is created by `OrchDaemon` in ZMQ mode before orchs that register queue-path handlers, similar to how `NotificationConsumerStatsOrch` is constructed before orchs that register `NotificationConsumer` stats. When ZMQ mode is enabled, feature orchs such as `FdbOrch` and `PortsOrch` register per-operation handlers and optional readiness predicates for the notification operations they own through `gSaiNotificationOrch->registerHandler()` once `gSaiNotificationOrch` is constructed. In non-ZMQ mode, notifications continue to use the existing Redis `NotificationConsumer` path and no queue handlers are registered.
+
+When the queue selectable becomes ready, the existing `OrchDaemon::start()` `Select` loop dispatches `SaiNotificationQueueExecutor::execute()` like any other executor. Head-of-line readiness, pop, and dispatch behavior are described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
+
+**Lifecycle.** The shared `SaiNotificationQueue` and `gSaiNotificationOrch` live for the `orchagent` process lifetime, consistent with other global orch infrastructure. `SaiNotificationQueueSelectable` is owned by `SaiNotificationQueueExecutor` and destroyed with the executor; the shared queue outlives the adapter. Once graceful shutdown begins, libsairedis ZMQ callbacks must not enqueue new notifications (for example by checking the same `gOrchShutdownRequested` flag used by `OrchDaemon::start()`), because the main loop will no longer dispatch the queue executor.
+
+**Selectable ownership.** The real `SaiNotificationQueue` is shared and kept for the lifetime of the `orchagent` process. However, `Executor` owns and deletes the `Selectable` object passed to it. To avoid giving ownership of the shared queue to the executor, the design passes a small `Selectable` adapter, `SaiNotificationQueueSelectable`, to `Executor`. The adapter is owned by the executor and forwards readiness checks to the shared `SaiNotificationQueue`.
 
 The existing main loop already waits on selectable executors:
 
@@ -680,7 +786,7 @@ void OrchDaemon::start(long heartBeatInterval)
 }
 ```
 
-The queued ZMQ notification path adds a new executor to this same model. The real `SaiNotificationQueue` is shared and kept for the lifetime of the `orchagent` process. However, `Executor` owns and deletes the `Selectable` object passed to it. To avoid giving ownership of the shared queue to the executor, the design passes a small `Selectable` adapter, `SaiNotificationQueueSelectable`, to `Executor`. The adapter is owned by the executor and forwards readiness checks to the shared `SaiNotificationQueue`.
+**Executor and dispatcher pseudo-code.** The snippets below show how the queue executor plugs into the existing `Executor` model, how `SaiNotificationDispatcher` handler registration and per-op readiness predicates work, and how `SaiNotificationOrch` is constructed and wired into `OrchDaemon`. Predicate evaluation, pop, and dispatch semantics are covered in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior).
 
 ```cpp
 class SaiNotificationQueueSelectable : public swss::Selectable
@@ -719,11 +825,25 @@ class SaiNotificationDispatcher
 {
 public:
     using Handler = std::function<void(swss::KeyOpFieldsValuesTuple &)>;
+    using ReadinessPredicate = std::function<bool()>;
 
-    void registerHandler(const std::string &op, Handler handler)
+    void registerHandler(const std::string &op, Handler handler,
+                         ReadinessPredicate ready = nullptr)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_handlers[op] = std::move(handler);
+        m_readiness[op] = std::move(ready);
+    }
+
+    bool isReady(const std::string &op) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        auto readyIt = m_readiness.find(op);
+        if (readyIt == m_readiness.end() || !readyIt->second)
+        {
+            return true;
+        }
+        return readyIt->second();
     }
 
     void dispatch(swss::KeyOpFieldsValuesTuple &entry)
@@ -749,6 +869,7 @@ public:
 private:
     std::mutex m_mutex;
     std::unordered_map<std::string, Handler> m_handlers;
+    std::unordered_map<std::string, ReadinessPredicate> m_readiness;
 };
 
 class SaiNotificationQueueExecutor : public Executor
@@ -766,6 +887,13 @@ public:
 
     void execute() override
     {
+        // Head-of-line readiness: do not pop if the front entry's op is not ready.
+        std::string frontOp;
+        if (!m_queue->peekFrontOp(frontOp) || !m_dispatcher->isReady(frontOp))
+        {
+            return;
+        }
+
         std::deque<swss::KeyOpFieldsValuesTuple> entries;
         m_queue->pops(entries);
 
@@ -781,35 +909,235 @@ private:
 };
 ```
 
-During `orchagent` initialization, the shared queue executor is registered once:
+`SaiNotificationQueue::peekFrontOp()` is a small helper used only by the executor to evaluate the readiness predicate for the notification queue head without dequeuing.
+
+`SaiNotificationOrch` registers the shared queue executor once during construction:
 
 ```cpp
-Orch::addExecutor(new SaiNotificationQueueExecutor(
-    getSaiNotificationQueue(),
-    this,
-    getSaiNotificationDispatcher(),
-    "SAI_NOTIFICATION_QUEUE"));
+class SaiNotificationOrch : public Orch
+{
+public:
+    SaiNotificationOrch();
+
+    void registerHandler(const std::string &op,
+                         SaiNotificationDispatcher::Handler handler,
+                         SaiNotificationDispatcher::ReadinessPredicate ready = nullptr);
+
+private:
+    SaiNotificationQueue *m_queue;
+    SaiNotificationDispatcher *m_dispatcher;
+};
+
+extern SaiNotificationOrch *gSaiNotificationOrch;
 ```
 
-Each target Orch registers handlers for the notification operations it owns. For example, an `FdbOrch` migration can register the `fdb_event` handler from the `FdbOrch` constructor:
+`OrchDaemon` constructs `SaiNotificationOrch` in ZMQ mode before orchs that register queue-path handlers:
+
+```cpp
+if (gRedisCommunicationMode == SAI_REDIS_COMMUNICATION_MODE_ZMQ_SYNC)
+{
+    gSaiNotificationOrch = new SaiNotificationOrch();
+}
+
+gPortsOrch = new PortsOrch(...);
+gFdbOrch = new FdbOrch(...);
+// other orchs register handlers from their constructors
+```
+
+#### 5.3.8 Readiness predicates and boot-time behavior
+
+**Why this is needed.** Option 3 must preserve the same boot-time behavior as the existing Redis `NotificationConsumer` path. In Redis, many orchs return from `doTask(NotificationConsumer&)` before `pop()` or `pops()` until their readiness conditions are met, so notifications stay in the consumer queue instead of being dropped. Option 3 uses the same model: the queue executor checks a per-operation readiness predicate for the notification queue head before `pops()`. If the head entry is not ready, the executor returns without popping.
+
+The predicate is evaluated on each `SaiNotificationQueueExecutor::execute()` call. `SaiNotificationOrch` does not receive a separate event when readiness changes (for example when `PortsOrch::allPortsReady()` becomes true). The orchagent main loop keeps invoking the queue executor while notifications remain queued, so the head readiness predicate is re-checked on later iterations until it passes.
+
+**How readiness is registered.** Each queue-path handler registers an optional readiness predicate alongside its handler through `SaiNotificationDispatcher::registerHandler()` (see the [Section 5.3.9](#539-notification-inventory) table). Do not use one shared `allPortsReady()` gate on `SaiNotificationOrch` for all notification types. The predicate must match the owning orch's Redis `doTask(NotificationConsumer&)` behavior for that op.
+
+**Early enqueue and handler registration.** Notifications can be enqueued before the owning orch calls `registerHandler()` (see [Section 5.3.6](#536-implementation-notes)). The `OrchDaemon` construction order in [Section 5.3.7](#537-main-loop-integration) creates `gSaiNotificationOrch` before feature orchs so handlers are registered during orch construction. A readiness-gated head-of-line predicate (for example port readiness) may keep entries queued until the predicate passes.
+
+**Missing handler at dispatch.** If `dispatch()` finds no registered handler for a popped entry, the implementation should log a warning rather than silently dropping the notification. By the time `dispatch()` runs, the executor has already popped the entry from the in-process queue, so a silent drop would lose the notification with no visible signal that handler logic never ran. The warning makes the gap visible when this condition occurs, instead of dropping the notification silently.
+
+**Readiness-gated notifications (example: port readiness).** Some ops register `gPortsOrch->allPortsReady()` as their readiness predicate — for example `port_state_change`, `fdb_event`, `port_host_tx_ready`, and `twamp_session_event`:
+
+- On boot, `PortsOrch::allPortsReady()` is false until `PortInitDone` is received and no ports remain in `m_pendingPortSet`.
+- If a readiness-gated op is at the queue head and its predicate is false, the executor returns without calling `pops()`; the notification stays in the queue.
+- After `allPortsReady()` becomes true, a later `execute()` sees the predicate pass, pops, and dispatches to the registered handler.
+
+**Non-readiness-gated notifications** (no readiness predicate registered — for example `bfd_session_state_change`, `icmp_echo_session_state_change`, MACsec post-status):
+
+- No `allPortsReady()` predicate is registered; the predicate is treated as always true.
+- When such an op is at the queue head, the executor may pop and dispatch on the next `execute()` without waiting for port initialization.
+- This matches Redis, where orchs such as `BfdOrch` call `consumer.pop()` without an `allPortsReady()` gate.
+
+**Shared queue caveat (head-of-line blocking).** Option 3 uses one shared notification message queue. Enqueue order is preserved, but dequeue is gated on the **queue head entry's** per-op readiness predicate. If a readiness-gated notification is at the head and its predicate is false, later entries — including those with no readiness predicate — remain queued behind it (head-of-line blocking). In the **Redis consumer path** (non-ZMQ mode and Option 2), separate `NotificationConsumer` instances give each orch its own admission queue on the shared `NOTIFICATIONS` channel. This behavioral difference from the Redis consumer path is documented in [Section 5.3.13](#5313-cons); follow-on mitigation options are in [Section 5.3.14](#5314-follow-on-work).
+
+##### 5.3.8.1 Readiness-gated boot-time sequence (example: port readiness)
+
+The diagram below shows a **readiness-gated** case where the registered predicate is `gPortsOrch->allPortsReady()`. In general, the executor tests whether the readiness predicate for the notification queue head op passes before `pops()`; other ops may register different predicates or none at all.
+
+```mermaid
+sequenceDiagram
+    participant syncd
+    participant Callback as ZMQ callback thread
+    participant Queue as SaiNotificationQueue
+    participant Executor as Queue executor
+    participant PortsOrch
+    participant FdbOrch
+
+    syncd->>Callback: port_state / fdb_event
+    Callback->>Queue: enqueue
+    Executor->>Executor: check head predicate
+    Note over Executor: allPortsReady() is false
+    Note over Queue: do not pop, stay queued
+
+    Note over PortsOrch: PortInitDone received
+    Note over PortsOrch: pending ports cleared
+    Note over PortsOrch: allPortsReady() is true
+
+    Executor->>Executor: check head predicate
+    Note over Executor: allPortsReady() is true
+    Executor->>Queue: pops
+    Executor->>FdbOrch: dispatch fdb_event
+    Executor->>PortsOrch: dispatch port_state_change
+```
+
+The final `pops()` step may drain multiple queued entries in one batch (`DEFAULT_NC_POP_BATCH_SIZE`). Dispatches to `FdbOrch` and `PortsOrch` illustrate two entries popped together, not one notification routed to both orchs.
+
+##### 5.3.8.2 Non-readiness-gated boot-time sequence
+
+The diagram below shows the case when the head entry has **no** readiness predicate (for example `bfd_session_state_change` at the queue head):
+
+```mermaid
+sequenceDiagram
+    participant syncd
+    participant Callback as ZMQ callback thread
+    participant Queue as SaiNotificationQueue
+    participant Executor as Queue executor
+    participant BfdOrch
+
+    syncd->>Callback: bfd_session_state_change
+    Callback->>Queue: enqueue
+    Executor->>Executor: check head predicate
+    Note over Executor: no readiness predicate
+    Executor->>Queue: pops
+    Executor->>BfdOrch: dispatch bfd_session_state_change
+```
+
+For example, an `FdbOrch` migration can register the `fdb_event` handler and a port-readiness predicate from the `FdbOrch` constructor:
 
 ```cpp
 FdbOrch::FdbOrch(...)
 {
     ...
 
-    getSaiNotificationDispatcher()->registerHandler(
+    gSaiNotificationOrch->registerHandler(
         "fdb_event",
         [this](swss::KeyOpFieldsValuesTuple &entry)
         {
             handleNotification(entry);
-        });
+        },
+        []() { return gPortsOrch != nullptr && gPortsOrch->allPortsReady(); });
 }
 ```
 
-When the shared executor drains the queue, the registered handler routes the entry to the target Orch notification-specific helper:
+A notification type that does not gate in Redis, such as `bfd_session_state_change`, omits the readiness predicate. `BfdOrch::doTask(NotificationConsumer&)` processes BFD session state as notifications arrive and does not wait on `PortsOrch::allPortsReady()`, because BFD session state is independent of port initialization completion. Option 3 matches that behavior by registering no port-readiness predicate:
 
 ```cpp
+gSaiNotificationOrch->registerHandler(
+    "bfd_session_state_change",
+    [this](swss::KeyOpFieldsValuesTuple &entry)
+    {
+        handleNotification(entry);
+    });
+```
+
+For the shared handler pattern, see [Section 5.3.10](#5310-priority-fairness-and-shared-handler).
+
+#### 5.3.9 Notification inventory
+
+The [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior) readiness model and registration examples above define the queue-path pattern; this section lists every notification op and how it maps to that pattern.
+
+Option 3 targets parity with the existing non-ZMQ `ASIC_DB:NOTIFICATIONS` path. The table below lists notification operations, their ZMQ delivery path today, the Option 3 plan for each, and the readiness predicate queue-path handlers register. The readiness predicate column uses the per-op predicates described in [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior); each value matches the owning orch's Redis `doTask(NotificationConsumer&)` behavior where a queue path applies.
+
+**Option 3 plan** values:
+
+| Value | Meaning |
+|---|---|
+| **Enqueue (required)** | ZMQ callback is no-op or incomplete today. A queue path is required to restore non-ZMQ parity. |
+| **Migrate to queue** | Already delivered via Option 2 Redis re-post today. Change to the in-process queue (latency benefit, no Redis re-post). |
+| **Unchanged** | ZMQ callback already handles the notification outside the queue/Redis-consumer path. Option 3 does not apply. |
+
+| Notification op | Owning orch | ZMQ path today | Option 3 plan | Option 3 readiness predicate |
+|---|---|---|---|---|
+| `port_state_change` | `PortsOrch` | Option 2 Redis re-post | Migrate to queue | `gPortsOrch->allPortsReady()` |
+| `port_host_tx_ready` | `PortsOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
+| `fdb_event` | `FdbOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
+| `bfd_session_state_change` | `BfdOrch` | No-op / incomplete callback | Enqueue (required) | None |
+| `icmp_echo_session_state_change` | `IcmpOrch` | No-op / incomplete callback | Enqueue (required) | None |
+| `twamp_session_event` | `TwampOrch` | No-op / incomplete callback | Enqueue (required) | `gPortsOrch->allPortsReady()` |
+| `switch_macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to queue | None |
+| `macsec_post_status` | `MACsecOrch` | Option 2 Redis re-post | Migrate to queue | None |
+| `ha_set_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to queue | None |
+| `ha_scope_event` | `DashHaOrch` | Option 2 Redis re-post | Migrate to queue | None |
+| `flow_bulk_get_session_event` | `DashHaFlowOrch` | Option 2 Redis re-post | Migrate to queue | None |
+| `tam_tel_type_config_change` | `HFTelOrch` | No-op / incomplete callback | Enqueue (required) | None |
+| `switch_shutdown_request` | `SwitchOrch` | Direct callback handling | Unchanged | N/A |
+| `switch_asic_sdk_health_event` | `SwitchOrch` | Direct callback handling | Unchanged | N/A |
+
+Out of scope for the Option 3 SAI notification queue (not `ASIC_DB:NOTIFICATIONS` SAI delivery over ZMQ):
+
+| Channel / request | Owning orch | Notes |
+|---|---|---|
+| `RESTARTCHECK` | `SwitchOrch` | Separate Redis channel, not `ASIC_DB:NOTIFICATIONS` |
+| `WATERMARK_CLEAR_REQUEST` | `WatermarkOrch` | `APPL_DB` request, not a syncd SAI callback |
+| `FLUSHFDBREQUEST` | `FdbOrch` | `APPL_DB` request |
+
+Option 3 coverage is added by registering one handler (and optional readiness predicate) per **Migrate to queue** / **Enqueue** row. Each follows the same pattern: ZMQ callback enqueues (or already enqueues), owning orch `registerHandler()` calling `handleNotification(entry)`, and notification-specific helpers shared with the Redis consumer path. Rollout is summarized in [Section 5.4](#54-recommendation).
+
+- `fdb_event`: `on_fdb_event()` enqueues the serialized FDB payload; `FdbOrch` registers the op, a readiness predicate that matches its Redis `doTask(NotificationConsumer&)` gate, and reuses its FDB event parsing/state-update helper.
+- `bfd_session_state_change`: `on_bfd_session_state_change()` enqueues the serialized BFD session-state payload; `BfdOrch` registers the op with no port-readiness predicate and reuses its BFD notification helper.
+- `port_host_tx_ready`: `on_port_host_tx_ready()` enqueues the serialized port host TX readiness payload; `PortsOrch` registers the op with a port-readiness predicate and reuses its port host TX readiness helper.
+- `icmp_echo_session_state_change`: `IcmpSaiSessionHandler::on_state_change()` enqueues the serialized ICMP echo session-state payload; `IcmpOrch` registers the op with no port-readiness predicate and reuses its ICMP session-state helper.
+- `port_state_change`: migrate `on_port_state_change()` from Redis re-posting to enqueueing; `PortsOrch` registers the op with a port-readiness predicate and calls `handlePortStateChangeNotification()`, the same helper used by the Redis `NotificationConsumer` path.
+- `twamp_session_event`: enqueue from the libsairedis callback; `TwampOrch` registers the op with a port-readiness predicate matching its Redis `doTask(NotificationConsumer&)`.
+- `switch_macsec_post_status` / `macsec_post_status`: migrate `on_switch_macsec_post_status_notify()` / `on_macsec_post_status_notify()` from Redis re-post to enqueue; `MACsecOrch` registers both ops and reuses `handleNotification()` POST-completion helpers.
+- `ha_set_event` / `ha_scope_event`: migrate `on_ha_set_event()` / `on_ha_scope_event()` from Redis re-post to enqueue; `DashHaOrch` registers both ops and reuses existing `doTask(NotificationConsumer&)` parsing.
+- `flow_bulk_get_session_event`: migrate `on_flow_bulk_get_session_event()` from Redis re-post to enqueue; `DashHaFlowOrch` registers the op and reuses existing notification handling.
+- `tam_tel_type_config_change`: `on_tam_tel_type_config_change()` enqueues the serialized TAM telemetry-type payload; `HFTelOrch` registers the op with no readiness predicate and reuses `handleTamTelTypeConfigChangeNotification()`, the same helper used by the Redis `NotificationConsumer` path.
+
+#### 5.3.10 Priority, Fairness, and Shared Handler
+
+**Executor model.** Migrated SAI notifications use one shared `SaiNotificationQueue` and one `SaiNotificationQueueExecutor` selectable priority, as illustrated in [Section 5.3.2](#532-option-3-flow) and [Section 5.3.4](#534-notification-dispatch-path-comparison-non-zmq-option-2-and-option-3), with implementation detail in [Sections 5.3.6](#536-implementation-notes) and [5.3.7](#537-main-loop-integration). That executor should use an appropriate priority so time-sensitive SAI notifications can be processed ahead of lower-priority regular `orchagent` work, following the existing `Select` behavior where ready selectables are dispatched according to priority.
+
+**Priority.** Option 3 should use the existing `Select` priority mechanism where practical instead of introducing separate internal priority queues. "Internal priority queues" means priority lanes that reorder messages within a single queue; it does not prohibit multiple per-orch queues, each drained by its own executor, with scheduling priority expressed via Select `m_priority` as described in [Section 5.3.14](#5314-follow-on-work).
+
+**Fairness.** Each `SaiNotificationQueueExecutor::execute()` drains at most `DEFAULT_NC_POP_BATCH_SIZE` entries per main-loop iteration. If more notifications remain, the queue re-notifies so other ready executors (including lower-priority orch consumers) can run before the next drain. This avoids the route-consumer pattern of draining an entire backlog in one `execute()` call (see `ZmqRouteConsumer`). **Priority** (Select `m_priority`) determines which ready executor runs first; **fairness** (batch-limited drain + re-notify) limits how long one executor holds the main loop once selected.
+
+**Interaction with route consumers.** The notification executor uses a higher Select priority than route table consumers (for example priority 100 for the Option 3 notification queue or Redis `NotificationConsumer` executors vs priority 5 for `RouteOrch`). When both are ready, the notification executor is scheduled first. However, an in-progress `ZmqRouteConsumer::execute()` that drains route updates until empty can still delay notification processing on the main loop until that `execute()` completes. This is not specific to Option 3: it applies equally to the Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post), because all executors share the same `orchagent` main loop and Select priority does not preempt an executor already running.
+
+**Shared handler.** Each target Orch owns its notification handler logic. The Redis `NotificationConsumer` path (non-ZMQ mode and Option 2 re-post) and the Option 3 `gSaiNotificationOrch->registerHandler()` queue-path callback both call the same **`handleNotification(swss::KeyOpFieldsValuesTuple &entry)`** entry point. That function extracts `op`/`data` from the tuple and delegates to the notification-specific helper (for example `handleFdbEventNotification()`). `doTask(NotificationConsumer&)` retains consumer-specific routing (flush vs FDB notification, readiness gates) and prepares the tuple after `pop()`; `registerHandler()` passes the queued tuple directly.
+
+```cpp
+void FdbOrch::doTask(NotificationConsumer &consumer)
+{
+    if (!m_portsOrch->allPortsReady())
+    {
+        return;
+    }
+
+    if (&consumer == m_flushNotificationsConsumer)
+    {
+        // ... flush handling unchanged ...
+        return;
+    }
+
+    if (&consumer == m_fdbNotificationConsumer)
+    {
+        KeyOpFieldsValuesTuple entry;
+        // populate entry from consumer.pop() — same op/key layout as queue path
+        handleNotification(entry);
+    }
+}
+
 void FdbOrch::handleNotification(swss::KeyOpFieldsValuesTuple &entry)
 {
     auto op = kfvOp(entry);
@@ -820,105 +1148,57 @@ void FdbOrch::handleNotification(swss::KeyOpFieldsValuesTuple &entry)
         handleFdbEventNotification(data);
     }
 }
+
+// Option 3 registration (FdbOrch constructor)
+gSaiNotificationOrch->registerHandler(
+    "fdb_event",
+    [this](KeyOpFieldsValuesTuple &entry) { handleNotification(entry); },
+    [this]() { return m_portsOrch->allPortsReady(); });
 ```
 
-### Priority and Fairness
+The Redis path calls `handleNotification(entry)` from `doTask(NotificationConsumer&)` after consumer routing and `pop()`. The Option 3 path calls the same function from `registerHandler()`. Both delegate to `handleFdbEventNotification()` for the deserialize/parse logic. Other notification types follow the same pattern in their owning Orch.
 
-Option 3 should use the existing `Select` priority mechanism where practical instead of introducing separate internal priority queues.
-
-The flow diagram and pseudo-code above show the initial Option 3 design, where migrated SAI notifications share one notification queue and one selectable/executor priority. That selectable/executor should use an appropriate priority so time-sensitive SAI notifications can be processed ahead of lower-priority regular `orchagent` work. This follows the existing `Select` behavior where ready selectables are dispatched according to priority.
-
-If notification-level priority is required, notifications can be split across multiple selectable/executor instances, such as a high-priority executor for port state, port host TX ready, and BFD notifications, and a normal-priority executor for other notifications. Each executor would use the existing `Select` priority mechanism.
-
-Option 3 notification dispatch should be implemented by the target Orch that owns the existing notification handler. The existing Redis-consumer handler can be refactored so the Redis path and Option 3 registered handler call the same notification-specific helper.
-
-```cpp
-void FdbOrch::handleNotification(NotificationConsumer &consumer,
-                                 swss::KeyOpFieldsValuesTuple &entry)
-{
-    auto op = kfvOp(entry);
-    auto data = kfvKey(entry);
-
-    if (&consumer == m_fdbNotificationConsumer && op == "fdb_event")
-    {
-        handleFdbEventNotification(data);
-    }
-}
-
-void FdbOrch::handleNotification(swss::KeyOpFieldsValuesTuple &entry)
-{
-    auto op = kfvOp(entry);
-    auto data = kfvKey(entry);
-
-    if (op == "fdb_event")
-    {
-        handleFdbEventNotification(data);
-    }
-}
-```
-
-Other notification types would follow the same pattern in their owning Orch: keep the existing Redis `NotificationConsumer` handler for non-ZMQ mode and Option 2, add an Option 3 queue handler for migrated ZMQ notifications, and share notification-specific parsing/state-update helpers where practical.
-
-### Migration Note for Existing Option 2-style Callbacks
-
-For phased rollout of the long-term Option 3 queue-based model, notification types can be migrated incrementally. Notifications not yet migrated can continue to use Option 2, where libsairedis callbacks re-post notifications to Redis and the existing Redis `NotificationConsumer` / `Notifier` / Orch `doTask(NotificationConsumer&)` path handles final Orch dispatch.
-
-Existing Option 2-style callbacks can be migrated notification type by notification type.
-
-Current short-term / Option 2-style path:
-
-```mermaid
-flowchart TD
-    zmqNotification["syncd sends notification<br/>over ZMQ"]
-    libsairedisCallback["orchagent libsairedis<br/>callback"]
-    redisRepost["Redis re-post"]
-    redisNotifications[("Redis ASIC_DB:<br/>NOTIFICATIONS channel")]
-
-    zmqNotification --> libsairedisCallback
-    libsairedisCallback --> redisRepost
-    redisRepost --> redisNotifications
-```
-
-Long-term / Option 3 queue-based path:
-
-```mermaid
-flowchart TD
-    zmqNotification["syncd sends notification<br/>over ZMQ"]
-    libsairedisCallback["orchagent libsairedis<br/>callback"]
-    notificationQueue[["in-process<br/>notification queue"]]
-
-    zmqNotification --> libsairedisCallback
-    libsairedisCallback --> notificationQueue
-```
-
-### Validation and Unit Test Coverage
+#### 5.3.11 Validation and Unit Test Coverage
 
 The implementation should include focused unit coverage for the new queue mechanics:
 
-- Queue tests should verify enqueue, cached-data visibility, batch-limited `pops()`, FIFO order, and empty-queue state.
-- Dispatcher tests should verify that a registered operation handler is invoked with the queued entry.
-- Callback tests should verify that a migrated ZMQ-mode callback enqueues the expected operation and preserves the serialized notification payload.
+- Queue tests should verify enqueue, cached-data visibility, batch-limited `pops()`, notification message queue order, and empty-queue state.
+- Executor and dispatcher tests should verify that a registered operation handler is invoked with the queued entry, that per-operation readiness predicates are honored before `pops()`, and that `dispatch()` logs a warning when no handler is registered for a popped op. Mock tests in `notifications_ut.cpp` include `SaiNotificationQueueExecutor` and `SaiNotificationQueueExecutorHeadOfLineBlocksUntilReady` for the executor readiness and head-of-line blocking behavior.
+- Callback tests should verify that each migrated ZMQ-mode callback enqueues the expected operation and preserves the serialized notification payload.
 
-Existing Redis-path tests should continue to cover the established `NotificationConsumer` handler behavior. If the first migrated notification changes during review, callback-specific Option 3 coverage should target the notification selected for queue-based migration, while the generic queue tests remain applicable.
+Existing Redis-path tests should continue to cover the established `NotificationConsumer` handler behavior. Callback-specific Option 3 coverage should target each notification type selected for queue-based migration, while the generic queue and readiness-predicate tests remain applicable. Multi-executor and per-op queue notification tests are deferred follow-on work ([Section 5.3.14](#5314-follow-on-work)).
 
 DUT validation for a migrated notification should confirm both expected Orch behavior and Redis bypass. For example, a `port_state_change` validation can flap a port in southbound ZMQ mode, confirm `PortsOrch` logs and operational state updates, and confirm `ASIC_DB:NOTIFICATIONS` does not receive a re-posted `port_state_change` notification.
 
-### Pros
+#### 5.3.12 Pros
 
 - Compared with Option 2, avoids the Redis re-post for migrated notifications and can reduce notification latency.
 - Keeps Orch state updates on the `orchagent` main-loop path.
 - Uses the existing selectable/executor model and `Select` priority mechanism where practical.
-- Supports incremental migration from Option 2 to Option 3 per notification type.
+- Supports consolidating all notification types listed in [Section 5.3.9](#539-notification-inventory) except **Unchanged** on one in-process queue under Option 3.
 
-### Cons
+#### 5.3.13 Cons
 
 - Requires implementation and validation of a new selectable/executor path for SAI notifications.
-- Requires backpressure behavior for the in-process notification queue.
-- Requires lifecycle handling for the shared queue and SAI notification queue selectable during startup, shutdown, and callback teardown.
 - More implementation and test effort than Option 2.
-- Larger design review scope.
+- **Cross-op head-of-line blocking:** Option 3 uses one shared queue with front-of-queue dequeue. When a readiness-gated entry is at the queue head and its readiness predicate is false, later entries behind it — including ops with no readiness predicate — remain queued. The Redis consumer path (non-ZMQ mode and Option 2) avoids this across orchs via separate per-orch `NotificationConsumer` queues (see [Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior)).
+
+#### 5.3.14 Follow-on work
+
+The following items are **out of scope** for this HLD and left for follow-on work:
+
+1. **Multi-executor with per-op or per-orch queues.** If the single shared queue design proves insufficient, follow-on work should split notifications across separate queues and executors per notification op or per owning orch, restoring the same isolation as the Redis consumer path (non-ZMQ mode and Option 2) and eliminating cross-op head-of-line blocking ([Section 5.3.8](#538-readiness-predicates-and-boot-time-behavior)). Enqueue routing selects the queue by `op`; each queue applies its own head readiness predicate independently. Executors can use the existing `Select` priority mechanism so time-sensitive notification ops are scheduled ahead of lower-priority orch work. A priority-tier split that groups multiple ops in one queue does not fully address cross-op head-of-line blocking and is not sufficient on its own.
+
+2. **Queue-depth monitoring and alarms.** Expose queue-depth metrics and raise an alarm when depth exceeds a configurable threshold under sustained load, so operators can detect main-loop stall or handler regressions.
+
+### 5.4 Recommendation
+
+- **Near-term:** Use **Option 2** ([sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619)) to restore missing ZMQ-mode notification delivery quickly with minimal risk. Callbacks re-post to `ASIC_DB:NOTIFICATIONS` and existing Orch `NotificationConsumer` handlers remain unchanged.
+- **Long-term:** Adopt **Option 3** as the target design for migrated `ASIC_DB:NOTIFICATIONS` types: enqueue on the libsairedis ZMQ callback thread, drain through the shared SAI notification queue consumer (`SaiNotificationOrch`), and preserve per-op readiness predicates and handler behavior.
+- **Option 3 rollout:** Migrate every [Section 5.3.9](#539-notification-inventory) op to the in-process queue except **Unchanged** (`switch_shutdown_request`, `switch_asic_sdk_health_event`). Follow-on work is listed in [Section 5.3.14](#5314-follow-on-work).
+- **Not recommended:** **Option 1** (Redis notification producer in `syncd` while request/response stays on ZMQ) is not proposed because it makes ZMQ mode asymmetric and reintroduces duplicate-delivery risk if callbacks also re-post.
 
 ## 6. References
 
-- [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541): Missing notification forwarding for FDB/BFD when ZMQ southbound is enabled
+- [sonic-buildimage issue #27541](https://github.com/sonic-net/sonic-buildimage/issues/27541): Missing notification delivery for FDB/BFD when ZMQ southbound is enabled (GitHub issue title uses "forwarding"; this HLD uses re-post terminology in [Section 5.2](#52-option-2-orchagent-callback-re-posts-to-asic_dbnotifications))
 - [sonic-swss PR #4619](https://github.com/sonic-net/sonic-swss/pull/4619): Forward SAI notifications to Redis in ZMQ southbound mode


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This PR adds an HLD describing options for handling SAI notifications when ZMQ southbound is enabled.
The goal is to document the current notification gap and provide design options for team review.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a new HLD document covering:

- Existing non-ZMQ SAI notification flow through Redis
- Current ZMQ notification behavior and missing callback handling
- Option 1: syncd publishes notifications through Redis
- Option 2: orchagent libsairedis callback re-posts notifications to Redis
- Option 3: In-process notification queue drained by the orchagent main loop
- Phased migration from Option 2 to Option 3 for ZMQ notification handling
- SONiC reference patterns for `NotificationConsumer`, `Notifier`, `Executor`, `SelectableEvent`, `Select` priority, `OrchDaemon` main-loop integration, and shared queue/handler-registry dispatch


#### How to verify it

Although this is a documentation-only PR, the Option 3 model was also prototyped locally outside this PR using `on_port_state_change()` and validated on a DUT in southbound ZMQ mode. Port flap testing confirmed `PortsOrch` processed the notification through the queue path and `ASIC_DB:NOTIFICATIONS` did not receive a re-posted `port_state_change` notification.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

None. Documentation-only HLD.

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

Not applicable. Documentation-only change.

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

