### PR TITLE
[sonic-yang-models]: Add TC_ACTION to sonic-acl

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/acl.json
@@ -210,5 +210,12 @@
     },
     "ACL_INNERSRCMACREWRITE_NO_INNERSRCIP": {
         "desc": "Configure INNERSRCMACREWRITE ACL with no inner src IP"
+    },
+    "ACL_RULE_WITH_VALID_TC_ACTION": {
+        "desc": "Configure ACL rule with valid TC_ACTION values (0..255)."
+    },
+    "ACL_RULE_WITH_INVALID_TC_ACTION": {
+        "desc": "Configure ACL rule with an out-of-range TC_ACTION value.",
+        "eStrKey": "Bounds"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/acl.json
@@ -2283,5 +2283,67 @@
                 ]
             }
         }
+    },
+    "ACL_RULE_WITH_VALID_TC_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "TC_ACTION": 0,
+                        "PRIORITY": 9991,
+                        "RULE_NAME": "Rule_1"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "TC_ACTION": 7,
+                        "PRIORITY": 9992,
+                        "RULE_NAME": "Rule_2"
+                    },
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "TC_ACTION": 255,
+                        "PRIORITY": 9993,
+                        "RULE_NAME": "Rule_3"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "policy_desc": "TC_TEST",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
+    },
+    "ACL_RULE_WITH_INVALID_TC_ACTION": {
+        "sonic-acl:sonic-acl": {
+            "sonic-acl:ACL_RULE": {
+                "ACL_RULE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "TC_ACTION": 256,
+                        "PRIORITY": 9991,
+                        "RULE_NAME": "Rule_1"
+                    }
+                ]
+            },
+            "sonic-acl:ACL_TABLE": {
+                "ACL_TABLE_LIST": [
+                    {
+                        "ACL_TABLE_NAME": "TC_TEST",
+                        "policy_desc": "TC_TEST",
+                        "ports": [ "" ],
+                        "stage": "INGRESS",
+                        "type": "L3"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-acl.yang.j2
@@ -96,6 +96,11 @@ module sonic-acl {
 					type yang:mac-address;
 				}
 
+				leaf TC_ACTION {
+					description "Traffic class (CoS) to set on matching packets";
+					type uint8;
+				}
+
 				leaf IP_TYPE {
 					description "IP type to match (IPv4, IPv6, ARP, etc.)";
 					type stypes:ip_type;


### PR DESCRIPTION
#### Why I did it
Model the new `TC_ACTION` ACL rule action (set traffic class) in the ACL YANG model so CONFIG_DB validation accepts it. Companion to the orchagent change that maps `TC_ACTION` to `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC`.

#### How I did it
- Add `leaf TC_ACTION { type uint8; }` to `sonic-acl.yang.j2`.
- Add positive (0/7/255) and negative (out-of-range 256) YANG model tests.
- `TC_ACTION` is modeled as `uint8` (0-255) to match the SAI type; the YANG stays platform-agnostic and the ASIC/SAI enforces the platform-specific traffic-class count at program time.

#### How to verify it
- `pytest` on `sonic-yang-models` (`yang_model_tests`) passes; a valid `TC_ACTION` renders and an out-of-range value is rejected (`Bounds`).

---
Related PRs:
- Implementation (orchagent): sonic-net/sonic-swss#4726
- HLD: sonic-net/SONiC#2432

