### PR TITLE
[radius] Fix RADIUS login for privilege-1 users after docker group removal

### DIFF
--- a/src/radius/nss/libnss-radius/nss_radius_common.c
+++ b/src/radius/nss/libnss-radius/nss_radius_common.c
@@ -157,7 +157,8 @@ static void init_rnm(RADIUS_NSS_CONF_B * conf) {
 
     memset((char *) rnm, 0, sizeof(conf->rnm));
 
-    rnm[0].gid   = 999;
+    rnm[0].gid   = 100;
+    rnm[0].groups = "users";
     rnm[0].gecos = "remote_user";
     rnm[0].shell = "/bin/bash";
     rnm[RADIUS_MAX_MPL-1].gid   = 1000;


### PR DESCRIPTION
PR #22933 removed the docker group from the read-only (level 1) RADIUS user but left rnm[0].groups NULL. user_add()/user_mod() pass "-G <groups>" to execl() unconditionally; a NULL groups terminates the execl varargs early, so useradd runs as "useradd -U -G" and fails ("option requires an argument -- 'G'"). Any RADIUS user mapping to privilege level 1 then fails to be created and cannot log in.

Set the level-1 user's supplementary groups to "" instead of NULL: this keeps #22933's intent (no docker group) while producing a valid useradd/usermod "-G ''".

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
PR #22933 removed the `docker` supplementary group from the read-only
(privilege level 1) RADIUS user in `init_rnm()`:
```c
     rnm[0].gid   = 999;
-    rnm[0].groups = "docker";
     rnm[0].gecos = "remote_user";
```
The intent (the RO user should not be in the docker group) is fine, but this
leaves rnm[0].groups == NULL (the struct is memset to 0 and nothing sets it
again). radius_create_user() → user_add() builds the command with a
NULL-terminated execl():
```
execl(cmd, cmd, "-U", "-G", sec_grp, "-c", ..., NULL);  /* sec_grp == rnm->groups == NULL */
```
A NULL sec_grp terminates the varargs list early, so useradd is invoked as
useradd -U -G (no group argument) and fails:
```
useradd: option requires an argument -- 'G'
```
As a result, any RADIUS user that maps to privilege level 1 can no longer be
created and login fails with invalid user, even though authentication
succeeds. This is hit whenever the server returns no Management-Privilege-Level
(the pre-auth "unconfirmed" bootstrap user is created at level 1). Privilege 15
is unaffected because rnm[14].groups is still set.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Set the RO user's supplementary groups to an empty string instead of leaving it
NULL — this preserves #22933's intent (no docker group) while producing a
valid useradd -G "" / usermod -G "" (both accept an empty group list):
```c
     rnm[0].gid   = 999;
+    rnm[0].groups = "";
     rnm[0].gecos = "remote_user";
```

#### How to verify it
With RADIUS configured and a server that returns no Management-Privilege-Level
(or a level-1 user):

- Before: SSH login fails; /var/log/auth.log shows nss: /usr/sbin/useradd <user> failed and useradd prints option requires an argument -- 'G'.

- After: the user is created and logs in normally.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 202605
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### Test Result
202605: PASS

Image: SONiC.202605.0-71ea3b2f9

Evidence:
- RADIUS authentication succeeded
- SSH login succeeded

Full test log:
```
admin@sonic:~$ show version

SONiC Software Version: SONiC.202605.0-71ea3b2f9
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 71ea3b2f9
Build date: Wed Aug 19 08:05:37 UTC 2026
Built by: micasrd@micasrd-PowerEdge-R730

Platform: x86_64-micas_m2-w6520-48c8qc-r0
HwSKU: M2-W6520-48C8QC
ASIC: broadcom
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 03:47:58 up 1 min,  2 users,  load average: 3.54, 1.20, 0.43
Date: Thu 20 Aug 2026 03:47:58

Docker images:
REPOSITORY                    TAG                  IMAGE ID       SIZE
docker-orchagent              202605.0-71ea3b2f9   dc96f76acb5a   334MB
docker-orchagent              latest               dc96f76acb5a   334MB
docker-macsec                 202605.0-71ea3b2f9   714bc74b7d78   321MB
docker-macsec                 latest               714bc74b7d78   321MB
docker-gnmi-watchdog          202605.0-71ea3b2f9   061637c58d92   287MB
docker-gnmi-watchdog          latest               061637c58d92   287MB
docker-sonic-mgmt-framework   202605.0-71ea3b2f9   4f51382a5cf0   344MB
docker-sonic-mgmt-framework   latest               4f51382a5cf0   344MB
docker-sonic-gnmi             202605.0-71ea3b2f9   de2328840bcb   427MB
docker-sonic-gnmi             latest               de2328840bcb   427MB
docker-restapi-sidecar        202605.0-71ea3b2f9   e0b179a5938d   281MB
docker-restapi-sidecar        latest               e0b179a5938d   281MB
docker-database               202605.0-71ea3b2f9   7da78b507024   287MB
docker-database               latest               7da78b507024   287MB
docker-sonic-otel             202605.0-71ea3b2f9   66de0eedf2ac   622MB
docker-sonic-otel             latest               66de0eedf2ac   622MB
docker-gbsyncd-agera2         202605.0-71ea3b2f9   e26e6b1bb4c8   340MB
docker-gbsyncd-agera2         latest               e26e6b1bb4c8   340MB
docker-gbsyncd-credo          202605.0-71ea3b2f9   d96dc1024178   310MB
docker-gbsyncd-credo          latest               d96dc1024178   310MB
docker-sonic-bmp              202605.0-71ea3b2f9   fe61ddfb8ece   282MB
docker-sonic-bmp              latest               fe61ddfb8ece   282MB
docker-eventd                 202605.0-71ea3b2f9   01a7793312b7   280MB
docker-eventd                 latest               01a7793312b7   280MB
docker-snmp                   202605.0-71ea3b2f9   3258b1afef8b   307MB
docker-snmp                   latest               3258b1afef8b   307MB
docker-platform-monitor       202605.0-71ea3b2f9   412630453e8d   407MB
docker-platform-monitor       latest               412630453e8d   407MB
docker-bmp-watchdog           202605.0-71ea3b2f9   45e51fb9bc9a   280MB
docker-bmp-watchdog           latest               45e51fb9bc9a   280MB
docker-dhcp-relay             202605.0-71ea3b2f9   4bcbf83950c3   323MB
docker-dhcp-relay             latest               4bcbf83950c3   323MB
docker-fpm-frr                202605.0-71ea3b2f9   c7ee0b7b7919   383MB
docker-fpm-frr                latest               c7ee0b7b7919   383MB
docker-dash-ha                202605.0-71ea3b2f9   a8f2e39889f3   338MB
docker-dash-ha                latest               a8f2e39889f3   338MB
docker-lldp                   202605.0-71ea3b2f9   83850f235159   289MB
docker-lldp                   latest               83850f235159   289MB
docker-router-advertiser      202605.0-71ea3b2f9   ad4ddad96157   281MB
docker-router-advertiser      latest               ad4ddad96157   281MB
docker-nat                    202605.0-71ea3b2f9   d017bdecf0b8   321MB
docker-nat                    latest               d017bdecf0b8   321MB
docker-syncd-brcm             202605.0-71ea3b2f9   6a3fcbbce85d   874MB
docker-syncd-brcm             latest               6a3fcbbce85d   874MB
docker-gnmi-sidecar           202605.0-71ea3b2f9   7f460145ba58   280MB
docker-gnmi-sidecar           latest               7f460145ba58   280MB
docker-gbsyncd-broncos        202605.0-71ea3b2f9   1df90dc70649   339MB
docker-gbsyncd-broncos        latest               1df90dc70649   339MB
docker-teamd                  202605.0-71ea3b2f9   3a214c2850fc   318MB
docker-teamd                  latest               3a214c2850fc   318MB
docker-mux                    202605.0-71ea3b2f9   6e809c53882f   293MB
docker-mux                    latest               6e809c53882f   293MB
docker-sysmgr                 202605.0-71ea3b2f9   93ae70ad9853   286MB
docker-sysmgr                 latest               93ae70ad9853   286MB
docker-sflow                  202605.0-71ea3b2f9   d1c391f38396   319MB
docker-sflow                  latest               d1c391f38396   319MB
admin@sonic:~$ sudo config aaa authentication login radius local
admin@sonic:~$ sudo config aaa authentication failthrough enable
admin@sonic:~$ sudo config radius add 172.31.32.50
admin@sonic:~$ sudo config radius passkey Radius@123
admin@sonic:~$ show aaa
AAA authentication login radius,local
AAA authentication failthrough True
AAA authorization login local (default)
AAA accounting login disable (default)

admin@sonic:~$ show radius
RADIUS global auth_type pap (default)
RADIUS global retransmit 3 (default)
RADIUS global timeout 5 (default)
RADIUS global passkey Radius@123

RADIUS_SERVER address 172.31.32.50
               auth_port 1812
               priority 1
root@sonic:/home/admin# tail -f /var/log/auth.log
2026 Aug 20 06:47:07.255130 sonic INFO sshd-session[637769]: pam_succeed_if(sshd:auth): requirement "user = root" not met by user "radiususer"
2026 Aug 20 06:47:07.298775 sonic INFO /usr/sbin/cache_radius[638323]: /usr/sbin/cache_radius: "/var/cache/radius/user/radiususer/Management-Privilege-Level": Absent.
2026 Aug 20 06:47:07.298879 sonic INFO /usr/sbin/cache_radius[638323]: /usr/sbin/cache_radius: MPL 15 updated for user radiususer
2026 Aug 20 06:47:07.298935 sonic INFO /usr/sbin/cache_radius[638323]: /usr/sbin/cache_radius: Adjusting Supplementary Groups for "radiususer"
2026 Aug 20 06:47:07.306669 sonic INFO usermod[638324]: add 'radiususer' to group 'sudo'
2026 Aug 20 06:47:07.306752 sonic INFO usermod[638324]: delete 'radiususer' from group 'users'
2026 Aug 20 06:47:07.306809 sonic INFO usermod[638324]: add 'radiususer' to group 'docker'
2026 Aug 20 06:47:07.306848 sonic INFO usermod[638324]: add 'radiususer' to group 'admin'
2026 Aug 20 06:47:07.306893 sonic INFO usermod[638324]: add 'radiususer' to shadow group 'sudo'
2026 Aug 20 06:47:07.306934 sonic INFO usermod[638324]: delete 'radiususer' from shadow group 'users'
2026 Aug 20 06:47:07.306975 sonic INFO usermod[638324]: add 'radiususer' to shadow group 'docker'
2026 Aug 20 06:47:07.307013 sonic INFO usermod[638324]: add 'radiususer' to shadow group 'admin'
2026 Aug 20 06:47:07.325307 sonic INFO sshd-session[637769]: Accepted password for radiususer from 172.27.13.205 port 63961 ssh2
2026 Aug 20 06:47:07.326938 sonic INFO sshd-session[637769]: pam_unix(sshd:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 06:47:07.336466 sonic INFO systemd-logind[971]: New session 31 of user radiususer.
2026 Aug 20 06:47:07.382434 sonic INFO sshd-session[638330]: Connection from 172.27.13.205 port 64040 on 172.17.224.110 port 22 rdomain ""
2026 Aug 20 06:47:07.383974 sonic INFO (systemd): pam_unix(systemd-user:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 06:47:07.386032 sonic INFO systemd-logind[971]: New session 32 of user radiususer.
2026 Aug 20 06:47:07.589305 sonic INFO sshd-session[638330]: pam_succeed_if(sshd:auth): requirement "user = root" not met by user "radiususer"
2026 Aug 20 06:47:07.659638 sonic INFO sshd-session[638330]: Accepted password for radiususer from 172.27.13.205 port 64040 ssh2
2026 Aug 20 06:47:07.661416 sonic INFO sshd-session[638330]: pam_unix(sshd:session): session opened for user radiususer(uid=1001) by radiususer(uid=0)
2026 Aug 20 06:47:07.665480 sonic INFO systemd-logind[971]: New session 33 of user radiususer.
2026 Aug 20 06:47:07.743149 sonic INFO sshd-session[637769]: User child is on pid 638368
2026 Aug 20 06:47:07.743570 sonic INFO sshd-session[638330]: User child is on pid 638369
2026 Aug 20 06:47:07.807691 sonic INFO sshd-session[638368]: Starting session: shell on pts/2 for radiususer from 172.27.13.205 port 63961 id 0
2026 Aug 20 06:47:07.807818 sonic INFO sshd-session[638368]: Starting session: command for radiususer from 172.27.13.205 port 63961 id 1
2026 Aug 20 06:47:07.820281 sonic INFO sshd-session[638369]: Starting session: subsystem 'sftp' for radiususer from 172.27.13.205 port 64040 id 0
2026 Aug 20 06:47:09.259934 sonic INFO sshd-session[627385]: Starting session: command for admin from 172.27.13.205 port 62436 id 1
2026 Aug 20 06:47:09.835345 sonic INFO sshd-session[638368]: Close session: user radiususer from 172.27.13.205 port 63961 id 1
```

#### A picture of a cute animal (not mandatory but encouraged)

