### PR TITLE
Fix sonic-swss-common builds

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -2028,4 +2028,4 @@ ccache-clear :
 
 ## To build some commonly used libs. Some submodules depend on these libs.
 ## It is used in component pipelines. For example: swss needs libnl, libyang
-lib-packages: $(addprefix $(DEBS_PATH)/,$(LIBNL3) $(LIBYANG) $(LIBYANG3) $(PROTOBUF) $(LIB_SONIC_DASH_API))
+lib-packages: $(addprefix $(DEBS_PATH)/,$(LIBNL3) $(LIBYANG) $(LIBYANG3) $(LIBYANG3_PY3) $(PROTOBUF) $(LIB_SONIC_DASH_API))


### PR DESCRIPTION
#### Why I did it

I noticed that the sonic-swss-common build was failing in https://github.com/sonic-net/sonic-swss-common/pull/1205 because the `python3-libyang*.deb` were not being published by sonic-buildimage builds.

#### How I did it

This PR fixes the issue by making the common_libs pipeline actually publish `python3-libyang`.

#### How to verify it

Ran a local build:
```
make init
BLDENV=bookworm make -f Makefile.work configure PLATFORM=vs ENABLE_DOCKER_BASE_PULL=y
BLDENV=bookworm SONIC_BUILD_JOBS=$(nproc) make -f Makefile.work lib-packages ENABLE_DOCKER_BASE_PULL=y
```

Verified that python3-libyang was built:
```
$> ls -lt target/debs/bookworm/ | grep libyang
-rw-r--r-- 1 bgallagher bgallagher   30284 Jun 11 21:47 python3-libyang_3.1.0-1_amd64.deb.log
-rw-r--r-- 1 bgallagher bgallagher   66648 Jun 11 21:47 python3-libyang_3.1.0-1_amd64.deb
-rw-r--r-- 1 bgallagher bgallagher     375 Jun 11 21:47 libyang-dev_3.12.2-1_amd64.deb-install.log
-rw-r--r-- 1 bgallagher bgallagher     436 Jun 11 21:47 libyang3_3.12.2-1_amd64.deb-install.log
-rw-r--r-- 1 bgallagher bgallagher     115 Jun 11 21:36 libyang-dev_3.12.2-1_amd64.deb.log
-rw-r--r-- 1 bgallagher bgallagher  829428 Jun 11 21:36 libyang-dev_3.12.2-1_amd64.deb
-rw-r--r-- 1 bgallagher bgallagher  656282 Jun 11 21:36 libyang3_3.12.2-1_amd64.deb.log
-rw-r--r-- 1 bgallagher bgallagher 1744356 Jun 11 21:36 libyang3-dbgsym_3.12.2-1_amd64.deb
-rw-r--r-- 1 bgallagher bgallagher  499644 Jun 11 21:36 libyang3_3.12.2-1_amd64.deb
-rw-r--r-- 1 bgallagher bgallagher   73504 Jun 11 21:36 libyang3-tools_3.12.2-1_amd64.deb
-rw-r--r-- 1 bgallagher bgallagher  132616 Jun 11 21:36 libyang3-tools-dbgsym_3.12.2-1_amd64.deb
```

Spun up a container, installed the packages and verified libyang can be imported in Python code:
```
docker run -it --rm -v $PWD/target/debs/bookworm:/debs \
  sonicdev-microsoft.azurecr.io:443/sonic-slave-bookworm:master-amd64 bash

(in the container)
root@668f226e35f3:/# sudo apt-get install -y /debs/libyang3_*.deb /debs/libyang-dev_3*.deb /debs/python3-libyang_*.deb
root@668f226e35f3:/# python3 -c 'import libyang; print("ok")'
ok
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Fix sonic-swss-common builds

#### Link to config_db schema for YANG module changes
N/A
