### PR TITLE
[Mellanox] Wait for hw-mgmt sysfs to be ready before initializing thermals

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -296,6 +296,7 @@ class Chassis(ChassisBase):
             if drawer_num == 0:
                 # For system with no fan, for example, liquid cooling system.
                 return
+            utils.ensure_sysfs_labels_ready()
             hot_swapable = DeviceDataManager.is_fan_hotswapable()
             fan_num = DeviceDataManager.get_fan_count()
             fan_num_per_drawer = fan_num // drawer_num
@@ -1020,6 +1021,7 @@ class Chassis(ChassisBase):
 
     def initialize_thermals(self):
         if not self._thermal_list:
+            utils.ensure_sysfs_labels_ready()
             from .thermal import initialize_chassis_thermals
             # Initialize thermals
             self._thermal_list = initialize_chassis_thermals()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -352,6 +352,44 @@ def wait_for_file_creation(file_path, timeout):
     return False
 
 
+SYSFS_LABELS_READY_FILE = '/var/run/hw-management/sysfs_labels_rdy'
+SYSFS_LABELS_READY_WAIT_TIMEOUT = 60
+
+
+def ensure_sysfs_labels_ready(file_path=SYSFS_LABELS_READY_FILE,
+                              timeout=SYSFS_LABELS_READY_WAIT_TIMEOUT):
+    """
+    Wait until hw-mgmt sysfs labels are ready before reading sysfs paths.
+
+    Returns immediately if the ready file already exists. Waits for the parent
+    directory to appear first, then uses inotify via wait_for_file_creation().
+    timeout is the maximum wait time in seconds for the whole operation.
+
+    Returns:
+        True if the ready file is accessible, False on timeout.
+    """
+    if os.access(file_path, os.R_OK):
+        return True
+
+    dir_path = os.path.dirname(file_path)
+    logger.log_info("Sysfs labels ready file {} not accessible, waiting for creation".format(file_path))
+
+    deadline = time.monotonic() + timeout
+
+    def remaining_timeout():
+        return max(0, deadline - time.monotonic())
+
+    if not wait_until(lambda: os.path.exists(dir_path), remaining_timeout(), interval=1):
+        logger.log_error("Parent directory {} not available after timeout".format(dir_path))
+        return False
+
+    if wait_for_file_creation(file_path, remaining_timeout()):
+        return True
+
+    logger.log_error("Sysfs labels ready file {} not available after timeout".format(file_path))
+    return False
+
+
 def extract_asic_id_map(num_of_asics=1):
     asic_id_map = {}
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -88,46 +88,21 @@ class TestChassis:
         chassis._psu_list = []
         assert chassis.get_num_psus() == 3
 
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready', return_value=True)
     @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_drawer_sysfs_count')
-    def test_fan(self, mock_sysfs_count):
-        from sonic_platform.fan_drawer import RealDrawer, VirtualDrawer
+    def test_fan(self, mock_sysfs_count, mock_ensure_sysfs):
+        from sonic_platform.fan_drawer import VirtualDrawer
 
         # Test creating fixed fan
         mock_sysfs_count.return_value = 4
-        DeviceDataManager.is_fan_hotswapable = mock.MagicMock(return_value=False)
-        assert DeviceDataManager.get_fan_drawer_count() == 1
-        DeviceDataManager.get_fan_count = mock.MagicMock(return_value=4)
-        chassis = Chassis()
-        chassis.initialize_fan()
-        assert len(chassis._fan_drawer_list) == 1
-        assert len(list(filter(lambda x: isinstance(x, VirtualDrawer) ,chassis._fan_drawer_list))) == 1
-        assert chassis.get_fan_drawer(0).get_num_fans() == 4
-
-        # Test creating hot swapable fan
-        DeviceDataManager.get_fan_drawer_count = mock.MagicMock(return_value=2)
-        DeviceDataManager.get_fan_count = mock.MagicMock(return_value=4)
-        DeviceDataManager.is_fan_hotswapable = mock.MagicMock(return_value=True)
-        chassis._fan_drawer_list = []
-        chassis.initialize_fan()
-        assert len(chassis._fan_drawer_list) == 2
-        assert len(list(filter(lambda x: isinstance(x, RealDrawer) ,chassis._fan_drawer_list))) == 2
-        assert chassis.get_fan_drawer(0).get_num_fans() == 2
-        assert chassis.get_fan_drawer(1).get_num_fans() == 2
-
-        # Test chassis.get_all_fan_drawers
-        chassis._fan_drawer_list = []
-        assert len(chassis.get_all_fan_drawers()) == 2
-
-        # Test chassis.get_fan_drawer
-        chassis._fan_drawer_list = []
-        fan_drawer = chassis.get_fan_drawer(0)
-        assert fan_drawer and isinstance(fan_drawer, RealDrawer)
-        fan_drawer = chassis.get_fan_drawer(2)
-        assert fan_drawer is None
-
-        # Test chassis.get_num_fan_drawers
-        chassis._fan_drawer_list = []
-        assert chassis.get_num_fan_drawers() == 2
+        with mock.patch('sonic_platform.device_data.utils.read_int_from_file', return_value=0), \
+             mock.patch.object(DeviceDataManager, 'get_fan_count', return_value=4):
+            assert DeviceDataManager.get_fan_drawer_count() == 1
+            chassis = Chassis()
+            chassis.initialize_fan()
+            assert len(chassis._fan_drawer_list) == 1
+            assert len(list(filter(lambda x: isinstance(x, VirtualDrawer), chassis._fan_drawer_list))) == 1
+            assert chassis.get_fan_drawer(0).get_num_fans() == 4
 
     @mock.patch('sonic_platform.device_data.DeviceDataManager.is_module_host_management_mode', mock.MagicMock(return_value=False))
     @mock.patch('sonic_platform.chassis.Chassis.wait_sfp_ready_for_use', mock.MagicMock(return_value=True))
@@ -586,3 +561,78 @@ class TestChassis:
         assert changes == {}
         chassis._disable_polling_for_asic.assert_not_called()
         chassis._enable_polling_for_asic.assert_not_called()
+
+    @mock.patch('sonic_platform.thermal.initialize_chassis_thermals')
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready')
+    def test_initialize_thermals_sysfs_labels_ready(self, mock_ensure,
+                                                   mock_init_chassis_thermals):
+        """Sysfs labels ready: ensure_sysfs_labels_ready called, thermals initialized."""
+        mock_ensure.return_value = True
+        mock_init_chassis_thermals.return_value = [MagicMock(), MagicMock()]
+
+        chassis = Chassis()
+        chassis._thermal_list = []
+        chassis.initialize_thermals()
+
+        mock_ensure.assert_called_once()
+        mock_init_chassis_thermals.assert_called_once()
+        assert len(chassis._thermal_list) == 2
+
+    @mock.patch('sonic_platform.thermal.initialize_chassis_thermals')
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready')
+    def test_initialize_thermals_wait_sysfs_labels_ready_timeout(self, mock_ensure,
+                                                                mock_init_chassis_thermals):
+        """Sysfs labels ready file never appears: timeout logged but thermals still initialized."""
+        mock_ensure.return_value = False
+        mock_init_chassis_thermals.return_value = [MagicMock()]
+
+        chassis = Chassis()
+        chassis._thermal_list = []
+        chassis.initialize_thermals()
+
+        mock_ensure.assert_called_once()
+        mock_init_chassis_thermals.assert_called_once()
+        assert len(chassis._thermal_list) == 1
+
+    @mock.patch('sonic_platform.device_data.utils.read_int_from_file', return_value=0)
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_count', return_value=4)
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_drawer_count', return_value=1)
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready')
+    def test_initialize_fan_sysfs_labels_ready(self, mock_ensure, mock_drawer_count,
+                                               mock_fan_count, mock_read_int):
+        """Fan init waits for sysfs labels ready before creating fan drawers."""
+        mock_ensure.return_value = True
+
+        chassis = Chassis()
+        chassis._fan_drawer_list = []
+        chassis.initialize_fan()
+
+        mock_ensure.assert_called_once()
+        assert len(chassis._fan_drawer_list) == 1
+
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_drawer_count', return_value=0)
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready')
+    def test_initialize_fan_no_wait_when_no_fan_drawer(self, mock_ensure, mock_drawer_count):
+        """Liquid cooling system with no fans should not wait for sysfs labels."""
+        chassis = Chassis()
+        chassis._fan_drawer_list = []
+        chassis.initialize_fan()
+
+        mock_ensure.assert_not_called()
+        assert len(chassis._fan_drawer_list) == 0
+
+    @mock.patch('sonic_platform.device_data.utils.read_int_from_file', return_value=0)
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_count', return_value=4)
+    @mock.patch('sonic_platform.device_data.DeviceDataManager.get_fan_drawer_count', return_value=1)
+    @mock.patch('sonic_platform.chassis.utils.ensure_sysfs_labels_ready')
+    def test_initialize_fan_wait_sysfs_labels_ready_timeout(self, mock_ensure, mock_drawer_count,
+                                                            mock_fan_count, mock_read_int):
+        """Fan init proceeds even if sysfs labels ready times out."""
+        mock_ensure.return_value = False
+
+        chassis = Chassis()
+        chassis._fan_drawer_list = []
+        chassis.initialize_fan()
+
+        mock_ensure.assert_called_once()
+        assert len(chassis._fan_drawer_list) == 1

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -380,6 +380,66 @@ class TestUtils:
 
         mock_log_error.assert_called_once()
 
+    @mock.patch('sonic_platform.utils.wait_for_file_creation')
+    @mock.patch('os.access')
+    def test_ensure_sysfs_labels_ready_immediate(self, mock_access, mock_wait):
+        mock_access.return_value = True
+        assert utils.ensure_sysfs_labels_ready()
+        mock_wait.assert_not_called()
+
+    @mock.patch('sonic_platform.utils.wait_for_file_creation')
+    @mock.patch('sonic_platform.utils.wait_until', return_value=True)
+    @mock.patch('os.access')
+    def test_ensure_sysfs_labels_ready_wait_success(self, mock_access, mock_wait_until, mock_wait):
+        mock_access.return_value = False
+        mock_wait.return_value = True
+        assert utils.ensure_sysfs_labels_ready()
+        mock_wait_until.assert_called_once()
+        mock_wait.assert_called_once()
+
+    @mock.patch('sonic_platform.utils.logger.log_error')
+    @mock.patch('sonic_platform.utils.wait_for_file_creation')
+    @mock.patch('sonic_platform.utils.wait_until', return_value=False)
+    @mock.patch('os.access')
+    def test_ensure_sysfs_labels_ready_parent_dir_timeout(self, mock_access, mock_wait_until,
+                                                          mock_wait, mock_log_error):
+        mock_access.return_value = False
+        assert not utils.ensure_sysfs_labels_ready()
+        mock_wait_until.assert_called_once()
+        mock_wait.assert_not_called()
+        mock_log_error.assert_called_once()
+
+    @mock.patch('sonic_platform.utils.logger.log_error')
+    @mock.patch('sonic_platform.utils.wait_for_file_creation')
+    @mock.patch('sonic_platform.utils.wait_until', return_value=True)
+    @mock.patch('os.access')
+    def test_ensure_sysfs_labels_ready_timeout(self, mock_access, mock_wait_until, mock_wait, mock_log_error):
+        mock_access.return_value = False
+        mock_wait.return_value = False
+        assert not utils.ensure_sysfs_labels_ready()
+        mock_wait_until.assert_called_once()
+        mock_wait.assert_called_once()
+        mock_log_error.assert_called_once()
+
+    def test_ensure_sysfs_labels_ready_late_parent_directory(self, tmp_path):
+        """Regression: wait succeeds when parent directory is created after the caller starts."""
+        parent_dir = tmp_path / 'late_hw_mgmt'
+        ready_file = parent_dir / 'sysfs_labels_rdy'
+
+        def create_parent_and_file():
+            time.sleep(0.5)
+            parent_dir.mkdir()
+            time.sleep(0.2)
+            ready_file.write_text('1')
+            os.chmod(ready_file, 0o644)
+
+        thread = threading.Thread(target=create_parent_and_file)
+        thread.start()
+        try:
+            assert utils.ensure_sysfs_labels_ready(str(ready_file), timeout=5)
+        finally:
+            thread.join()
+
     def test_timer(self):
         timer = utils.Timer()
         timer.start()


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Mellanox chassis thermal init can run before hw-mgmt finishes exporting sysfs labels, which triggers spurious “file not found” errors in logs. This change waits up to 60s for /var/run/hw-management/sysfs_labels_rdy in initialize_thermals() to avoid it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
added a function all to wait for it until 60 seconds

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
UT and manual test

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
tested on 202605

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

