### PR TITLE
[Yang]: Fix high frequency telemetry poll interval unit

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -47,7 +47,7 @@ module sonic-high-frequency-telemetry {
 
                 leaf poll_interval {
                     mandatory true;
-                    description "The interval to poll counter, unit milliseconds.";
+                    description "The interval to poll counter, unit microseconds.";
                     type uint32;
                 }
 


### PR DESCRIPTION
#### Why I did it
The high-frequency telemetry YANG model describes poll_interval as milliseconds, but the configured unit is microseconds.

#### How I did it
Updated the poll_interval description to use microseconds.

#### How to verify it
Documentation-only YANG description change.