### PR TITLE
[ASAN] Enable SYS_PTRACE in frr, orchagent, and teamd for ASAN Enabled SONiC

### DIFF
--- a/rules/docker-fpm-frr.mk
+++ b/rules/docker-fpm-frr.mk
@@ -29,6 +29,9 @@ SONIC_DOCKER_DBG_IMAGES += $(DOCKER_FPM_FRR_DBG)
 
 $(DOCKER_FPM_FRR)_CONTAINER_NAME = bgp
 $(DOCKER_FPM_FRR)_RUN_OPT += -t --cap-add=NET_ADMIN --cap-add=SYS_ADMIN
+ifeq ($(ENABLE_ASAN), y)
+$(DOCKER_FPM_FRR)_RUN_OPT += --cap-add=SYS_PTRACE
+endif
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_FPM_FRR)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 

--- a/rules/docker-orchagent.mk
+++ b/rules/docker-orchagent.mk
@@ -37,6 +37,9 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_ORCHAGENT_DBG)
 
 $(DOCKER_ORCHAGENT)_CONTAINER_NAME = swss
 $(DOCKER_ORCHAGENT)_RUN_OPT += -t --cap-add=NET_ADMIN --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
+ifeq ($(ENABLE_ASAN), y)
+$(DOCKER_ORCHAGENT)_RUN_OPT += --cap-add=SYS_PTRACE
+endif
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/network/interfaces:/etc/network/interfaces:ro
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro 
 $(DOCKER_ORCHAGENT)_RUN_OPT += -v /etc/network/interfaces.d/:/etc/network/interfaces.d/:ro

--- a/rules/docker-teamd.mk
+++ b/rules/docker-teamd.mk
@@ -33,6 +33,9 @@ endif
 
 $(DOCKER_TEAMD)_CONTAINER_NAME = teamd
 $(DOCKER_TEAMD)_RUN_OPT += -t --cap-add=NET_ADMIN
+ifeq ($(ENABLE_ASAN), y)
+$(DOCKER_TEAMD)_RUN_OPT += --cap-add=SYS_PTRACE
+endif
 $(DOCKER_TEAMD)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_TEAMD)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro 
 


### PR DESCRIPTION
#### Why I did it
When orchagent (and the other swss/bgp/teamd daemons) are built with AddressSanitizer/
LeakSanitizer (`ENABLE_ASAN=y`), LeakSanitizer's leak report runs at process exit and needs to
ptrace the process to walk its memory. The SONiC service containers do not grant the
`SYS_PTRACE` capability, so when orchagent receives SIGTERM, LeakSanitizer cannot attach and the
process crashes instead of producing a clean leak report.
##### Work item tracking
- Microsoft ADO **(number only)**: N/A
#### How I did it
- `rules/docker-orchagent.mk`: add `--cap-add=SYS_PTRACE` to the swss container `_RUN_OPT`,
  guarded by `ifeq ($(ENABLE_ASAN), y)` so it only applies in ASAN builds.
- `rules/docker-fpm-frr.mk`: same ASAN-guarded `--cap-add=SYS_PTRACE` addition for the bgp
  container.
- `rules/docker-teamd.mk`: same ASAN-guarded `--cap-add=SYS_PTRACE` addition for the teamd
  container.
#### How to verify it
- Build an image with `ENABLE_ASAN=y`.
- Bring up the device and let orchagent (swss) start.
- Send `SIGTERM` to orchagent (e.g. stop the swss service).
- Confirm LeakSanitizer produces its leak report cleanly at exit and orchagent no longer crashes
 Repeat for the bgp (frr) and teamd containers.
#### Which release branch to backport (provide reason below if selected)

#### Tested branch (Please provide the tested image version)
- [x] master
- [x] 202605
#### Description for the changelog
Enable SYS_PTRACE in frr, orchagent, and teamd for ASAN Enabled SONiC