### PR TITLE
[yang] Add HFT aggregator schema

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -14,12 +14,12 @@
         "desc": "Invalid stats.",
         "eStrKey": "Must"
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_REF": {
-        "desc": "Invalid harmonizer reference.",
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_REF": {
+        "desc": "Invalid aggregator reference.",
         "eStrKey": "LeafRef"
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_COUNTER": {
-        "desc": "Invalid harmonizer counter.",
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_COUNTER": {
+        "desc": "Invalid aggregator counter.",
         "eStrKey": "Must"
     },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -14,6 +14,14 @@
         "desc": "Invalid stats.",
         "eStrKey": "Must"
     },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_REF": {
+        "desc": "Invalid harmonizer reference.",
+        "eStrKey": "LeafRef"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_COUNTER": {
+        "desc": "Invalid harmonizer counter.",
+        "eStrKey": "Must"
+    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {
         "desc": "Invalid dummy table1.",
         "eStrKey": "InvalidJSON"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -2,6 +2,10 @@
     "HIGH_FREQUENCY_TELEMETRY_VALID_CASE": {
         "desc": "Valid high frequency telemetry configuration."
     },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_POLL_INTERVAL_ZERO": {
+        "desc": "Profile poll interval must be greater than zero.",
+        "eStrKey": "Range"
+    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_PORT": {
         "desc": "Invalid port.",
         "eStrKey": "Must"
@@ -65,15 +69,6 @@
         "desc": "Rollover bit width 64 is unsupported.",
         "eStrKey": "Range"
     },
-    "HIGH_FREQUENCY_TELEMETRY_DEFAULT_BUCKET_COUNT": {
-        "desc": "Heatmap default bucket count is 256.",
-        "eStrKey": "Verify",
-        "verify": {
-            "xpath": "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST[name='default_bucket_count']/heatmap_default_bucket_count",
-            "key": "sonic-high-frequency-telemetry:heatmap_default_bucket_count",
-            "value": 256
-        }
-    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_COUNTERS_MISSING": {
         "desc": "Heatmap interval requires heatmap counters.",
         "eStrKey": "None",
@@ -115,14 +110,6 @@
         "eStr": [
             "Watermark and current-occupancy counters must not be configured in rollover_counters"
         ]
-    },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_LOW": {
-        "desc": "Heatmap default bucket count cannot be less than four.",
-        "eStrKey": "Range"
-    },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_HIGH": {
-        "desc": "Heatmap default bucket count cannot exceed 512.",
-        "eStrKey": "Range"
     },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_PARENT_REF": {
         "desc": "Histogram entry must reference an existing aggregator.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -22,33 +22,117 @@
         "desc": "Invalid aggregator counter.",
         "eStrKey": "Must"
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS": {
-        "desc": "Heatmap counters require bucket boundaries.",
-        "eStrKey": "None",
-        "eStr": [
-            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
-        ]
+    "HIGH_FREQUENCY_TELEMETRY_DEFAULT_BUCKET_COUNT": {
+        "desc": "Heatmap default bucket count is 256.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST[name='default_bucket_count']/heatmap_default_bucket_count",
+            "key": "sonic-high-frequency-telemetry:heatmap_default_bucket_count",
+            "value": 256
+        }
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS_ONLY": {
-        "desc": "Heatmap bucket boundaries require heatmap counters.",
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_COUNTERS_MISSING": {
+        "desc": "Heatmap interval requires heatmap counters.",
         "eStrKey": "None",
         "eStr": [
-            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
+            "heatmap_interval and heatmap_counters must be configured together"
         ]
     },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_INTERVAL_MISSING": {
         "desc": "Heatmap configuration requires an interval.",
         "eStrKey": "None",
         "eStr": [
-            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
+            "heatmap_interval and heatmap_counters must be configured together"
         ]
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKET_ORDER": {
-        "desc": "Heatmap bucket boundaries must be strictly increasing.",
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_NAME": {
+        "desc": "Aggregator names cannot contain the CONFIG_DB key separator.",
         "eStrKey": "None",
         "eStr": [
-            "heatmap_bucket_boundaries must be strictly increasing"
+            "Aggregator name must not contain '|'"
         ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_NAME_WHITESPACE": {
+        "desc": "Aggregator names cannot have leading or trailing whitespace.",
+        "eStrKey": "None",
+        "eStr": [
+            "Aggregator name must not have leading or trailing whitespace"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_WATERMARK_ROLLOVER": {
+        "desc": "Watermark selector is rejected by the watermark/current-occupancy rollover restriction.",
+        "eStrKey": "None",
+        "eStr": [
+            "Watermark and current-occupancy counters must not be configured in rollover_counters"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_CURRENT_OCCUPANCY_ROLLOVER": {
+        "desc": "Current-occupancy counters cannot be rollover counters.",
+        "eStrKey": "None",
+        "eStr": [
+            "Watermark and current-occupancy counters must not be configured in rollover_counters"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_LOW": {
+        "desc": "Heatmap default bucket count cannot be less than four.",
+        "eStrKey": "Range"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_HIGH": {
+        "desc": "Heatmap default bucket count cannot exceed 512.",
+        "eStrKey": "Range"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_PARENT_REF": {
+        "desc": "Histogram entry must reference an existing aggregator.",
+        "eStrKey": "LeafRef"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_GROUP": {
+        "desc": "Histogram group must be a supported group.",
+        "eStrKey": "None",
+        "eStr": [
+            "Invalid enumeration value"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_COUNTER": {
+        "desc": "Histogram counter must be valid for its group.",
+        "eStrKey": "None",
+        "eStr": [
+            "counter_name is not valid for group_name"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_COUNTER_NOT_SELECTED": {
+        "desc": "Histogram counter must be selected by its parent.",
+        "eStrKey": "None",
+        "eStr": [
+            "Histogram counter must be selected in the parent heatmap_counters"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_EMPTY": {
+        "desc": "Histogram explicit bounds cannot be empty.",
+        "eStrKey": "MinElements"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_UNORDERED": {
+        "desc": "Histogram explicit bounds must be increasing.",
+        "eStrKey": "None",
+        "eStr": [
+            "explicit_bounds must be strictly increasing"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_DUPLICATE": {
+        "desc": "Histogram explicit bounds cannot contain duplicates.",
+        "eStrKey": "None",
+        "eStr": [
+            "uplicate",
+            "instance",
+            "explicit_bounds"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_RANGE": {
+        "desc": "Histogram explicit bounds cannot exceed 2^53.",
+        "eStrKey": "Range"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_TOO_MANY": {
+        "desc": "Histogram explicit bounds cannot contain more than 511 entries.",
+        "eStrKey": "MaxElements"
     },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {
         "desc": "Invalid dummy table1.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -22,6 +22,49 @@
         "desc": "Invalid aggregator counter.",
         "eStrKey": "Must"
     },
+    "HIGH_FREQUENCY_TELEMETRY_ROLLOVER_EXPLICIT_WIDTH": {
+        "desc": "A selected rollover counter can override its width explicitly."
+    },
+    "HIGH_FREQUENCY_TELEMETRY_ROLLOVER_DEFAULT_WIDTH": {
+        "desc": "Absence of a child row, rather than a defaulted child leaf, gives a selected rollover counter the documented effective 32-bit width."
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_PARENT_REF": {
+        "desc": "Rollover width entry must reference an existing aggregator.",
+        "eStrKey": "LeafRef"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_GROUP": {
+        "desc": "Rollover width group must be a supported group.",
+        "eStrKey": "None",
+        "eStr": [
+            "Invalid enumeration value"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_COUNTER": {
+        "desc": "Rollover width counter must be valid for its group.",
+        "eStrKey": "None",
+        "eStr": [
+            "counter_name is not valid for group_name"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_COUNTER_NOT_SELECTED": {
+        "desc": "Rollover width counter must be selected by its parent.",
+        "eStrKey": "None",
+        "eStr": [
+            "Rollover counter must be selected in the parent rollover_counters"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_MISSING": {
+        "desc": "Rollover override rows require a bit width.",
+        "eStrKey": "Mandatory"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_ZERO": {
+        "desc": "Rollover bit width cannot be zero.",
+        "eStrKey": "Range"
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_64": {
+        "desc": "Rollover bit width 64 is unsupported.",
+        "eStrKey": "Range"
+    },
     "HIGH_FREQUENCY_TELEMETRY_DEFAULT_BUCKET_COUNT": {
         "desc": "Heatmap default bucket count is 256.",
         "eStrKey": "Verify",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/high_frequency_telemetry.json
@@ -22,6 +22,34 @@
         "desc": "Invalid aggregator counter.",
         "eStrKey": "Must"
     },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS": {
+        "desc": "Heatmap counters require bucket boundaries.",
+        "eStrKey": "None",
+        "eStr": [
+            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS_ONLY": {
+        "desc": "Heatmap bucket boundaries require heatmap counters.",
+        "eStrKey": "None",
+        "eStr": [
+            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_INTERVAL_MISSING": {
+        "desc": "Heatmap configuration requires an interval.",
+        "eStrKey": "None",
+        "eStr": [
+            "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together"
+        ]
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKET_ORDER": {
+        "desc": "Heatmap bucket boundaries must be strictly increasing.",
+        "eStrKey": "None",
+        "eStr": [
+            "heatmap_bucket_boundaries must be strictly increasing"
+        ]
+    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_DUMMY_TABLE1": {
         "desc": "Invalid dummy table1.",
         "eStrKey": "InvalidJSON"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -69,7 +69,7 @@
                         "name": "high_frequency_counters",
                         "stream_state": "enabled",
                         "poll_interval": 100,
-                        "harmonizer": "default_harmonizer"
+                        "aggregator": "default_aggregator"
                     },
                     {
                         "name": "partial_objects",
@@ -83,10 +83,10 @@
                     }
                 ]
             },
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_HARMONIZER": {
-                "HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST": [
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
                     {
-                        "name": "default_harmonizer",
+                        "name": "default_aggregator",
                         "reporting_rate": 1000,
                         "rollover_counters": [
                             "PORT|IF_IN_UCAST_PKTS",
@@ -204,26 +204,26 @@
             }
         }
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_REF": {
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_REF": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
                 "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
                     {
-                        "name": "invalid_harmonizer_ref",
+                        "name": "invalid_aggregator_ref",
                         "stream_state": "enabled",
                         "poll_interval": 100,
-                        "harmonizer": "missing_harmonizer"
+                        "aggregator": "missing_aggregator"
                     }
                 ]
             }
         }
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_COUNTER": {
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_COUNTER": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_HARMONIZER": {
-                "HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST": [
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
                     {
-                        "name": "invalid_harmonizer_counter",
+                        "name": "invalid_aggregator_counter",
                         "rollover_counters": [
                             "PORT|IF_IN_UCAST_PKTS",
                             "QUEUE|IF_IN_UCAST_PKTS"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -68,7 +68,8 @@
                     {
                         "name": "high_frequency_counters",
                         "stream_state": "enabled",
-                        "poll_interval": 100
+                        "poll_interval": 100,
+                        "harmonizer": "default_harmonizer"
                     },
                     {
                         "name": "partial_objects",
@@ -79,6 +80,24 @@
                         "name": "dummy_profile",
                         "stream_state": "disabled",
                         "poll_interval": 100000
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_HARMONIZER": {
+                "HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST": [
+                    {
+                        "name": "default_harmonizer",
+                        "reporting_rate": 1000,
+                        "rollover_counters": [
+                            "PORT|IF_IN_UCAST_PKTS",
+                            "BUFFER_POOL|DROPPED_PACKETS",
+                            "INGRESS_PRIORITY_GROUP|XOFF_ROOM_WATERMARK_BYTES",
+                            "QUEUE|DROPPED_PACKETS"
+                        ],
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS",
+                            "QUEUE|WRED_ECN_MARKED_PACKETS"
+                        ]
                     }
                 ]
             },
@@ -180,6 +199,38 @@
                     {
                         "profile_name": "dummy_profile",
                         "group_name": "PORT"
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_REF": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "invalid_harmonizer_ref",
+                        "stream_state": "enabled",
+                        "poll_interval": 100,
+                        "harmonizer": "missing_harmonizer"
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HARMONIZER_COUNTER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_HARMONIZER": {
+                "HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST": [
+                    {
+                        "name": "invalid_harmonizer_counter",
+                        "rollover_counters": [
+                            "PORT|IF_IN_UCAST_PKTS",
+                            "QUEUE|IF_IN_UCAST_PKTS"
+                        ],
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -91,19 +91,28 @@
                         "rollover_counters": [
                             "PORT|IF_IN_UCAST_PKTS",
                             "BUFFER_POOL|DROPPED_PACKETS",
-                            "INGRESS_PRIORITY_GROUP|XOFF_ROOM_WATERMARK_BYTES",
+                            "INGRESS_PRIORITY_GROUP|DROPPED_PACKETS",
                             "QUEUE|DROPPED_PACKETS"
                         ],
                         "heatmap_interval": 1000000,
                         "heatmap_counters": [
                             "PORT|IF_OUT_ERRORS",
                             "QUEUE|WRED_ECN_MARKED_PACKETS"
-                        ],
-                        "heatmap_bucket_boundaries": [
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "default_aggregator",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
                             "0",
                             "1024",
                             "4096",
-                            "16384"
+                            "9007199254740992"
                         ]
                     }
                 ]
@@ -234,26 +243,18 @@
                         "rollover_counters": [
                             "PORT|IF_IN_UCAST_PKTS",
                             "QUEUE|IF_IN_UCAST_PKTS"
-                        ],
-                        "heatmap_counters": [
-                            "PORT|IF_OUT_ERRORS"
-                        ],
-                        "heatmap_interval": 1000000,
-                        "heatmap_bucket_boundaries": [
-                            "0",
-                            "1024"
                         ]
                     }
                 ]
             }
         }
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS": {
+    "HIGH_FREQUENCY_TELEMETRY_DEFAULT_BUCKET_COUNT": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
                 "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
                     {
-                        "name": "missing_heatmap_buckets",
+                        "name": "default_bucket_count",
                         "heatmap_interval": 1000000,
                         "heatmap_counters": [
                             "PORT|IF_OUT_ERRORS"
@@ -263,37 +264,13 @@
             }
         }
     },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS_ONLY": {
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_COUNTERS_MISSING": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
                 "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
                     {
-                        "name": "heatmap_buckets_without_counters",
-                        "heatmap_interval": 1000000,
-                        "heatmap_bucket_boundaries": [
-                            "0",
-                            "1024"
-                        ]
-                    }
-                ]
-            }
-        }
-    },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKET_ORDER": {
-        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
-                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
-                    {
-                        "name": "unordered_heatmap_buckets",
-                        "heatmap_interval": 1000000,
-                        "heatmap_counters": [
-                            "PORT|IF_OUT_ERRORS"
-                        ],
-                        "heatmap_bucket_boundaries": [
-                            "0",
-                            "4096",
-                            "1024"
-                        ]
+                        "name": "heatmap_counters_missing",
+                        "heatmap_interval": 1000000
                     }
                 ]
             }
@@ -307,10 +284,345 @@
                         "name": "heatmap_interval_missing",
                         "heatmap_counters": [
                             "PORT|IF_OUT_ERRORS"
-                        ],
-                        "heatmap_bucket_boundaries": [
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_NAME": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "invalid|aggregator"
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_NAME_WHITESPACE": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": " whitespace "
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_WATERMARK_ROLLOVER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "watermark_rollover",
+                        "rollover_counters": [
+                            "QUEUE|WATERMARK_BYTES"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_CURRENT_OCCUPANCY_ROLLOVER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "current_occupancy_rollover",
+                        "rollover_counters": [
+                            "PORT|OUT_CURR_OCCUPANCY_BYTES"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_LOW": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "bucket_count_low",
+                        "heatmap_default_bucket_count": 3
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_HIGH": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "bucket_count_high",
+                        "heatmap_default_bucket_count": 513
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_PARENT_REF": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "missing_aggregator",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
+                            "0"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_GROUP": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "invalid_histogram_group",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "invalid_histogram_group",
+                        "group_name": "INVALID",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
+                            "0"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_COUNTER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "invalid_histogram_counter",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "invalid_histogram_counter",
+                        "group_name": "PORT",
+                        "counter_name": "WATERMARK_BYTES",
+                        "explicit_bounds": [
+                            "0"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_COUNTER_NOT_SELECTED": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "histogram_counter_not_selected",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "histogram_counter_not_selected",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "explicit_bounds": [
+                            "0"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_EMPTY": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "empty_histogram_bounds",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "empty_histogram_bounds",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": []
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_UNORDERED": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "unordered_histogram_bounds",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "unordered_histogram_bounds",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
                             "0",
+                            "4096",
                             "1024"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_DUPLICATE": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "duplicate_histogram_bounds",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "duplicate_histogram_bounds",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
+                            "0",
+                            "1024",
+                            "1024"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_RANGE": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "out_of_range_histogram_bounds",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "out_of_range_histogram_bounds",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
+                            "9007199254740993"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HISTOGRAM_BOUNDS_TOO_MANY": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "too_many_histogram_bounds",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
+                    {
+                        "aggregator_name": "too_many_histogram_bounds",
+                        "group_name": "PORT",
+                        "counter_name": "IF_OUT_ERRORS",
+                        "explicit_bounds": [
+                            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15",
+                            "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
+                            "32", "33", "34", "35", "36", "37", "38", "39", "40", "41", "42", "43", "44", "45", "46", "47",
+                            "48", "49", "50", "51", "52", "53", "54", "55", "56", "57", "58", "59", "60", "61", "62", "63",
+                            "64", "65", "66", "67", "68", "69", "70", "71", "72", "73", "74", "75", "76", "77", "78", "79",
+                            "80", "81", "82", "83", "84", "85", "86", "87", "88", "89", "90", "91", "92", "93", "94", "95",
+                            "96", "97", "98", "99", "100", "101", "102", "103", "104", "105", "106", "107", "108", "109", "110", "111",
+                            "112", "113", "114", "115", "116", "117", "118", "119", "120", "121", "122", "123", "124", "125", "126", "127",
+                            "128", "129", "130", "131", "132", "133", "134", "135", "136", "137", "138", "139", "140", "141", "142", "143",
+                            "144", "145", "146", "147", "148", "149", "150", "151", "152", "153", "154", "155", "156", "157", "158", "159",
+                            "160", "161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172", "173", "174", "175",
+                            "176", "177", "178", "179", "180", "181", "182", "183", "184", "185", "186", "187", "188", "189", "190", "191",
+                            "192", "193", "194", "195", "196", "197", "198", "199", "200", "201", "202", "203", "204", "205", "206", "207",
+                            "208", "209", "210", "211", "212", "213", "214", "215", "216", "217", "218", "219", "220", "221", "222", "223",
+                            "224", "225", "226", "227", "228", "229", "230", "231", "232", "233", "234", "235", "236", "237", "238", "239",
+                            "240", "241", "242", "243", "244", "245", "246", "247", "248", "249", "250", "251", "252", "253", "254", "255",
+                            "256", "257", "258", "259", "260", "261", "262", "263", "264", "265", "266", "267", "268", "269", "270", "271",
+                            "272", "273", "274", "275", "276", "277", "278", "279", "280", "281", "282", "283", "284", "285", "286", "287",
+                            "288", "289", "290", "291", "292", "293", "294", "295", "296", "297", "298", "299", "300", "301", "302", "303",
+                            "304", "305", "306", "307", "308", "309", "310", "311", "312", "313", "314", "315", "316", "317", "318", "319",
+                            "320", "321", "322", "323", "324", "325", "326", "327", "328", "329", "330", "331", "332", "333", "334", "335",
+                            "336", "337", "338", "339", "340", "341", "342", "343", "344", "345", "346", "347", "348", "349", "350", "351",
+                            "352", "353", "354", "355", "356", "357", "358", "359", "360", "361", "362", "363", "364", "365", "366", "367",
+                            "368", "369", "370", "371", "372", "373", "374", "375", "376", "377", "378", "379", "380", "381", "382", "383",
+                            "384", "385", "386", "387", "388", "389", "390", "391", "392", "393", "394", "395", "396", "397", "398", "399",
+                            "400", "401", "402", "403", "404", "405", "406", "407", "408", "409", "410", "411", "412", "413", "414", "415",
+                            "416", "417", "418", "419", "420", "421", "422", "423", "424", "425", "426", "427", "428", "429", "430", "431",
+                            "432", "433", "434", "435", "436", "437", "438", "439", "440", "441", "442", "443", "444", "445", "446", "447",
+                            "448", "449", "450", "451", "452", "453", "454", "455", "456", "457", "458", "459", "460", "461", "462", "463",
+                            "464", "465", "466", "467", "468", "469", "470", "471", "472", "473", "474", "475", "476", "477", "478", "479",
+                            "480", "481", "482", "483", "484", "485", "486", "487", "488", "489", "490", "491", "492", "493", "494", "495",
+                            "496", "497", "498", "499", "500", "501", "502", "503", "504", "505", "506", "507", "508", "509", "510", "511"
                         ]
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -94,9 +94,16 @@
                             "INGRESS_PRIORITY_GROUP|XOFF_ROOM_WATERMARK_BYTES",
                             "QUEUE|DROPPED_PACKETS"
                         ],
+                        "heatmap_interval": 1000000,
                         "heatmap_counters": [
                             "PORT|IF_OUT_ERRORS",
                             "QUEUE|WRED_ECN_MARKED_PACKETS"
+                        ],
+                        "heatmap_bucket_boundaries": [
+                            "0",
+                            "1024",
+                            "4096",
+                            "16384"
                         ]
                     }
                 ]
@@ -230,6 +237,80 @@
                         ],
                         "heatmap_counters": [
                             "PORT|IF_OUT_ERRORS"
+                        ],
+                        "heatmap_interval": 1000000,
+                        "heatmap_bucket_boundaries": [
+                            "0",
+                            "1024"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "missing_heatmap_buckets",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKETS_ONLY": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "heatmap_buckets_without_counters",
+                        "heatmap_interval": 1000000,
+                        "heatmap_bucket_boundaries": [
+                            "0",
+                            "1024"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_BUCKET_ORDER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "unordered_heatmap_buckets",
+                        "heatmap_interval": 1000000,
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ],
+                        "heatmap_bucket_boundaries": [
+                            "0",
+                            "4096",
+                            "1024"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_INTERVAL_MISSING": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "heatmap_interval_missing",
+                        "heatmap_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ],
+                        "heatmap_bucket_boundaries": [
+                            "0",
+                            "1024"
                         ]
                     }
                 ]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -102,6 +102,16 @@
                     }
                 ]
             },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "default_aggregator",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_UCAST_PKTS",
+                        "bit_width": 24
+                    }
+                ]
+            },
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM": {
                 "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST": [
                     {
@@ -244,6 +254,201 @@
                             "PORT|IF_IN_UCAST_PKTS",
                             "QUEUE|IF_IN_UCAST_PKTS"
                         ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_ROLLOVER_EXPLICIT_WIDTH": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "explicit_rollover_width",
+                        "rollover_counters": [
+                            "PORT|IF_IN_OCTETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "explicit_rollover_width",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 24
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_ROLLOVER_DEFAULT_WIDTH": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "default_rollover_width",
+                        "rollover_counters": [
+                            "QUEUE|DROPPED_PACKETS"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_PARENT_REF": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "missing_aggregator",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 24
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_GROUP": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "invalid_rollover_group",
+                        "rollover_counters": [
+                            "PORT|IF_IN_OCTETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "invalid_rollover_group",
+                        "group_name": "INVALID",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 24
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_COUNTER": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "invalid_rollover_counter",
+                        "rollover_counters": [
+                            "QUEUE|DROPPED_PACKETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "invalid_rollover_counter",
+                        "group_name": "QUEUE",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 24
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_COUNTER_NOT_SELECTED": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "rollover_counter_not_selected",
+                        "rollover_counters": [
+                            "PORT|IF_OUT_ERRORS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "rollover_counter_not_selected",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 24
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_MISSING": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "missing_rollover_width",
+                        "rollover_counters": [
+                            "PORT|IF_IN_OCTETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "missing_rollover_width",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS"
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_ZERO": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "zero_rollover_width",
+                        "rollover_counters": [
+                            "PORT|IF_IN_OCTETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "zero_rollover_width",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 0
+                    }
+                ]
+            }
+        }
+    },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_ROLLOVER_WIDTH_64": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
+                    {
+                        "name": "rollover_width_64",
+                        "rollover_counters": [
+                            "PORT|IF_IN_OCTETS"
+                        ]
+                    }
+                ]
+            },
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER": {
+                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST": [
+                    {
+                        "aggregator_name": "rollover_width_64",
+                        "group_name": "PORT",
+                        "counter_name": "IF_IN_OCTETS",
+                        "bit_width": 64
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/high_frequency_telemetry.json
@@ -230,6 +230,19 @@
             }
         }
     },
+    "HIGH_FREQUENCY_TELEMETRY_INVALID_POLL_INTERVAL_ZERO": {
+        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
+            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
+                "HIGH_FREQUENCY_TELEMETRY_PROFILE_LIST": [
+                    {
+                        "name": "zero_poll_interval",
+                        "stream_state": "enabled",
+                        "poll_interval": 0
+                    }
+                ]
+            }
+        }
+    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_AGGREGATOR_REF": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_PROFILE": {
@@ -454,21 +467,6 @@
             }
         }
     },
-    "HIGH_FREQUENCY_TELEMETRY_DEFAULT_BUCKET_COUNT": {
-        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
-                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
-                    {
-                        "name": "default_bucket_count",
-                        "heatmap_interval": 1000000,
-                        "heatmap_counters": [
-                            "PORT|IF_OUT_ERRORS"
-                        ]
-                    }
-                ]
-            }
-        }
-    },
     "HIGH_FREQUENCY_TELEMETRY_INVALID_HEATMAP_COUNTERS_MISSING": {
         "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
             "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
@@ -540,30 +538,6 @@
                         "rollover_counters": [
                             "PORT|OUT_CURR_OCCUPANCY_BYTES"
                         ]
-                    }
-                ]
-            }
-        }
-    },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_LOW": {
-        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
-                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
-                    {
-                        "name": "bucket_count_low",
-                        "heatmap_default_bucket_count": 3
-                    }
-                ]
-            }
-        }
-    },
-    "HIGH_FREQUENCY_TELEMETRY_INVALID_DEFAULT_BUCKET_COUNT_HIGH": {
-        "sonic-high-frequency-telemetry:sonic-high-frequency-telemetry": {
-            "sonic-high-frequency-telemetry:HIGH_FREQUENCY_TELEMETRY_AGGREGATOR": {
-                "HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST": [
-                    {
-                        "name": "bucket_count_high",
-                        "heatmap_default_bucket_count": 513
                     }
                 ]
             }

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -51,10 +51,10 @@ module sonic-high-frequency-telemetry {
                     type uint32;
                 }
 
-                leaf harmonizer {
-                    description "Optional harmonizer configuration applied by this profile.";
+                leaf aggregator {
+                    description "Optional aggregator configuration applied by this profile.";
                     type leafref {
-                        path "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_HARMONIZER/HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST/name";
+                        path "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST/name";
                     }
                 }
 
@@ -75,20 +75,20 @@ module sonic-high-frequency-telemetry {
             }
         }
 
-        container HIGH_FREQUENCY_TELEMETRY_HARMONIZER {
-            description "Harmonizer configuration for high-frequency telemetry profiles.";
-            list HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST {
+        container HIGH_FREQUENCY_TELEMETRY_AGGREGATOR {
+            description "Aggregator configuration for high-frequency telemetry profiles.";
+            list HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST {
                 key "name";
 
                 leaf name {
                     type string {
                         length 1..128;
                     }
-                    description "Unique name for this harmonizer configuration.";
+                    description "Unique name for this aggregator configuration.";
                 }
 
                 leaf reporting_rate {
-                    description "The reporting interval after harmonization, unit microseconds.";
+                    description "The reporting interval after aggregation, unit microseconds.";
                     type uint32;
                 }
 

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -47,8 +47,15 @@ module sonic-high-frequency-telemetry {
 
                 leaf poll_interval {
                     mandatory true;
-                    description "The interval to poll counter, unit milliseconds.";
+                    description "The interval to poll counter, unit microseconds.";
                     type uint32;
+                }
+
+                leaf harmonizer {
+                    description "Optional harmonizer configuration applied by this profile.";
+                    type leafref {
+                        path "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_HARMONIZER/HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST/name";
+                    }
                 }
 
                 leaf otel_endpoint {
@@ -63,6 +70,44 @@ module sonic-high-frequency-telemetry {
                     type string {
                         length 1..4096;
                     }
+                }
+
+            }
+        }
+
+        container HIGH_FREQUENCY_TELEMETRY_HARMONIZER {
+            description "Harmonizer configuration for high-frequency telemetry profiles.";
+            list HIGH_FREQUENCY_TELEMETRY_HARMONIZER_LIST {
+                key "name";
+
+                leaf name {
+                    type string {
+                        length 1..128;
+                    }
+                    description "Unique name for this harmonizer configuration.";
+                }
+
+                leaf reporting_rate {
+                    description "The reporting interval after harmonization, unit microseconds.";
+                    type uint32;
+                }
+
+                leaf-list rollover_counters {
+                    description "List of group and counter pairs that require rollover correction. It is encoded as a comma-separated string in CONFIG_DB.";
+                    type string;
+                    must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
+                        + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
+                        + " or ( substring-before(current(), '|') = 'INGRESS_PRIORITY_GROUP' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
+                        + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
+                }
+
+                leaf-list heatmap_counters {
+                    description "List of group and counter pairs that should be treated as heatmap data. It is encoded as a comma-separated string in CONFIG_DB.";
+                    type string;
+                    must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
+                        + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
+                        + " or ( substring-before(current(), '|') = 'INGRESS_PRIORITY_GROUP' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
+                        + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
                 }
 
             }

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -47,8 +47,10 @@ module sonic-high-frequency-telemetry {
 
                 leaf poll_interval {
                     mandatory true;
-                    description "The interval to poll counter, unit microseconds.";
-                    type uint32;
+                    description "The interval to poll counter, unit microseconds. For a heatmap byte-delta counter without explicit bounds, the nominal interval is this value when reporting_rate is absent and max(poll_interval, reporting_rate) otherwise.";
+                    type uint32 {
+                        range "1..max";
+                    }
                 }
 
                 leaf aggregator {
@@ -94,7 +96,7 @@ module sonic-high-frequency-telemetry {
                 }
 
                 leaf reporting_rate {
-                    description "The reporting interval after aggregation, unit microseconds.";
+                    description "The reporting interval after aggregation, unit microseconds. For default byte-delta heatmap bounds, the nominal interval is max(reporting_rate, the bound profile poll_interval).";
                     type uint32 {
                         range "1..max";
                     }
@@ -120,21 +122,19 @@ module sonic-high-frequency-telemetry {
                 }
 
                 leaf-list heatmap_counters {
-                    description "List of group and counter pairs that should be treated as heatmap data. Each entry uses the GROUP|COUNTER format.";
+                    description
+                        "List of group and counter pairs that should be treated as heatmap data. Each entry uses the "
+                        + "GROUP|COUNTER format. Runtime classifies counters from numeric SAI object and stat IDs. "
+                        + "Cumulative byte/octet counters use raw byte deltas; cumulative packet, error, and discard "
+                        + "counters use raw count deltas; watermark and current-occupancy byte counters use raw "
+                        + "absolute bytes; and cell counters use raw cells. Values are not normalized into per-second "
+                        + "rates. A selected counter without a child histogram row uses its fixed semantic default "
+                        + "layout, resolved once for the effective profile and aggregator configuration.";
                     type string;
                     must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
                         + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'INGRESS_PRIORITY_GROUP' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
-                }
-
-                leaf heatmap_default_bucket_count {
-                    when "../heatmap_interval";
-                    description "Total bucket count for the default heatmap layout used by counters without explicit bounds.";
-                    type uint16 {
-                        range "4..512";
-                    }
-                    default 256;
                 }
 
                 must "(not(heatmap_interval) and count(heatmap_counters) = 0) or (heatmap_interval and count(heatmap_counters) > 0)" {
@@ -191,7 +191,20 @@ module sonic-high-frequency-telemetry {
         }
 
         container HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM {
-            description "Per-counter explicit histogram layouts for high-frequency telemetry aggregators.";
+            description
+                "Per-counter explicit histogram layouts for high-frequency telemetry aggregators. "
+                + "A child row overrides the selected counter's semantic default. Without a row, runtime classifies "
+                + "numeric SAI object/stat IDs as delta bytes, absolute bytes, delta count, absolute cells, or native. "
+                + "Delta-byte bounds use Gbit/s anchors 0,5,10,20,40,50,100,150,200,300,400,600,800,1200,1600 "
+                + "and the exact formula anchor_gbps * 125 * nominal_interval_us, where the nominal interval is "
+                + "max(reporting_rate, profile poll_interval) when both exist, or whichever exists. Absolute-byte bounds are "
+                + "0,512,1024,524288,1048576,5242880,10485760,52428800,104857600. Delta-count bounds are "
+                + "0,1,2,5,10,20,50,100,200,500,1000,2000,5000,10000,20000,50000,100000,200000,500000,1000000,"
+                + "2000000,5000000,10000000,20000000,50000000,100000000,200000000,500000000. Absolute-cell "
+                + "bounds are 0 followed by powers 2^0 through 2^24; native bounds are 0 followed by powers 2^0 "
+                + "through 2^53. These layouts have 16, 10, 29, 27, and 56 buckets respectively. Values and OTLP "
+                + "units remain raw and are never normalized into per-second rates. OTLP identifies the quantity "
+                + "with heatmap_quantity and the complete effective layout with heatmap_schema.";
             list HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST {
                 key "aggregator_name group_name counter_name";
 
@@ -233,7 +246,7 @@ module sonic-high-frequency-telemetry {
                     ordered-by user;
                     min-elements 1;
                     max-elements 511;
-                    description "Strictly increasing inclusive upper bounds for this counter's OTLP histogram.";
+                    description "Strictly increasing inclusive upper bounds for this counter's OTLP histogram. These bounds override the semantic default layout and use the counter's unchanged raw heatmap unit.";
                     must "not(preceding-sibling::*[local-name() = 'explicit_bounds']) or number(current()) > number(preceding-sibling::*[local-name() = 'explicit_bounds'][1])" {
                         error-message "explicit_bounds must be strictly increasing.";
                     }

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -195,14 +195,15 @@ module sonic-high-frequency-telemetry {
                 "Per-counter explicit histogram layouts for high-frequency telemetry aggregators. "
                 + "A child row overrides the selected counter's semantic default. Without a row, runtime classifies "
                 + "numeric SAI object/stat IDs as delta bytes, absolute bytes, delta count, absolute cells, or native. "
-                + "Delta-byte bounds use Gbit/s anchors 0,5,10,20,40,50,100,150,200,300,400,600,800,1200,1600 "
-                + "and the exact formula anchor_gbps * 125 * nominal_interval_us, where the nominal interval is "
+                + "Delta-byte bounds use 50,75,90,95,98,99,99.5,99.8,100 percent of common "
+                + "100,200,400,800,1600 Gbit/s link speeds. The sorted, deduplicated union includes zero and uses "
+                + "the exact formula floor(speed_gbps * utilization_basis_points * nominal_interval_us / 80), where the nominal interval is "
                 + "max(reporting_rate, profile poll_interval) when both exist, or whichever exists. Absolute-byte bounds are "
                 + "0,512,1024,524288,1048576,5242880,10485760,52428800,104857600. Delta-count bounds are "
                 + "0,1,2,5,10,20,50,100,200,500,1000,2000,5000,10000,20000,50000,100000,200000,500000,1000000,"
                 + "2000000,5000000,10000000,20000000,50000000,100000000,200000000,500000000. Absolute-cell "
                 + "bounds are 0 followed by powers 2^0 through 2^24; native bounds are 0 followed by powers 2^0 "
-                + "through 2^53. These layouts have 16, 10, 29, 27, and 56 buckets respectively. Values and OTLP "
+                + "through 2^53. These layouts have 43, 10, 29, 27, and 56 buckets respectively. Values and OTLP "
                 + "units remain raw and are never normalized into per-second rates. OTLP identifies the quantity "
                 + "with heatmap_quantity and the complete effective layout with heatmap_schema.";
             list HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST {

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -101,7 +101,7 @@ module sonic-high-frequency-telemetry {
                 }
 
                 leaf-list rollover_counters {
-                    description "List of group and counter pairs that require rollover correction. Each entry uses the GROUP|COUNTER format.";
+                    description "List of group and counter pairs that require rollover correction. Each entry uses the GROUP|COUNTER format. A selected counter with no HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER row uses an effective width of 32 bits.";
                     type string;
                     must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
                         + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
@@ -141,6 +141,52 @@ module sonic-high-frequency-telemetry {
                     error-message "heatmap_interval and heatmap_counters must be configured together.";
                 }
 
+            }
+        }
+
+        container HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER {
+            description "Optional per-counter width overrides for rollover counters. A counter selected in the parent rollover_counters with no row here uses an effective width of 32 bits.";
+            list HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_ROLLOVER_LIST {
+                key "aggregator_name group_name counter_name";
+
+                leaf aggregator_name {
+                    type leafref {
+                        path "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST/name";
+                    }
+                    description "Reference to the parent aggregator configuration.";
+                }
+
+                leaf group_name {
+                    type enumeration {
+                        enum PORT;
+                        enum BUFFER_POOL;
+                        enum QUEUE;
+                        enum INGRESS_PRIORITY_GROUP;
+                    }
+                    description "SAI object type for the rollover counter.";
+                }
+
+                leaf counter_name {
+                    type string;
+                    description "Counter selected for a rollover width override.";
+                    must "( ../group_name = 'PORT' and re-match(current(), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
+                        + " or ( ../group_name = 'BUFFER_POOL' and re-match(current(), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
+                        + " or ( ../group_name = 'INGRESS_PRIORITY_GROUP' and re-match(current(), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
+                        + " or ( ../group_name = 'QUEUE' and re-match(current(), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )" {
+                        error-message "counter_name is not valid for group_name.";
+                    }
+                    must "concat(../group_name, '|', current()) = /sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST[name = current()/../aggregator_name]/rollover_counters" {
+                        error-message "Rollover counter must be selected in the parent rollover_counters.";
+                    }
+                }
+
+                leaf bit_width {
+                    mandatory true;
+                    type uint8 {
+                        range "1..63";
+                    }
+                    description "Counter width override. This leaf has no default; absence of the entire row selects the effective 32-bit width.";
+                }
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -83,6 +83,12 @@ module sonic-high-frequency-telemetry {
                 leaf name {
                     type string {
                         length 1..128;
+                        pattern '[^|]+' {
+                            error-message "Aggregator name must not contain '|'.";
+                        }
+                        pattern '\S(.*\S)?' {
+                            error-message "Aggregator name must not have leading or trailing whitespace.";
+                        }
                     }
                     description "Unique name for this aggregator configuration.";
                 }
@@ -101,6 +107,9 @@ module sonic-high-frequency-telemetry {
                         + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'INGRESS_PRIORITY_GROUP' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
+                    must "not(contains(substring-after(current(), '|'), 'WATERMARK') or contains(substring-after(current(), '|'), 'CURR_OCCUPANCY'))" {
+                        error-message "Watermark and current-occupancy counters must not be configured in rollover_counters.";
+                    }
                 }
 
                 leaf heatmap_interval {
@@ -119,21 +128,70 @@ module sonic-high-frequency-telemetry {
                         + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
                 }
 
-                leaf-list heatmap_bucket_boundaries {
-                    ordered-by user;
-                    description "Strictly increasing inclusive upper bounds shared by every configured heatmap counter.";
+                leaf heatmap_default_bucket_count {
+                    when "../heatmap_interval";
+                    description "Total bucket count for the default heatmap layout used by counters without explicit bounds.";
+                    type uint16 {
+                        range "4..512";
+                    }
+                    default 256;
+                }
+
+                must "(not(heatmap_interval) and count(heatmap_counters) = 0) or (heatmap_interval and count(heatmap_counters) > 0)" {
+                    error-message "heatmap_interval and heatmap_counters must be configured together.";
+                }
+
+            }
+        }
+
+        container HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM {
+            description "Per-counter explicit histogram layouts for high-frequency telemetry aggregators.";
+            list HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_HISTOGRAM_LIST {
+                key "aggregator_name group_name counter_name";
+
+                leaf aggregator_name {
+                    type leafref {
+                        path "/sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST/name";
+                    }
+                    description "Reference to the parent aggregator configuration.";
+                }
+
+                leaf group_name {
+                    type enumeration {
+                        enum PORT;
+                        enum BUFFER_POOL;
+                        enum QUEUE;
+                        enum INGRESS_PRIORITY_GROUP;
+                    }
+                    description "SAI object type for the histogram counter.";
+                }
+
+                leaf counter_name {
+                    type string;
+                    description "Counter selected for a custom explicit histogram layout.";
+                    must "( ../group_name = 'PORT' and re-match(current(), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
+                        + " or ( ../group_name = 'BUFFER_POOL' and re-match(current(), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
+                        + " or ( ../group_name = 'INGRESS_PRIORITY_GROUP' and re-match(current(), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
+                        + " or ( ../group_name = 'QUEUE' and re-match(current(), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )" {
+                        error-message "counter_name is not valid for group_name.";
+                    }
+                    must "concat(../group_name, '|', current()) = /sonic-high-frequency-telemetry:sonic-high-frequency-telemetry/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR/HIGH_FREQUENCY_TELEMETRY_AGGREGATOR_LIST[name = current()/../aggregator_name]/heatmap_counters" {
+                        error-message "Histogram counter must be selected in the parent heatmap_counters.";
+                    }
+                }
+
+                leaf-list explicit_bounds {
                     type uint64 {
                         range "0..9007199254740992";
                     }
-                    must "not(preceding-sibling::*[local-name() = 'heatmap_bucket_boundaries']) or number(current()) > number(preceding-sibling::*[local-name() = 'heatmap_bucket_boundaries'][1])" {
-                        error-message "heatmap_bucket_boundaries must be strictly increasing.";
+                    ordered-by user;
+                    min-elements 1;
+                    max-elements 511;
+                    description "Strictly increasing inclusive upper bounds for this counter's OTLP histogram.";
+                    must "not(preceding-sibling::*[local-name() = 'explicit_bounds']) or number(current()) > number(preceding-sibling::*[local-name() = 'explicit_bounds'][1])" {
+                        error-message "explicit_bounds must be strictly increasing.";
                     }
                 }
-
-                must "(not(heatmap_interval) and count(heatmap_counters) = 0 and count(heatmap_bucket_boundaries) = 0) or (heatmap_interval and count(heatmap_counters) > 0 and count(heatmap_bucket_boundaries) > 0)" {
-                    error-message "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together.";
-                }
-
             }
         }
 

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -248,7 +248,7 @@ module sonic-high-frequency-telemetry {
                     min-elements 1;
                     max-elements 511;
                     description "Strictly increasing inclusive upper bounds for this counter's OTLP histogram. These bounds override the semantic default layout and use the counter's unchanged raw heatmap unit.";
-                    must "not(preceding-sibling::*[local-name() = 'explicit_bounds']) or number(current()) > number(preceding-sibling::*[local-name() = 'explicit_bounds'][1])" {
+                    must "boolean(../explicit_bounds[. = current() and position() = count(../explicit_bounds[. <= current()])])" {
                         error-message "explicit_bounds must be strictly increasing.";
                     }
                 }

--- a/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
+++ b/src/sonic-yang-models/yang-models/sonic-high-frequency-telemetry.yang
@@ -89,11 +89,13 @@ module sonic-high-frequency-telemetry {
 
                 leaf reporting_rate {
                     description "The reporting interval after aggregation, unit microseconds.";
-                    type uint32;
+                    type uint32 {
+                        range "1..max";
+                    }
                 }
 
                 leaf-list rollover_counters {
-                    description "List of group and counter pairs that require rollover correction. It is encoded as a comma-separated string in CONFIG_DB.";
+                    description "List of group and counter pairs that require rollover correction. Each entry uses the GROUP|COUNTER format.";
                     type string;
                     must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
                         + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
@@ -101,13 +103,35 @@ module sonic-high-frequency-telemetry {
                         + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
                 }
 
+                leaf heatmap_interval {
+                    description "Independent heatmap aggregation interval, unit microseconds.";
+                    type uint32 {
+                        range "1..max";
+                    }
+                }
+
                 leaf-list heatmap_counters {
-                    description "List of group and counter pairs that should be treated as heatmap data. It is encoded as a comma-separated string in CONFIG_DB.";
+                    description "List of group and counter pairs that should be treated as heatmap data. Each entry uses the GROUP|COUNTER format.";
                     type string;
                     must "( substring-before(current(), '|') = 'PORT' and re-match(substring-after(current(), '|'), 'IF_IN_OCTETS|IF_IN_UCAST_PKTS|IF_IN_DISCARDS|IF_IN_ERRORS|IN_CURR_OCCUPANCY_BYTES|IF_OUT_OCTETS|IF_OUT_DISCARDS|IF_OUT_ERRORS|IF_OUT_UCAST_PKTS|OUT_CURR_OCCUPANCY_BYTES|TRIM_PACKETS|PAUSE_RX_PKTS|PAUSE_TX_PKTS|PFC_[0-7]_RX_PKTS|PFC_[0-7]_TX_PKTS') )"
                         + " or ( substring-before(current(), '|') = 'BUFFER_POOL' and re-match(substring-after(current(), '|'), 'DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_WATERMARK_BYTES|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'INGRESS_PRIORITY_GROUP' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|XOFF_ROOM_CURR_OCCUPANCY_BYTES|XOFF_ROOM_WATERMARK_BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS|XOFF_ROOM_CURR_OCCUPANCY_CELLS|XOFF_ROOM_WATERMARK_CELLS') )"
                         + " or ( substring-before(current(), '|') = 'QUEUE' and re-match(substring-after(current(), '|'), 'PACKETS|BYTES|DROPPED_PACKETS|CURR_OCCUPANCY_BYTES|WATERMARK_BYTES|WRED_ECN_MARKED_PACKETS|TRIM_PACKETS|CURR_OCCUPANCY_CELLS|WATERMARK_CELLS') )";
+                }
+
+                leaf-list heatmap_bucket_boundaries {
+                    ordered-by user;
+                    description "Strictly increasing inclusive upper bounds shared by every configured heatmap counter.";
+                    type uint64 {
+                        range "0..9007199254740992";
+                    }
+                    must "not(preceding-sibling::*[local-name() = 'heatmap_bucket_boundaries']) or number(current()) > number(preceding-sibling::*[local-name() = 'heatmap_bucket_boundaries'][1])" {
+                        error-message "heatmap_bucket_boundaries must be strictly increasing.";
+                    }
+                }
+
+                must "(not(heatmap_interval) and count(heatmap_counters) = 0 and count(heatmap_bucket_boundaries) = 0) or (heatmap_interval and count(heatmap_counters) > 0 and count(heatmap_bucket_boundaries) > 0)" {
+                    error-message "heatmap_interval, heatmap_counters, and heatmap_bucket_boundaries must be configured together.";
                 }
 
             }


### PR DESCRIPTION
**What I did**

Updated the High Frequency Telemetry YANG model for composable aggregator configuration.

This PR adds:

- `HIGH_FREQUENCY_TELEMETRY_AGGREGATOR`.
- Optional `HIGH_FREQUENCY_TELEMETRY_PROFILE.aggregator` leafref.
- Positive `uint32` `reporting_rate` in microseconds.
- Group-specific validation for `rollover_counters`.
- Positive `uint32` `heatmap_interval` in microseconds.
- Group-specific validation for `heatmap_counters`.
- Ordered `heatmap_bucket_boundaries` from 0 through `2^53`.
- All-or-none validation for `heatmap_interval`, `heatmap_counters`, and `heatmap_bucket_boundaries`.

The associated runtime applies methods in this order:

`rollover(raw samples) -> reporting -> heatmap`

Reporting and heatmap intervals are independent. When reporting is enabled, each completed reporting window contributes one point to the heatmap.

**Why I did it**

This aligns the buildimage schema with the HFT aggregator contract in sonic-net/SONiC#2079 and the CounterSyncd implementation in sonic-net/sonic-swss#4691.

**How I verified it**

- Both updated JSON test files pass `python -m json.tool`.
- The HFT module passes `pyang` syntax validation with minimal import stubs.
- `yanglint` accepts valid reporting/rollover/heatmap configuration.
- `yanglint` rejects heatmap counters and boundaries when `heatmap_interval` is absent.
- YANG model fixtures cover invalid references, invalid group/counter pairs, missing heatmap fields, and unordered bucket bounds.

**Details if related**

The `poll_interval` description change from milliseconds to microseconds is a documentation correction, not a runtime contract change. HFT already programs `SAI_TAM_REPORT_INTERVAL_UNIT_USEC`, and the HLD has consistently defined this field in microseconds.

Related PRs:

- sonic-net/SONiC#2079
- sonic-net/sonic-utilities#4631
- sonic-net/sonic-swss#4691
