### PR TITLE
[container_checker/service_checker]: Guard newer device_info APIs against stale sonic_py_common

### DIFF
--- a/files/image_config/monit/container_checker
+++ b/files/image_config/monit/container_checker
@@ -111,10 +111,13 @@ def get_expected_running_containers():
             else:
                 always_running_containers.add(container_name)
 
-    if device_info.is_supervisor() or device_info.is_disaggregated_chassis() or device_info.is_smartswitch():
+    is_disaggregated_chassis = hasattr(device_info, 'is_disaggregated_chassis') and device_info.is_disaggregated_chassis()
+    is_smartswitch = hasattr(device_info, 'is_smartswitch') and device_info.is_smartswitch()
+
+    if device_info.is_supervisor() or is_disaggregated_chassis or is_smartswitch:
         always_running_containers.add("database-chassis")
 
-    if device_info.is_smartswitch():
+    if is_smartswitch:
         raw_dpustable = config_db.get_table("DPUS")
         for dpu_name in raw_dpustable:
             container_name = f"databasedpu{dpu_name.replace('dpu', '')}"

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -141,7 +141,7 @@ class ServiceChecker(HealthChecker):
                     expected_running_containers.add(container_name)
                     container_feature_dict[container_name] = container_name
                     
-        if device_info.is_supervisor() or device_info.is_disaggregated_chassis():
+        if device_info.is_supervisor() or (hasattr(device_info, 'is_disaggregated_chassis') and device_info.is_disaggregated_chassis()):
             expected_running_containers.add("database-chassis")
             container_feature_dict["database-chassis"] = "database"
         return expected_running_containers, container_feature_dict


### PR DESCRIPTION
#### Why I did it

On a running device, monit's `container_checker` failed every cycle with:

```
ERR monit: 'container_checker' status failed (1) -- Traceback (most recent call last):
  File "/usr/bin/container_checker", line 224, in main
    expected_running_containers, always_running_containers = get_expected_running_containers()
  File "/usr/bin/container_checker", line 114, in get_expected_running_containers
    if device_info.is_supervisor() or device_info.is_disaggregated_chassis() or device_info.is_smartswitch():
AttributeError: module 'sonic_py_common.device_info' has no attribute 'is_disaggregated_chassis'
```

`container_checker` and system-health's `service_checker` run on the host and
call newer `sonic_py_common.device_info` APIs (`is_disaggregated_chassis`, added
in #21709; `is_smartswitch`). These host scripts are copied verbatim into the
image, but `sonic_py_common` ships as a pip wheel pinned at `version='1.0'` that
the build can reuse from cache without the newer functions. The resulting
version drift makes `container_checker` crash and disables container health
monitoring.

##### Work item tracking
- Microsoft ADO **(number only)**: 37065889

#### How I did it

Guarded the newer `device_info` APIs with `hasattr()` before calling them,
matching the existing convention in sonic-utilities
`utilities_common/chassis.py`. When `device_info` is older and lacks the
function, the check degrades to `False` instead of raising `AttributeError`.

- `files/image_config/monit/container_checker`: guard `is_disaggregated_chassis`
  and `is_smartswitch` (computed once, reused for the DPU logic).
- `src/system-health/health_checker/service_checker.py`: guard
  `is_disaggregated_chassis`.

#### How to verify it

1. Simulate a stale `device_info` that lacks the newer API and confirm no crash:
   ```python
   import types
   di = types.ModuleType("device_info")
   di.is_supervisor = lambda: False
   di.is_smartswitch = lambda: True   # no is_disaggregated_chassis attribute
   # Old code raises AttributeError here; guarded code returns cleanly:
   assert (di.is_supervisor()
           or (hasattr(di, 'is_disaggregated_chassis') and di.is_disaggregated_chassis())
           or (hasattr(di, 'is_smartswitch') and di.is_smartswitch())) is True
   ```
2. Run the system-health unit tests in the slave container:
   `pytest src/system-health/tests/test_system_health.py -k service_checker`
3. On a device, confirm `monit summary` no longer shows `container_checker`
   status failed and `/var/log/syslog` is free of the `AttributeError`.

#### Which release branch to backport (provide reason below if selected)

The `is_disaggregated_chassis()` call exists in `container_checker` on 202505,
202511 and 202605, so those branches are exposed to the same crash when an older
`sonic_py_common` wheel is installed.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version -->

#### Description for the changelog

Guard newer sonic_py_common.device_info APIs in container_checker/service_checker to avoid AttributeError on stale sonic_py_common wheels.

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.
