### PR TITLE
Remove unused hwsku read from pddf_util

### DIFF
--- a/platform/pddf/i2c/utils/pddf_util.py
+++ b/platform/pddf/i2c/utils/pddf_util.py
@@ -149,8 +149,8 @@ def driver_check():
     return True
 
 def get_path_to_device():
-    # Get platform and hwsku
-    (platform, hwsku) = device_info.get_platform_and_hwsku()
+    # Get platform
+    platform = device_info.get_platform()
 
     # Load platform module from source
     platform_path = "/".join([PLATFORM_ROOT_PATH, platform])


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fixes https://github.com/sonic-net/sonic-buildimage/issues/27988

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
get_platform_and_hwsku() -> get_hwsku() → get_localhost_info('hwsku') with no config_db, which unconditionally opens a connection:

```
device_info.py:

def get_localhost_info(field, config_db=None):
    try:
        # TODO: enforce caller to provide config_db explicitly and remove its default value
        if not config_db:
            config_db = ConfigDBConnector()
            config_db.connect()
```

Connect() is what triggers SonicDBConfig::initialize() → parseDatabaseConfig → the ERR line, because /var/run/redis/sonic-db/database_config.json doesn't exist that early in boot.

Also we see that 'hwsku' is not used in get_path_to_device().

#### How to verify it

Verified by checking the reboot logs on x86_64-marvell_d64p512t-r0 platform and by running the 'vrf/test_vrf.py::TestVrfWarmReboot::test_vrf_system_warm_reboot' sonic-mgmt tests. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

Fix is applicable to all older branches which have pddf support, however requested for backport to only above 2 branches as UT is covered on them.

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511
- [x] 202605

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

