### PR TITLE
Enable P4RT Docker build by default

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -211,7 +211,7 @@ INCLUDE_DHCP_RELAY = y
 INCLUDE_DHCP_SERVER ?= n
 
 # INCLUDE_P4RT - build docker-p4rt for P4RT support
-INCLUDE_P4RT = n
+INCLUDE_P4RT = y
 
 # INCLUDE_PTF - build docker-ptf and docker-ptf-sai test containers.
 # These are only needed for PTF (Packet Test Framework) testing and are

--- a/src/sonic-p4rt/Makefile
+++ b/src/sonic-p4rt/Makefile
@@ -40,6 +40,16 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		cd $(CURDIR)/sonic-pins && bazel $(BAZEL_OPTS) shutdown
 	}
 	trap cleanup EXIT
+
+	# TODO: Remove this Makefile workaround
+	# once Bazel natively supports generating cfg_schema.h.
+	if [[ ! -f /sonic/src/sonic-swss-common/common/cfg_schema.h && -f /usr/include/swss/cfg_schema.h ]]; then \
+		if [ ! -d /sonic/src/sonic-swss-common/common ]; then \
+			mkdir -p /sonic/src/sonic-swss-common/common; \
+		fi; \
+		cp /usr/include/swss/cfg_schema.h /sonic/src/sonic-swss-common/common/cfg_schema.h; \
+	fi
+
 	pushd ./sonic-pins
 	bazel $(BAZEL_OPTS) build $(BAZEL_BUILD_OPTS) $(BAZEL_BUILD_TARGETS)
 	bazel $(BAZEL_OPTS) test $(BAZEL_BUILD_OPTS) //$(BAZEL_TARGET_PATH)/...


### PR DESCRIPTION
### **Why I did it**
Currently, the P4RT Docker build is disabled by default, requiring manual configuration overrides. This change enables the P4RT Docker build by default to streamline the build process and ensure the P4RT component is consistently included across standard platforms.


P4RT is currently built exclusively for x86 architectures (vs, vpp, alpinevs, broadcom, mellanox).
It is explicitly disabled for **armhf** and **arm64** platforms in [slave.mk](https://github.com/sonic-net/sonic-buildimage/blob/d30f733c4cabab819dfbb7de32bb962319d35b48/slave.mk#L230) due to incompatible CPU architecture.

The integration of P4RT results in a minimal resource footprint, with a consistent increase of approximately **37 MB** to the total system image size across both VS and Broadcom platforms. 
Compilation overhead is likewise negligible, adding roughly 2 minutes to the overall build time.

Image Size Increase on VS : +37.19 MB
Image Size Increase on Broadcom : +37.12 MB

In internal testing, adding P4RT to the build increased the total compilation time by approximately 3% (from ~69 minutes to ~72 minutes).

The P4RT integration introduces the following standalone artifact sizes:
Docker Image (docker-sonic-p4rt.gz): 121.36 MB
Debian Package (sonic-p4rt_0.0.1_amd64.deb): 31.44 MB

In the Azure builds, a head to head comparison with and without P4RT is difficult because the build times show huge variations. 

In at the Azure build logs, sonic-p4rt runs in parallel with swss. Because they compile concurrently, the overall end-to-end pipeline execution time sees minimal impact. Numbers from a recent test : 
swss Build Window: 07:19:00 to 08:22:24 (~63 mins)
sonic-p4rt Build Window: 07:11:47 to 08:32:47 (~81 mins)

The total build time for vs in Azure, without caching, is around 9-10 hours.  Once the caching kicks in, future builds of P4RT should take very little time. 

### **How I did it**
enabled the build flag from config to build the p4rt docker by default.
Updated rules/config to set the build flag INCLUDE_P4RT = y

### **How to verify it**
Verified with the P4rt docker is getting built by default.