### PR TITLE
Add EVPN MH handlers in frrcfgd

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -101,6 +101,8 @@ class BgpdClientMgr(threading.Thread):
             'BGP_GLOBALS_EVPN_VNI': ['bgpd'],
             'BGP_GLOBALS_EVPN_RT': ['bgpd'],
             'BGP_GLOBALS_EVPN_VNI_RT': ['bgpd'],
+            'EVPN_ETHERNET_SEGMENT': ['mgmtd'],
+            'EVPN_MH_GLOBAL': ['zebra'],
             'BFD_PEER': ['bfdd'],
             'BFD_PEER_SINGLE_HOP': ['bfdd'],
             'BFD_PEER_MULTI_HOP': ['bfdd'],
@@ -1989,6 +1991,10 @@ class BGPConfigDaemon:
                                ('import-rts',                                  '{no:no-prefix}route-target import {}', hdl_import_list),
                                ('export-rts',                                  '{no:no-prefix}route-target export {}', hdl_export_list)]
 
+    evpn_mh_global_key_map = [('startup_delay',                  '{no:no-prefix}evpn mh startup-delay {}'),
+                              ('mac_holdtime',                   '{no:no-prefix}evpn mh mac-holdtime {}'),
+                              ('neigh_holdtime',                 '{no:no-prefix}evpn mh neigh-holdtime {}')]
+
     ospfv2_global_key_map = [('enable',                        '{no:no-prefix}'),
                              ('auto-cost-reference-bandwidth', '{no:no-prefix}auto-cost reference-bandwidth {}'),
                              ('ospf-rfc1583-compatible',       '{no:no-prefix}compatible rfc1583', ['true', 'false']),
@@ -2118,6 +2124,7 @@ class BGPConfigDaemon:
                       'BGP_GLOBALS_AF_AGGREGATE_ADDR':  af_aggregate_key_map,
                       'BGP_GLOBALS_AF_NETWORK':         af_network_key_map,
                       'BGP_GLOBALS_EVPN_VNI':           global_evpn_vni_key_map,
+                      'EVPN_MH_GLOBAL':                 evpn_mh_global_key_map,
                       'BFD_PEER_SINGLE_HOP':            bfd_peer_shop_key_map,
                       'BFD_PEER_MULTI_HOP':             bfd_peer_mhop_key_map,
                       'IP_SLA':                         ip_sla_key_map,
@@ -2312,6 +2319,8 @@ class BGPConfigDaemon:
             ('BGP_GLOBALS_EVPN_VNI', self.bgp_table_handler_common),
             ('BGP_GLOBALS_EVPN_RT', self.bgp_table_handler_common),
             ('BGP_GLOBALS_EVPN_VNI_RT', self.bgp_table_handler_common),
+            ('EVPN_ETHERNET_SEGMENT', self.bgp_table_handler_common),
+            ('EVPN_MH_GLOBAL', self.bgp_table_handler_common),
             ('BFD_PEER', self.bfd_handler),
             ('NEIGHBOR_SET', self.bgp_table_handler_common),
             ('NEXTHOP_SET', self.bgp_table_handler_common),
@@ -3110,6 +3119,50 @@ class BGPConfigDaemon:
                     continue
                 else:
                     data['route-target-type'].status = CachedDataWithOp.STAT_SUCC
+            elif table == 'EVPN_MH_GLOBAL':
+                cmd_prefix = ['configure terminal']
+                if not key_map.run_command(self, table, data, cmd_prefix):
+                    syslog.syslog(syslog.LOG_ERR, 'failed running EVPN MH global config command')
+                    continue
+            elif table == 'EVPN_ETHERNET_SEGMENT':
+                ifname = prefix
+                intf_cmd = 'interface {}'.format(ifname)
+                command = "vtysh -c 'configure terminal' -c '{}'" \
+                          " -c 'no evpn mh es-sys-mac'" \
+                          " -c 'no evpn mh es-df-pref'" \
+                          " -c 'no evpn mh es-id'".format(intf_cmd)
+                entry = {} if del_table else self.config_db.get_entry('EVPN_ETHERNET_SEGMENT', ifname)
+                if entry:
+                    es_type = entry.get('type', '')
+                    esi = entry.get('esi', '')
+                    es_id = entry.get('es_id', '')
+                    df_pref = entry.get('df_pref', '')
+                    es_configured = False
+                    if es_type == 'TYPE_0_OPERATOR_CONFIGURED' and esi and esi != 'AUTO':
+                        command += " -c 'evpn mh es-id {}'".format(esi)
+                        es_configured = True
+                    elif es_type == 'TYPE_3_MAC_BASED':
+                        if not es_id:
+                            match = re.search(r'[a-zA-Z]+(?P<port_id>[0-9_]+)', ifname)
+                            if match:
+                                port_id = match.group('port_id').replace('_', '')
+                                if port_id:
+                                    es_id = str(int(port_id))
+                        if es_id:
+                            command += " -c 'evpn mh es-id {}'".format(es_id)
+                            es_sys_mac = entry.get('es_sys_mac', '')
+                            if not es_sys_mac:
+                                pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
+                                if pc_entry and 'system_mac' in pc_entry:
+                                    es_sys_mac = pc_entry['system_mac']
+                            if es_sys_mac:
+                                command += " -c 'evpn mh es-sys-mac {}'".format(es_sys_mac)
+                            es_configured = True
+                    if es_configured and df_pref and str(df_pref) != '32767':
+                        command += " -c 'evpn mh es-df-pref {}'".format(df_pref)
+                if not self.__run_command(table, command):
+                    syslog.syslog(syslog.LOG_ERR, 'failed running EVPN ethernet segment config command')
+                    continue
             elif table == 'ROUTE_MAP':
                 map_name = prefix
                 seq_no = key

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1991,9 +1991,9 @@ class BGPConfigDaemon:
                                ('import-rts',                                  '{no:no-prefix}route-target import {}', hdl_import_list),
                                ('export-rts',                                  '{no:no-prefix}route-target export {}', hdl_export_list)]
 
-    evpn_mh_global_key_map = [('startup_delay',                  '{no:no-prefix}evpn mh startup-delay {}'),
-                              ('mac_holdtime',                   '{no:no-prefix}evpn mh mac-holdtime {}'),
-                              ('neigh_holdtime',                 '{no:no-prefix}evpn mh neigh-holdtime {}')]
+    evpn_mh_global_key_map = [('startup_delay',  '{no:no-prefix}evpn mh startup-delay {}'),
+                              ('mac_holdtime',   '{no:no-prefix}evpn mh mac-holdtime {}'),
+                              ('neigh_holdtime', '{no:no-prefix}evpn mh neigh-holdtime {}')]
 
     ospfv2_global_key_map = [('enable',                        '{no:no-prefix}'),
                              ('auto-cost-reference-bandwidth', '{no:no-prefix}auto-cost reference-bandwidth {}'),
@@ -3120,26 +3120,29 @@ class BGPConfigDaemon:
                 else:
                     data['route-target-type'].status = CachedDataWithOp.STAT_SUCC
             elif table == 'EVPN_MH_GLOBAL':
+                # Global EVPN MH timers (zebra); key-map handles add/'no' per field.
                 cmd_prefix = ['configure terminal']
                 if not key_map.run_command(self, table, data, cmd_prefix):
                     syslog.syslog(syslog.LOG_ERR, 'failed running EVPN MH global config command')
                     continue
             elif table == 'EVPN_ETHERNET_SEGMENT':
+                # Per-interface EVPN MH config (mgmtd): clear then re-apply the
+                # full ConfigDB row, since Type-0/Type-3 logic needs the whole entry.
                 ifname = prefix
                 intf_cmd = 'interface {}'.format(ifname)
-                command = "vtysh -c 'configure terminal' -c '{}'" \
-                          " -c 'no evpn mh es-sys-mac'" \
-                          " -c 'no evpn mh es-df-pref'" \
-                          " -c 'no evpn mh es-id'".format(intf_cmd)
+                command = ['vtysh', '-c', 'configure terminal', '-c', intf_cmd,
+                           '-c', 'no evpn mh es-sys-mac',
+                           '-c', 'no evpn mh es-df-pref',
+                           '-c', 'no evpn mh es-id']
                 entry = {} if del_table else self.config_db.get_entry('EVPN_ETHERNET_SEGMENT', ifname)
                 if entry:
                     es_type = entry.get('type', '')
-                    esi = entry.get('esi', '')
-                    es_id = entry.get('es_id', '')
+                    esi     = entry.get('esi', '')
+                    es_id   = entry.get('es_id', '')
                     df_pref = entry.get('df_pref', '')
                     es_configured = False
                     if es_type == 'TYPE_0_OPERATOR_CONFIGURED' and esi and esi != 'AUTO':
-                        command += " -c 'evpn mh es-id {}'".format(esi)
+                        command += ['-c', 'evpn mh es-id {}'.format(esi)]
                         es_configured = True
                     elif es_type == 'TYPE_3_MAC_BASED':
                         if not es_id:
@@ -3149,17 +3152,18 @@ class BGPConfigDaemon:
                                 if port_id:
                                     es_id = str(int(port_id))
                         if es_id:
-                            command += " -c 'evpn mh es-id {}'".format(es_id)
+                            command += ['-c', 'evpn mh es-id {}'.format(es_id)]
+                            # prefer es_sys_mac from EVPN_ETHERNET_SEGMENT, fall back to PORTCHANNEL system_mac
                             es_sys_mac = entry.get('es_sys_mac', '')
                             if not es_sys_mac:
                                 pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
                                 if pc_entry and 'system_mac' in pc_entry:
                                     es_sys_mac = pc_entry['system_mac']
                             if es_sys_mac:
-                                command += " -c 'evpn mh es-sys-mac {}'".format(es_sys_mac)
+                                command += ['-c', 'evpn mh es-sys-mac {}'.format(es_sys_mac)]
                             es_configured = True
                     if es_configured and df_pref and str(df_pref) != '32767':
-                        command += " -c 'evpn mh es-df-pref {}'".format(df_pref)
+                        command += ['-c', 'evpn mh es-df-pref {}'.format(df_pref)]
                 if not self.__run_command(table, command):
                     syslog.syslog(syslog.LOG_ERR, 'failed running EVPN ethernet segment config command')
                     continue

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -3145,28 +3145,28 @@ class BGPConfigDaemon:
                         command += ['-c', 'evpn mh es-id {}'.format(esi)]
                         es_configured = True
                     elif es_type == 'TYPE_3_MAC_BASED':
-                        if not es_id:
-                            match = re.search(r'[a-zA-Z]+(?P<port_id>[0-9_]+)', ifname)
-                            if match:
-                                port_id = match.group('port_id').replace('_', '')
-                                if port_id:
-                                    es_id = str(int(port_id))
-                        if es_id:
+                        # prefer es_sys_mac from EVPN_ETHERNET_SEGMENT, fall back to PORTCHANNEL system_mac
+                        es_sys_mac = entry.get('es_sys_mac', '')
+                        if not es_sys_mac:
+                            pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
+                            if pc_entry and 'system_mac' in pc_entry:
+                                es_sys_mac = pc_entry['system_mac']
+                        if es_id and es_sys_mac:
                             command += ['-c', 'evpn mh es-id {}'.format(es_id)]
-                            # prefer es_sys_mac from EVPN_ETHERNET_SEGMENT, fall back to PORTCHANNEL system_mac
-                            es_sys_mac = entry.get('es_sys_mac', '')
-                            if not es_sys_mac:
-                                pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
-                                if pc_entry and 'system_mac' in pc_entry:
-                                    es_sys_mac = pc_entry['system_mac']
-                            if es_sys_mac:
-                                command += ['-c', 'evpn mh es-sys-mac {}'.format(es_sys_mac)]
+                            command += ['-c', 'evpn mh es-sys-mac {}'.format(es_sys_mac)]
                             es_configured = True
+                        elif es_id:
+                            syslog.syslog(syslog.LOG_WARNING,
+                                'EVPN ES {}: es_sys_mac not set and no PORTCHANNEL system_mac; '
+                                'Type-3 ES not created (es-id and es-sys-mac both required)'.format(ifname))
                     if es_configured and df_pref and str(df_pref) != '32767':
                         command += ['-c', 'evpn mh es-df-pref {}'.format(df_pref)]
                 if not self.__run_command(table, command):
                     syslog.syslog(syslog.LOG_ERR, 'failed running EVPN ethernet segment config command')
                     continue
+                # Mark all row attributes applied to keep the cache in sync.
+                for _, dval in data.items():
+                    dval.status = CachedDataWithOp.STAT_SUCC
             elif table == 'ROUTE_MAP':
                 map_name = prefix
                 seq_no = key

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -3120,53 +3120,83 @@ class BGPConfigDaemon:
                 else:
                     data['route-target-type'].status = CachedDataWithOp.STAT_SUCC
             elif table == 'EVPN_MH_GLOBAL':
-                # Global EVPN MH timers (zebra); key-map handles add/'no' per field.
                 cmd_prefix = ['configure terminal']
                 if not key_map.run_command(self, table, data, cmd_prefix):
                     syslog.syslog(syslog.LOG_ERR, 'failed running EVPN MH global config command')
                     continue
             elif table == 'EVPN_ETHERNET_SEGMENT':
-                # Per-interface EVPN MH config (mgmtd): clear then re-apply the
-                # full ConfigDB row, since Type-0/Type-3 logic needs the whole entry.
                 ifname = prefix
                 intf_cmd = 'interface {}'.format(ifname)
-                command = ['vtysh', '-c', 'configure terminal', '-c', intf_cmd,
-                           '-c', 'no evpn mh es-sys-mac',
-                           '-c', 'no evpn mh es-df-pref',
-                           '-c', 'no evpn mh es-id']
                 entry = {} if del_table else self.config_db.get_entry('EVPN_ETHERNET_SEGMENT', ifname)
-                if entry:
-                    es_type = entry.get('type', '')
-                    esi     = entry.get('esi', '')
-                    es_id   = entry.get('es_id', '')
-                    df_pref = entry.get('df_pref', '')
-                    es_configured = False
-                    if es_type == 'TYPE_0_OPERATOR_CONFIGURED' and esi and esi != 'AUTO':
-                        command += ['-c', 'evpn mh es-id {}'.format(esi)]
-                        es_configured = True
-                    elif es_type == 'TYPE_3_MAC_BASED':
-                        # prefer es_sys_mac from EVPN_ETHERNET_SEGMENT, fall back to PORTCHANNEL system_mac
-                        es_sys_mac = entry.get('es_sys_mac', '')
-                        if not es_sys_mac:
-                            pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
-                            if pc_entry and 'system_mac' in pc_entry:
-                                es_sys_mac = pc_entry['system_mac']
-                        if es_id and es_sys_mac:
-                            command += ['-c', 'evpn mh es-id {}'.format(es_id)]
+
+                # Tear the ES down only when its identity changed; a df_pref-only update must not.
+                changed = set(f for f, dval in data.items()
+                              if isinstance(dval, CachedDataWithOp) and dval.op != CachedDataWithOp.OP_NONE)
+                identity_changed = del_table or bool(changed - {'df_pref'})
+
+                es_type = entry.get('type', '')
+                esi     = entry.get('esi', '')
+                es_id   = ''
+                es_sys_mac = ''
+                if es_type == 'TYPE_0_OPERATOR_CONFIGURED' and esi and esi != 'AUTO':
+                    es_id = esi
+                elif es_type == 'TYPE_3_MAC_BASED':
+                    es_id = entry.get('es_id', '')
+                    if not es_id:
+                        m = re.search(r'(\d+)$', ifname)
+                        if m and 1 <= int(m.group(1)) <= 16777215:
+                            es_id = str(int(m.group(1)))
+                    es_sys_mac = entry.get('es_sys_mac', '')
+                    if not es_sys_mac:
+                        pc_entry = self.config_db.get_entry('PORTCHANNEL', ifname)
+                        if pc_entry and 'system_mac' in pc_entry:
+                            es_sys_mac = pc_entry['system_mac']
+
+                if es_type == 'TYPE_3_MAC_BASED':
+                    es_valid = bool(es_id) and bool(es_sys_mac)
+                else:
+                    es_valid = bool(es_id)
+
+                command = ['vtysh', '-c', 'configure terminal', '-c', intf_cmd]
+                emitted = False
+                es_applied = False
+                if identity_changed:
+                    command += ['-c', 'no evpn mh es-sys-mac',
+                                '-c', 'no evpn mh es-df-pref',
+                                '-c', 'no evpn mh es-id']
+                    emitted = True
+                    if es_valid:
+                        command += ['-c', 'evpn mh es-id {}'.format(es_id)]
+                        if es_sys_mac:
                             command += ['-c', 'evpn mh es-sys-mac {}'.format(es_sys_mac)]
-                            es_configured = True
-                        elif es_id:
-                            syslog.syslog(syslog.LOG_WARNING,
-                                'EVPN ES {}: es_sys_mac not set and no PORTCHANNEL system_mac; '
-                                'Type-3 ES not created (es-id and es-sys-mac both required)'.format(ifname))
-                    if es_configured and df_pref and str(df_pref) != '32767':
+                        es_applied = True
+                    elif es_type == 'TYPE_3_MAC_BASED':
+                        syslog.syslog(syslog.LOG_WARNING,
+                            'EVPN ES {}: Type-3 ES not created; es-id ({}) and es-sys-mac ({}) '
+                            'both required (set PORTCHANNEL.system_mac and es_id, or use a '
+                            'numbered interface)'.format(ifname, es_id or 'unset', es_sys_mac or 'unset'))
+
+                # DF preference applied as a delta so a df_pref-only change is non-disruptive.
+                df_pref = entry.get('df_pref', '')
+                if es_valid and (identity_changed or 'df_pref' in changed):
+                    if df_pref and str(df_pref) != '32767':
                         command += ['-c', 'evpn mh es-df-pref {}'.format(df_pref)]
+                    elif not identity_changed:
+                        command += ['-c', 'no evpn mh es-df-pref']
+                    emitted = True
+                    es_applied = True
+
+                if not emitted:
+                    continue
                 if not self.__run_command(table, command):
                     syslog.syslog(syslog.LOG_ERR, 'failed running EVPN ethernet segment config command')
                     continue
-                # Mark all row attributes applied to keep the cache in sync.
-                for _, dval in data.items():
-                    dval.status = CachedDataWithOp.STAT_SUCC
+                # Mark applied only when the ES was programmed; a skipped Type-3 stays pending.
+                if del_table or es_applied:
+                    for _, dval in data.items():
+                        if isinstance(dval, CachedDataWithOp):
+                            dval.status = CachedDataWithOp.STAT_SUCC
+
             elif table == 'ROUTE_MAP':
                 map_name = prefix
                 seq_no = key

--- a/src/sonic-frr-mgmt-framework/setup.py
+++ b/src/sonic-frr-mgmt-framework/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
                                      'templates/staticd/staticd.conf.j2',
                                      'templates/staticd/staticd.db.conf.j2',
                                      'templates/staticd/staticd.db.default_route.conf.j2',
-                                     'templates/frr/frr.conf.j2'])
+                                     'templates/frr/frr.conf.j2',
+                                     'templates/frr/frr.conf.evpn_mh.j2'])
     ]
 )

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
@@ -5,8 +5,9 @@
 ! - EVPN_ETHERNET_SEGMENT: per-interface Ethernet Segment (es-id/es-sys-mac/es-df-pref)
 !
 {# ------------------------- EVPN MH global timers ------------------------------------- #}
-{% if EVPN_MH_GLOBAL is defined and EVPN_MH_GLOBAL|length > 0 %}
-{% for mh_key, mh_val in EVPN_MH_GLOBAL.items() %}
+{# EVPN_MH_GLOBAL is a singleton keyed by 'default'; render only that row. #}
+{% if EVPN_MH_GLOBAL is defined and 'default' in EVPN_MH_GLOBAL %}
+{% set mh_val = EVPN_MH_GLOBAL['default'] %}
 {% if 'startup_delay' in mh_val %}
 evpn mh startup-delay {{ mh_val['startup_delay'] }}
 {% endif %}
@@ -16,7 +17,6 @@ evpn mh mac-holdtime {{ mh_val['mac_holdtime'] }}
 {% if 'neigh_holdtime' in mh_val %}
 evpn mh neigh-holdtime {{ mh_val['neigh_holdtime'] }}
 {% endif %}
-{% endfor %}
 {% endif %}
 {# ------------------------- EVPN MH per-interface Ethernet Segment -------------------- #}
 {% if EVPN_ETHERNET_SEGMENT is defined and EVPN_ETHERNET_SEGMENT|length > 0 %}
@@ -25,24 +25,14 @@ evpn mh neigh-holdtime {{ mh_val['neigh_holdtime'] }}
 {% if es_val.get('type', '') == 'TYPE_0_OPERATOR_CONFIGURED' and es_val.get('esi', '') and es_val['esi'] != 'AUTO' %}
 {% set ns.es_id = es_val['esi'] %}
 {% set ns.configured = true %}
-{% elif es_val.get('type', '') == 'TYPE_3_MAC_BASED' %}
-{% set ns.es_id = es_val.get('es_id', '') %}
-{% if not ns.es_id %}
-{% set digits = namespace(val='') %}
-{% for ch in ifname %}
-{% if ch in '0123456789' %}
-{% set digits.val = digits.val ~ ch %}
-{% endif %}
-{% endfor %}
-{% if digits.val %}
-{% set ns.es_id = digits.val | int | string %}
-{% endif %}
-{% endif %}
-{% if ns.es_id %}
+{% elif es_val.get('type', '') == 'TYPE_3_MAC_BASED' and es_val.get('es_id', '') %}
+{% set ns.es_id = es_val['es_id'] %}
 {% set ns.sys_mac = es_val.get('es_sys_mac', '') %}
 {% if not ns.sys_mac and PORTCHANNEL is defined and ifname in PORTCHANNEL and 'system_mac' in PORTCHANNEL[ifname] %}
 {% set ns.sys_mac = PORTCHANNEL[ifname]['system_mac'] %}
 {% endif %}
+{# FRR creates the local ES only when both es-id and es-sys-mac are set. #}
+{% if ns.sys_mac %}
 {% set ns.configured = true %}
 {% endif %}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
@@ -1,0 +1,61 @@
+! template: frr/frr.conf.evpn_mh.j2
+!
+! EVPN Multihoming (MH) configuration using config DB tables
+! - EVPN_MH_GLOBAL:        global MH timers (zebra, top-level)
+! - EVPN_ETHERNET_SEGMENT: per-interface Ethernet Segment (es-id/es-sys-mac/es-df-pref)
+!
+{# ------------------------- EVPN MH global timers ------------------------------------- #}
+{% if EVPN_MH_GLOBAL is defined and EVPN_MH_GLOBAL|length > 0 %}
+{% for mh_key, mh_val in EVPN_MH_GLOBAL.items() %}
+{% if 'startup_delay' in mh_val %}
+evpn mh startup-delay {{ mh_val['startup_delay'] }}
+{% endif %}
+{% if 'mac_holdtime' in mh_val %}
+evpn mh mac-holdtime {{ mh_val['mac_holdtime'] }}
+{% endif %}
+{% if 'neigh_holdtime' in mh_val %}
+evpn mh neigh-holdtime {{ mh_val['neigh_holdtime'] }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{# ------------------------- EVPN MH per-interface Ethernet Segment -------------------- #}
+{% if EVPN_ETHERNET_SEGMENT is defined and EVPN_ETHERNET_SEGMENT|length > 0 %}
+{% for ifname, es_val in EVPN_ETHERNET_SEGMENT.items() %}
+{% set ns = namespace(configured=false, sys_mac='', es_id='') %}
+{% if es_val.get('type', '') == 'TYPE_0_OPERATOR_CONFIGURED' and es_val.get('esi', '') and es_val['esi'] != 'AUTO' %}
+{% set ns.es_id = es_val['esi'] %}
+{% set ns.configured = true %}
+{% elif es_val.get('type', '') == 'TYPE_3_MAC_BASED' %}
+{% set ns.es_id = es_val.get('es_id', '') %}
+{% if not ns.es_id %}
+{% set digits = namespace(val='') %}
+{% for ch in ifname %}
+{% if ch in '0123456789' %}
+{% set digits.val = digits.val ~ ch %}
+{% endif %}
+{% endfor %}
+{% if digits.val %}
+{% set ns.es_id = digits.val | int | string %}
+{% endif %}
+{% endif %}
+{% if ns.es_id %}
+{% set ns.sys_mac = es_val.get('es_sys_mac', '') %}
+{% if not ns.sys_mac and PORTCHANNEL is defined and ifname in PORTCHANNEL and 'system_mac' in PORTCHANNEL[ifname] %}
+{% set ns.sys_mac = PORTCHANNEL[ifname]['system_mac'] %}
+{% endif %}
+{% set ns.configured = true %}
+{% endif %}
+{% endif %}
+{% if ns.configured %}
+interface {{ ifname }}
+ evpn mh es-id {{ ns.es_id }}
+{% if ns.sys_mac %}
+ evpn mh es-sys-mac {{ ns.sys_mac }}
+{% endif %}
+{% if es_val.get('df_pref', '') and es_val['df_pref']|string != '32767' %}
+ evpn mh es-df-pref {{ es_val['df_pref'] }}
+{% endif %}
+!
+{% endif %}
+{% endfor %}
+{% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.evpn_mh.j2
@@ -21,18 +21,34 @@ evpn mh neigh-holdtime {{ mh_val['neigh_holdtime'] }}
 {# ------------------------- EVPN MH per-interface Ethernet Segment -------------------- #}
 {% if EVPN_ETHERNET_SEGMENT is defined and EVPN_ETHERNET_SEGMENT|length > 0 %}
 {% for ifname, es_val in EVPN_ETHERNET_SEGMENT.items() %}
-{% set ns = namespace(configured=false, sys_mac='', es_id='') %}
+{% set ns = namespace(configured=false, sys_mac='', es_id='', digits='') %}
 {% if es_val.get('type', '') == 'TYPE_0_OPERATOR_CONFIGURED' and es_val.get('esi', '') and es_val['esi'] != 'AUTO' %}
 {% set ns.es_id = es_val['esi'] %}
 {% set ns.configured = true %}
-{% elif es_val.get('type', '') == 'TYPE_3_MAC_BASED' and es_val.get('es_id', '') %}
+{% elif es_val.get('type', '') == 'TYPE_3_MAC_BASED' %}
+{# es-id: explicit es_id if set, else derived from the trailing interface number. #}
+{% if es_val.get('es_id', '') %}
 {% set ns.es_id = es_val['es_id'] %}
-{% set ns.sys_mac = es_val.get('es_sys_mac', '') %}
-{% if not ns.sys_mac and PORTCHANNEL is defined and ifname in PORTCHANNEL and 'system_mac' in PORTCHANNEL[ifname] %}
+{% else %}
+{% for ch in ifname %}
+{% if ch in '0123456789' %}
+{% set ns.digits = ns.digits ~ ch %}
+{% else %}
+{% set ns.digits = '' %}
+{% endif %}
+{% endfor %}
+{% if ns.digits and (ns.digits | int) >= 1 and (ns.digits | int) <= 16777215 %}
+{% set ns.es_id = ns.digits | int %}
+{% endif %}
+{% endif %}
+{# es-sys-mac: explicit es_sys_mac if set, else the PortChannel's system_mac. #}
+{% if es_val.get('es_sys_mac', '') %}
+{% set ns.sys_mac = es_val['es_sys_mac'] %}
+{% elif PORTCHANNEL is defined and ifname in PORTCHANNEL and 'system_mac' in PORTCHANNEL[ifname] %}
 {% set ns.sys_mac = PORTCHANNEL[ifname]['system_mac'] %}
 {% endif %}
 {# FRR creates the local ES only when both es-id and es-sys-mac are set. #}
-{% if ns.sys_mac %}
+{% if ns.es_id and ns.sys_mac %}
 {% set ns.configured = true %}
 {% endif %}
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -40,3 +40,5 @@ fpm address 127.0.0.1
 !
 {% include "bfdd.conf.j2" %}
 !
+{% include "frr.conf.evpn_mh.j2" %}
+!

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -222,6 +222,17 @@ neighbor_shutdown_data = [
                   conf_bgp_cmd('default', 100) + ['{}no neighbor 10.1.1.5 shutdown'])
 ]
 
+# EVPN MH global timer configuration (EVPN_MH_GLOBAL). This handler is key-map
+# driven, so it follows the same add/delete pattern as the BGP globals tests.
+evpn_mh_global_data = [
+    CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'startup_delay': '30'},
+                   [conf_cmd, '{}evpn mh startup-delay 30']),
+    CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'mac_holdtime': '1080'},
+                   [conf_cmd, '{}evpn mh mac-holdtime 1080']),
+    CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'neigh_holdtime': '1080'},
+                   [conf_cmd, '{}evpn mh neigh-holdtime 1080']),
+]
+
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
 def data_set_del_test(test_data, run_cmd, skip_del=False):
@@ -307,3 +318,76 @@ def test_bgp_neighbor_description_injection(run_cmd):
         if any('description' in arg for arg in cmd):
             assert any(injection_payload in arg for arg in cmd), \
                 "injection payload not found as literal arg: {}".format(cmd)
+
+def test_evpn_mh_global():
+    data_set_del_test(evpn_mh_global_data)
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_evpn_ethernet_segment(run_cmd):
+    from frrcfgd.frrcfgd import BGPConfigDaemon
+    daemon = BGPConfigDaemon()
+    hdlr = [h for t, h in daemon.table_handler_list if t == 'EVPN_ETHERNET_SEGMENT']
+    assert(len(hdlr) == 1)
+    hdlr = hdlr[0]
+
+    # Every config of an ethernet segment first clears the previous es-* settings,
+    # then re-applies the row read back from ConfigDB.
+    es_clear = ("vtysh -c 'configure terminal' -c 'interface {}'"
+                " -c 'no evpn mh es-sys-mac'"
+                " -c 'no evpn mh es-df-pref'"
+                " -c 'no evpn mh es-id'")
+
+    def set_entries(es_entry, pc_entry=None):
+        def _get_entry(table, key):
+            if table == 'EVPN_ETHERNET_SEGMENT':
+                return es_entry
+            if table == 'PORTCHANNEL':
+                return pc_entry if pc_entry is not None else {}
+            return {}
+        daemon.config_db.get_entry = MagicMock(side_effect=_get_entry)
+
+    # Type-0 operator-configured ESI: the full ESI is applied directly via es-id,
+    # and the default df_pref (32767) is not programmed.
+    set_entries({'type': 'TYPE_0_OPERATOR_CONFIGURED',
+                 'esi': '00:01:02:03:04:05:06:07:08:AA',
+                 'df_pref': '32767'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet10',
+         {'type': 'TYPE_0_OPERATOR_CONFIGURED',
+          'esi': '00:01:02:03:04:05:06:07:08:AA',
+          'df_pref': '32767'})
+    expected = es_clear.format('Ethernet10') + " -c 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA'"
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Type-3 MAC-based with explicit es_id and es_sys_mac plus a non-default df_pref.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
+                 'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet10',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
+          'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
+    expected = (es_clear.format('Ethernet10')
+                + " -c 'evpn mh es-id 10'"
+                + " -c 'evpn mh es-sys-mac 00:11:22:33:44:55'"
+                + " -c 'evpn mh es-df-pref 12345'")
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Type-3 MAC-based with es_id derived from the interface name and es_sys_mac
+    # taken from the PORTCHANNEL system_mac fallback.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'},
+                pc_entry={'system_mac': '44:38:39:ff:ff:01'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
+    expected = (es_clear.format('PortChannel001')
+                + " -c 'evpn mh es-id 1'"
+                + " -c 'evpn mh es-sys-mac 44:38:39:ff:ff:01'"
+                + " -c 'evpn mh es-df-pref 50000'")
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Delete: only the clearing commands are issued and ConfigDB is not queried.
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001', None)
+    expected = es_clear.format('PortChannel001')
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -331,8 +331,7 @@ def test_evpn_ethernet_segment(run_cmd):
     assert(len(hdlr) == 1)
     hdlr = hdlr[0]
 
-    # Every config of an ethernet segment first clears the previous es-* settings,
-    # then re-applies the row read back from ConfigDB.
+    # Each config clears the previous es-* settings, then re-applies the ConfigDB row.
     def es_clear(ifname):
         return ['vtysh', '-c', 'configure terminal', '-c', 'interface {}'.format(ifname),
                 '-c', 'no evpn mh es-sys-mac',
@@ -348,8 +347,7 @@ def test_evpn_ethernet_segment(run_cmd):
             return {}
         daemon.config_db.get_entry = MagicMock(side_effect=_get_entry)
 
-    # Type-0 operator-configured ESI: the full ESI is applied directly via es-id,
-    # and the default df_pref (32767) is not programmed.
+    # Type-0: full ESI via es-id; default df_pref (32767) not programmed.
     set_entries({'type': 'TYPE_0_OPERATOR_CONFIGURED',
                  'esi': '00:01:02:03:04:05:06:07:08:AA',
                  'df_pref': '32767'})
@@ -361,7 +359,7 @@ def test_evpn_ethernet_segment(run_cmd):
     expected = es_clear('Ethernet10') + ['-c', 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA']
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Type-3 MAC-based with explicit es_id and es_sys_mac plus a non-default df_pref.
+    # Type-3: explicit es_id + es_sys_mac + non-default df_pref.
     set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
                  'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
     run_cmd.reset_mock()
@@ -374,21 +372,103 @@ def test_evpn_ethernet_segment(run_cmd):
                 + ['-c', 'evpn mh es-df-pref 12345'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Type-3 MAC-based with es_id derived from the interface name and es_sys_mac
-    # taken from the PORTCHANNEL system_mac fallback.
-    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'},
+    # Type-3: es_sys_mac taken from PORTCHANNEL system_mac fallback.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '1', 'df_pref': '50000'},
                 pc_entry={'system_mac': '44:38:39:ff:ff:01'})
     run_cmd.reset_mock()
     hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001',
-         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '1', 'df_pref': '50000'})
     expected = (es_clear('PortChannel001')
                 + ['-c', 'evpn mh es-id 1']
                 + ['-c', 'evpn mh es-sys-mac 44:38:39:ff:ff:01']
                 + ['-c', 'evpn mh es-df-pref 50000'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Delete: only the clearing commands are issued and ConfigDB is not queried.
+    # Type-3 without es_id: not derived from interface name, only clears are issued.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet0',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
+    expected = es_clear('Ethernet0')
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Type-3 with es_id but no es_sys_mac (and no PORTCHANNEL fallback): FRR needs
+    # both, so only clears are issued and a warning is logged.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '5', 'df_pref': '50000'})
+    run_cmd.reset_mock()
+    with patch('frrcfgd.frrcfgd.syslog') as mock_syslog:
+        mock_syslog.LOG_WARNING = 4
+        hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet40',
+             {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '5', 'df_pref': '50000'})
+        warned = any(call.args and call.args[0] == mock_syslog.LOG_WARNING
+                     and 'es_sys_mac' in call.args[1]
+                     for call in mock_syslog.syslog.call_args_list)
+        assert warned, 'expected a warning when es_sys_mac is missing for Type-3 ES'
+    expected = es_clear('Ethernet40')
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Delete: only clears are issued and ConfigDB is not queried.
     run_cmd.reset_mock()
     hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001', None)
     expected = es_clear('PortChannel001')
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+
+def test_evpn_mh_template():
+    """Render frr.conf.evpn_mh.j2 and confirm it matches the frrcfgd handler:
+    explicit es_id only (no interface-name derivation), default df_pref omitted,
+    and es_sys_mac PORTCHANNEL fallback."""
+    import os
+    from jinja2 import Environment, FileSystemLoader
+    tmpl_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                            'templates', 'frr')
+    env = Environment(loader=FileSystemLoader(tmpl_dir), trim_blocks=True, lstrip_blocks=True)
+    tmpl = env.get_template('frr.conf.evpn_mh.j2')
+
+    ctx = {
+        'EVPN_MH_GLOBAL': {'default': {'startup_delay': '30',
+                                       'mac_holdtime': '1080',
+                                       'neigh_holdtime': '1080'},
+                           'bogus': {'startup_delay': '99'}},
+        'EVPN_ETHERNET_SEGMENT': {
+            'Ethernet10': {'type': 'TYPE_0_OPERATOR_CONFIGURED',
+                           'esi': '00:01:02:03:04:05:06:07:08:AA', 'df_pref': '32767'},
+            'Ethernet20': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10',
+                           'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'},
+            'PortChannel001': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
+                               'es_id': '1', 'df_pref': '50000'},
+            'Ethernet30': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
+                           'es_id': '30'},  # es_id but no es_sys_mac -> skipped
+            'Ethernet0': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO'},  # no es_id -> skipped
+        },
+        'PORTCHANNEL': {'PortChannel001': {'system_mac': '44:38:39:ff:ff:01'}},
+    }
+    out = tmpl.render(**ctx)
+    lines = [l.strip() for l in out.splitlines() if l.strip()]
+
+    # Global MH timers: only the 'default' row is rendered (singleton).
+    assert 'evpn mh startup-delay 30' in lines
+    assert 'evpn mh mac-holdtime 1080' in lines
+    assert 'evpn mh neigh-holdtime 1080' in lines
+    assert 'evpn mh startup-delay 99' not in out
+
+    # Type-0: full ESI via es-id; default df_pref (32767) is omitted.
+    assert 'interface Ethernet10' in out
+    assert 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA' in lines
+    assert 'evpn mh es-df-pref 32767' not in out
+
+    # Type-3 explicit es_id + es_sys_mac + non-default df_pref.
+    assert 'interface Ethernet20' in out
+    assert 'evpn mh es-id 10' in lines
+    assert 'evpn mh es-sys-mac 00:11:22:33:44:55' in lines
+    assert 'evpn mh es-df-pref 12345' in lines
+
+    # Type-3 es_sys_mac taken from PORTCHANNEL system_mac fallback.
+    assert 'interface PortChannel001' in out
+    assert 'evpn mh es-sys-mac 44:38:39:ff:ff:01' in lines
+
+    # Type-3 with es_id but no es_sys_mac: FRR needs both, so nothing is emitted.
+    assert 'interface Ethernet30' not in out
+
+    # Type-3 without es_id: not derived from interface name, nothing emitted.
+    assert 'interface Ethernet0' not in out

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -226,11 +226,11 @@ neighbor_shutdown_data = [
 # driven, so it follows the same add/delete pattern as the BGP globals tests.
 evpn_mh_global_data = [
     CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'startup_delay': '30'},
-                   [conf_cmd, '{}evpn mh startup-delay 30']),
+                  [conf_cmd, '{}evpn mh startup-delay 30']),
     CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'mac_holdtime': '1080'},
-                   [conf_cmd, '{}evpn mh mac-holdtime 1080']),
+                  [conf_cmd, '{}evpn mh mac-holdtime 1080']),
     CmdMapTestInfo('EVPN_MH_GLOBAL', 'default', {'neigh_holdtime': '1080'},
-                   [conf_cmd, '{}evpn mh neigh-holdtime 1080']),
+                  [conf_cmd, '{}evpn mh neigh-holdtime 1080']),
 ]
 
 @patch.dict('sys.modules', **mockmapping)
@@ -333,10 +333,11 @@ def test_evpn_ethernet_segment(run_cmd):
 
     # Every config of an ethernet segment first clears the previous es-* settings,
     # then re-applies the row read back from ConfigDB.
-    es_clear = ("vtysh -c 'configure terminal' -c 'interface {}'"
-                " -c 'no evpn mh es-sys-mac'"
-                " -c 'no evpn mh es-df-pref'"
-                " -c 'no evpn mh es-id'")
+    def es_clear(ifname):
+        return ['vtysh', '-c', 'configure terminal', '-c', 'interface {}'.format(ifname),
+                '-c', 'no evpn mh es-sys-mac',
+                '-c', 'no evpn mh es-df-pref',
+                '-c', 'no evpn mh es-id']
 
     def set_entries(es_entry, pc_entry=None):
         def _get_entry(table, key):
@@ -357,7 +358,7 @@ def test_evpn_ethernet_segment(run_cmd):
          {'type': 'TYPE_0_OPERATOR_CONFIGURED',
           'esi': '00:01:02:03:04:05:06:07:08:AA',
           'df_pref': '32767'})
-    expected = es_clear.format('Ethernet10') + " -c 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA'"
+    expected = es_clear('Ethernet10') + ['-c', 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA']
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
     # Type-3 MAC-based with explicit es_id and es_sys_mac plus a non-default df_pref.
@@ -367,10 +368,10 @@ def test_evpn_ethernet_segment(run_cmd):
     hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet10',
          {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
           'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
-    expected = (es_clear.format('Ethernet10')
-                + " -c 'evpn mh es-id 10'"
-                + " -c 'evpn mh es-sys-mac 00:11:22:33:44:55'"
-                + " -c 'evpn mh es-df-pref 12345'")
+    expected = (es_clear('Ethernet10')
+                + ['-c', 'evpn mh es-id 10']
+                + ['-c', 'evpn mh es-sys-mac 00:11:22:33:44:55']
+                + ['-c', 'evpn mh es-df-pref 12345'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
     # Type-3 MAC-based with es_id derived from the interface name and es_sys_mac
@@ -380,14 +381,14 @@ def test_evpn_ethernet_segment(run_cmd):
     run_cmd.reset_mock()
     hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001',
          {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
-    expected = (es_clear.format('PortChannel001')
-                + " -c 'evpn mh es-id 1'"
-                + " -c 'evpn mh es-sys-mac 44:38:39:ff:ff:01'"
-                + " -c 'evpn mh es-df-pref 50000'")
+    expected = (es_clear('PortChannel001')
+                + ['-c', 'evpn mh es-id 1']
+                + ['-c', 'evpn mh es-sys-mac 44:38:39:ff:ff:01']
+                + ['-c', 'evpn mh es-df-pref 50000'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
     # Delete: only the clearing commands are issued and ConfigDB is not queried.
     run_cmd.reset_mock()
     hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001', None)
-    expected = es_clear.format('PortChannel001')
+    expected = es_clear('PortChannel001')
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -359,41 +359,43 @@ def test_evpn_ethernet_segment(run_cmd):
     expected = es_clear('Ethernet10') + ['-c', 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA']
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Type-3: explicit es_id + es_sys_mac + non-default df_pref.
-    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
-                 'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
+    # Type-3 with explicit es_id; es-sys-mac from PORTCHANNEL; non-default df_pref.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '12345'},
+                pc_entry={'system_mac': '00:11:22:33:44:55'})
     run_cmd.reset_mock()
-    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet10',
-         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
-          'es_id': '10', 'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'})
-    expected = (es_clear('Ethernet10')
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel0002',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '12345'})
+    expected = (es_clear('PortChannel0002')
                 + ['-c', 'evpn mh es-id 10']
                 + ['-c', 'evpn mh es-sys-mac 00:11:22:33:44:55']
                 + ['-c', 'evpn mh es-df-pref 12345'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Type-3: es_sys_mac taken from PORTCHANNEL system_mac fallback.
-    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '1', 'df_pref': '50000'},
+    # Type-3 with explicit es_id + explicit es_sys_mac in the row (no PORTCHANNEL needed).
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '7',
+                 'es_sys_mac': '00:aa:bb:cc:dd:ee'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet20',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '7',
+          'es_sys_mac': '00:aa:bb:cc:dd:ee'})
+    expected = (es_clear('Ethernet20')
+                + ['-c', 'evpn mh es-id 7']
+                + ['-c', 'evpn mh es-sys-mac 00:aa:bb:cc:dd:ee'])
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # Type-3 without es_id: es-id derived from the PortChannel number; mac from PORTCHANNEL.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'},
                 pc_entry={'system_mac': '44:38:39:ff:ff:01'})
     run_cmd.reset_mock()
-    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001',
-         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '1', 'df_pref': '50000'})
-    expected = (es_clear('PortChannel001')
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel0001',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
+    expected = (es_clear('PortChannel0001')
                 + ['-c', 'evpn mh es-id 1']
                 + ['-c', 'evpn mh es-sys-mac 44:38:39:ff:ff:01']
                 + ['-c', 'evpn mh es-df-pref 50000'])
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
-    # Type-3 without es_id: not derived from interface name, only clears are issued.
-    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
-    run_cmd.reset_mock()
-    hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet0',
-         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'df_pref': '50000'})
-    expected = es_clear('Ethernet0')
-    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
-
-    # Type-3 with es_id but no es_sys_mac (and no PORTCHANNEL fallback): FRR needs
-    # both, so only clears are issued and a warning is logged.
+    # Type-3 with es_id but no PORTCHANNEL system_mac: FRR needs both, only clears + warning.
     set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '5', 'df_pref': '50000'})
     run_cmd.reset_mock()
     with patch('frrcfgd.frrcfgd.syslog') as mock_syslog:
@@ -401,23 +403,37 @@ def test_evpn_ethernet_segment(run_cmd):
         hdlr('EVPN_ETHERNET_SEGMENT', 'Ethernet40',
              {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '5', 'df_pref': '50000'})
         warned = any(call.args and call.args[0] == mock_syslog.LOG_WARNING
-                     and 'es_sys_mac' in call.args[1]
+                     and 'es-sys-mac' in call.args[1]
                      for call in mock_syslog.syslog.call_args_list)
-        assert warned, 'expected a warning when es_sys_mac is missing for Type-3 ES'
+        assert warned, 'expected a warning when es-sys-mac is missing for Type-3 ES'
     expected = es_clear('Ethernet40')
+    run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
+
+    # df_pref-only update on a valid Type-3 ES: no teardown, only es-df-pref re-applied.
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '12345'},
+                pc_entry={'system_mac': '00:11:22:33:44:55'})
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel0009',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '12345'})
+    set_entries({'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '20000'},
+                pc_entry={'system_mac': '00:11:22:33:44:55'})
+    run_cmd.reset_mock()
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel0009',
+         {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10', 'df_pref': '20000'})
+    expected = ['vtysh', '-c', 'configure terminal', '-c', 'interface PortChannel0009',
+                '-c', 'evpn mh es-df-pref 20000']
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
     # Delete: only clears are issued and ConfigDB is not queried.
     run_cmd.reset_mock()
-    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel001', None)
-    expected = es_clear('PortChannel001')
+    hdlr('EVPN_ETHERNET_SEGMENT', 'PortChannel0009', None)
+    expected = es_clear('PortChannel0009')
     run_cmd.assert_called_with('EVPN_ETHERNET_SEGMENT', expected, True, None)
 
 
 def test_evpn_mh_template():
     """Render frr.conf.evpn_mh.j2 and confirm it matches the frrcfgd handler:
-    explicit es_id only (no interface-name derivation), default df_pref omitted,
-    and es_sys_mac PORTCHANNEL fallback."""
+    Type-3 es-id is explicit es_id or derived from the interface number, es-sys-mac
+    comes from PORTCHANNEL.system_mac, and default df_pref is omitted."""
     import os
     from jinja2 import Environment, FileSystemLoader
     tmpl_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
@@ -433,15 +449,18 @@ def test_evpn_mh_template():
         'EVPN_ETHERNET_SEGMENT': {
             'Ethernet10': {'type': 'TYPE_0_OPERATOR_CONFIGURED',
                            'esi': '00:01:02:03:04:05:06:07:08:AA', 'df_pref': '32767'},
-            'Ethernet20': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10',
-                           'es_sys_mac': '00:11:22:33:44:55', 'df_pref': '12345'},
-            'PortChannel001': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
-                               'es_id': '1', 'df_pref': '50000'},
+            'PortChannel0002': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '10',
+                                'df_pref': '12345'},
+            'PortChannel0001': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
+                                'df_pref': '50000'},  # es_id derived from PortChannel number
+            'Ethernet25': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO', 'es_id': '7',
+                           'es_sys_mac': '00:aa:bb:cc:dd:ee'},  # explicit es_sys_mac, no PORTCHANNEL
             'Ethernet30': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO',
-                           'es_id': '30'},  # es_id but no es_sys_mac -> skipped
-            'Ethernet0': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO'},  # no es_id -> skipped
+                           'es_id': '30'},  # es_id but no system_mac -> skipped
+            'Ethernet0': {'type': 'TYPE_3_MAC_BASED', 'esi': 'AUTO'},  # derived es-id 0 + no mac -> skipped
         },
-        'PORTCHANNEL': {'PortChannel001': {'system_mac': '44:38:39:ff:ff:01'}},
+        'PORTCHANNEL': {'PortChannel0001': {'system_mac': '44:38:39:ff:ff:01'},
+                        'PortChannel0002': {'system_mac': '00:11:22:33:44:55'}},
     }
     out = tmpl.render(**ctx)
     lines = [l.strip() for l in out.splitlines() if l.strip()]
@@ -457,18 +476,26 @@ def test_evpn_mh_template():
     assert 'evpn mh es-id 00:01:02:03:04:05:06:07:08:AA' in lines
     assert 'evpn mh es-df-pref 32767' not in out
 
-    # Type-3 explicit es_id + es_sys_mac + non-default df_pref.
-    assert 'interface Ethernet20' in out
+    # Type-3 explicit es_id + es-sys-mac from PORTCHANNEL + non-default df_pref.
+    assert 'interface PortChannel0002' in out
     assert 'evpn mh es-id 10' in lines
     assert 'evpn mh es-sys-mac 00:11:22:33:44:55' in lines
     assert 'evpn mh es-df-pref 12345' in lines
 
-    # Type-3 es_sys_mac taken from PORTCHANNEL system_mac fallback.
-    assert 'interface PortChannel001' in out
+    # Type-3 with derived es-id (from PortChannel number) + es-sys-mac from PORTCHANNEL.
+    assert 'interface PortChannel0001' in out
+    assert 'evpn mh es-id 1' in lines
     assert 'evpn mh es-sys-mac 44:38:39:ff:ff:01' in lines
+    assert 'evpn mh es-df-pref 50000' in lines
 
-    # Type-3 with es_id but no es_sys_mac: FRR needs both, so nothing is emitted.
+    # Type-3 with explicit es_sys_mac in the row (no PORTCHANNEL needed).
+    assert 'interface Ethernet25' in out
+    assert 'evpn mh es-id 7' in lines
+    assert 'evpn mh es-sys-mac 00:aa:bb:cc:dd:ee' in lines
+
+    # Type-3 with es_id but no PORTCHANNEL system_mac: FRR needs both, so nothing is emitted.
     assert 'interface Ethernet30' not in out
 
-    # Type-3 without es_id: not derived from interface name, nothing emitted.
+    # Type-3 with no es_id and a derived es-id of 0 (Ethernet0) + no mac: nothing emitted.
     assert 'interface Ethernet0' not in out
+

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/evpn.json
@@ -40,6 +40,21 @@
     "EVPN_MH_VALID_TEST": {
         "desc": "Valid EVPN Ethernet Segment Configuration"
     },
+    "EVPN_ES_TYPE3_EXPLICIT_ESID_VALID": {
+        "desc": "Valid Type 3 ES with explicit es_id and PortChannel system_mac"
+    },
+    "EVPN_INVALID_ES_ID_RANGE": {
+        "desc": "ES ID value out of range 1..16777215",
+        "eStr": "ES ID value out of range"
+    },
+    "EVPN_INVALID_ES_ID_ON_TYPE_0": {
+        "desc": "es_id set on a Type 0 segment is not allowed",
+        "eStr": "es_id is only valid for TYPE_3_MAC_BASED segments"
+    },
+    "EVPN_INVALID_ES_SYS_MAC_ON_TYPE_0": {
+        "desc": "es_sys_mac set on a Type 0 segment is not allowed",
+        "eStr": "es_sys_mac is only valid for TYPE_3_MAC_BASED segments"
+    },
     "EVPN_INVALID_STARTUP_DELAY": {
         "desc": "Global Startup Delay value out of range",
         "eStr": "Startup Delay value out of range"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/evpn.json
@@ -280,6 +280,111 @@
             }
         }
     },
+    "EVPN_ES_TYPE3_EXPLICIT_ESID_VALID": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "name": "PortChannel0001",
+                        "admin_status": "up",
+                        "min_links": "1",
+                        "mtu": "9100",
+                        "mode": "routed",
+                        "system_mac": "00:11:22:33:44:55"
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "PortChannel0001",
+                        "esi": "AUTO",
+                        "type": "TYPE_3_MAC_BASED",
+                        "es_id": 10,
+                        "es_sys_mac": "00:11:22:33:44:55",
+                        "df_pref": 5000
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_ES_ID_RANGE": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "AUTO",
+                        "type": "TYPE_3_MAC_BASED",
+                        "es_id": 16777216
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_ES_ID_ON_TYPE_0": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED",
+                        "es_id": 10
+                    }
+                ]
+            }
+        }
+    },
+    "EVPN_INVALID_ES_SYS_MAC_ON_TYPE_0": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                    {
+                        "name": "Ethernet10",
+                        "lanes": "1,2,3,4",
+                        "speed": 1000
+                    }
+                ]
+            }
+        },
+        "sonic-evpn:sonic-evpn": {
+            "sonic-evpn:EVPN_ETHERNET_SEGMENT": {
+                "EVPN_ETHERNET_SEGMENT_LIST": [
+                    {
+                        "ifname": "Ethernet10",
+                        "esi": "00:01:02:03:04:05:06:07:08:FF",
+                        "type": "TYPE_0_OPERATOR_CONFIGURED",
+                        "es_sys_mac": "00:11:22:33:44:55"
+                    }
+                ]
+            }
+        }
+    },
     "EVPN_INVALID_STARTUP_DELAY": {
         "sonic-evpn:sonic-evpn": {
             "sonic-evpn:EVPN_MH_GLOBAL": {

--- a/src/sonic-yang-models/yang-models/sonic-evpn.yang
+++ b/src/sonic-yang-models/yang-models/sonic-evpn.yang
@@ -12,6 +12,10 @@ module sonic-evpn {
         prefix lag;
     }
 
+    import ietf-yang-types {
+        prefix yang;
+    }
+
     organization
         "SONiC";
 
@@ -87,6 +91,39 @@ module sonic-evpn {
                         }
                     }
                     default 32767;
+                }
+
+                leaf es_id {
+                    description
+                        "Optional explicit local discriminator (3-byte) used to build the Type-3
+                         (MAC-based) ESI, mapped to FRR 'evpn mh es-id'. When unset for a Type-3
+                         segment, it is derived from the interface/PortChannel number. Not used
+                         for Type-0 segments, which carry the full ESI in the 'esi' leaf.";
+                    type uint32 {
+                        range "1..16777215" {
+                            error-message "ES ID value out of range";
+                            error-app-tag es-id-invalid;
+                        }
+                    }
+                }
+
+                leaf es_sys_mac {
+                    description
+                        "Optional explicit system MAC used to build the Type-3 (MAC-based) ESI,
+                         mapped to FRR 'evpn mh es-sys-mac'. When unset for a Type-3 segment, the
+                         PortChannel's system_mac is used. Not used for Type-0 segments.";
+                    type yang:mac-address;
+                }
+
+                /* es_id and es_sys_mac are Type-3 inputs; Type-0 carries the full ESI instead. */
+                must "not(es_id) or type = 'TYPE_3_MAC_BASED'" {
+                    error-message "es_id is only valid for TYPE_3_MAC_BASED segments";
+                    error-app-tag es-id-type-invalid;
+                }
+
+                must "not(es_sys_mac) or type = 'TYPE_3_MAC_BASED'" {
+                    error-message "es_sys_mac is only valid for TYPE_3_MAC_BASED segments";
+                    error-app-tag es-sys-mac-type-invalid;
                 }
 
                 /*


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
SONiC's frrcfgd had no handling for EVPN Multihoming (MH) configuration. This change adds support so that EVPN-MH can be configured through ConfigDB and rendered into FRR:
- EVPN_ETHERNET_SEGMENT – per-interface Ethernet Segment configuration (Type-0 operator-configured ESI and Type-3 MAC-based ESI, with DF preference).
- EVPN_MH_GLOBAL – global EVPN-MH timers (startup-delay, mac-holdtime, neigh-holdtime).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Registered EVPN_ETHERNET_SEGMENT (handled via mgmtd) and EVPN_MH_GLOBAL (handled via zebra) in the daemon table lists and the common BGP table handler.
- Added evpn_mh_global_key_map so each global timer field is added/removed (no-prefixed) individually.
- Added an EVPN_ETHERNET_SEGMENT handler that clears the interface's ES config and re-applies the full ConfigDB row:
  - Type-0: applies the explicit ESI via evpn mh es-id <esi>.
  - Type-3: derives es-id (falling back to the interface port number) and es-sys-mac (falling back to the PORTCHANNEL system_mac), then applies them.
- Applies es-df-pref when set to a non-default value.
- Added unit tests in test_config.py covering the new handlers:
    - test_evpn_mh_global – verifies render/remove of each EVPN_MH_GLOBAL timer (startup_delay, mac_holdtime, neigh_holdtime).
    - test_evpn_ethernet_segment – verifies the Type-0 explicit-ESI path, the Type-3 path with explicit es_id/es_sys_mac, the Type-3 fallback (es_id derived from interface, es_sys_mac from PORTCHANNEL system_mac), and the delete path confirming the no evpn mh ... cleanup.

#### How to verify it
Run the unit tests:
```cd src/sonic-frr-mgmt-framework && python3 -m pytest tests/test_config.py -v ```
- On a device, configure an Ethernet Segment and global MH timers in ConfigDB and confirm the corresponding evpn mh ... commands appear in the FRR running config (vtysh -c 'show running-config').
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
On a device, configure an Ethernet Segment and global MH timers in ConfigDB and confirm the corresponding evpn mh ... commands appear in the FRR running config (vtysh -c 'show running-config').
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

