### PR TITLE
Pin jsonpath to 1.7.0, last working version

### DIFF
--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -570,9 +570,9 @@ RUN patch -p1 -i /disable-non-manylinux.patch /usr/local/lib/python3.11/dist-pac
 RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
-# Exclude jsonpath_ng 1.8.0 because it causes DASH pipeline failures
+# Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
 # In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
-RUN pip3 install jsonpath_ng!=1.8.0
+RUN pip3 install jsonpath_ng==1.7.0
 RUN pip3 install pyyaml-include
 
 # For building sonic_ycabled

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -571,7 +571,7 @@ RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
 # Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
-# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+# see https://github.com/h2non/jsonpath-ng/issues/216 for details
 RUN pip3 install jsonpath_ng==1.7.0
 RUN pip3 install pyyaml-include
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -620,7 +620,9 @@ RUN pip3 install mmh3==2.5.1
 RUN pip3 install parameterized==0.8.1
 
 # For DASH BMv2
-RUN pip3 install jsonpath_ng
+# Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
+# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+RUN pip3 install jsonpath_ng==1.7.0
 
 RUN eatmydata apt-get install -y xsltproc
 

--- a/sonic-slave-bullseye/Dockerfile.j2
+++ b/sonic-slave-bullseye/Dockerfile.j2
@@ -621,7 +621,7 @@ RUN pip3 install parameterized==0.8.1
 
 # For DASH BMv2
 # Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
-# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+# see https://github.com/h2non/jsonpath-ng/issues/216 for details
 RUN pip3 install jsonpath_ng==1.7.0
 
 RUN eatmydata apt-get install -y xsltproc

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -591,7 +591,7 @@ RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
 # Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
-# In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
+# see https://github.com/h2non/jsonpath-ng/issues/216 for details
 RUN pip3 install jsonpath_ng==1.7.0 pyyaml-include
 
 # For building sonic_ycabled

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -590,9 +590,9 @@ RUN eatmydata apt-get install -y golang-go \
 RUN pip3 install fastentrypoints mock
 
 # For DASH BMv2
-# Exclude jsonpath_ng 1.8.0 because it causes DASH pipeline failures
+# Pin jsonpath_ng to 1.7.0, since future versions cause DASH pipeline failures
 # In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
-RUN pip3 install jsonpath_ng!=1.8.0 pyyaml-include
+RUN pip3 install jsonpath_ng==1.7.0 pyyaml-include
 
 # For building sonic_ycabled
 # Note: Match version in trixie


### PR DESCRIPTION
I opened 2 issues for jsonpath-ng incorrectly parsing the P4IRTree.program JSON

https://github.com/h2non/jsonpath-ng/issues/216
and
https://github.com/sonic-net/DASH/issues/697

This PR pins jsonpath package to 1.7.0 instead of using !1.8.0

https://github.com/sonic-net/sonic-buildimage/pull/26141 fixed the issue by excluding 1.8.0 however I feel it is better to pin to the last working version instead of excluding a broken version because the next version may still have this regression. We should unpin when https://github.com/h2non/jsonpath-ng/issues/216 is closed.

Summary:
Fixes #28582 

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
Sonic dash now no longer fails on vs builds using the correct last-working JSONpath version.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->