### PR TITLE
ci: add all to include_jobs  docker-sonic-mgmt PR test

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -156,7 +156,7 @@ stages:
     parameters:
       CHECKOUT_SONIC_MGMT: true
       # todo: enable vpp build in sonic-mgmt docker image build pipeline, and add vpp test pipeline back.
-      INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      INCLUDE_JOBS: "all"
       OVERRIDE_PARAMS:
         REPO_NAME: "sonic-mgmt"
         SETUP_CONTAINER_PARAMS: "-i ${{ parameters.registry_url }}/docker-sonic-mgmt:lastbuild"


### PR DESCRIPTION
#### Why I did it

The impacted-area PR test invoked from `.azure-pipelines/docker-sonic-mgmt.yml` never ran the **dualtor** topology.

Every topology job in sonic-mgmt's `pr_test_template.yml` is gated by two conditions:

```
RUN_BY_INCLUDE_JOBS = or(eq(INCLUDE_JOBS, 'all'), contains(INCLUDE_JOBS, '<job>'))
condition: ... and contains(PR_CHECKERS, 'dualtor_checker') and eq(RUN_BY_INCLUDE_JOBS, 'True')
```

The `INCLUDE_JOBS` value passed from `docker-sonic-mgmt.yml` omitted `dualtor_job` (it is also absent from the template's default value). So even when the impacted-area scan collects `dualtor_checker` scripts — e.g. on a full-scan run where every other topology executes — the dualtor job's condition always evaluated to `False` and the job was silently skipped. Because a condition-skipped Azure DevOps job posts no GitHub check, dualtor did not even surface in the PR checks.

Observed on PR #27743 (build 1131719): `t0`, `t0-2vlans`, `t0-sonic`, `t1-lag`, `multi-asic-t1`, `dpu`, `t2` (and `t1-lag-vpp`) all ran, but `dualtor` did not.

##### Work item tracking
- Microsoft ADO **(number only)**: 38213269

#### How I did it

Added `all` to the `INCLUDE_JOBS` parameter passed to `pr_test_template.yml@sonic-mgmt` in `.azure-pipelines/docker-sonic-mgmt.yml`:

```diff
-      INCLUDE_JOBS: "t0_job,t1_job,t2_job,t0_2vlans_job,t0_sonic_job,dpu_job,t1_multi_asic_job"
+      INCLUDE_JOBS: "all"
```

This is a CI/pipeline-configuration change only; no product code, image content, or YANG/config_db schema is affected.

#### How to verify it

Trigger docker-sonic-mgmt PR validation (any PR that builds the docker-sonic-mgmt image). Confirm the **"impacted-area-kvmtest-dualtor by Elastictest"** job now runs when `dualtor_checker` is in scope (previously it was skipped/absent), while all other topology jobs continue to run unchanged.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

Reason: dualtor PR coverage is missing on these branches as well.
- **202605** carries the same `INCLUDE_JOBS` override, so this is a clean one-line backport.
- **202511** does **not** yet define an `INCLUDE_JOBS` override (it inherits the `pr_test_template.yml` default, which also omits `dualtor_job`). Its backport must *add* an `INCLUDE_JOBS` line that includes `dualtor_job` while preserving that branch's existing job set, rather than a straight cherry-pick.

#### Tested branch (Please provide the tested image version)

- [ ] N/A — CI/pipeline configuration change; validated by this PR's own docker-sonic-mgmt run.

#### Description for the changelog

ci: run the dualtor topology in docker-sonic-mgmt impacted-area PR tests

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.
