### PR TITLE
[BMC] Create /host/bmc dir before pmon docker create

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -736,6 +736,17 @@ start() {
     fi
 {%- endif %}
 {%- endif %}
+{%- if docker_container_name == "pmon" %}
+    # On Switch-BMC systems, ensure the persistent BMC event log directory
+    # and file exist on /host (eMMC-backed) before the pmon container is
+    # created, so the conditional bind-mount below picks it up.
+    PLATFORM_ENV_CONF="/usr/share/sonic/device/$PLATFORM/platform_env.conf"
+    if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
+        mkdir -p /host/bmc
+        touch /host/bmc/event.log
+        chmod 640 /host/bmc/event.log
+    fi
+{%- endif %}
     docker create {{docker_image_run_opt}} \
         -v /host/warmboot$DEV:/var/warmboot \
 {%- if docker_container_name != "dhcp_server" %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -736,17 +736,6 @@ start() {
     fi
 {%- endif %}
 {%- endif %}
-{%- if docker_container_name == "pmon" %}
-    # On Switch-BMC systems, ensure the persistent BMC event log directory
-    # and file exist on /host (eMMC-backed) before the pmon container is
-    # created, so the conditional bind-mount below picks it up.
-    PLATFORM_ENV_CONF="/usr/share/sonic/device/$PLATFORM/platform_env.conf"
-    if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
-        mkdir -p /host/bmc
-        touch /host/bmc/event.log
-        chmod 640 /host/bmc/event.log
-    fi
-{%- endif %}
     docker create {{docker_image_run_opt}} \
         -v /host/warmboot$DEV:/var/warmboot \
 {%- if docker_container_name != "dhcp_server" %}

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -428,6 +428,16 @@ if [ -f $FIRST_BOOT_FILE ]; then
     # Kdump tools configuration
     [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
 
+    # On Switch-BMC systems, create the persistent BMC event log directory and
+    # file on /host (eMMC-backed) so that leak, power and host-state events
+    # survive reboots.  /var/log is on tmpfs so it is NOT used for this.
+    PLATFORM_ENV_CONF="/usr/share/sonic/device/$platform/platform_env.conf"
+    if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
+        mkdir -p /host/bmc
+        touch /host/bmc/event.log
+        chmod 640 /host/bmc/event.log
+    fi
+
     firsttime_exit
 fi
 
@@ -435,16 +445,6 @@ fi
 if [ -f /var/log/fsck.log.gz ]; then
     gunzip -d -c /var/log/fsck.log.gz | logger -t "FSCK"
     rm -f /var/log/fsck.log.gz
-fi
-
-# On Switch-BMC systems, create the persistent BMC event log directory and
-# file on /host (eMMC-backed) so that leak, power and host-state events
-# survive reboots.  /var/log is on tmpfs so it is NOT used for this.
-PLATFORM_ENV_CONF="/usr/share/sonic/device/$platform/platform_env.conf"
-if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
-    mkdir -p /host/bmc
-    touch /host/bmc/event.log
-    chmod 640 /host/bmc/event.log
 fi
 
 exit 0

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -428,6 +428,16 @@ if [ -f $FIRST_BOOT_FILE ]; then
     # Kdump tools configuration
     [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
 
+    # On Switch-BMC systems, create the persistent BMC event log directory and
+    # file on /host (eMMC-backed) so that leak, power and host-state events
+    # survive reboots.  /var/log is on tmpfs so it is NOT used for this.
+    PLATFORM_ENV_CONF="/usr/share/sonic/device/$platform/platform_env.conf"
+    if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
+        mkdir -p /host/bmc
+        touch /host/bmc/event.log
+        chmod 640 /host/bmc/event.log
+    fi
+
     firsttime_exit
 fi
 

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -428,16 +428,6 @@ if [ -f $FIRST_BOOT_FILE ]; then
     # Kdump tools configuration
     [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
 
-    # On Switch-BMC systems, create the persistent BMC event log directory and
-    # file on /host (eMMC-backed) so that leak, power and host-state events
-    # survive reboots.  /var/log is on tmpfs so it is NOT used for this.
-    PLATFORM_ENV_CONF="/usr/share/sonic/device/$platform/platform_env.conf"
-    if [ -f "$PLATFORM_ENV_CONF" ] && grep -q '^switch_bmc=1' "$PLATFORM_ENV_CONF" 2>/dev/null; then
-        mkdir -p /host/bmc
-        touch /host/bmc/event.log
-        chmod 640 /host/bmc/event.log
-    fi
-
     firsttime_exit
 fi
 


### PR DESCRIPTION
#### Why I did it
Create the DIR /host/bmc - first boot itself.
Fixes #27573

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Move the logic to create the /host/bmc before we do first_time_boot_exit

#### How to verify it
Verified that the directory/file (host/bmc/event.log) is present on first boot and subsequent boots

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

