### PR TITLE
[ifupdown2] Tolerate non-IP address families so management interfaces can DHCP on systems with MCTP netdevs

### DIFF
--- a/src/ifupdown2/patch/0005-nlpacket-tolerate-unsupported-address-families-mctp.patch
+++ b/src/ifupdown2/patch/0005-nlpacket-tolerate-unsupported-address-families-mctp.patch
@@ -1,0 +1,147 @@
+From: Julien Fortin <jfortin@nvidia.com>
+Date: Mon, 1 Jun 2026 18:14:57 +0200
+
+nlpacket: tolerate unsupported address families on decode (AF_MCTP)
+
+A global RTM_GETADDR (AF_UNSPEC) dump returns addresses of every registered
+family. On a host with an AF_MCTP interface (family 45) the dump contains an
+MCTP address, and AttributeIPAddress.__init__() raised "45 is not a supported
+address family" while decoding it - aborting the whole dump before any
+per-interface policy runs, so "ifup -a" configured nothing.
+
+Let each attribute class declare the families it can decode via
+Attribute.supported_families, and have add_attribute() fall back to
+AttributeGeneric for any unsupported family instead of letting the constructor
+abort the dump. Define AF_MCTP (45); the address cache and route nexthops keep
+only AF_INET / AF_INET6.
+
+Signed-off-by: Julien Fortin <jfortin@nvidia.com>
+Signed-off-by: William Tsai <willtsai@nvidia.com>
+---
+diff --git a/ifupdown2/lib/nlcache.py b/ifupdown2/lib/nlcache.py
+index 2b94f1c..5acc840 100644
+--- a/ifupdown2/lib/nlcache.py
++++ b/ifupdown2/lib/nlcache.py
+@@ -2171,6 +2171,13 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
+             self.errorq = []
+ 
+     def rx_rtm_newaddr(self, rxed_addr_packet):
++        # The address cache is keyed by IP version and only models AF_INET and
++        # AF_INET6. A global RTM_GETADDR (AF_UNSPEC) dump also returns addresses
++        # of families we don't model (e.g. AF_MCTP), which carry only IFA_LOCAL
++        # and no IFA_ADDRESS to cache; skip them here, mirroring the family guards
++        # already used by rx_rtm_newlink()/rx_rtm_dellink().
++        if rxed_addr_packet.family not in (socket.AF_INET, socket.AF_INET6):
++            return
+         super(NetlinkListenerWithCache, self).rx_rtm_newaddr(rxed_addr_packet)
+         self.cache.add_address(rxed_addr_packet)
+ 
+diff --git a/ifupdown2/nlmanager/nlpacket.py b/ifupdown2/nlmanager/nlpacket.py
+index 495930a..0edf3bc 100644
+--- a/ifupdown2/nlmanager/nlpacket.py
++++ b/ifupdown2/nlmanager/nlpacket.py
+@@ -162,6 +162,7 @@ RT_SCOPES = {
+ }
+ 
+ AF_MPLS = 28
++AF_MCTP = 45
+ 
+ 
+ AF_FAMILY = dict()
+@@ -170,6 +171,7 @@ for family in [attr for attr in dir(socket) if attr.startswith('AF_')]:
+     AF_FAMILY[getattr(socket, family)] = family
+ 
+ AF_FAMILY[AF_MPLS] = 'AF_MPLS'
++AF_FAMILY[AF_MCTP] = 'AF_MCTP'
+ 
+ 
+ def get_family_str(family):
+@@ -905,6 +907,13 @@ class NetlinkPacket_IFLA_LINKINFO_Attributes:
+ 
+ class Attribute(object):
+ 
++    # Address families this attribute type knows how to decode. None means the
++    # attribute is family-agnostic (integers, strings, raw bytes, ...). A subclass
++    # that only understands specific families overrides this; add_attribute() then
++    # falls back to AttributeGeneric for any family not listed, instead of letting
++    # the constructor raise and abort decoding of the whole dump.
++    supported_families = None
++
+     def __init__(self, atype, string, logger):
+         self.atype = atype
+         self.string = string
+@@ -1367,20 +1376,23 @@ class AttributeStringInterfaceName(AttributeString):
+ 
+ class AttributeIPAddress(Attribute):
+ 
++    # family -> struct format used to (un)pack the address. Single source of truth
++    # for the families this attribute can handle: supported_families is derived from
++    # it, and add_attribute() uses that to fall back gracefully.
++    family_to_pack = {
++        AF_INET:   '>L',
++        AF_INET6:  '>QQ',
++        AF_BRIDGE: '>L',
++    }
++    supported_families = tuple(family_to_pack)
++
+     def __init__(self, atype, string, family, logger):
+         Attribute.__init__(self, atype, string, logger)
+         self.family = family
+ 
+-        if self.family == AF_INET:
+-            self.PACK = '>L'
+-
+-        elif self.family == AF_INET6:
+-            self.PACK = '>QQ'
+-
+-        elif self.family == AF_BRIDGE:
+-            self.PACK = '>L'
+-
+-        else:
++        try:
++            self.PACK = self.family_to_pack[family]
++        except KeyError:
+             raise Exception("%s is not a supported address family" % self.family)
+ 
+         self.LEN = calcsize(self.PACK)
+@@ -1422,7 +1434,7 @@ class AttributeIPAddress(Attribute):
+     def encode(self):
+         length = self.HEADER_LEN + self.LEN
+ 
+-        if self.family not in [AF_INET, AF_INET6, AF_BRIDGE]:
++        if self.family not in self.supported_families:
+             raise Exception("%s is not a supported address family" % self.family)
+ 
+         raw = pack(self.HEADER_PACK, length, self.atype) + self.value.packed
+@@ -3635,6 +3647,18 @@ class NetlinkPacket(object):
+             self.log.debug("Attribute %d is not defined in %s.attribute_to_class, assuming AttributeGeneric" %
+                            (attr_type, self.__class__.__name__))
+ 
++        # Some attribute types can only decode a subset of address families (the
++        # class advertises this via 'supported_families'). A global AF_UNSPEC dump
++        # can return families we don't model - e.g. AF_MCTP (45) addresses. Rather
++        # than letting the attribute's constructor raise and abort decoding of the
++        # whole dump, fall back to raw bytes here and let the consumer skip what it
++        # does not care about.
++        if attr_class.supported_families is not None and self.family not in attr_class.supported_families:
++            self.log.debug("Attribute %d: %s does not support address family %s, decoding as AttributeGeneric" %
++                           (attr_type, attr_class.__name__, self.family))
++            attr_string = "UNKNOWN_ATTRIBUTE_%d" % attr_type
++            attr_class = AttributeGeneric
++
+         attr = attr_class(attr_type, attr_string, self.family, self.log)
+ 
+         attr.set_value(value)
+@@ -5450,6 +5474,12 @@ class Route(NetlinkPacket):
+         return ifname
+ 
+     def get_nexthops(self, ifname_by_index={}):
++        # Nexthops are (IP, ifname) pairs and only make sense for the IP route
++        # families we model. For anything else (e.g. AF_MCTP) the address
++        # attributes are decoded as raw bytes, so there is no IP nexthop to render.
++        if self.family not in (AF_INET, AF_INET6):
++            return []
++
+         nexthop = self.get_attribute_value(self.RTA_GATEWAY)
+         multipath = self.get_attribute_value(self.RTA_MULTIPATH)
+         nexthops = []

--- a/src/ifupdown2/patch/series
+++ b/src/ifupdown2/patch/series
@@ -3,3 +3,4 @@
 0003-Fix-the-return-value-of-utils._execute_subprocess-me.patch
 bug-296-python-3.12-compability.patch
 0004-Ensure-etc-iproute2-rt_tables.d-directory-present-fo.patch
+0005-nlpacket-tolerate-unsupported-address-families-mctp.patch


### PR DESCRIPTION
#### Why I did it

On platforms that expose an **AF_MCTP** interface (Management Component Transport Protocol, family `45` — common on BMC/server platforms), `ifup -a` fails and the box never gets a DHCP lease, even though the MCTP interface is not referenced in `/etc/network/interfaces`.

Root cause: ifupdown2 enumerates addresses with a single global `RTM_GETADDR` dump sent with `ifa_family = AF_UNSPEC`, so the kernel returns addresses of **every** registered family at once. The dump then contains an MCTP address, and `AttributeIPAddress` only models `AF_INET` / `AF_INET6` / `AF_BRIDGE` — its constructor raises `"45 is not a supported address family"` *while decoding the dump*, before any per-interface policy runs. That aborts the whole operation, so ifupdown2 configures nothing.

The ifupdown2 version packaged in sonic-buildimage (`3.0.0-1`) has no handling for address families it does not model, so any unmodeled family in a global dump is enough to break networking.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a new patch to the ifupdown2 package patch series — `src/ifupdown2/patch/0005-nlpacket-tolerate-unsupported-address-families-mctp.patch`, registered in `src/ifupdown2/patch/series` — that makes netlink attribute decoding tolerant of address families it does not model, instead of aborting the whole dump:

- `nlmanager/nlpacket.py`: each attribute class declares the address families it can decode via a new `Attribute.supported_families` (default `None` = family-agnostic). `AttributeIPAddress` derives its supported set from a single `family -> pack` map that also drives `__init__()` and `encode()` (one source of truth).
- `nlmanager/nlpacket.py`: `NetlinkPacket.add_attribute()` falls back to `AttributeGeneric` (raw bytes) for any family an attribute class does not support, rather than letting the constructor raise.
- `nlmanager/nlpacket.py`: defines `AF_MCTP` (`45`) and registers it in `AF_FAMILY`; `Route.get_nexthops()` returns no nexthops for non-IP families (`AF_INET` / `AF_INET6` only).
- `lib/nlcache.py`: `NetlinkListenerWithCache.rx_rtm_newaddr()` skips addresses whose family is not `AF_INET` / `AF_INET6` (the address cache is keyed by IP version), mirroring the family guards already used by `rx_rtm_newlink()` / `rx_rtm_dellink()`.

No new functionality is added — the change only prevents unrelated/unmodeled netlink objects (e.g. MCTP) from breaking existing flows. IPv4 / IPv6 / bridge decoding is unchanged.

Big thanks to @julienfortin for authoring this fix and for his guidance on the netlink decode path.

#### How to verify it

1. Build the ifupdown2 package: the build applies the full `src/ifupdown2/patch/series` on the upstream `3.0.0-1` source, so confirm every patch applies with no rejects and that `python3 -m py_compile ifupdown2/nlmanager/nlpacket.py ifupdown2/lib/nlcache.py` passes.
2. Functional decode check (no MCTP hardware required): build a synthetic AF_MCTP (family `45`) `RTM_NEWADDR` message carrying only `IFA_LOCAL` and decode it — before the fix, decoding raises `Exception('45 is not a supported address family')` and aborts the dump; after the fix, the message decodes, the `IFA_LOCAL` attribute falls back to `AttributeGeneric` and is skipped by the address cache, while a normal IPv4 and IPv6 `RTM_NEWADDR` still decode as `AttributeIPAddress` unchanged.
3. On a target with an AF_MCTP interface present, confirm `ifup -a` now completes and the management interface obtains its DHCP lease.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [x] 202605
Based on the network related test results, didn't see any issue as the patch only ignore the families that ifupdown2 not support.
- [ ] <!-- image version 2 -->

#### Description for the changelog

ifupdown2: tolerate unsupported netlink address families (e.g. AF_MCTP) during the global address dump so an MCTP interface no longer breaks `ifup -a` / DHCP.

#### Link to config_db schema for YANG module changes

N/A — no config_db / YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)
