### PR TITLE
Add SONIC_PRE_IMAGE_HOOK support

### DIFF
--- a/rules/config
+++ b/rules/config
@@ -57,6 +57,13 @@ SONIC_CONFIG_MAKE_JOBS = $(shell nproc)
 # Supported format: simple, none
 DEFAULT_BUILD_LOG_TIMESTAMP = none
 
+# SONIC_PRE_IMAGE_HOOK - optional command to run after build_debian.sh and
+# before build_image.sh for installer image targets. The command may include
+# arguments and receives TARGET_MACHINE, TARGET_MACHINE_EXT, IMAGE_TYPE, and
+# TARGET_PATH in its environment. A non-zero exit status fails the installer
+# target.
+# SONIC_PRE_IMAGE_HOOK =
+
 # SONIC_CONFIG_USE_NATIVE_DOCKERD_FOR_BUILD - use native dockerd for build.
 # If set to y SONiC build container will use native dockerd instead of dind for faster build.
 # Special handling of the docker image file names is needed to avoid conflicts with

--- a/slave.mk
+++ b/slave.mk
@@ -481,6 +481,7 @@ $(info "BUILD_LOG_TIMESTAMP"             : "$(BUILD_LOG_TIMESTAMP)")
 $(info "SONIC_IMAGE_VERSION"             : "$(SONIC_IMAGE_VERSION)")
 $(info "BLDENV"                          : "$(BLDENV)")
 $(info "VS_PREPARE_MEM"                  : "$(VS_PREPARE_MEM)")
+$(info "SONIC_PRE_IMAGE_HOOK"            : "$(SONIC_PRE_IMAGE_HOOK)")
 $(info "INCLUDE_MGMT_FRAMEWORK"          : "$(INCLUDE_MGMT_FRAMEWORK)")
 $(info "INCLUDE_ICCPD"                   : "$(INCLUDE_ICCPD)")
 $(info "INCLUDE_STP"                     : "$(INCLUDE_STP)")
@@ -1832,6 +1833,15 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		ENABLE_SBOM="$(ENABLE_SBOM)" \
 		TARGET_PATH="$(TARGET_PATH)" \
 			./build_debian.sh $(LOG)
+
+		$(if $(SONIC_PRE_IMAGE_HOOK), \
+			echo "Running SONIC_PRE_IMAGE_HOOK: $(SONIC_PRE_IMAGE_HOOK)" && \
+			TARGET_MACHINE=$(dep_machine) \
+			TARGET_MACHINE_EXT=$(TARGET_MACHINE_EXT) \
+			IMAGE_TYPE=$($*_IMAGE_TYPE) \
+			TARGET_PATH=$(TARGET_PATH) \
+				$(SONIC_PRE_IMAGE_HOOK) \
+		)
 
 		USERNAME="$(USERNAME)" \
 		PASSWORD="$(PASSWORD)" \


### PR DESCRIPTION
Allow a pre-image hook script to run between build_debian.sh and build_image.sh in the installer target. When SONIC_PRE_IMAGE_HOOK is set to a script path (optionally with arguments), it executes with installer build context before the final image is assembled.

When SONIC_PRE_IMAGE_HOOK is unset, this is a no-op. This preserves the default behavior.

#### Why I did it

For certain build types we have a need to inject some additional binaries into the final image. These binaries aide in testing but are not needed for release, and so it does not make sense to upstream patches for individual packages.

This change introduces the SONIC_PRE_IMAGE_HOOK param as a flexible way for vendors to introduce additional content into the build without the need for invasive patches.

#### How I did it

SONIC_PRE_IMAGE_HOOK, if nonempty, runs after the `build_debian.sh` step but before the `build_image.sh` step.

#### How to verify it

When unset, this PR should have no impact on the resulting image.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

- [ ] 202511

#### Description for the changelog
Introduce SONIC_PRE_IMAGE_HOOK build flag which provides a flexible mechanism for vendors to influence the inputs to the image build process.

#### A picture of a cute animal (not mandatory but encouraged)

Juvenile California Scrub-Jay getting fed by a parent. Lake San Antonio. June 21st
<img width="2298" height="1724" alt="image" src="https://github.com/user-attachments/assets/0c3a6491-0790-4586-9676-8c2d46b25744" />
