### PR TITLE
[docker-snmp]: Fix SNMP agentAddress rendering for IPv4 and IPv6

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -26,7 +26,12 @@
 
 {% if SNMP_AGENT_ADDRESS_CONFIG %}
 {% for (agentip, port, vrf) in SNMP_AGENT_ADDRESS_CONFIG %}
-agentAddress {{ protocol(agentip) }}:[{{ agentip }}]{% if vrf %}@{{ vrf }}{% endif %}{% if port %}:{{ port }}{% endif %}{{ "" }}
+{% set agent_proto = protocol(agentip).strip() %}
+{% if agent_proto == 'udp6' %}
+agentAddress {{ agent_proto }}:[{{ agentip }}]{% if vrf %}@{{ vrf }}{% endif %}{% if port %}:{{ port }}{% endif %}{{ "" }}
+{% else %}
+agentAddress {{ agent_proto }}:{{ agentip }}{% if vrf %}@{{ vrf }}{% endif %}{% if port %}:{{ port }}{% endif %}{{ "" }}
+{% endif %}
 {% endfor %}
 {% else %}
 agentAddress udp:161


### PR DESCRIPTION
Fix snmpd template rendering for agentAddress by splitting IPv4 and IPv6 formatting. Emit udp:<ipv4> (no brackets) and udp6:[<ipv6>] (with brackets), and strip protocol output for whitespace safety.

#### Why I did it

The snmpd Jinja template currently wraps both IPv4 and IPv6 agent addresses in brackets.  
That generates invalid net-snmp syntax for IPv4, for example udp:[1.2.3.4]:161.

This change fixes address rendering so:
- IPv4 is emitted as udp:<ipv4>[:port] with no brackets
- IPv6 is emitted as udp6:[<ipv6>][:port] with brackets

This is a runtime template bug in snmpd.conf.j2

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Updated the agentAddress render block in snmpd.conf.j2
- Introduced a local variable from protocol(agentip).strip()
- Added protocol-specific formatting:
  - udp6 branch keeps bracketed address
  - udp branch uses unbracketed address
  
#### How to verify it

1. Configure SNMP_AGENT_ADDRESS_CONFIG with one IPv4 and one IPv6 entry.
2. Render snmpd.conf through the normal SONiC config generation path.
3. Confirm output lines are:
   - IPv4: agentAddress udp:1.2.3.4:161
   - IPv6: agentAddress udp6:[2001:db8::1]:161
4. Confirm there is no bracketed IPv4 form like udp:[1.2.3.4]:161.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202605

Backport reason: 

#### Tested branch (Please provide the tested image version)

- [x] master 

#### Description for the changelog

Fix SNMP agentAddress template rendering to use unbracketed IPv4 and bracketed IPv6 formats required by net-snmp.

#### Link to config_db schema for YANG module changes

N/A - No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

<img width="1206" height="961" alt="sasha" src="https://github.com/user-attachments/assets/5c4944f5-a361-4204-8d19-5a4ca5358465" />
