### PR TITLE
pmon: tolerate /dev reordering and bus hot-plug

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -28,12 +28,25 @@ link_namespace() {
 {%- endif %}
 
 {%- if docker_container_name == "pmon" %}
-# DEVNAMEs of every device carrying the "pmon-hotplug" udev tag.
-pmon_tagged_devnodes() {
-    local syspath
-    for syspath in $(udevadm info -e --tag-match=pmon-hotplug | grep ^P: | sed 's,P:\s*,/sys,' 2>/dev/null); do
-        udevadm info --query=property --path="$syspath" 2>/dev/null | sed -n 's/^DEVNAME=//p'
+# "DEVNAME MAJOR" for every device carrying the "pmon-hotplug" udev tag, read from a single
+# `udevadm info` export
+pmon_tagged_devinfo() {
+    local dn="" maj="" line
+    { udevadm info -e --tag-match=pmon-hotplug 2>/dev/null; echo; } | while IFS= read -r line; do
+        case "$line" in
+            "E: DEVNAME="*) dn="${line#E: DEVNAME=}" ;;
+            "E: MAJOR="*)   maj="${line#E: MAJOR=}" ;;
+            "")
+                [ -n "$dn" ] && echo "$dn ${maj:-0}"
+                dn=""; maj=""
+                ;;
+        esac
     done
+}
+
+# DEVNAMEs of every device carrying the "pmon-hotplug" udev tag
+pmon_tagged_devnodes() {
+    pmon_tagged_devinfo | cut -d' ' -f1
 }
 
 get_pmon_device_mounts() {
@@ -61,15 +74,14 @@ get_pmon_device_cgroup_rules() {
     # the whole device class so later-appearing siblings are already permitted.
     declare -A seen_major
     local devname major
-    for devname in $(pmon_tagged_devnodes); do
+    while read -r devname major; do
         [ -c "$devname" ] || continue   # character bus interfaces only
-        major="$(udevadm info --query=property --name="$devname" 2>/dev/null | sed -n 's/^MAJOR=//p')"
         [ -n "$major" ] && [ "$major" -gt 0 ] 2>/dev/null || continue
         if [ -z "${seen_major[c:$major]:-}" ]; then
             seen_major[c:$major]=1
             echo "c $major:* rwm"
         fi
-    done
+    done < <(pmon_tagged_devinfo)
 }
 {%- endif %}
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -33,9 +33,38 @@ get_pmon_device_mounts() {
     local devpathregex="$(echo "$devregex" | sed -E 's#(^|\|)#\1/dev/#g')"
     for device in $(find /dev/ -maxdepth 1 | grep -E "$devpathregex"); do
         if [ ! -L "$device" ] && [ -b "$device" -o -c "$device" ]; then
+
+            # Skip block-device partitions (sda1, nvme0n1p1 etc). Their names are assigned
+            # in kernel probe order, so a partition baked into this frozen device list at
+            # 'docker create' can vanish after a disk reorder and break 'docker start'
+
+            if [ -b "$device" ] && [ -e "/sys/class/block/$(basename "$device")/partition" ]; then
+                continue
+            fi
             echo "--device=$device"
         else
             echo "--mount=type=bind,source=$device,destination=$device"
+        fi
+    done
+}
+
+get_pmon_device_cgroup_rules() {
+    # Pre-authorize the whole MAJOR (device class) for hot-pluggable bus/FRU interfaces, so
+    # that a sibling appearing AFTER 'docker create' (e.g. a new i2c bus created when an
+    # optic/FRU is inserted behind a mux) is already permitted.
+
+    local hotplugregex='i2c-[0-9]+|cpld[0-9]|fpga[0-9]|ipmi[0-9]+|uio.*|spidev.*|gpiochip[0-9]+|mtd[0-9]+(ro)?'
+    local hotplugpathregex="$(echo "$hotplugregex" | sed -E 's#(^|\|)#\1/dev/#g')"
+    declare -A seen_major
+    for device in $(find /dev/ -maxdepth 1 | grep -E "$hotplugpathregex"); do
+        [ -L "$device" ] && continue
+        [ -c "$device" ] || continue            # character bus interfaces only
+        local majorhex major
+        majorhex="$(stat -c '%t' "$device" 2>/dev/null)"
+        major=$(( 16#${majorhex:-0} ))
+        if [ "$major" -gt 0 ] && [ -z "${seen_major[c:$major]:-}" ]; then
+            seen_major[c:$major]=1
+            echo "c $major:* rwm"
         fi
     done
 }
@@ -402,6 +431,14 @@ function postStartAction()
             docker cp $PSENSOR pmon:/usr/bin/
         fi
     fi
+
+    # Converge the pmon container's /dev with the host now that it is running: mirror in any
+    # hot-pluggable bus node (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) that appeared between
+    # 'docker create' (which froze the --device list) and now.
+
+    if [ -x /usr/local/bin/pmon-dev-bridge.sh ]; then
+        /usr/local/bin/pmon-dev-bridge.sh resync || true
+    fi
 {%- elif docker_container_name == "eventd" %}
     HOST_RSYSLOG_PLUGIN_CONF_FILE="/etc/rsyslog.d/host_events.conf"
     if [ ! -f ${HOST_RSYSLOG_PLUGIN_CONF_FILE} ]; then
@@ -736,6 +773,14 @@ start() {
     fi
 {%- endif %}
 {%- endif %}
+{%- if docker_container_name == "pmon" %}
+    # Pre-authorize hot-pluggable bus-class majors so a device inserted after 'docker create'
+    # is preauthorized.
+    PMON_DEVICE_CGROUP_RULES=()
+    while IFS= read -r _pmon_rule; do
+        [ -n "$_pmon_rule" ] && PMON_DEVICE_CGROUP_RULES+=( "--device-cgroup-rule=$_pmon_rule" )
+    done < <(get_pmon_device_cgroup_rules)
+{%- endif %}
     docker create {{docker_image_run_opt}} \
         -v /host/warmboot$DEV:/var/warmboot \
 {%- if docker_container_name != "dhcp_server" %}
@@ -791,6 +836,7 @@ start() {
     -v /usr/share/sonic/firmware:/usr/share/sonic/firmware:rw \
     $(if [ -d /host/bmc ]; then echo "-v /host/bmc:/host/bmc:rw"; fi) \
     $(get_pmon_device_mounts) \
+    "${PMON_DEVICE_CGROUP_RULES[@]}" \
 {%- endif %}
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -31,7 +31,7 @@ link_namespace() {
 # DEVNAMEs of every device carrying the "pmon-hotplug" udev tag.
 pmon_tagged_devnodes() {
     local syspath
-    for syspath in $(udevadm trigger --verbose --dry-run --type=devices --tag-match=pmon-hotplug 2>/dev/null); do
+    for syspath in $(udevadm info -e --tag-match=pmon-hotplug | grep ^P: | sed 's,P:\s*,/sys,' 2>/dev/null); do
         udevadm info --query=property --path="$syspath" 2>/dev/null | sed -n 's/^DEVNAME=//p'
     done
 }

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -28,16 +28,24 @@ link_namespace() {
 {%- endif %}
 
 {%- if docker_container_name == "pmon" %}
+# DEVNAMEs of every device carrying the "pmon-hotplug" udev tag.
+pmon_tagged_devnodes() {
+    local syspath
+    for syspath in $(udevadm trigger --verbose --dry-run --type=devices --tag-match=pmon-hotplug 2>/dev/null); do
+        udevadm info --query=property --path="$syspath" 2>/dev/null | sed -n 's/^DEVNAME=//p'
+    done
+}
+
 get_pmon_device_mounts() {
-    local devregex='i2c-[0-9]+|cpld[0-9]|fpga[0-9]|ipmi[0-9]+|sd[a-z]+|mmcblk[0-9].*|nvme[0-9].*|uio.*|watchdog[0-9]*'
-    local devpathregex="$(echo "$devregex" | sed -E 's#(^|\|)#\1/dev/#g')"
-    for device in $(find /dev/ -maxdepth 1 | grep -E "$devpathregex"); do
+    # Emit --device/--mount flags for the nodes pmon needs at 'docker create': tagged bus/FRU
+    # nodes plus fixed storage and watchdog devices.
+    local fixedregex='sd[a-z]+|mmcblk[0-9].*|nvme[0-9].*|watchdog[0-9]*'
+    local fixedpathregex="$(echo "$fixedregex" | sed -E 's#(^|\|)#\1/dev/#g')"
+
+    { pmon_tagged_devnodes; find /dev/ -maxdepth 1 | grep -E "$fixedpathregex"; } | sort -u | while read -r device; do
+        [ -e "$device" ] || continue
         if [ ! -L "$device" ] && [ -b "$device" -o -c "$device" ]; then
-
-            # Skip block-device partitions (sda1, nvme0n1p1 etc). Their names are assigned
-            # in kernel probe order, so a partition baked into this frozen device list at
-            # 'docker create' can vanish after a disk reorder and break 'docker start'
-
+            # Skip block-device partitions (sda1, nvme0n1p1 etc).
             if [ -b "$device" ] && [ -e "/sys/class/block/$(basename "$device")/partition" ]; then
                 continue
             fi
@@ -49,20 +57,15 @@ get_pmon_device_mounts() {
 }
 
 get_pmon_device_cgroup_rules() {
-    # Pre-authorize the whole MAJOR (device class) for hot-pluggable bus/FRU interfaces, so
-    # that a sibling appearing AFTER 'docker create' (e.g. a new i2c bus created when an
-    # optic/FRU is inserted behind a mux) is already permitted.
-
-    local hotplugregex='i2c-[0-9]+|cpld[0-9]|fpga[0-9]|ipmi[0-9]+|uio.*|spidev.*|gpiochip[0-9]+|mtd[0-9]+(ro)?'
-    local hotplugpathregex="$(echo "$hotplugregex" | sed -E 's#(^|\|)#\1/dev/#g')"
+    # Emit a cgroup rule ("c <major>:* rwm") for each tagged bus/FRU node's MAJOR, authorizing
+    # the whole device class so later-appearing siblings are already permitted.
     declare -A seen_major
-    for device in $(find /dev/ -maxdepth 1 | grep -E "$hotplugpathregex"); do
-        [ -L "$device" ] && continue
-        [ -c "$device" ] || continue            # character bus interfaces only
-        local majorhex major
-        majorhex="$(stat -c '%t' "$device" 2>/dev/null)"
-        major=$(( 16#${majorhex:-0} ))
-        if [ "$major" -gt 0 ] && [ -z "${seen_major[c:$major]:-}" ]; then
+    local devname major
+    for devname in $(pmon_tagged_devnodes); do
+        [ -c "$devname" ] || continue   # character bus interfaces only
+        major="$(udevadm info --query=property --name="$devname" 2>/dev/null | sed -n 's/^MAJOR=//p')"
+        [ -n "$major" ] && [ "$major" -gt 0 ] 2>/dev/null || continue
+        if [ -z "${seen_major[c:$major]:-}" ]; then
             seen_major[c:$major]=1
             echo "c $major:* rwm"
         fi
@@ -432,10 +435,7 @@ function postStartAction()
         fi
     fi
 
-    # Converge the pmon container's /dev with the host now that it is running: mirror in any
-    # hot-pluggable bus node (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) that appeared between
-    # 'docker create' (which froze the --device list) and now.
-
+    # Mirror any hot-pluggable bus nodes that appeared before pmon started into its /dev.
     if [ -x /usr/local/bin/pmon-dev-bridge.sh ]; then
         /usr/local/bin/pmon-dev-bridge.sh resync || true
     fi
@@ -774,8 +774,7 @@ start() {
 {%- endif %}
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
-    # Pre-authorize hot-pluggable bus-class majors so a device inserted after 'docker create'
-    # is preauthorized.
+    # Build --device-cgroup-rule flags authorizing each hot-pluggable bus-class major.
     PMON_DEVICE_CGROUP_RULES=()
     while IFS= read -r _pmon_rule; do
         [ -n "$_pmon_rule" ] && PMON_DEVICE_CGROUP_RULES+=( "--device-cgroup-rule=$_pmon_rule" )

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -44,18 +44,13 @@ pmon_tagged_devinfo() {
     done
 }
 
-# DEVNAMEs of every device carrying the "pmon-hotplug" udev tag
-pmon_tagged_devnodes() {
-    pmon_tagged_devinfo | cut -d' ' -f1
-}
-
 get_pmon_device_mounts() {
-    # Emit --device/--mount flags for the nodes pmon needs at 'docker create': tagged bus/FRU
-    # nodes plus fixed storage and watchdog devices.
+    # Emit --device/--mount flags for the FIXED devices pmon needs at 'docker create': storage
+    # and watchdog. Hot-pluggable tagged bus/FRU nodes are deliberately NOT baked in here.
     local fixedregex='sd[a-z]+|mmcblk[0-9].*|nvme[0-9].*|watchdog[0-9]*'
     local fixedpathregex="$(echo "$fixedregex" | sed -E 's#(^|\|)#\1/dev/#g')"
 
-    { pmon_tagged_devnodes; find /dev/ -maxdepth 1 | grep -E "$fixedpathregex"; } | sort -u | while read -r device; do
+    find /dev/ -maxdepth 1 | grep -E "$fixedpathregex" | sort -u | while read -r device; do
         [ -e "$device" ] || continue
         if [ ! -L "$device" ] && [ -b "$device" -o -c "$device" ]; then
             # Skip block-device partitions (sda1, nvme0n1p1 etc).

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -28,22 +28,6 @@ link_namespace() {
 {%- endif %}
 
 {%- if docker_container_name == "pmon" %}
-# "DEVNAME MAJOR" for every device carrying the "pmon-hotplug" udev tag, read from a single
-# `udevadm info` export
-pmon_tagged_devinfo() {
-    local dn="" maj="" line
-    { udevadm info -e --tag-match=pmon-hotplug 2>/dev/null; echo; } | while IFS= read -r line; do
-        case "$line" in
-            "E: DEVNAME="*) dn="${line#E: DEVNAME=}" ;;
-            "E: MAJOR="*)   maj="${line#E: MAJOR=}" ;;
-            "")
-                [ -n "$dn" ] && echo "$dn ${maj:-0}"
-                dn=""; maj=""
-                ;;
-        esac
-    done
-}
-
 get_pmon_device_mounts() {
     # Emit --device/--mount flags for the FIXED devices pmon needs at 'docker create': storage
     # and watchdog. Hot-pluggable tagged bus/FRU nodes are deliberately NOT baked in here.
@@ -65,18 +49,10 @@ get_pmon_device_mounts() {
 }
 
 get_pmon_device_cgroup_rules() {
-    # Emit a cgroup rule ("c <major>:* rwm") for each tagged bus/FRU node's MAJOR, authorizing
-    # the whole device class so later-appearing siblings are already permitted.
-    declare -A seen_major
-    local devname major
-    while read -r devname major; do
-        [ -c "$devname" ] || continue   # character bus interfaces only
-        [ -n "$major" ] && [ "$major" -gt 0 ] 2>/dev/null || continue
-        if [ -z "${seen_major[c:$major]:-}" ]; then
-            seen_major[c:$major]=1
-            echo "c $major:* rwm"
-        fi
-    done < <(pmon_tagged_devinfo)
+    # Grant pmon access to all character devices. A cgroup rule is fixed at 'docker create' and can't
+    # be added to a running container, so granting all of them up front covers hot-pluggable bus/FRU
+    # nodes that appear after creation.
+    echo "c *:* rwm"
 }
 {%- endif %}
 
@@ -781,7 +757,7 @@ start() {
 {%- endif %}
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
-    # Build --device-cgroup-rule flags authorizing each hot-pluggable bus-class major.
+    # Build the --device-cgroup-rule flag authorizing pmon's character-device access.
     PMON_DEVICE_CGROUP_RULES=()
     while IFS= read -r _pmon_rule; do
         [ -n "$_pmon_rule" ] && PMON_DEVICE_CGROUP_RULES+=( "--device-cgroup-rule=$_pmon_rule" )

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -49,11 +49,10 @@ get_pmon_device_mounts() {
 }
 
 get_pmon_device_cgroup_rules() {
-    # Scope pmon to the hot-plug bus/FRU char majors (keeps /dev/mem out): known drivers from
-    # /proc/devices (covers a node-less-but-registered class like spidev) plus any pmon-hotplug-tagged
-    # major (platform char nodes such as cpld/fpga).
+    # Scope pmon to the hot-plug bus/FRU char majors (keeps /dev/mem out): known bus/FRU driver names
+    # in /proc/devices (covers a registered-but-node-less class) plus the major of any pmon-hotplug-tagged node.
     {
-        sed -n '/Character devices:/,/Block devices:/p' /proc/devices | awk '$2 ~ /^(i2c|spi|mtd|gpiochip|uio|ipmidev|ipmi)$/ { print $1 }'
+        sed -n '/Character devices:/,/Block devices:/p' /proc/devices | awk '$2 ~ /^(i2c|spi|mtd|gpiochip|uio|ipmidev|ipmi|cpld|fpga)$/ { print $1 }'
         udevadm info -e --tag-match=pmon-hotplug 2>/dev/null | sed -n 's/^E: MAJOR=//p'
     } | sort -un | while read -r major; do
         [ "${major:-0}" -gt 0 ] 2>/dev/null && echo "c $major:* rwm"

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -49,10 +49,15 @@ get_pmon_device_mounts() {
 }
 
 get_pmon_device_cgroup_rules() {
-    # Grant pmon access to all character devices. A cgroup rule is fixed at 'docker create' and can't
-    # be added to a running container, so granting all of them up front covers hot-pluggable bus/FRU
-    # nodes that appear after creation.
-    echo "c *:* rwm"
+    # Scope pmon to the hot-plug bus/FRU char majors (keeps /dev/mem out): known drivers from
+    # /proc/devices (covers a node-less-but-registered class like spidev) plus any pmon-hotplug-tagged
+    # major (platform char nodes such as cpld/fpga).
+    {
+        sed -n '/Character devices:/,/Block devices:/p' /proc/devices | awk '$2 ~ /^(i2c|spi|mtd|gpiochip|uio|ipmidev|ipmi)$/ { print $1 }'
+        udevadm info -e --tag-match=pmon-hotplug 2>/dev/null | sed -n 's/^E: MAJOR=//p'
+    } | sort -un | while read -r major; do
+        [ "${major:-0}" -gt 0 ] 2>/dev/null && echo "c $major:* rwm"
+    done
 }
 {%- endif %}
 
@@ -757,7 +762,7 @@ start() {
 {%- endif %}
 {%- endif %}
 {%- if docker_container_name == "pmon" %}
-    # Build the --device-cgroup-rule flag authorizing pmon's character-device access.
+    # Build --device-cgroup-rule flags from the hot-plug bus/FRU majors.
     PMON_DEVICE_CGROUP_RULES=()
     while IFS= read -r _pmon_rule; do
         [ -n "$_pmon_rule" ] && PMON_DEVICE_CGROUP_RULES+=( "--device-cgroup-rule=$_pmon_rule" )

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -544,6 +544,13 @@ sudo cp $IMAGE_CONFIGS/systemd/network/* $FILESYSTEM_ROOT_ETC/systemd/network/
 sudo mkdir -p $FILESYSTEM_ROOT_ETC/udev/rules.d
 sudo cp $IMAGE_CONFIGS/udev/rules.d/* $FILESYSTEM_ROOT_ETC/udev/rules.d/
 
+# pmon /dev hot-plug bridge: mirrors a hot-plugged bus node
+# (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) into the running pmon container, paired with
+# the per-class --device-cgroup-rule in get_pmon_device_cgroup_rules() and 99-pmon-dev-bridge.rules.
+
+sudo LANG=C cp $IMAGE_CONFIGS/pmon/pmon-dev-bridge.sh $FILESYSTEM_ROOT/usr/local/bin/pmon-dev-bridge.sh
+sudo chmod 755 $FILESYSTEM_ROOT/usr/local/bin/pmon-dev-bridge.sh
+
 # copy core file uploader files
 sudo cp $IMAGE_CONFIGS/corefile_uploader/core_uploader.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl disable core_uploader.service

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -544,10 +544,7 @@ sudo cp $IMAGE_CONFIGS/systemd/network/* $FILESYSTEM_ROOT_ETC/systemd/network/
 sudo mkdir -p $FILESYSTEM_ROOT_ETC/udev/rules.d
 sudo cp $IMAGE_CONFIGS/udev/rules.d/* $FILESYSTEM_ROOT_ETC/udev/rules.d/
 
-# pmon /dev hot-plug bridge: mirrors a hot-plugged bus node
-# (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) into the running pmon container, paired with
-# the per-class --device-cgroup-rule in get_pmon_device_cgroup_rules() and 99-pmon-dev-bridge.rules.
-
+# Install the pmon /dev hot-plug bridge.
 sudo LANG=C cp $IMAGE_CONFIGS/pmon/pmon-dev-bridge.sh $FILESYSTEM_ROOT/usr/local/bin/pmon-dev-bridge.sh
 sudo chmod 755 $FILESYSTEM_ROOT/usr/local/bin/pmon-dev-bridge.sh
 

--- a/files/image_config/pmon/pmon-dev-bridge.sh
+++ b/files/image_config/pmon/pmon-dev-bridge.sh
@@ -1,38 +1,29 @@
 #!/bin/bash
 #
-# pmon-dev-bridge.sh -- mirror hot-pluggable bus nodes (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd)
-# into the running pmon container's /dev, so a node that appears after 'docker create' becomes
-# visible without recreating the container.
+# Mirror hot-pluggable bus nodes (tagged "pmon-hotplug") into the running pmon container's /dev.
 #
 # Usage:
-#   pmon-dev-bridge.sh resync                       # converge all allowed nodes (called on pmon start)
-#   pmon-dev-bridge.sh event <add|remove> <devname> # one hot-plug event (called by udev)
+#   pmon-dev-bridge.sh resync                       # mirror all tagged nodes (called on pmon start)
+#   pmon-dev-bridge.sh event <add|remove> <devname> # handle one hot-plug event (called by udev)
 
 set -u
-
-# Hot-pluggable bus-class allowlist. MUST stay in sync with $hotplugregex in
-# get_pmon_device_cgroup_rules() (files/build_templates/docker_image_ctl.j2): we only mirror
-# nodes whose class major was actually granted, so visibility and permission stay aligned.
-# Anchored to whole node names.
-PMON_HOTPLUG_ALLOW='^(i2c-[0-9]+|cpld[0-9]|fpga[0-9]|ipmi[0-9]+|uio.*|spidev.*|gpiochip[0-9]+|mtd[0-9]+(ro)?)$'
 
 # Names of running pmon containers (single-asic: "pmon"; multi-asic: "pmon0", "pmon1", ...).
 pmon_containers() {
     docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^pmon[0-9]*$'
 }
 
-# True if the node's basename is a hot-plug bus class pmon is granted. Cheapest check -> run
-# it first so the flood of unrelated uevents at boot exits before we ever touch docker.
-is_allowed() {
-    basename "$1" | grep -Eq "$PMON_HOTPLUG_ALLOW"
+# DEVNAMEs of every device carrying the pmon-hotplug udev tag.
+tagged_devnodes() {
+    local syspath
+    for syspath in $(udevadm trigger --verbose --dry-run --type=devices --tag-match=pmon-hotplug 2>/dev/null); do
+        udevadm info --query=property --path="$syspath" 2>/dev/null | sed -n 's/^DEVNAME=//p'
+    done
 }
 
-# Create the node inside every running pmon container (idempotent; guarded by existence
-# check). mknod succeeds because the container already holds 'c <major>:* rwm' (the
-# 'm'/mknod bit) for this class and Docker's default cap set includes CAP_MKNOD.
+# Create the node inside every running pmon container (idempotent).
 mirror_add() {
     local node="$1" c majorhex minorhex major minor
-    is_allowed "$node" || return 0
     [ -e "$node" ] || return 0
     [ -c "$node" ] || return 0              # character bus interfaces only
     majorhex="$(stat -c '%t' "$node" 2>/dev/null)"
@@ -48,7 +39,6 @@ mirror_add() {
 # Remove the node from every running pmon container (best-effort).
 mirror_remove() {
     local node="$1" c
-    is_allowed "$node" || return 0
     for c in $(pmon_containers); do
         docker exec "$c" sh -c "rm -f '$node'" 2>/dev/null || true
     done
@@ -56,9 +46,8 @@ mirror_remove() {
 
 case "${1:-}" in
     resync)
-        # Converge the container with whatever the host currently exposes: idempotent.
-        # Covers anything that appeared between 'docker create' and now.
-        for node in $(find /dev -maxdepth 1 -type c 2>/dev/null); do
+        # Mirror all currently-tagged nodes into the container.
+        for node in $(tagged_devnodes); do
             mirror_add "$node"
         done
         ;;

--- a/files/image_config/pmon/pmon-dev-bridge.sh
+++ b/files/image_config/pmon/pmon-dev-bridge.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+#
+# pmon-dev-bridge.sh -- mirror hot-pluggable bus nodes (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd)
+# into the running pmon container's /dev, so a node that appears after 'docker create' becomes
+# visible without recreating the container.
+#
+# Usage:
+#   pmon-dev-bridge.sh resync                       # converge all allowed nodes (called on pmon start)
+#   pmon-dev-bridge.sh event <add|remove> <devname> # one hot-plug event (called by udev)
+
+set -u
+
+# Hot-pluggable bus-class allowlist. MUST stay in sync with $hotplugregex in
+# get_pmon_device_cgroup_rules() (files/build_templates/docker_image_ctl.j2): we only mirror
+# nodes whose class major was actually granted, so visibility and permission stay aligned.
+# Anchored to whole node names.
+PMON_HOTPLUG_ALLOW='^(i2c-[0-9]+|cpld[0-9]|fpga[0-9]|ipmi[0-9]+|uio.*|spidev.*|gpiochip[0-9]+|mtd[0-9]+(ro)?)$'
+
+# Names of running pmon containers (single-asic: "pmon"; multi-asic: "pmon0", "pmon1", ...).
+pmon_containers() {
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^pmon[0-9]*$'
+}
+
+# True if the node's basename is a hot-plug bus class pmon is granted. Cheapest check -> run
+# it first so the flood of unrelated uevents at boot exits before we ever touch docker.
+is_allowed() {
+    basename "$1" | grep -Eq "$PMON_HOTPLUG_ALLOW"
+}
+
+# Create the node inside every running pmon container (idempotent; guarded by existence
+# check). mknod succeeds because the container already holds 'c <major>:* rwm' (the
+# 'm'/mknod bit) for this class and Docker's default cap set includes CAP_MKNOD.
+mirror_add() {
+    local node="$1" c majorhex minorhex major minor
+    is_allowed "$node" || return 0
+    [ -e "$node" ] || return 0
+    [ -c "$node" ] || return 0              # character bus interfaces only
+    majorhex="$(stat -c '%t' "$node" 2>/dev/null)"
+    minorhex="$(stat -c '%T' "$node" 2>/dev/null)"
+    major=$(( 16#${majorhex:-0} ))
+    minor=$(( 16#${minorhex:-0} ))
+    [ "$major" -gt 0 ] || return 0
+    for c in $(pmon_containers); do
+        docker exec "$c" sh -c "[ -e '$node' ] || mknod '$node' c $major $minor" 2>/dev/null || true
+    done
+}
+
+# Remove the node from every running pmon container (best-effort).
+mirror_remove() {
+    local node="$1" c
+    is_allowed "$node" || return 0
+    for c in $(pmon_containers); do
+        docker exec "$c" sh -c "rm -f '$node'" 2>/dev/null || true
+    done
+}
+
+case "${1:-}" in
+    resync)
+        # Converge the container with whatever the host currently exposes: idempotent.
+        # Covers anything that appeared between 'docker create' and now.
+        for node in $(find /dev -maxdepth 1 -type c 2>/dev/null); do
+            mirror_add "$node"
+        done
+        ;;
+    event)
+        action="${2:-}"
+        devname="${3:-}"
+        [ -n "$devname" ] || exit 0
+        case "$devname" in /dev/*) ;; *) devname="/dev/$devname" ;; esac
+        case "$action" in
+            add)    mirror_add "$devname" ;;
+            remove) mirror_remove "$devname" ;;
+        esac
+        ;;
+    *)
+        echo "usage: $0 {resync | event <add|remove> <devname>}" >&2
+        exit 2
+        ;;
+esac
+exit 0

--- a/files/image_config/pmon/pmon-dev-bridge.sh
+++ b/files/image_config/pmon/pmon-dev-bridge.sh
@@ -8,22 +8,22 @@
 
 set -u
 
-# Names of running pmon containers (single-asic: "pmon"; multi-asic: "pmon0", "pmon1", ...).
-pmon_containers() {
-    docker ps --format '{{.Names}}' 2>/dev/null | grep -E '^pmon[0-9]*$'
+# pmon is a single global container (one instance even on multi-asic platforms).
+PMON=pmon
+
+pmon_running() {
+    docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$PMON"
 }
 
-# DEVNAMEs of every device carrying the pmon-hotplug udev tag.
-tagged_devnodes() {
-    local syspath
-    for syspath in $(udevadm trigger --verbose --dry-run --type=devices --tag-match=pmon-hotplug 2>/dev/null); do
-        udevadm info --query=property --path="$syspath" 2>/dev/null | sed -n 's/^DEVNAME=//p'
-    done
+# Feed a script of shell commands to the pmon container in a single exec.
+apply_in_pmon() {
+    [ -n "$1" ] || return 0
+    printf '%s' "$1" | docker exec -i "$PMON" sh 2>/dev/null || true
 }
 
-# Create the node inside every running pmon container (idempotent).
-mirror_add() {
-    local node="$1" c majorhex minorhex major minor
+# Emit an idempotent mknod for one character node (major/minor read on the host).
+mknod_cmd() {
+    local node="$1" majorhex minorhex major minor
     [ -e "$node" ] || return 0
     [ -c "$node" ] || return 0              # character bus interfaces only
     majorhex="$(stat -c '%t' "$node" 2>/dev/null)"
@@ -31,34 +31,43 @@ mirror_add() {
     major=$(( 16#${majorhex:-0} ))
     minor=$(( 16#${minorhex:-0} ))
     [ "$major" -gt 0 ] || return 0
-    for c in $(pmon_containers); do
-        docker exec "$c" sh -c "[ -e '$node' ] || mknod '$node' c $major $minor" 2>/dev/null || true
-    done
+    printf "[ -e '%s' ] || mknod '%s' c %d %d\n" "$node" "$node" "$major" "$minor"
 }
 
-# Remove the node from every running pmon container (best-effort).
-mirror_remove() {
-    local node="$1" c
-    for c in $(pmon_containers); do
-        docker exec "$c" sh -c "rm -f '$node'" 2>/dev/null || true
+# Emit idempotent mknods for every pmon-hotplug node from a single udevadm export
+# (DEVNAME/MAJOR/MINOR come straight from the udev db -- no per-node udevadm or stat).
+tagged_mknod_script() {
+    local dn="" maj="" min="" line
+    { udevadm info -e --tag-match=pmon-hotplug 2>/dev/null; echo; } | while IFS= read -r line; do
+        case "$line" in
+            "E: DEVNAME="*) dn="${line#E: DEVNAME=}" ;;
+            "E: MAJOR="*)   maj="${line#E: MAJOR=}" ;;
+            "E: MINOR="*)   min="${line#E: MINOR=}" ;;
+            "")
+                if [ -n "$dn" ] && [ -n "$maj" ] && [ "$maj" != "0" ]; then
+                    printf "[ -e '%s' ] || mknod '%s' c %s %s\n" "$dn" "$dn" "$maj" "$min"
+                fi
+                dn=""; maj=""; min=""
+                ;;
+        esac
     done
 }
 
 case "${1:-}" in
     resync)
-        # Mirror all currently-tagged nodes into the container.
-        for node in $(tagged_devnodes); do
-            mirror_add "$node"
-        done
+        # Mirror all currently-tagged nodes into the container in a single docker exec.
+        pmon_running || exit 0
+        apply_in_pmon "$(tagged_mknod_script)"
         ;;
     event)
         action="${2:-}"
         devname="${3:-}"
         [ -n "$devname" ] || exit 0
         case "$devname" in /dev/*) ;; *) devname="/dev/$devname" ;; esac
+        pmon_running || exit 0
         case "$action" in
-            add)    mirror_add "$devname" ;;
-            remove) mirror_remove "$devname" ;;
+            add)    apply_in_pmon "$(mknod_cmd "$devname")" ;;
+            remove) apply_in_pmon "rm -f '$devname'" ;;
         esac
         ;;
     *)

--- a/files/image_config/udev/rules.d/99-pmon-dev-bridge.rules
+++ b/files/image_config/udev/rules.d/99-pmon-dev-bridge.rules
@@ -1,0 +1,5 @@
+# Forward add/remove uevents to pmon-dev-bridge.sh, which mirrors hot-plugged bus nodes
+# (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) into the running pmon container(s) -- the node
+# list baked in at 'docker create' cannot otherwise change.
+
+ACTION=="add|remove", ENV{DEVNAME}!="", RUN+="/usr/local/bin/pmon-dev-bridge.sh event $env{ACTION} $env{DEVNAME}"

--- a/files/image_config/udev/rules.d/99-pmon-dev-bridge.rules
+++ b/files/image_config/udev/rules.d/99-pmon-dev-bridge.rules
@@ -1,5 +1,17 @@
-# Forward add/remove uevents to pmon-dev-bridge.sh, which mirrors hot-plugged bus nodes
-# (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) into the running pmon container(s) -- the node
-# list baked in at 'docker create' cannot otherwise change.
+# Tag hot-pluggable bus/FRU device classes with the "pmon-hotplug" udev tag, giving pmon access
+# to devices that appear after its container is created. The tag is read by
+# get_pmon_device_cgroup_rules() (per-class cgroup grant) and pmon-dev-bridge.sh (mirrors nodes
+# into the running pmon container).
 
-ACTION=="add|remove", ENV{DEVNAME}!="", RUN+="/usr/local/bin/pmon-dev-bridge.sh event $env{ACTION} $env{DEVNAME}"
+# Tag each hot-pluggable bus/FRU class.
+SUBSYSTEM=="i2c-dev",                          TAG+="pmon-hotplug"
+SUBSYSTEM=="spidev",                           TAG+="pmon-hotplug"
+SUBSYSTEM=="uio",                              TAG+="pmon-hotplug"
+SUBSYSTEM=="mtd",    KERNEL=="mtd[0-9]*",      TAG+="pmon-hotplug"
+SUBSYSTEM=="gpio",   KERNEL=="gpiochip[0-9]*", TAG+="pmon-hotplug"
+KERNEL=="ipmi[0-9]*",                          TAG+="pmon-hotplug"
+KERNEL=="cpld[0-9]*",                          TAG+="pmon-hotplug"
+KERNEL=="fpga[0-9]*",                          TAG+="pmon-hotplug"
+
+# Forward add/remove of a tagged node to the bridge.
+TAG=="pmon-hotplug", ACTION=="add|remove", ENV{DEVNAME}!="", RUN+="/usr/local/bin/pmon-dev-bridge.sh event $env{ACTION} $env{DEVNAME}"


### PR DESCRIPTION

#### Why I did it

Aimed at #25142

pmon runs against a fixed --device list captured at 'docker create', which breaks in two ways: a block-device partition (e.g. sda1) named in kernel probe order can disappear after a disk reorder and fail 'docker start', and a bus node that appears after create (i2c/cpld/fpga/ipmi/uio/spidev/gpiochip/mtd) is denied and invisible to the container.

#### How I did it

Pass reorder-invariant whole disks, pre-authorize the hot-plug device classes, and keep the container's /dev in sync at runtime. The change is strictly narrower than --privileged.

files/build_templates/docker_image_ctl.j2
  - get_pmon_device_mounts(): skip block-device partitions and pass the reorder-invariant whole disk instead.
  - get_pmon_device_cgroup_rules() (new): emit 'c <major>:* rwm' for each hot-pluggable bus class so a sibling created after 'docker create' (e.g. an i2c bus behind a mux on optic insert) is already permitted.
  - start(): pass those rules as --device-cgroup-rule on docker create.
  - postStartAction(): call pmon-dev-bridge.sh resync to converge /dev.

files/image_config/pmon/pmon-dev-bridge.sh (new)
  - Helper that mirrors allowed character bus nodes into the running pmon container(s): 'resync' converges every allowed node on start; 'event add|remove' handles a single udev hot-plug event via mknod/rm.

files/image_config/udev/rules.d/99-pmon-dev-bridge.rules (new)
  - udev rule forwarding add/remove uevents to pmon-dev-bridge.sh so the container's device view tracks hot-plug after creation.

files/build_templates/sonic_debian_extension.j2
  - Install pmon-dev-bridge.sh to /usr/local/bin (mode 755) at image build time.

#### How to verify it

All checks are read-only except the dynamic-bridge demonstration, which is **container-only
and fully reversible** — the host `/dev` is never modified. Run on a device built from /
flashed with this fix. 

Results: [pmon-how-to-verify-it.md](https://github.com/user-attachments/files/28871000/pmon-how-to-verify-it.md).

[PMON-HOTPLUG-TEST-REPORT.md](https://github.com/user-attachments/files/29029346/PMON-HOTPLUG-TEST-REPORT.md)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] masterI20260609135544_asrinivasan
- [x] SONiC.hpe_202605.0-dirty-20260721.170244 - logs: [pmon-start-issue-logs-202605.txt](https://github.com/user-attachments/files/30248975/pmon-start-issue-logs-202605.txt),  
[pmon-cgroup-all-char-logs-202605.txt](https://github.com/user-attachments/files/30300120/pmon-cgroup-all-char-logs-202605.txt) and 
[pmon-cgroup-scoped-logs-202605.txt](https://github.com/user-attachments/files/30765895/pmon-cgroup-scoped-logs-202605.txt)




#### Description for the changelog
pmon: tolerate /dev reordering and bus hot-plug (fixes #25142)