### PR TITLE
Add pmbus entries in sensors.conf for arista_7280r4_32qf_32df

### DIFF
--- a/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
+++ b/device/arista/x86_64-arista_7280r4_32qf_32df/sensors.conf
@@ -81,6 +81,22 @@ chip "dps800-i2c-23-58"
     ignore fan3
     ignore fan4
 
+chip "pmbus-i2c-22-58"
+    label temp1 "Power supply 1 inlet sensor"
+    label temp2 "Power supply 1 secondary hotspot sensor"
+    label temp3 "Power supply 1 primary hotspot sensor"
+
+    ignore fan3
+    ignore fan4
+
+chip "pmbus-i2c-23-58"
+    label temp1 "Power supply 2 inlet sensor"
+    label temp2 "Power supply 2 secondary hotspot sensor"
+    label temp3 "Power supply 2 primary hotspot sensor"
+
+    ignore fan3
+    ignore fan4
+
 chip "nvme-pci-0500"
     ignore temp2
     ignore temp3


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Need these entries to false alarms on pmbus driven psus.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added entry in sensors.conf

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
Run `sensors`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202511

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/8156aac0-dded-4ceb-8eba-52874b6082f6" />

