### PR TITLE
[build] Rebuild cached targets when only build flags change

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -648,7 +648,8 @@ $(addsuffix .$(3),$(addprefix $(2)/, $(1))) : $(2)/%.$(3) : \
 	@$$(eval $$*_DEP_FILES_MODIFIED := $$? )
 	@$$(file >$$@.tmp,$$($$*_DEP_FILES))
 	@cat $$@.tmp |xargs git hash-object >$$@.sha.tmp
-	@if ! cmp -s $$@.sha.tmp $$@.sha; then cp $$@.tmp $$@; cp $$@.sha.tmp $$@.sha; fi
+	@if ! cmp -s $$@.sha.tmp $$@.sha; then cp $$@.tmp $$@; cp $$@.sha.tmp $$@.sha; \
+	elif [ -n "$$(filter %.flags,$$?)" ]; then touch $$@; fi
 	@rm -f $$@.tmp $$@.sha.tmp
 	@$$(if $$(MDEBUG), $$(info DEP: $$@, MOD:$$?))
 endef


### PR DESCRIPTION
**Why I did it**
The DPKG cache only refreshed a target's .dep/.dep.sha when its dependency-file contents changed. Build flags live in a separate .flags file, but .deb/docker targets depend on .dep, not .flags. So a flag-only change (e.g. ENABLE_ASAN) can leave .dep's timestamp untouched, which make will see as up-to-date and a stale cached artifact will be reused instead of rebuilding with ASan.

**How I did it**
In SHA_DEP_RULES (Makefile.cache), when the dependency SHA is unchanged but a .flags file is in the modified prerequisites ($?), touch the .dep file. This bumps its timestamp (contents unchanged) so the recipe re-runs on any flag change and LOAD_CACHE picks the right entry.

**How to verify it**
The .flags file always shows the new value, so check the build log instead. After a non-ASan build, rm -rf target/sonic-mellanox.bin and rebuild with ENABLE_ASAN=y:

grep "FLAGS  DEPENDS" target/debs/trixie/swss_1.0.0_amd64.deb.log
grep -c fsanitize    target/debs/trixie/swss_1.0.0_amd64.deb.log

Without the change the old version of swss will be included:
`1 mellanox amd64 trixie n trixie`

Including the change fixes the flag that it was built with and triggers a rebuild:

`1 mellanox amd64 trixie y trixie`

#### Which release branch to backport (provide reason below if selected)
- [x] 202511 -> Using this change to optimize ASAN builds

#### Description for the changelog
Rebuild cached targets when only build flags change