### PR TITLE
[Pensando] Enable chassisd for SmartSwitch DPU platform

### DIFF
--- a/device/pensando/arm64-elba-asic-flash128-r0/pmon_daemon_control.json
+++ b/device/pensando/arm64-elba-asic-flash128-r0/pmon_daemon_control.json
@@ -6,7 +6,7 @@
     "skip_syseepromd": false,
     "skip_xcvrd": true,
     "skip_chassis_db_init": false,
-    "skip_chassisd": true,
+    "skip_chassisd": false,
     "skip_pcied": false,
     "include_sensormond": true
 }

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
@@ -15,6 +15,7 @@ try:
     import subprocess
     from sonic_platform_base.chassis_base import ChassisBase
     from .helper import APIHelper
+    import redis
     import syslog
     import inspect
     from sonic_py_common import syslogger
@@ -32,6 +33,11 @@ REBOOT_CAUSE_EXTERNAL = "External causes"
 RESET_CAUSE_PATH = "/sys/firmware/pensando/rstcause/this_cause"
 DOCKER_HWSKU_PATH = '/usr/share/sonic/platform'
 SLOT_ID_MASK = 0x7
+
+REDIS_CHASSIS_SERVER_PORT = 6380
+REDIS_CHASSIS_SERVER_IP = '169.254.200.254'
+CHASSIS_STATE_DB_ID = 13
+DPU_HEALTH_INFO_TABLE_NAME = 'DPU_STATE'
 
 #cpld masks for system led
 SYSTEM_LED_GREEN   = 0x7
@@ -432,4 +438,48 @@ class Chassis(ChassisBase):
 
     def get_revision(self):
         return self._api_helper.get_board_rev()
+
+    ##############################################
+    # SmartSwitch methods
+    ##############################################
+
+    def _get_chassis_state_db(self):
+        if not hasattr(self, '_chassis_state_db') or self._chassis_state_db is None:
+            try:
+                self._chassis_state_db = redis.Redis(
+                    host=REDIS_CHASSIS_SERVER_IP,
+                    port=REDIS_CHASSIS_SERVER_PORT,
+                    decode_responses=True,
+                    db=CHASSIS_STATE_DB_ID)
+                self._chassis_state_db.ping()
+            except Exception:
+                self._chassis_state_db = None
+        return self._chassis_state_db
+
+    def is_smartswitch(self):
+        return True
+
+    def is_dpu(self):
+        return True
+
+    def get_dpu_id(self, **kwargs):
+        return self.get_my_slot()
+
+    def get_dataplane_state(self):
+        db = self._get_chassis_state_db()
+        if db is None:
+            return False
+        slot_id = self.get_my_slot()
+        table = f'{DPU_HEALTH_INFO_TABLE_NAME}|DPU{slot_id}'
+        state = db.hget(table, 'dpu_data_plane_state')
+        return state == 'up'
+
+    def get_controlplane_state(self):
+        db = self._get_chassis_state_db()
+        if db is None:
+            return False
+        slot_id = self.get_my_slot()
+        table = f'{DPU_HEALTH_INFO_TABLE_NAME}|DPU{slot_id}'
+        state = db.hget(table, 'dpu_control_plane_state')
+        return state == 'up'
 


### PR DESCRIPTION
Implement missing SmartSwitch chassis APIs for Pensando DPU platform (arm64-elba-asic-flash128-r0) and enable the chassisd daemon.

- Add is_smartswitch() and is_dpu() returning True for Mt Fuji SmartSwitch boards
- Add get_dpu_id() mapping to hardware slot ID via get_my_slot()
- Add get_dataplane_state() and get_controlplane_state() reading from CHASSIS_STATE_DB, populated by the dpu-db-util service using pdsctl, pdsagent status, container health, and uplink checks via gRPC events
- Add _get_chassis_state_db() helper for lazy Redis connection to the switch host chassis state DB at 169.254.200.254:6380
- Enable chassisd by setting skip_chassisd to false in pmon_daemon_control.json

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
chassisd was disabled and relevant APIs were missing in chassis.py. On enablement of chassisd was throwing errors for missing APIs. So added missing APIs and enabled chassisd for Pensando-elba platform
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Add is_smartswitch() and is_dpu() returning True for Mt Fuji SmartSwitch boards
- Add get_dpu_id() mapping to hardware slot ID via get_my_slot()
- Add get_dataplane_state() and get_controlplane_state() reading from CHASSIS_STATE_DB, populated by the dpu-db-util service using pdsctl, pdsagent status, container health, and uplink checks via gRPC events
- Add _get_chassis_state_db() helper for lazy Redis connection to the switch host chassis state DB at 169.254.200.254:6380
- Enable chassisd by setting skip_chassisd to false in pmon_daemon_control.json

#### How to verify it
chassisd should be up and running and update control plane and data plane state to CHASSIS_STATE_DB. Make sure chassis.py apis are returning correct values
```
root@sonic:/home/admin# python3
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_platform
>>> p = sonic_platform.platform.Platform()
>>> c = p.get_chassis()
>>> c.get_controlplane_state()
True
>>> c.get_dataplane_state()
True
>>> c.is_smartswitch()
True
>>> c.is_dpu()
True
>>>
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20251106.23

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

