### PR TITLE
[nvidia-bluefield] Update MFT version to 4.36.0-147

### DIFF
--- a/platform/nvidia-bluefield/recipes/mft.mk
+++ b/platform/nvidia-bluefield/recipes/mft.mk
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-MFT_VERSION = 4.34.0
-MFT_REVISION = 148
+MFT_VERSION = 4.36.0
+MFT_REVISION = 147
 
 MFT_INTERNAL_SOURCE_BASE_URL =
 


### PR DESCRIPTION
#### Why I did it

Align the DPU (nvidia-bluefield) MFT version with the switch (Mellanox) MFT version.

In #27810 the switch MFT version was bumped to `4.36.0-147` (in `platform/mellanox/mft.mk`). The DPU has its own separate makefile (`platform/nvidia-bluefield/recipes/mft.mk`) which was still pinned to `4.34.0-148`.

##### Work item tracking

- Microsoft ADO **(number only)**:

#### How I did it

Updated `platform/nvidia-bluefield/recipes/mft.mk`:

```
MFT_VERSION  = 4.36.0
MFT_REVISION = 147
```

#### How to verify it

Build the nvidia-bluefield (DPU) image and verify the MFT packages of version `4.36.0-147` are produced/installed.

#### Description for the changelog

[nvidia-bluefield] Update MFT to 4.36.0-147 (align DPU MFT version with switch)