### PR TITLE
Add PDDF runtime firmware variant support

### DIFF
--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_component.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_component.py
@@ -120,17 +120,45 @@ class PddfComponent(ComponentBase, DeviceBase):
 
     def get_available_firmware_version(self, image_path):
         """
-        Retrieves the available firmware version of the component
+        Retrieves the available (target) firmware version of the component.
 
-        Note: the firmware version will be read from image
+        Resolution order:
+          1. If the component defines an "available_version" command in
+             pddf-device.json, run it and return its output. This lets a
+             platform compute the target version at runtime instead of
+             hard-coding a static "version" in platform_components.json -- for
+             example a slot that may hold parts from different vendors/variants,
+             each with its own target firmware version. If the command string
+             contains "{}", it is formatted with image_path (the component's
+             "firmware" value), mirroring how the "update" command works.
+          2. Otherwise return "Unknown" (the historical default), so existing
+             platforms that do not define the command are unaffected.
+
+        Note: fwutil only calls this when a component omits the static "version"
+        key in platform_components.json.
 
         Args:
-            image_path: A string, path to firmware image
+            image_path: A string, path to firmware image / firmware directory.
 
         Returns:
-            A string containing the available firmware version of the component
+            A string containing the available firmware version, or "Unknown".
         """
-        # Used only if "version" is not in platform_components.json
+        available_version_cmd = self._get_cmd("available_version")
+        if available_version_cmd is not None:
+            try:
+                if "{}" in available_version_cmd and image_path is not None:
+                    available_version_cmd = available_version_cmd.format(image_path)
+                result = self.pddf_obj.get_cmd_output(available_version_cmd)
+                if getattr(result, "returncode", 1) == 0:
+                    output = result.stdout.decode("utf-8").strip()
+                    if output:
+                        return output
+            except Exception:
+                # Never let a platform helper break fwutil status rendering;
+                # fall through to the default below.
+                pass
+
+        # Default: version is read from the image by the platform, or unknown.
         return "Unknown"
 
     def _install_firmware(self, image_path):

--- a/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fw_variant.py
+++ b/platform/pddf/platform-api-pddf-base/sonic_platform_pddf_base/pddf_fw_variant.py
@@ -1,0 +1,175 @@
+#############################################################################
+# PDDF
+#
+# Generic firmware-variant selector for PDDF platforms.
+#
+# A single component slot can be populated by parts from different
+# vendors/variants (e.g. an SSD slot holding a Virtium or a Swissbit drive, a
+# transceiver cage holding optics from different makers, a dual-sourced PSU).
+# Each variant typically needs a *different* firmware image and reports a
+# *different* target version.
+#
+# This module provides a small, dependency-free helper that maps an installed
+# part -- identified at runtime by the platform (model string, vendor name,
+# part number, running firmware version, ...) -- to the firmware image and
+# target version it should use, from a JSON manifest. It is intentionally
+# device-class agnostic: the *detection* of the identity is left to the
+# platform (smartctl for SSDs, EEPROM/`ethtool -m` for optics, an I2C/PMBus
+# read for PSUs, etc.), while the *matching* logic is shared here.
+#
+# Standard manifest schema
+# ------------------------
+#   {
+#     "variants": [
+#       {
+#         "variant":        "Virtium",                 # human label (optional)
+#         "id_match":       ["VIRTIUM", "VTSM"],       # case-insensitive substrings of the identity
+#         "version_prefix": ["0710"],                  # fallback: running-version prefixes
+#         "image":          "/usr/sbin/fw/...bin",     # image to flash
+#         "version":        "0710-001"                 # target version to report as "available"
+#       }
+#     ],
+#     "default": null                                  # optional entry when nothing matches
+#   }
+#
+# Matching order:
+#   1) any "id_match" substring (case-insensitive) found in the identity,
+#   2) any "version_prefix" that the running firmware version starts with,
+#   3) the manifest "default" (may be null/None).
+#
+# Backward-compatible aliases (so existing platform manifests keep working):
+#   top-level "models"   == "variants"
+#   per-entry "model_match" == "id_match"
+#   per-entry label "vendor" / "name" == "variant"
+#
+# Copyright (c) 2026, Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: Apache-2.0
+#############################################################################
+
+try:
+    import os
+    import json
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+
+# Accepted top-level keys holding the list of variant entries.
+_LIST_KEYS = ("variants", "models")
+# Accepted per-entry keys holding the identity-match substrings.
+_ID_MATCH_KEYS = ("id_match", "model_match")
+# Accepted per-entry keys holding the human-readable label.
+_LABEL_KEYS = ("variant", "vendor", "name")
+
+
+def load_manifest_file(path):
+    """
+    Load and return a manifest dict from a JSON file path.
+
+    Returns {} on any error (missing file, bad JSON, wrong shape) so callers
+    can degrade gracefully without raising.
+    """
+    if not path or not os.path.isfile(path):
+        return {}
+    try:
+        with open(path, "r") as handle:
+            data = json.load(handle)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def load_manifest(path_hint, manifest_filename=None):
+    """
+    Resolve and load a manifest from a hint that may be:
+      - a directory containing `manifest_filename`,
+      - a direct path to a .json manifest,
+      - None / empty (returns {}).
+
+    Returns the manifest dict, or {} when nothing usable is found.
+    """
+    if not path_hint:
+        return {}
+
+    hint = path_hint.rstrip()
+    if os.path.isdir(hint):
+        if not manifest_filename:
+            return {}
+        return load_manifest_file(os.path.join(hint, manifest_filename))
+    if hint.endswith(".json"):
+        return load_manifest_file(hint)
+    return {}
+
+
+def iter_variants(manifest):
+    """Return the list of variant entries from a manifest (handles aliases)."""
+    if not isinstance(manifest, dict):
+        return []
+    for key in _LIST_KEYS:
+        value = manifest.get(key)
+        if isinstance(value, list):
+            return value
+    return []
+
+
+def _entry_field(entry, keys, default=None):
+    if not isinstance(entry, dict):
+        return default
+    for key in keys:
+        if key in entry and entry[key] is not None:
+            return entry[key]
+    return default
+
+
+def variant_label(entry):
+    """Human-readable label for a matched entry (variant/vendor/name)."""
+    return _entry_field(entry, _LABEL_KEYS, default="")
+
+
+def variant_image(entry):
+    """Firmware image path for a matched entry."""
+    return _entry_field(entry, ("image",), default="")
+
+
+def variant_version(entry):
+    """Target ('available') firmware version for a matched entry."""
+    return _entry_field(entry, ("version",), default="")
+
+
+def select_variant(manifest, identity, running_version=""):
+    """
+    Select the manifest entry for the installed part.
+
+    Args:
+        manifest:        manifest dict (from load_manifest*).
+        identity:        identity string for the installed part, e.g. the
+                         model/vendor/part-number reported by the platform.
+        running_version: currently-running firmware version (optional), used
+                         only for the version_prefix fallback.
+
+    Matching order: id_match substring -> version_prefix -> manifest 'default'.
+
+    Returns:
+        The matched entry dict, or the manifest 'default' (which may be None).
+    """
+    entries = iter_variants(manifest)
+    identity_uc = (identity or "").upper()
+    version_uc = (running_version or "").upper()
+
+    # 1) identity substring match
+    if identity_uc:
+        for entry in entries:
+            for needle in _entry_field(entry, _ID_MATCH_KEYS, default=[]) or []:
+                if needle and needle.upper() in identity_uc:
+                    return entry
+
+    # 2) running-version prefix fallback
+    if version_uc:
+        for entry in entries:
+            for prefix in (entry.get("version_prefix") if isinstance(entry, dict) else None) or []:
+                if prefix and version_uc.startswith(prefix.upper()):
+                    return entry
+
+    # 3) default (may be None)
+    if isinstance(manifest, dict):
+        return manifest.get("default")
+    return None

--- a/platform/pddf/platform-api-pddf-base/tests/test_pddf_component_available_version.py
+++ b/platform/pddf/platform-api-pddf-base/tests/test_pddf_component_available_version.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for the generic 'available_version' runtime hook added to
+sonic_platform_pddf_base.pddf_component.PddfComponent.get_available_firmware_version().
+
+fwutil calls get_available_firmware_version() only when a component omits the
+static "version" in platform_components.json. The base class now honors an
+optional "available_version" command in pddf-device.json so platforms can
+compute the target version at runtime. When the command is absent it must keep
+returning the historical "Unknown".
+"""
+
+import sys
+import types
+
+import pytest
+
+
+def _install_sonic_platform_base_stubs():
+    """Minimal stubs so the real pddf_component module imports without the
+    full sonic_platform_base package present."""
+    if "sonic_platform_base" not in sys.modules:
+        sys.modules["sonic_platform_base"] = types.ModuleType("sonic_platform_base")
+
+    cb = types.ModuleType("sonic_platform_base.component_base")
+    cb.ComponentBase = type("ComponentBase", (), {"__init__": lambda self: None})
+    cb.FW_AUTO_ERR_BOOT_TYPE = -1
+    cb.FW_AUTO_ERR_IMAGE = -2
+    cb.FW_AUTO_ERR_UNKNOWN = -3
+    cb.FW_AUTO_UPDATED = 2
+    cb.FW_AUTO_SCHEDULED = 3
+    sys.modules["sonic_platform_base.component_base"] = cb
+
+    db = types.ModuleType("sonic_platform_base.device_base")
+    db.DeviceBase = type("DeviceBase", (), {"__init__": lambda self: None})
+    sys.modules["sonic_platform_base.device_base"] = db
+
+
+_install_sonic_platform_base_stubs()
+
+try:
+    from sonic_platform_pddf_base import pddf_component as pc
+except Exception as exc:  # pragma: no cover - environment-dependent
+    pytest.skip("pddf_component not importable: %s" % exc, allow_module_level=True)
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+class _FakePddf:
+    """Records the last command and returns a canned result (or raises)."""
+    def __init__(self, result=None, raise_exc=None):
+        self.result = result
+        self.raise_exc = raise_exc
+        self.last_cmd = None
+
+    def get_cmd_output(self, cmd):
+        self.last_cmd = cmd
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return self.result
+
+
+def _make_component(cmd, pddf):
+    comp = pc.PddfComponent.__new__(pc.PddfComponent)
+    # Instance-level _get_cmd shadows the class method; returns our cmd for the
+    # "available_version" attr and None otherwise.
+    comp._get_cmd = lambda name: cmd if name == "available_version" else None
+    comp.pddf_obj = pddf
+    return comp
+
+
+def test_returns_command_output_when_rc_zero():
+    pddf = _FakePddf(_FakeResult(0, b"0710-001\n"))
+    comp = _make_component("get_ssd_available_firmware_version ata5", pddf)
+    assert comp.get_available_firmware_version("/usr/sbin/fw/ssd/") == "0710-001"
+
+
+def test_formats_brace_placeholder_with_image_path():
+    pddf = _FakePddf(_FakeResult(0, b"SBR10021"))
+    comp = _make_component("resolve_ver {}", pddf)
+    out = comp.get_available_firmware_version("/usr/sbin/fw/ssd/")
+    assert out == "SBR10021"
+    assert pddf.last_cmd == "resolve_ver /usr/sbin/fw/ssd/"
+
+
+def test_unknown_when_command_absent():
+    pddf = _FakePddf(_FakeResult(0, b"should-not-be-used"))
+    comp = pc.PddfComponent.__new__(pc.PddfComponent)
+    comp._get_cmd = lambda name: None      # no available_version cmd
+    comp.pddf_obj = pddf
+    assert comp.get_available_firmware_version("/img") == "Unknown"
+    assert pddf.last_cmd is None           # command never run
+
+
+def test_unknown_when_rc_nonzero():
+    pddf = _FakePddf(_FakeResult(1, b"garbage"))
+    comp = _make_component("some_cmd", pddf)
+    assert comp.get_available_firmware_version("/img") == "Unknown"
+
+
+def test_unknown_when_output_empty():
+    pddf = _FakePddf(_FakeResult(0, b"   \n"))
+    comp = _make_component("some_cmd", pddf)
+    assert comp.get_available_firmware_version("/img") == "Unknown"
+
+
+def test_unknown_when_command_raises():
+    pddf = _FakePddf(raise_exc=RuntimeError("boom"))
+    comp = _make_component("some_cmd", pddf)
+    assert comp.get_available_firmware_version("/img") == "Unknown"

--- a/platform/pddf/platform-api-pddf-base/tests/test_pddf_fw_variant.py
+++ b/platform/pddf/platform-api-pddf-base/tests/test_pddf_fw_variant.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+# Copyright (c) 2026, Hewlett Packard Enterprise Development LP.
+# SPDX-License-Identifier: Apache-2.0
+"""
+Unit tests for sonic_platform_pddf_base.pddf_fw_variant -- the generic,
+device-class-agnostic firmware-variant selector shared by PDDF platforms.
+"""
+
+import json
+import os
+import tempfile
+
+from sonic_platform_pddf_base import pddf_fw_variant as fwv
+
+
+CANONICAL_MANIFEST = {
+    "variants": [
+        {
+            "variant": "Virtium",
+            "id_match": ["VIRTIUM", "VTSM"],
+            "version_prefix": ["0710"],
+            "image": "/usr/sbin/fw/Virtium_ISP.bin",
+            "version": "0710-001",
+        },
+        {
+            "variant": "Swissbit",
+            "id_match": ["SWISSBIT", "SFSA"],
+            "version_prefix": ["SBR"],
+            "image": "/usr/sbin/fw/swissbit_ISP.bin",
+            "version": "SBR10021",
+        },
+    ],
+    "default": None,
+}
+
+# Same content using the legacy aliases (models / vendor / model_match).
+ALIAS_MANIFEST = {
+    "models": [
+        {
+            "vendor": "Virtium",
+            "model_match": ["VIRTIUM", "VTSM"],
+            "version_prefix": ["0710"],
+            "image": "/usr/sbin/fw/Virtium_ISP.bin",
+            "version": "0710-001",
+        },
+    ],
+    "default": None,
+}
+
+
+class TestSelectVariant:
+    def test_match_by_identity_substring(self):
+        e = fwv.select_variant(CANONICAL_MANIFEST, "Virtium VTSM24 200GB", "0710-001")
+        assert fwv.variant_label(e) == "Virtium"
+        assert fwv.variant_version(e) == "0710-001"
+        assert fwv.variant_image(e) == "/usr/sbin/fw/Virtium_ISP.bin"
+
+    def test_match_is_case_insensitive(self):
+        e = fwv.select_variant(CANONICAL_MANIFEST, "swissbit sfsa200", "")
+        assert fwv.variant_label(e) == "Swissbit"
+
+    def test_version_prefix_fallback_when_model_unknown(self):
+        # Identity does not match any id_match; running version 'SBR...' selects Swissbit.
+        e = fwv.select_variant(CANONICAL_MANIFEST, "GENERIC SSD", "SBR10009")
+        assert fwv.variant_label(e) == "Swissbit"
+
+    def test_identity_takes_priority_over_version(self):
+        # Virtium identity but a Swissbit-looking version -> identity wins.
+        e = fwv.select_variant(CANONICAL_MANIFEST, "VIRTIUM drive", "SBR9999")
+        assert fwv.variant_label(e) == "Virtium"
+
+    def test_no_match_returns_default_none(self):
+        assert fwv.select_variant(CANONICAL_MANIFEST, "FOO BAR", "ZZ.1") is None
+
+    def test_default_entry_used_when_present(self):
+        manifest = dict(CANONICAL_MANIFEST)
+        sentinel = {"variant": "Generic", "image": "/x.bin", "version": "9.9"}
+        manifest = {"variants": CANONICAL_MANIFEST["variants"], "default": sentinel}
+        assert fwv.select_variant(manifest, "unknown", "unknown") is sentinel
+
+    def test_alias_schema_models_vendor_model_match(self):
+        e = fwv.select_variant(ALIAS_MANIFEST, "Virtium VTSM", "")
+        assert fwv.variant_label(e) == "Virtium"        # 'vendor' alias
+        assert fwv.variant_version(e) == "0710-001"
+
+    def test_empty_manifest(self):
+        assert fwv.select_variant({}, "anything", "1.0") is None
+        assert fwv.iter_variants({}) == []
+
+
+class TestManifestLoading:
+    def test_load_manifest_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "m.json")
+            with open(path, "w") as f:
+                json.dump(CANONICAL_MANIFEST, f)
+            loaded = fwv.load_manifest_file(path)
+            assert fwv.iter_variants(loaded)
+            assert fwv.select_variant(loaded, "VTSM", "") is not None
+
+    def test_load_manifest_from_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "fw_data.json")
+            with open(path, "w") as f:
+                json.dump(CANONICAL_MANIFEST, f)
+            loaded = fwv.load_manifest(d, "fw_data.json")
+            assert fwv.iter_variants(loaded)
+
+    def test_load_manifest_missing_returns_empty(self):
+        assert fwv.load_manifest_file("/no/such/file.json") == {}
+        assert fwv.load_manifest("/no/such/dir", "x.json") == {}
+        assert fwv.load_manifest(None) == {}
+
+    def test_load_manifest_bad_json_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = os.path.join(d, "bad.json")
+            with open(path, "w") as f:
+                f.write("{ not valid json ")
+            assert fwv.load_manifest_file(path) == {}


### PR DESCRIPTION
Add a generic PDDF available_version hook so component firmware target versions can be resolved at runtime when platform_components.json omits a static version. This allows platforms to compute the available firmware version from pddf-device.json instead of hard-coding a single value in the fwutil manifest.

Also add a reusable firmware variant selector for components whose slot may be populated by different vendor parts. The selector loads a JSON manifest and chooses a matching entry by identity substring, running firmware version prefix, or default entry. This supports multi-source parts such as SSDs, PSUs, optics, and other vendor-dependent firmware components.

Add unit tests covering:
- available_version command execution and fallback to Unknown
- image-path placeholder formatting
- command failure/empty-output handling
- firmware variant matching by identity, version prefix, aliases, and manifest loading

#### Why I did it
Some firmware components cannot use a single static [version](vscode-file://vscode-app/private/var/folders/dm/ltc_ygjn7qj364jk3pf0vpk80000gn/T/AppTranslocation/B7AC040B-178A-47E5-8911-4D20DA3AD3A1/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) value in [platform_components.json](vscode-file://vscode-app/private/var/folders/dm/ltc_ygjn7qj364jk3pf0vpk80000gn/T/AppTranslocation/B7AC040B-178A-47E5-8911-4D20DA3AD3A1/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) because the correct target firmware version may depend on the hardware variant installed at runtime. Examples include components with multiple vendors, alternate part sources, or model-specific firmware images.

This change adds a generic PDDF mechanism for resolving the available firmware version dynamically, allowing [fwutil show status](vscode-file://vscode-app/private/var/folders/dm/ltc_ygjn7qj364jk3pf0vpk80000gn/T/AppTranslocation/B7AC040B-178A-47E5-8911-4D20DA3AD3A1/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and fwutil show updates to report accurate firmware status for variant-dependent components while preserving existing behavior for all other components.

#### Work item tracking
Microsoft ADO (number only): <ADO number>

#### How I did it
- Added optional available_version command support to PddfComponent.get_available_firmware_version()
If a PDDF component defines available_version in pddf-device.json, the command is executed to compute the target firmware version at runtime.
If the command is absent, fails, or returns empty output, the existing fallback behavior remains Unknown.
Added optional {} formatting support so the component firmware path can be passed into the available_version command, matching existing update-command behavior.
Added a generic pddf_fw_variant helper for manifest-based firmware variant selection.
The variant selector is device-class agnostic and can match entries by:
  - runtime identity string
  - running firmware version prefix
  - optional default manifest entry
Added unit tests for the runtime available-version hook and firmware variant selector.

#### How to verify it
Functional verification on a PDDF platform:
- Add a component entry in pddf-device.json with an available_version command.
- Omit static version from the matching component in platform_components.json.
- Run:
   fwutil show status
   fwutil show updates

=> Expected result:
Components without available_version keep existing behavior.
Components with available_version show the command-returned target version.
If the runtime target version matches the current version, fwutil reports up-to-date.
If it differs, fwutil reports "update is required".

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)
- [x] master


#### Description for the changelog
Add generic PDDF support for runtime firmware available-version resolution and manifest-based firmware variant selection.

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

