### PR TITLE
[sonic-yang-models]: Add PACKET_COLOR_ACTION to sonic-acl YANG

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -210,5 +210,12 @@
     },
     "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {
         "desc": "Configure INNERSRCMACREWRITE ACL with no inner src IP"
+    },
+    "ACL_RULE_WITH_VALID_PACKET_COLOR_ACTION": {
+        "desc": "Configure ACL rule with valid PACKET_COLOR_ACTION values (GREEN/YELLOW/RED)."
+    },
+    "ACL_RULE_WITH_INVALID_PACKET_COLOR_ACTION": {
+        "desc": "Configure ACL rule with an invalid PACKET_COLOR_ACTION value.",
+        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -2283,5 +2283,67 @@
                 ]
             }
         }
+    },
+    "ACL_RULE_WITH_VALID_PACKET_COLOR_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "PACKET_COLOR_ACTION": "GREEN",
+                        "PRIORITY": 9991,
+                        "RULE_NAME": "Rule_1"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "PACKET_COLOR_ACTION": "YELLOW",
+                        "PRIORITY": 9992,
+                        "RULE_NAME": "Rule_2"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "PACKET_COLOR_ACTION": "RED",
+                        "PRIORITY": 9993,
+                        "RULE_NAME": "Rule_3"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "policy_desc": "PACKET_COLOR_TEST",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_INVALID_PACKET_COLOR_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "PACKET_COLOR_ACTION": "PURPLE",
+                        "PRIORITY": 9991,
+                        "RULE_NAME": "Rule_1"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "PACKET_COLOR_TEST",
+                        "policy_desc": "PACKET_COLOR_TEST",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -96,6 +96,15 @@ module sonic-acl {
 					type yang:mac-address;
 				}
 
+				leaf PACKET_COLOR_ACTION {
+					description "Packet color to set on matching packets";
+					type enumeration {
+						enum GREEN;
+						enum YELLOW;
+						enum RED;
+					}
+				}
+
 				leaf IP_TYPE {
 					description "IP type to match (IPv4, IPv6, ARP, etc.)";
 					type stypes:ip_type;


### PR DESCRIPTION
#### What I did
Add the `PACKET_COLOR_ACTION` leaf (enum `GREEN`/`YELLOW`/`RED`) to the `sonic-acl` YANG model so a CONFIG_DB ACL rule can carry the packet-color action. This is the YANG counterpart to the orchagent support in sonic-net/sonic-swss#4717.

#### Details
- `yang-templates/sonic-acl.yang.j2`: new `leaf PACKET_COLOR_ACTION` (enumeration GREEN/YELLOW/RED) under the ACL rule.
- `yang_model_tests`: positive case `ACL_RULE_WITH_VALID_PACKET_COLOR_ACTION` and negative case `ACL_RULE_WITH_INVALID_PACKET_COLOR_ACTION` (rejects a non-enum value).

#### How I verified
Ran the full `sonic-yang-models` pytest (`tests/yang_model_tests`) — both new cases pass, no mismatches.

Related: sonic-net/sonic-swss#4717 (orchagent support), sonic-net/sonic-swss#4716 (issue).
