### PR TITLE
frr: enable LLGR helper-only mode on UpperRegionalHub

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -121,6 +121,10 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
   bgp graceful-restart preserve-fw-state
   bgp graceful-restart select-defer-time {{ constants.bgp.graceful_restart.select_defer_time | default(45) }}
 {% endif %}
+{% if DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
+  bgp graceful-restart-disable
+  bgp long-lived-graceful-restart stale-time 864000
+{% endif %}
 !
 {# set frr_bmp info #}
 {% if (FEATURE is defined) and

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_urh.conf
@@ -18,6 +18,9 @@ router bgp 65001
   no bgp default ipv4-unicast
   no bgp ebgp-requires-policy
 !
+  bgp graceful-restart-disable
+  bgp long-lived-graceful-restart stale-time 864000
+!
   bgp router-id 55.55.55.55
 !
   network 55.55.55.55/32

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -260,3 +260,40 @@ def test_bgp_confed_urh_single_asic():
              "bgpd/bgpd.main.conf.j2",
              "bgpd.main.conf.j2/single_asic_urh.json",
              "bgpd.main.conf.j2/single_asic_urh.conf")
+
+def _render_bgpd_main(json_path):
+    template_path = os.path.join(TEMPLATE_PATH, "bgpd/bgpd.main.conf.j2")
+    json_full_path = os.path.join(DATA_PATH, json_path)
+    command = ['sonic-cfggen', "-T", TEMPLATE_PATH, "-t", template_path, "-y", json_full_path]
+    p = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = p.communicate()
+    assert p.returncode == 0, "sonic-cfggen returned %d. stderr=%r" % (p.returncode, stderr)
+    return stdout.decode("ascii")
+
+def test_bgpd_main_llgr_helper_emitted_on_urh():
+    """LLGR helper-only block must be emitted for UpperRegionalHub."""
+    rendered = _render_bgpd_main("bgpd.main.conf.j2/single_asic_urh.json")
+    assert "bgp graceful-restart-disable" in rendered, \
+        "Expected 'bgp graceful-restart-disable' on UpperRegionalHub, got:\n%s" % rendered
+    assert "bgp long-lived-graceful-restart stale-time 864000" in rendered, \
+        "Expected 'bgp long-lived-graceful-restart stale-time 864000' on UpperRegionalHub, got:\n%s" % rendered
+
+def test_bgpd_main_llgr_helper_absent_on_non_urh():
+    """LLGR helper-only block must NOT be emitted for any non-UpperRegionalHub type."""
+    non_urh_fixtures = [
+        "bgpd.main.conf.j2/all.json",                  # ToRRouter
+        "bgpd.main.conf.j2/defaults.json",             # ToRRouter
+        "bgpd.main.conf.j2/single_asic_lt2.json",      # LowerSpineRouter
+        "bgpd.main.conf.j2/single_asic_ft2.json",      # FabricSpineRouter
+        "bgpd.main.conf.j2/single_asic_lrh.json",      # LowerRegionalHub
+        "bgpd.main.conf.j2/single_asic_frh.json",      # FabricRegionalHub
+        "bgpd.main.conf.j2/single_asic_upper_t2.json", # UpperSpineRouter
+        "bgpd.main.conf.j2/voq_chassis.json",          # SpineRouter
+        "bgpd.main.conf.j2/base.json",                 # type unset
+    ]
+    for fixture in non_urh_fixtures:
+        rendered = _render_bgpd_main(fixture)
+        assert "bgp graceful-restart-disable" not in rendered, \
+            "%s must not contain 'bgp graceful-restart-disable'" % fixture
+        assert "long-lived-graceful-restart" not in rendered, \
+            "%s must not contain 'long-lived-graceful-restart'" % fixture


### PR DESCRIPTION
#### Why I did it

On UpperRegionalHub devices, we want this router to act as a **Long-Lived Graceful Restart (LLGR) helper** only — i.e. retain a downed peer's routes for an extended (10-day) window, without itself being a GR restarter. With the default config, LLGR is off and every peer either gets full GR or none at all, which doesn't match the operational requirement for UpperRegionalHub.

#### How I did it

Added a small Jinja2 block in `dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2`, gated on `DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub'`, that emits:

```
  bgp graceful-restart-disable
  bgp long-lived-graceful-restart stale-time 864000
```

- `bgp graceful-restart-disable` sets the BGP-instance default GR mode to *disabled*. Peers with no explicit `graceful-restart*` setting inherit *disable* (`PEER_FLAG_GRACEFUL_RESTART_GLOBAL_INHERIT`) and will not advertise GR (nor LLGR). Per-peer LLGR helper behavior can then be opted in selectively via `neighbor <X> graceful-restart-helper`.
- `bgp long-lived-graceful-restart stale-time 864000` sets the LLGR stale-time to 10 days (864000 s). This is within FRR's allowed range `1-16777215` seconds. LLGR is advertised only to peers that also negotiate the regular GR capability (gated at `bgp_open.c` in FRR), so this is safe — non-GR peers see no behavior change.

The block is independent of the existing ToRRouter GR block and does not affect any other device type.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How to verify it

On an UpperRegionalHub device after the change is applied and bgpd is restarted:

```
vtysh -c 'show running-config bgpd' | grep -E 'graceful-restart-disable|long-lived'
```

Expected:
```
 bgp graceful-restart-disable
 bgp long-lived-graceful-restart stale-time 864000
```

On non-UpperRegionalHub devices (ToRRouter, SpineRouter, etc.) the rendered `bgpd.conf` is unchanged.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog
frr: enable LLGR helper-only mode (`graceful-restart-disable` + 10-day LLGR stale-time) on UpperRegionalHub devices.

#### Link to config_db schema for YANG module changes
N/A — Jinja template change only, no schema change.