### PR TITLE
[SRv6] fix decap config dependency on vrf creation

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -27,6 +27,7 @@ from .managers_rm import RouteMapMgr
 from .managers_device_global import DeviceGlobalCfgMgr
 from .managers_chassis_app_db import ChassisAppDbMgr
 from .managers_bfd import BfdMgr
+from .managers_vrf import VRFMgr
 from .managers_srv6 import SRv6Mgr
 from .managers_prefix_list import PrefixListMgr
 from .managers_as_path import AsPathMgr
@@ -104,6 +105,8 @@ def do_work():
         DeviceGlobalCfgMgr(common_objs, "CONFIG_DB", swsscommon.CFG_BGP_DEVICE_GLOBAL_TABLE_NAME),
         # Bgp Aggregate Address Manager
         AggregateAddressMgr(common_objs, "CONFIG_DB", BGP_AGGREGATE_ADDRESS_TABLE_NAME),
+        # VRF Manager
+        VRFMgr(common_objs, "APPL_DB", "VRF_TABLE"),
         # SRv6 Manager
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_SIDS"),
         SRv6Mgr(common_objs, "CONFIG_DB", "SRV6_MY_LOCATORS"),

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_srv6.py
@@ -29,6 +29,29 @@ class SRv6Mgr(Manager):
             table,
             wait_for_all_deps=False
         )
+        self.vrf_dep_sids = {}
+        self.sid_vrf_deps = {}
+
+    def _track_vrf_dependency(self, key, vrf_dep):
+        self.sid_vrf_deps[key] = vrf_dep
+        self.vrf_dep_sids.setdefault(vrf_dep, set()).add(key)
+        if vrf_dep not in self.deps:
+            self.deps.add(vrf_dep)
+            self.directory.subscribe([vrf_dep], self.on_deps_change)
+
+    def _release_vrf_dependency(self, key):
+        vrf_dep = self.sid_vrf_deps.pop(key, None)
+        if vrf_dep is None:
+            return
+
+        sid_keys = self.vrf_dep_sids[vrf_dep]
+        sid_keys.remove(key)
+        if sid_keys:
+            return
+
+        del self.vrf_dep_sids[vrf_dep]
+        self.deps.remove(vrf_dep)
+        self.directory.unsubscribe([vrf_dep])
 
     def set_handler(self, key, data):
         if self.table_name == SRV6_MY_SIDS_TABLE_NAME:
@@ -94,9 +117,7 @@ class SRv6Mgr(Manager):
             if not self.directory.path_exist(APPL_DB, VRF_TABLE_NAME, sid.decap_vrf):
                 log_warn("Found a SRv6 SID config entry with a decap_vrf that does not exist yet: {} | {}".format(key, data))
                 vrf_dep = (APPL_DB, VRF_TABLE_NAME, sid.decap_vrf)
-                if vrf_dep not in self.deps:
-                    self.deps.add(vrf_dep)
-                    self.directory.subscribe([vrf_dep], self.on_deps_change)
+                self._track_vrf_dependency(key, vrf_dep)
                 return False
             sid_cmd += ' vrf {}'.format(sid.decap_vrf)
         cmd_list.append(sid_cmd)
@@ -105,6 +126,7 @@ class SRv6Mgr(Manager):
         log_debug("{} SRv6 static configuration {}|{} is scheduled for updates. {}".format(self.db_name, self.table_name, key, str(cmd_list)))
 
         self.directory.put(self.db_name, self.table_name, key.replace("/", "\\"), (sid, sid_cmd))
+        self._release_vrf_dependency(key)
         return True
 
     def del_handler(self, key):
@@ -128,6 +150,13 @@ class SRv6Mgr(Manager):
         locator_name = key.split("|")[0]
         ip_prefix = key.split("|")[1].lower()
         key = "{}|{}".format(locator_name, ip_prefix)
+
+        self.set_queue = [
+            (queued_key, queued_data)
+            for queued_key, queued_data in self.set_queue
+            if "{}|{}".format(queued_key.split("|")[0], queued_key.split("|")[1].lower()) != key
+        ]
+        self._release_vrf_dependency(key)
 
         if not self.directory.path_exist(self.db_name, self.table_name, key.replace("/", "\\")):
             log_warn("Encountered a config deletion with a SRv6 SID that does not exist: {}".format(key))

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_vrf.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_vrf.py
@@ -1,0 +1,32 @@
+from .log import log_err, log_debug, log_warn
+from .manager import Manager
+
+class VRFMgr(Manager):
+    """ This class populates the Directory with VRF table data from APPL_DB.
+        Other managers (e.g. SRv6) can use this to check VRF dependency before
+        pushing configuration that requires the VRF to exist.
+    """
+    def __init__(self, common_objs, db, table):
+        """
+        Initialize the object
+        :param common_objs: common object dictionary
+        :param db: name of the db
+        :param table: name of the table in the db
+        """
+        super(VRFMgr, self).__init__(
+            common_objs,
+            [],
+            db,
+            table,
+        )
+
+    def set_handler(self, key, data):
+        """ Implementation of 'SET' command - store VRF in directory """
+        log_debug("VRFMgr VRF config: {} | {}".format(key, data))
+        self.directory.put(self.db_name, self.table_name, key, data)
+        return True
+
+    def del_handler(self, key):
+        """ Implementation of 'DEL' command - remove VRF from directory """
+        log_debug("VRFMgr VRF de-config: {}".format(key))
+        self.directory.remove(self.db_name, self.table_name, key)

--- a/src/sonic-bgpcfgd/tests/test_srv6.py
+++ b/src/sonic-bgpcfgd/tests/test_srv6.py
@@ -238,12 +238,14 @@ def test_uDT46_add_vrf_not_exist():
     # Vrf1 NOT in directory - should defer
 
     key, data = "loc1|FCBB:BBBB:1:F2::/64", {'action': 'uDT46', 'decap_vrf': 'Vrf1'}
-    op_test(sid_mgr, 'SET', (key, data), expected_ret=False, expected_cmds=[])
+    sid_mgr.handler(key, 'SET', data)
 
     assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::\\64")
+    assert sid_mgr.set_queue == [(key, data)]
 
-    # Simulate handler adding to set_queue when set_handler returns False
-    sid_mgr.set_queue.append((key, data))
+    # Deleting a deferred SID must prevent it from being programmed later.
+    sid_mgr.handler(key, 'DEL', {})
+    assert sid_mgr.set_queue == []
 
     # Add Vrf1 to directory - directory.put triggers on_deps_change for subscribed handlers
     push_list_called = []
@@ -252,7 +254,31 @@ def test_uDT46_add_vrf_not_exist():
     sid_mgr.cfg_mgr.push_list = capture_push_list
     sid_mgr.directory.put("APPL_DB", "VRF_TABLE", "Vrf1", {})
 
-    # SID should now be programmed (on_deps_change was triggered by directory.put)
+    assert not sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::\\64")
+    assert not push_list_called
+
+def test_uDT46_shared_vrf_dependency_cleanup():
+    loc_mgr, sid_mgr = constructor()
+    assert loc_mgr.set_handler("loc1", {'prefix': 'fcbb:bbbb:1::'})
+
+    sid_data = {'action': 'uDT46', 'decap_vrf': 'Vrf1'}
+    first_key = "loc1|FCBB:BBBB:1:F1::/64"
+    second_key = "loc1|FCBB:BBBB:1:F2::/64"
+    sid_mgr.handler(first_key, 'SET', sid_data)
+    sid_mgr.handler(second_key, 'SET', sid_data)
+
+    vrf_dep = ("APPL_DB", "VRF_TABLE", "Vrf1")
+    assert len(sid_mgr.set_queue) == 2
+    assert sid_mgr.vrf_dep_sids[vrf_dep] == {
+        "loc1|fcbb:bbbb:1:f1::/64",
+        "loc1|fcbb:bbbb:1:f2::/64",
+    }
+
+    sid_mgr.handler(first_key, 'DEL', {})
+    assert sid_mgr.set_queue == [(second_key, sid_data)]
+    assert sid_mgr.vrf_dep_sids[vrf_dep] == {"loc1|fcbb:bbbb:1:f2::/64"}
+
+    sid_mgr.directory.put("APPL_DB", "VRF_TABLE", "Vrf1", {})
     assert sid_mgr.directory.path_exist(sid_mgr.db_name, sid_mgr.table_name, "loc1|fcbb:bbbb:1:f2::\\64")
-    assert len(push_list_called) == 1
-    assert 'sid fcbb:bbbb:1:f2::/64 locator loc1 behavior uDT46 vrf Vrf1' in push_list_called[0]
+    assert vrf_dep not in sid_mgr.deps
+    assert "Vrf1" not in sid_mgr.directory.notify["APPL_DB__VRF_TABLE"]


### PR DESCRIPTION
## Summary
- Add `VRFMgr` to populate `APPL_DB` `VRF_TABLE` into the bgpcfgd directory
- Defer SRv6 SID programming when `decap_vrf` is non-default and the VRF does not exist yet
- Subscribe to VRF creation and retry SID configuration once the dependency is satisfied
- Add unit tests for uDT46 VRF dependency handling

Related to [#25449](https://github.com/sonic-net/sonic-buildimage/pull/25449)

## Test plan
- [ ] Run bgpcfgd SRv6 tests: `pytest src/sonic-bgpcfgd/tests/test_srv6.py`
- [ ] Verify uDT46 SID with non-default `decap_vrf` is deferred until VRF exists in APPL_DB