### PR TITLE
[radius] Load OpenSSL legacy provider so PEAP/MS-CHAPv2 works under FIPS

### DIFF
--- a/src/radius/pam/debian/patches/0005-fips-md4-legacy-provider.patch
+++ b/src/radius/pam/debian/patches/0005-fips-md4-legacy-provider.patch
@@ -1,0 +1,64 @@
+Index: pam_radius/src/mschapv2.c
+===================================================================
+--- pam_radius.orig/src/mschapv2.c
++++ pam_radius/src/mschapv2.c
+@@ -64,6 +64,29 @@
+ #include <efence.h>
+ #endif
+ 
++#if OPENSSL_VERSION_NUMBER >= 0x30000000L
++#include <openssl/provider.h>
++/*
++ * MS-CHAPv2 relies on MD4, which on OpenSSL 3.x lives in the "legacy"
++ * provider.  FIPS / SymCrypt enabled images do not load it by default, so
++ * EVP_md4() cannot be fetched, EVP_DigestInit() fails and the digest calls
++ * below would run on an uninitialised context and crash the PAM module
++ * (taking the whole login session down).  Pull in the legacy (and default)
++ * provider once so MD4 is available to this module.
++ */
++static void mschap_ensure_md4_provider(void)
++{
++  static int done = 0;
++  if (!done) {
++    OSSL_PROVIDER_load(NULL, "legacy");
++    OSSL_PROVIDER_load(NULL, "default");
++    done = 1;
++  }
++}
++#else
++#define mschap_ensure_md4_provider() do { } while (0)
++#endif
++
+ void ChallengeHash(char *PeerChallenge, char *AuthenticatorChallenge,
+ 		   char *UserName, char *Challenge)
+ {
+@@ -142,9 +165,11 @@
+   uniPassword = to_unicode(Password);
+   len = (strlen(Password))*2;
+ 
+-  EVP_DigestInit(cntx, EVP_md4());
+-  EVP_DigestUpdate(cntx, uniPassword, len);
+-  EVP_DigestFinal(cntx, (uint8_t *)&retVal, (u_int *)&i);
++  mschap_ensure_md4_provider();
++  if (EVP_DigestInit(cntx, EVP_md4()) == 1) {
++    EVP_DigestUpdate(cntx, uniPassword, len);
++    EVP_DigestFinal(cntx, (uint8_t *)&retVal, (u_int *)&i);
++  }
+   EVP_MD_CTX_free(cntx);
+ 
+   memcpy(PasswordHash, &retVal, 16);
+@@ -165,9 +190,11 @@
+   if (!xsup_assert((PasswordHashHash != NULL), "PasswordHashHash != NULL",
+ 		   FALSE)) return;
+ 
+-  EVP_DigestInit(cntx, EVP_md4());
+-  EVP_DigestUpdate(cntx, PasswordHash, 16);
+-  EVP_DigestFinal(cntx, (uint8_t *) PasswordHashHash, (u_int *) &i);
++  mschap_ensure_md4_provider();
++  if (EVP_DigestInit(cntx, EVP_md4()) == 1) {
++    EVP_DigestUpdate(cntx, PasswordHash, 16);
++    EVP_DigestFinal(cntx, (uint8_t *) PasswordHashHash, (u_int *) &i);
++  }
+   EVP_MD_CTX_free(cntx);
+ 
+ }

--- a/src/radius/pam/debian/patches/series
+++ b/src/radius/pam/debian/patches/series
@@ -1,4 +1,5 @@
 0001-chap-support.patch
 0002-peap-mschapv2-support.patch
 0003-nas-ip-address-config.patch
-0004-fix-blastradius.patch 
+0004-fix-blastradius.patch
+0005-fips-md4-legacy-provider.patch


### PR DESCRIPTION
Fixes #27193
This is a bug fix.With FIPS enabled, OpenSSL's default provider is FIPS/SymCrypt and the legacy provider is not loaded, so MD4 is unavailable. pam_radius's PEAP/EAP-MSCHAPv2 path computes the NT hash with EVP_md4() in mschapv2.c without checking EVP_DigestInit()'s return value, so RADIUS mschapv2 authentication fails for all users (and crashes the PAM module on OpenSSL 3.0, closing the SSH session for everyone).

Load the legacy (and default) OpenSSL provider once before MD4 is used so EVP_md4() can be fetched, and guard EVP_DigestInit() so a missing MD4 can no longer crash the module. The provider is loaded only within the pam_radius process, leaving the system FIPS posture unchanged.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When FIPS is enabled (`sonic_fips=1`), OpenSSL's active provider is the
FIPS/SymCrypt provider and the `legacy` provider is not loaded, so **MD4 is
unavailable**:
```
$ echo -n x | openssl dgst -md4
... Algorithm (MD4 : 88) ... unsupported ... initialization error
```
PEAP / EAP-MSCHAPv2 (used by `libpam-radius-auth` when RADIUS `auth_type` is
`mschapv2`) computes the NT hash with MD4 in `src/mschapv2.c`
(`NtPasswordHash()` / `HashNtPasswordHash()`):

```c
EVP_DigestInit(cntx, EVP_md4());      /* fails under FIPS, return value ignored */
EVP_DigestUpdate(cntx, uniPassword, len);
EVP_DigestFinal(cntx, (uint8_t *)&retVal, (u_int *)&i);
```
EVP_DigestInit() fails (MD4 cannot be fetched) but the return value is not
checked, so the code keeps operating on an uninitialised digest context.

Result, with FIPS enabled and RADIUS auth_type mschapv2:

The NT-Response is computed wrong → the RADIUS server rejects every RADIUS user (PEAP/MS-CHAPv2 authentication fails). PAP/CHAP are unaffected because they don't use MD4.
On OpenSSL 3.0.x the unchecked failure dereferences an invalid context and crashes the PAM module, which closes the SSH session for every user (the stack never reaches the local pam_unix fallback). On newer OpenSSL it doesn't crash but still fails authentication silently.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a quilt patch 0005-fips-md4-legacy-provider.patch to
libpam-radius-auth. In src/mschapv2.c, before MD4 is used it:

loads the OpenSSL legacy (and default) provider once, so EVP_md4() can be fetched even when the FIPS/SymCrypt provider is the default. legacy.so already ships in the image; it is loaded only inside the pam_radius process, leaving the system-wide FIPS posture unchanged.
checks the EVP_DigestInit() return value before Update/Final, so a missing MD4 can never crash the module again (graceful auth failure instead).
Note: MS-CHAPv2 intrinsically relies on MD4/DES, which are not FIPS-approved;
this change makes the feature functional when both FIPS and mschapv2 are
configured, without claiming FIPS compliance for the MS-CHAPv2 exchange itself.

#### How to verify it
On a FIPS-enabled image with a RADIUS server doing PEAP/EAP-MSCHAPv2:
```
config radius authtype mschapv2
```
SSH in as a RADIUS user.
Before: authentication fails for all RADIUS users (and on OpenSSL 3.0 the SSH session is closed for every user, including local accounts).
After: the RADIUS user authenticates via PEAP/MS-CHAPv2 and logs in.
openssl dgst -md4 still fails at the shell (system FIPS posture unchanged); only pam_radius_auth loads the legacy provider internally.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)
<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### Test Result
202605: PASS

Image: SONiC.202605.0-71ea3b2f9

Evidence:
- RADIUS mschapv2 authentication succeeded
- SSH login succeeded

Full test log:
```
admin@sonic:~$ show version

SONiC Software Version: SONiC.202605.0-71ea3b2f9
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 71ea3b2f9
Build date: Wed Aug 19 08:05:37 UTC 2026
Built by: micasrd@micasrd-PowerEdge-R730

Platform: x86_64-micas_m2-w6520-48c8qc-r0
HwSKU: M2-W6520-48C8QC
ASIC: broadcom
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 03:47:58 up 1 min,  2 users,  load average: 3.54, 1.20, 0.43
Date: Thu 20 Aug 2026 03:47:58

Docker images:
REPOSITORY                    TAG                  IMAGE ID       SIZE
docker-orchagent              202605.0-71ea3b2f9   dc96f76acb5a   334MB
docker-orchagent              latest               dc96f76acb5a   334MB
docker-macsec                 202605.0-71ea3b2f9   714bc74b7d78   321MB
docker-macsec                 latest               714bc74b7d78   321MB
docker-gnmi-watchdog          202605.0-71ea3b2f9   061637c58d92   287MB
docker-gnmi-watchdog          latest               061637c58d92   287MB
docker-sonic-mgmt-framework   202605.0-71ea3b2f9   4f51382a5cf0   344MB
docker-sonic-mgmt-framework   latest               4f51382a5cf0   344MB
docker-sonic-gnmi             202605.0-71ea3b2f9   de2328840bcb   427MB
docker-sonic-gnmi             latest               de2328840bcb   427MB
docker-restapi-sidecar        202605.0-71ea3b2f9   e0b179a5938d   281MB
docker-restapi-sidecar        latest               e0b179a5938d   281MB
docker-database               202605.0-71ea3b2f9   7da78b507024   287MB
docker-database               latest               7da78b507024   287MB
docker-sonic-otel             202605.0-71ea3b2f9   66de0eedf2ac   622MB
docker-sonic-otel             latest               66de0eedf2ac   622MB
docker-gbsyncd-agera2         202605.0-71ea3b2f9   e26e6b1bb4c8   340MB
docker-gbsyncd-agera2         latest               e26e6b1bb4c8   340MB
docker-gbsyncd-credo          202605.0-71ea3b2f9   d96dc1024178   310MB
docker-gbsyncd-credo          latest               d96dc1024178   310MB
docker-sonic-bmp              202605.0-71ea3b2f9   fe61ddfb8ece   282MB
docker-sonic-bmp              latest               fe61ddfb8ece   282MB
docker-eventd                 202605.0-71ea3b2f9   01a7793312b7   280MB
docker-eventd                 latest               01a7793312b7   280MB
docker-snmp                   202605.0-71ea3b2f9   3258b1afef8b   307MB
docker-snmp                   latest               3258b1afef8b   307MB
docker-platform-monitor       202605.0-71ea3b2f9   412630453e8d   407MB
docker-platform-monitor       latest               412630453e8d   407MB
docker-bmp-watchdog           202605.0-71ea3b2f9   45e51fb9bc9a   280MB
docker-bmp-watchdog           latest               45e51fb9bc9a   280MB
docker-dhcp-relay             202605.0-71ea3b2f9   4bcbf83950c3   323MB
docker-dhcp-relay             latest               4bcbf83950c3   323MB
docker-fpm-frr                202605.0-71ea3b2f9   c7ee0b7b7919   383MB
docker-fpm-frr                latest               c7ee0b7b7919   383MB
docker-dash-ha                202605.0-71ea3b2f9   a8f2e39889f3   338MB
docker-dash-ha                latest               a8f2e39889f3   338MB
docker-lldp                   202605.0-71ea3b2f9   83850f235159   289MB
docker-lldp                   latest               83850f235159   289MB
docker-router-advertiser      202605.0-71ea3b2f9   ad4ddad96157   281MB
docker-router-advertiser      latest               ad4ddad96157   281MB
docker-nat                    202605.0-71ea3b2f9   d017bdecf0b8   321MB
docker-nat                    latest               d017bdecf0b8   321MB
docker-syncd-brcm             202605.0-71ea3b2f9   6a3fcbbce85d   874MB
docker-syncd-brcm             latest               6a3fcbbce85d   874MB
docker-gnmi-sidecar           202605.0-71ea3b2f9   7f460145ba58   280MB
docker-gnmi-sidecar           latest               7f460145ba58   280MB
docker-gbsyncd-broncos        202605.0-71ea3b2f9   1df90dc70649   339MB
docker-gbsyncd-broncos        latest               1df90dc70649   339MB
docker-teamd                  202605.0-71ea3b2f9   3a214c2850fc   318MB
docker-teamd                  latest               3a214c2850fc   318MB
docker-mux                    202605.0-71ea3b2f9   6e809c53882f   293MB
docker-mux                    latest               6e809c53882f   293MB
docker-sysmgr                 202605.0-71ea3b2f9   93ae70ad9853   286MB
docker-sysmgr                 latest               93ae70ad9853   286MB
docker-sflow                  202605.0-71ea3b2f9   d1c391f38396   319MB
docker-sflow                  latest               d1c391f38396   319MB
admin@sonic:~$ sudo config aaa authentication login radius local
admin@sonic:~$ sudo config aaa authentication failthrough enable
admin@sonic:~$ sudo config radius add 172.31.32.50
admin@sonic:~$ sudo config radius passkey Radius@123
admin@sonic:~$ sudo config radius authtype mschapv2
admin@sonic:~$ show aaa
AAA authentication login radius,local
AAA authentication failthrough True
AAA authorization login local (default)
AAA accounting login disable (default)

admin@sonic:~$ show radius
RADIUS global auth_type mschapv2
RADIUS global retransmit 3 (default)
RADIUS global timeout 5 (default)
RADIUS global passkey Radius@123

RADIUS_SERVER address 172.31.32.50
               auth_port 1812
               priority 1
root@sonic:/home/admin# tail -f /var/log/auth.log
2026 Aug 20 07:01:47.954061 sonic NOTICE su[689750]: (to root) root on pts/1
2026 Aug 20 07:01:47.954353 sonic INFO su[689750]: pam_unix(su:session): session opened for user root(uid=0) by admin(uid=0)
2026 Aug 20 07:01:49.656158 sonic NOTICE sudo:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/vtysh -c 'show ip route json'
2026 Aug 20 07:01:49.657039 sonic NOTICE sudo:     root : PWD=/ ; USER=root ; COMMAND=/usr/bin/vtysh -c 'show ipv6 route json'
2026 Aug 20 07:01:49.657124 sonic INFO sudo: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
2026 Aug 20 07:01:49.657179 sonic INFO sudo: pam_unix(sudo:session): session opened for user root(uid=0) by (uid=0)
2026 Aug 20 07:01:49.809759 sonic INFO sudo: pam_unix(sudo:session): session closed for user root
2026 Aug 20 07:01:49.812582 sonic INFO sudo: pam_unix(sudo:session): session closed for user root
2026 Aug 20 07:01:50.308619 sonic INFO sshd-session[627385]: Close session: user admin from 172.27.13.205 port 62436 id 1
2026 Aug 20 07:01:51.698702 sonic INFO sshd-session[627385]: Starting session: command for admin from 172.27.13.205 port 62436 id 1





2026 Aug 20 07:02:01.834674 sonic INFO sshd-session[627385]: Close session: user admin from 172.27.13.205 port 62436 id 1
2026 Aug 20 07:02:02.454453 sonic INFO sshd-session[690794]: Connection from 172.27.13.205 port 55080 on 172.17.224.110 port 22 rdomain ""
2026 Aug 20 07:02:07.540101 sonic INFO sshd-session[627385]: Starting session: command for admin from 172.27.13.205 port 62436 id 1
2026 Aug 20 07:02:09.565410 sonic INFO sshd-session[627385]: Close session: user admin from 172.27.13.205 port 62436 id 1
2026 Aug 20 07:02:10.527543 sonic INFO sshd-session[690794]: pam_succeed_if(sshd:auth): requirement "user = root" not met by user "radiususer"
2026 Aug 20 07:02:10.527631 sonic DEBUG sshd-session[690794]: pam_radius_auth: talk_radius: Auth type is PEAP
2026 Aug 20 07:02:10.527684 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.562760 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.562820 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.562864 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.562907 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=144, length=64
2026 Aug 20 07:02:10.562955 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.563002 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.563044 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.563115 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling process_eap_message
2026 Aug 20 07:02:10.567960 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling setup_TLS_session
2026 Aug 20 07:02:10.568024 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: before record_init
2026 Aug 20 07:02:10.569930 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling SSL_read
2026 Aug 20 07:02:10.569980 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling BIO_read
2026 Aug 20 07:02:10.570021 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling rad_alloc
2026 Aug 20 07:02:10.570072 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling compose_radius_pkt
2026 Aug 20 07:02:10.570114 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling compose_eap_packet
2026 Aug 20 07:02:10.570156 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.611358 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.611430 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.611475 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.611515 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=145, length=1068
2026 Aug 20 07:02:10.611565 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.611617 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.611663 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.611723 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.644982 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.645040 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.645081 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.645127 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=146, length=222
2026 Aug 20 07:02:10.645170 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.645218 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.645267 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.648417 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.682132 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.682177 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.682215 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.682262 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=147, length=115
2026 Aug 20 07:02:10.682311 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.682357 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.682402 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.682462 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.716765 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.716835 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.716880 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.716921 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=148, length=98
2026 Aug 20 07:02:10.716968 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.717010 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.717070 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.717118 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.750214 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.750270 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.750308 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.750349 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=149, length=132
2026 Aug 20 07:02:10.750392 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.750433 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.750476 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.750529 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: peap_data = 1a
2026 Aug 20 07:02:10.750834 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: Compose MSCHAPv2 response of peap_data_length = 66
2026 Aug 20 07:02:10.750890 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: get_tls_data returned success
2026 Aug 20 07:02:10.750943 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: compose_eap_packet returned success
2026 Aug 20 07:02:10.750991 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: get_tls_data returned success
2026 Aug 20 07:02:10.751051 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: compose_eap_packet returned success
2026 Aug 20 07:02:10.751123 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: Client State = 0x810
2026 Aug 20 07:02:10.751171 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.784219 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.784290 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.784336 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.784384 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=150, length=140
2026 Aug 20 07:02:10.784435 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.784492 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.784560 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.784612 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.817558 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.817628 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.817670 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.817707 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=151, length=104
2026 Aug 20 07:02:10.817748 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.817798 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.817844 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.817889 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:10.850514 sonic DEBUG sshd-session[690794]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:10.850564 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:10.850604 sonic DEBUG sshd-session[690794]: pam_radius_auth: rad_recv: Access-Accept packet from host 172.31.32.50:1812
2026 Aug 20 07:02:10.850648 sonic DEBUG sshd-session[690794]: pam_radius_auth: , id=152, length=172
2026 Aug 20 07:02:10.850703 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:10.850761 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:10.850812 sonic DEBUG sshd-session[690794]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:10.850861 sonic DEBUG sshd-session[690794]: pam_radius_auth: pam_peap_authenticate: Authentication succeeded Getting vendor specific attributes
2026 Aug 20 07:02:10.850926 sonic DEBUG sshd-session[690794]: pam_radius_auth: pam_peap_authenticate: rad_pkt_len is 172
2026 Aug 20 07:02:10.851004 sonic DEBUG sshd-session[690794]: pam_radius_auth: pam_peap_authenticate: Copying the response
2026 Aug 20 07:02:10.851053 sonic DEBUG sshd-session[690794]: pam_radius_auth: #012pam_peap_authenticate:Authenticated Successfully > Bye...
2026 Aug 20 07:02:10.851115 sonic DEBUG sshd-session[690794]: pam_radius_auth: talk_radius: PEAP authentication successful
2026 Aug 20 07:02:10.851165 sonic ERR sshd-session[690794]: pam_radius_auth: RADIUS Access-Accept received with Management-Privilege-Level missing
2026 Aug 20 07:02:10.852679 sonic INFO /usr/sbin/cache_radius[691332]: /usr/sbin/cache_radius: Missing or bad Privilege in environment:""
2026 Aug 20 07:02:10.852741 sonic INFO /usr/sbin/cache_radius[691332]: /usr/sbin/cache_radius: MPL 1 updated for user radiususer
2026 Aug 20 07:02:10.852791 sonic INFO /usr/sbin/cache_radius[691332]: /usr/sbin/cache_radius: Adjusting Supplementary Groups for "radiususer"
2026 Aug 20 07:02:10.857255 sonic INFO usermod[691333]: delete 'radiususer' from group 'sudo'
2026 Aug 20 07:02:10.857327 sonic INFO usermod[691333]: add 'radiususer' to group 'users'
2026 Aug 20 07:02:10.857380 sonic INFO usermod[691333]: delete 'radiususer' from group 'docker'
2026 Aug 20 07:02:10.857429 sonic INFO usermod[691333]: delete 'radiususer' from group 'admin'
2026 Aug 20 07:02:10.857477 sonic INFO usermod[691333]: delete 'radiususer' from shadow group 'sudo'
2026 Aug 20 07:02:10.857519 sonic INFO usermod[691333]: add 'radiususer' to shadow group 'users'
2026 Aug 20 07:02:10.857569 sonic INFO usermod[691333]: delete 'radiususer' from shadow group 'docker'
2026 Aug 20 07:02:10.857609 sonic INFO usermod[691333]: delete 'radiususer' from shadow group 'admin'
2026 Aug 20 07:02:11.072055 sonic INFO sshd-session[690794]: Accepted password for radiususer from 172.27.13.205 port 55080 ssh2
2026 Aug 20 07:02:11.073797 sonic INFO sshd-session[690794]: pam_unix(sshd:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 07:02:11.083036 sonic INFO systemd-logind[971]: New session 35 of user radiususer.
2026 Aug 20 07:02:11.126618 sonic INFO sshd-session[691339]: Connection from 172.27.13.205 port 55135 on 172.17.224.110 port 22 rdomain ""
2026 Aug 20 07:02:11.160208 sonic INFO (systemd): pam_unix(systemd-user:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 07:02:11.162154 sonic INFO systemd-logind[971]: New session 36 of user radiususer.
2026 Aug 20 07:02:11.350123 sonic INFO sshd-session[691339]: pam_succeed_if(sshd:auth): requirement "user = root" not met by user "radiususer"
2026 Aug 20 07:02:11.350404 sonic DEBUG sshd-session[691339]: pam_radius_auth: talk_radius: Auth type is PEAP
2026 Aug 20 07:02:11.350476 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.385276 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.385323 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.385370 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.385415 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=144, length=64
2026 Aug 20 07:02:11.385461 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.385508 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.385552 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.385605 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling process_eap_message
2026 Aug 20 07:02:11.390555 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling setup_TLS_session
2026 Aug 20 07:02:11.390619 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: before record_init
2026 Aug 20 07:02:11.392558 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling SSL_read
2026 Aug 20 07:02:11.392618 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling BIO_read
2026 Aug 20 07:02:11.392665 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling rad_alloc
2026 Aug 20 07:02:11.392712 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling compose_radius_pkt
2026 Aug 20 07:02:11.392758 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling compose_eap_packet
2026 Aug 20 07:02:11.392803 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.432934 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.433003 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.433054 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.433100 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=145, length=1068
2026 Aug 20 07:02:11.433146 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.433192 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.433237 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.433283 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.468434 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.468493 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.468542 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.468587 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=146, length=222
2026 Aug 20 07:02:11.468633 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.468682 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.468729 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.471995 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.506568 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.506620 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.506727 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.506839 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=147, length=115
2026 Aug 20 07:02:11.506949 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.507004 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.507050 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.507095 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.514110 sonic INFO sshd-session[690794]: User child is on pid 691363
2026 Aug 20 07:02:11.540763 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.540838 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.540888 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.540933 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=148, length=98
2026 Aug 20 07:02:11.540979 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.541023 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.541067 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.541110 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.575102 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.575168 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.575218 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.575266 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=149, length=132
2026 Aug 20 07:02:11.575316 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.575361 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.575402 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.575447 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: peap_data = 1a
2026 Aug 20 07:02:11.575777 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: Compose MSCHAPv2 response of peap_data_length = 66
2026 Aug 20 07:02:11.575832 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: get_tls_data returned success
2026 Aug 20 07:02:11.575880 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: compose_eap_packet returned success
2026 Aug 20 07:02:11.575918 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: get_tls_data returned success
2026 Aug 20 07:02:11.575958 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: compose_eap_packet returned success
2026 Aug 20 07:02:11.575997 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: Client State = 0x810
2026 Aug 20 07:02:11.576035 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.583836 sonic INFO sshd-session[691363]: Starting session: shell on pts/2 for radiususer from 172.27.13.205 port 55080 id 0
2026 Aug 20 07:02:11.583960 sonic INFO sshd-session[691363]: Starting session: command for radiususer from 172.27.13.205 port 55080 id 1
2026 Aug 20 07:02:11.609714 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.609807 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.609852 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.609893 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=150, length=140
2026 Aug 20 07:02:11.609937 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.609979 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.610028 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.610069 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.645016 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.645119 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.645161 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Challenge packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.645198 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=151, length=104
2026 Aug 20 07:02:11.645236 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.645278 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.645319 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.645361 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after rad_peap_send
2026 Aug 20 07:02:11.680079 sonic DEBUG sshd-session[691339]: pam_radius_auth: wait_for_server_response: Server responded. Moving ahead
2026 Aug 20 07:02:11.680165 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling rad_peap_recv
2026 Aug 20 07:02:11.680207 sonic DEBUG sshd-session[691339]: pam_radius_auth: rad_recv: Access-Accept packet from host 172.31.32.50:1812
2026 Aug 20 07:02:11.680250 sonic DEBUG sshd-session[691339]: pam_radius_auth: , id=152, length=172
2026 Aug 20 07:02:11.680299 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling process_rad_rep
2026 Aug 20 07:02:11.680352 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: calling extract_eap_message
2026 Aug 20 07:02:11.680393 sonic DEBUG sshd-session[691339]: pam_radius_auth: handle_req_rep: after calling extract_eap_message
2026 Aug 20 07:02:11.680436 sonic DEBUG sshd-session[691339]: pam_radius_auth: pam_peap_authenticate: Authentication succeeded Getting vendor specific attributes
2026 Aug 20 07:02:11.680483 sonic DEBUG sshd-session[691339]: pam_radius_auth: pam_peap_authenticate: rad_pkt_len is 172
2026 Aug 20 07:02:11.680533 sonic DEBUG sshd-session[691339]: pam_radius_auth: pam_peap_authenticate: Copying the response
2026 Aug 20 07:02:11.680584 sonic DEBUG sshd-session[691339]: pam_radius_auth: #012pam_peap_authenticate:Authenticated Successfully > Bye...
2026 Aug 20 07:02:11.680634 sonic DEBUG sshd-session[691339]: pam_radius_auth: talk_radius: PEAP authentication successful
2026 Aug 20 07:02:11.680683 sonic ERR sshd-session[691339]: pam_radius_auth: RADIUS Access-Accept received with Management-Privilege-Level missing
2026 Aug 20 07:02:11.682198 sonic INFO /usr/sbin/cache_radius[691376]: /usr/sbin/cache_radius: Missing or bad Privilege in environment:""
2026 Aug 20 07:02:11.894892 sonic INFO sshd-session[691339]: Accepted password for radiususer from 172.27.13.205 port 55135 ssh2
2026 Aug 20 07:02:11.896596 sonic INFO sshd-session[691339]: pam_unix(sshd:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 07:02:11.900476 sonic INFO systemd-logind[971]: New session 37 of user radiususer.
2026 Aug 20 07:02:11.947173 sonic INFO sshd-session[691339]: User child is on pid 691382
2026 Aug 20 07:02:12.025877 sonic INFO sshd-session[691382]: Starting session: subsystem 'sftp' for radiususer from 172.27.13.205 port 55135 id 0
2026 Aug 20 07:02:12.596463 sonic INFO sshd-session[691363]: Close session: user radiususer from 172.27.13.205 port 55080 id 1
2026 Aug 20 07:02:12.644115 sonic INFO sshd-session[627385]: Starting session: command for admin from 172.27.13.205 port 62436 id 1
```

