### PR TITLE
Fix platform.json for Arista DCS-7060X6-16PE-384C

### DIFF
--- a/device/arista/x86_64-arista_7060x6_16pe_384c/platform.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c/platform.json
@@ -63,15 +63,6 @@
                     "controllable": false
                 },
                 "fans": []
-            },
-            {
-                "name": "psu2",
-                "voltage_high_threshold": false,
-                "voltage_low_threshold": false,
-                "status_led": {
-                    "controllable": false
-                },
-                "fans": []
             }
         ],
         "thermals": [

--- a/device/arista/x86_64-arista_7060x6_16pe_384c_b/platform.json
+++ b/device/arista/x86_64-arista_7060x6_16pe_384c_b/platform.json
@@ -67,15 +67,6 @@
                     "controllable": false
                 },
                 "fans": []
-            },
-            {
-                "name": "psu2",
-                "voltage_high_threshold": false,
-                "voltage_low_threshold": false,
-                "status_led": {
-                    "controllable": false
-                },
-                "fans": []
             }
         ],
         "thermals": [


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This device has a single ECB connected to a 48V bus bar modeled as one PSU, not two. Remove the second PSU entry from platform.json for both DCS-7060X6-16PE-384C and its -B variant.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Backport to branches supporting this device model.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Fix platform.conf PSUs for Arista DCS-7060X6-16PE-384C

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
