### PR TITLE
Fix show system-health summary/detail/monitor-list CLI for BMC

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/chassis.py
@@ -319,3 +319,36 @@ class Chassis(ChassisBase):
             return None
         return self._fan_list[index]
 
+    ##############################################
+    # System LED methods
+    ##############################################
+
+    def initizalize_system_led(self):
+        """
+        Initialize the system status LED.
+
+        The B27 BMC has no controllable system LED, so there is nothing to
+        initialize.
+        """
+        return True
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the system LED.
+
+        Returns:
+            bool: True if system LED state is set successfully, False if not
+        """
+        # LED control not supported on BMC platform.
+        return False
+
+    def get_status_led(self):
+        """
+        Gets the state of the system LED.
+
+        Returns:
+            A string representing the LED color
+        """
+        # LED control not supported on BMC platform.
+        return "N/A"
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`show system-health summary`, `show system-health detail`, and `show system-health monitor-list` crashed on the Nexthop B27 BMC with:

  `AttributeError: 'Chassis' object has no attribute 'initizalize_system_led'`

  The aspeed Nexthop chassis extends plain ChassisBase and never implemented the system-LED methods that sonic-utilities/show/system_health.py relies on:
  - `get_system_health_status()` calls `chassis.initizalize_system_led()` - missing entirely → AttributeError (hit by all three CLIs).
  - summary/detail then call `chassis.get_status_led()` directly (uncaught) - the ChassisBase default raises `NotImplementedError`, so those two would crash even after the first fix.
  - health_checker/manager.py calls `chassis.set_status_led()`; the base `NotImplementedError` produced the noisy `chassis.set_status_led` is not implemented line (caught, but cosmetic).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added the three system-LED methods to `platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/chassis.py` as no-ops appropriate for a BMC with no controllable LED:
  - **initizalize_system_led()** → returns True (fixes the crash).
  - **get_status_led()** → returns "N/A"
  - **set_status_led(color)** → returns False (no LED to set; also suppresses the not implemented message since it no longer raises).

#### How to verify it
Running the commands on BMC:
* Confirm none of the commands traceback:
  - show system-health summary
  - show system-health detail
  - show system-health monitor-list
* summary/detail should print System status LED  N/A.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

