### PR TITLE
[docker-sonic-mgmt] pin ansible to 13.6.0 to avoid ansible-core 2.21 broken pipe

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -63,7 +63,7 @@ RUN sed -i 's|^PATH="|PATH="/opt/venv/bin:|' /etc/environment \
 RUN uv pip install --no-cache \
     aiohttp \
     allure-pytest \
-    ansible \
+    ansible==13.6.0 \
     azure-storage-blob \
     azure-kusto-data \
     azure-kusto-ingest \


### PR DESCRIPTION
#### Why I did it

PR #27301 unpinned ansible in the docker-sonic-mgmt image (`ansible==11.10.0` -> `ansible`). With the pin removed, the image now floats to **ansible 14.x / ansible-core 2.21.x**.

ansible-core 2.21 intermittently fails ssh module execution from forked sanity-check workers (e.g. `check_critical_processes` via `parallel_run`) with:

```
Task failed: [Errno 32] Broken pipe
```

This shows up across kvm PR-test topologies (t1-lag, multi-asic-t1, t2, t1-lag-vpp), driving widespread failures and retry-induced flakiness. The last known-good image used **ansible 11.10.0 (ansible-core 2.18.11)**.

#### How I did it

Pin the ansible meta-package to a known-good version that stays below ansible-core 2.21:

```
ansible==13.6.0
```

`ansible==13.6.0` requires `ansible-core~=2.20.5` (i.e. `>=2.20.5,<2.21`), so it will not pull ansible-core 2.21.

| ansible (meta) | ansible-core | broken pipe |
| --- | --- | --- |
| 11.10.0 (previous pin) | 2.18.11 | no |
| **13.6.0 (this PR)** | **~=2.20.5** | no |
| 14.1.0 (current unpinned) | 2.21.1 | yes |

#### How to verify it

Build the docker-sonic-mgmt image and confirm:

```
$ python3 -c "import importlib.metadata as m; print(m.version('ansible'), m.version('ansible-core'))"
13.6.0 2.20.5
```

Then run kvm PR tests; the `[Errno 32] Broken pipe` failures from forked sanity workers should no longer occur.

> Note: this is a targeted mitigation for the ansible-core 2.21 regression. Full ansible-core 2.21 compatibility is being addressed separately in sonic-mgmt (PR sonic-net/sonic-mgmt#25545).