### PR TITLE
[YANG]Relax the contraints of sonic-tunnel YANG model and make it general for other use cases.

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2710,6 +2710,22 @@ example mux tunnel configuration for when tunnel_qos_remap is enabled
 }
 ```
 
+An example for general tunnel config not related to dualtor:
+```
+{
+    "TUNNEL": {
+        "MyTunnel": {
+            "dscp_mode": "uniform",
+            "dst_ip": "fc00::72",
+            "ecn_mode": "copy_from_outer",
+            "encap_ecn_mode": "standard",
+            "ttl_mode": "pipe",
+            "tunnel_type": "IPINIP"
+        }
+    }
+}
+```
+
 ### Trimming
 
 When the lossy queue exceeds a buffer threshold, it drops packets without any notification to the destination host.

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2710,12 +2710,13 @@ example mux tunnel configuration for when tunnel_qos_remap is enabled
 }
 ```
 
-An example for general tunnel config not related to dualtor:
+An example for general tunnel config not related to dualtor (note that `src_ip` and `dst_ip` must belong to the same address family):
 ```
 {
     "TUNNEL": {
         "MyTunnel": {
             "dscp_mode": "uniform",
+            "src_ip": "fc00::71",
             "dst_ip": "fc00::72",
             "ecn_mode": "copy_from_outer",
             "encap_ecn_mode": "standard",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
@@ -7,7 +7,11 @@
     },
     "TUNNEL_INVALID_ADDR": {
         "desc": "Load TUNNEL with invalid IP address.",
-        "eStrKey": "Pattern"
+        "eStrKey": "InvalidValue"
+    },
+    "TUNNEL_MIXED_AF": {
+        "desc": "Load TUNNEL with mismatched address families (IPv4 src_ip + IPv6 dst_ip) must be rejected.",
+        "eStrKey": "Must"
     },
     "TUNNEL_MISSING_TUNNEL_NAME": {
         "desc": "Load TUNNEL missing tunnel_name key.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
@@ -1,17 +1,16 @@
 {
     "TUNNEL_LOAD_NORMAL": {
-        "desc": "Load TUNNEL for dualtor device."
+        "desc": "Load TUNNEL with an IPv4 destination."
+    },
+    "TUNNEL_LOAD_IPV6": {
+        "desc": "Load TUNNEL with IPv6 source and destination addresses."
     },
     "TUNNEL_INVALID_ADDR": {
-        "desc": "Load TUNNEL with invalid IPv4 Address.",
+        "desc": "Load TUNNEL with invalid IP address.",
         "eStrKey": "Pattern"
     },
-    "TUNNEL_SRC_IP_NOT_PEER_SWITCH": {
-        "desc": "Load TUNNEL with wrong IPv4 Address.",
-        "eStrKey": "LeafRef"
-    },
-    "TUNNEL_MISSING_MUX_TUNNEL": {
-        "desc": "Load MUX_TUNNEL missing name.",
+    "TUNNEL_MISSING_TUNNEL_NAME": {
+        "desc": "Load TUNNEL missing tunnel_name key.",
         "eStrKey": "ListKey"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
@@ -1,15 +1,5 @@
 {
     "TUNNEL_LOAD_NORMAL": {
-        "sonic-peer-switch:sonic-peer-switch": {
-            "sonic-peer-switch:PEER_SWITCH": {
-                "PEER_SWITCH_LIST": [
-                    {
-                        "peer_switch": "vlab-05",
-                        "address_ipv4":  "10.1.0.33"
-                    }
-                ]
-            }
-        },
         "sonic-dscp-tc-map:sonic-dscp-tc-map": {
             "sonic-dscp-tc-map:DSCP_TO_TC_MAP": {
                 "DSCP_TO_TC_MAP_LIST": [
@@ -82,9 +72,28 @@
             "sonic-tunnel:TUNNEL": {
                 "TUNNEL_LIST": [
                     {
-                        "tunnel_name": "MuxTunnel0",
+                        "tunnel_name": "MyIPv6Tunnel",
                         "dscp_mode": "pipe",
                         "src_ip":  "fc00:1::33",
+                        "dst_ip":  "fc00:1::32",
+                        "ecn_mode":  "standard",
+                        "encap_ecn_mode":  "standard",
+                        "ttl_mode":  "pipe",
+                        "tunnel_type":  "IPINIP"
+                    }
+                ]
+            }
+        }
+    },
+
+    "TUNNEL_MIXED_AF": {
+        "sonic-tunnel:sonic-tunnel": {
+            "sonic-tunnel:TUNNEL": {
+                "TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "MixedAFTunnel",
+                        "dscp_mode": "pipe",
+                        "src_ip":  "10.1.0.33",
                         "dst_ip":  "fc00:1::32",
                         "ecn_mode":  "standard",
                         "encap_ecn_mode":  "standard",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
@@ -59,7 +59,7 @@
             "sonic-tunnel:TUNNEL": {
                 "TUNNEL_LIST": [
                     {
-                        "mux_tunnel": "MuxTunnel0",
+                        "tunnel_name": "MuxTunnel0",
                         "dscp_mode": "pipe",
                         "src_ip":  "10.1.0.33",
                         "dst_ip":  "10.1.0.32",
@@ -77,12 +77,31 @@
         }
     },
 
+    "TUNNEL_LOAD_IPV6": {
+        "sonic-tunnel:sonic-tunnel": {
+            "sonic-tunnel:TUNNEL": {
+                "TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "MuxTunnel0",
+                        "dscp_mode": "pipe",
+                        "src_ip":  "fc00:1::33",
+                        "dst_ip":  "fc00:1::32",
+                        "ecn_mode":  "standard",
+                        "encap_ecn_mode":  "standard",
+                        "ttl_mode":  "pipe",
+                        "tunnel_type":  "IPINIP"
+                    }
+                ]
+            }
+        }
+    },
+
     "TUNNEL_INVALID_ADDR": {
         "sonic-tunnel:sonic-tunnel": {
             "sonic-tunnel:TUNNEL": {
                 "TUNNEL_LIST": [
                     {
-                        "mux_tunnel": "MuxTunnel0",
+                        "tunnel_name": "MuxTunnel0",
                         "dscp_mode": "pipe",
                         "dst_ip":  "10.1.0.33/32",
                         "ecn_mode":  "standard",
@@ -95,36 +114,7 @@
         }
     },
 
-    "TUNNEL_SRC_IP_NOT_PEER_SWITCH": {
-        "sonic-peer-switch:sonic-peer-switch": {
-            "sonic-peer-switch:PEER_SWITCH": {
-                "PEER_SWITCH_LIST": [
-                    {
-                        "peer_switch": "vlab-05",
-                        "address_ipv4":  "10.1.0.33"
-                    }
-                ]
-            }
-        },
-        "sonic-tunnel:sonic-tunnel": {
-            "sonic-tunnel:TUNNEL": {
-                "TUNNEL_LIST": [
-                    {
-                        "mux_tunnel": "MuxTunnel0",
-                        "dscp_mode": "pipe",
-                        "dst_ip":  "10.1.0.32",
-                        "src_ip":  "10.1.0.32",
-                        "ecn_mode":  "standard",
-                        "encap_ecn_mode":  "standard",
-                        "ttl_mode":  "pipe",
-                        "tunnel_type":  "IPINIP"
-                    }
-                ]
-            }
-        }
-    },
-
-    "TUNNEL_MISSING_MUX_TUNNEL": {
+    "TUNNEL_MISSING_TUNNEL_NAME": {
         "sonic-tunnel:sonic-tunnel": {
             "sonic-tunnel:TUNNEL": {
                 "TUNNEL_LIST": [

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -7,10 +7,6 @@ module sonic-tunnel {
 		prefix inet;
 	}
 
-	import sonic-peer-switch {
-		prefix ps;
-	}
-
 	organization
 		"SONiC";
 
@@ -20,9 +16,14 @@ module sonic-tunnel {
 	description
 		"SONiC tunnel config";
 
-	revision 2026-06-17 {
+	revision 2022-08-23 {
 		description
 			"Initial revision";
+	}
+
+	revision 2026-06-17 {
+		description
+			"Revision to extend the model";
 	}
 
 	container sonic-tunnel {

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -16,14 +16,14 @@ module sonic-tunnel {
 	description
 		"SONiC tunnel config";
 
+	revision 2026-06-17 {
+		description
+			"Relax constraints to make the model usable for general IPinIP tunnels (not DualToR-only).";
+	}
+
 	revision 2022-08-23 {
 		description
 			"Initial revision";
-	}
-
-	revision 2026-06-17 {
-		description
-			"Revision to extend the model";
 	}
 
 	container sonic-tunnel {
@@ -32,9 +32,17 @@ module sonic-tunnel {
 			list TUNNEL_LIST {
 				key "tunnel_name";
 
+				must "(contains(src_ip, ':') and contains(dst_ip, ':')) or " +
+				     "(not(contains(src_ip, ':')) and not(contains(dst_ip, ':')))" {
+					error-message "src_ip and dst_ip must belong to the same address family (both IPv4 or both IPv6).";
+				}
+
 				leaf tunnel_name {
 					description "Name of Tunnel";
-					type string;
+					type string {
+						length "1..255";
+						pattern "[a-zA-Z0-9_-]+";
+					}
 				}
 
 				leaf dscp_mode {
@@ -45,12 +53,12 @@ module sonic-tunnel {
 				}
 
 				leaf src_ip {
-					description "Source IP address off the tunnel.";
+					description "Source IP address of the tunnel.";
 					type inet:ip-address;
 				}
 
 				leaf dst_ip {
-					description "IPv4 or IPv6 address of this switch.";
+					description "Destination IP address of the tunnel endpoint (IPv4 or IPv6).";
 					type inet:ip-address;
 				}
 

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -33,9 +33,7 @@ module sonic-tunnel {
 				key "tunnel_name";
 
 				must "(contains(src_ip, ':') and contains(dst_ip, ':')) or " +
-				     "(not(contains(src_ip, ':')) and not(contains(dst_ip, ':')))" {
-					error-message "src_ip and dst_ip must belong to the same address family (both IPv4 or both IPv6).";
-				}
+				     "(not(contains(src_ip, ':')) and not(contains(dst_ip, ':')))";
 
 				leaf tunnel_name {
 					description "Name of Tunnel";

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -18,24 +18,22 @@ module sonic-tunnel {
 		"SONiC";
 
 	description
-		"SONiC DualToR tunnel data";
+		"SONiC tunnel config";
 
-	revision 2022-08-23 {
+	revision 2026-06-17 {
 		description
 			"Initial revision";
 	}
 
 	container sonic-tunnel {
 		container TUNNEL {
-			description "TUNNEL configuration for SONiC Dual-ToR";
+			description "General TUNNEL configuration for SONiC";
 			list TUNNEL_LIST {
-				key "mux_tunnel";
+				key "tunnel_name";
 
-				leaf mux_tunnel {
-					description "Name of MuxTunnel";
-					type string {
-						pattern "MuxTunnel[0-9]+";
-					}
+				leaf tunnel_name {
+					description "Name of Tunnel";
+					type string;
 				}
 
 				leaf dscp_mode {
@@ -46,15 +44,13 @@ module sonic-tunnel {
 				}
 
 				leaf src_ip {
-					description "source IPv4 address off the tunnel. Must be SONiC DualToR peer IPv4 address.";
-					type leafref {
-						path "/ps:sonic-peer-switch/ps:PEER_SWITCH/ps:PEER_SWITCH_LIST/ps:address_ipv4";
-					}
+					description "Source IP address off the tunnel.";
+					type inet:ip-address;
 				}
 
 				leaf dst_ip {
-					description "IPv4 address of this switch.";
-					type inet:ipv4-address;
+					description "IPv4 or IPv6 address of this switch.";
+					type inet:ip-address;
 				}
 
 				leaf ecn_mode {


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Previously the sonic-tunnel.yang YANG model is very restricted and only allow for dualtor use case. Now, we want to extend it to be a general config knob for setting up an IPinIP tunnel in SONiC.

##### Work item tracking
- Microsoft ADO **(number only)**: 37956726

#### How I did it

Modify the definition of YANG model.

#### How to verify it

Run the UT and verify the new YANG model on a SONiC device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 -->202511
- [x] <!-- image version 2 -->202605

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/BYGX-wcr/sonic-buildimage/blob/2ef6d316d4e9b7fcab0884ccf0c77c32949aa418/src/sonic-yang-models/doc/Configuration.md#tunnel

#### A picture of a cute animal (not mandatory but encouraged)

