### PR TITLE
Fix decap_dscp_to_tc_map for Arista-7060X6-64PE-B-C448O16/C512S2

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -4,8 +4,14 @@
 
 {# Check if the ASIC is Broadcom #}
 {% set is_broadcom = false %}
+{% set set_azure_qos = false %}
 {% if ASIC_VENDOR is defined and "broadcom" in ASIC_VENDOR|lower %}
   {% set is_broadcom = true %}
+  {% if DEVICE_METADATA['localhost']['hwsku'] in ['Arista-7060X6-64PE-B-C448O16', 'Arista-7060X6-64PE-B-C512S2'] %}
+    {% set set_azure_qos = true %}
+  {% endif %}
+{% else %}
+  {% set set_azure_qos = true %}
 {% endif %}
 
 {% set is_broadcom_t1 = false %}
@@ -103,9 +109,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and set_azure_qos %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -133,9 +139,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and set_azure_qos %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -170,9 +176,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and set_azure_qos %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -200,9 +206,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and set_azure_qos %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On Broadcom, ipinip decap uses decap_dscp_to_tc_map from ipinip.json, falling back to the global dscp_to_tc_map in config_db.json, then to SAI's built-in default.
These HWSKUs define macro generate_port_qos_map_per_sku in qos.json.j2, which prevents the global map from being set, so SAI's default is used.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set decap_dscp_to_tc_map in ipinip.json to apply the customized mapping.
Limited to these two HWSKUs as older TH ASICs don't support it.

#### How to verify it

qos/test_qos_dscp_mapping.py passed on Arista-7060X6-64PE-B-C448O16/C512S2

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix decap_dscp_to_tc_map for Arista-7060X6-64PE-B-C448O16/C512S2

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

