### PR TITLE
[system-health] fix sysmonitor stop

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -84,6 +84,8 @@ class MonitorSystemBusTask(ThreadTaskBase):
         ThreadTaskBase.__init__(self)
         self.task_queue = myQ
         self._subscription_ready = subscription_ready
+        self.loop = None
+        self.loop_lock = threading.Lock()
 
     def on_job_removed(self, id, job, unit, result):
         if result == "done" or result == "failed":
@@ -107,8 +109,16 @@ class MonitorSystemBusTask(ThreadTaskBase):
         if self._subscription_ready is not None:
             self._subscription_ready.set()
 
-        loop = GLib.MainLoop()
-        loop.run()
+        # Assign the loop and re-check the stop flag atomically so that a stop
+        # requested before the loop starts prevents run() from ever being
+        # entered. task_stop() takes the same lock, so once it releases with the
+        # flag set, this thread observes it here; and if the loop is assigned
+        # first, task_stop() will observe it and call quit().
+        with self.loop_lock:
+            if self.task_stopping_event.is_set():
+                return
+            self.loop = GLib.MainLoop()
+        self.loop.run()
 
     def task_worker(self):
         if self.task_stopping_event.is_set():
@@ -120,8 +130,18 @@ class MonitorSystemBusTask(ThreadTaskBase):
         # Signal the thread to stop
         self.task_stopping_event.set()
         
-        # Note: GLib.MainLoop() doesn't respond to thread stopping event gracefully
-        # The thread will be daemon-like and terminate when main program exits
+        # GLib.MainLoop.quit() is thread-safe; it makes loop.run() return so the
+        # worker thread exits instead of blocking interpreter shutdown. Take the
+        # lock so we reliably observe a loop assigned concurrently by
+        # subscribe_sysbus() and coordinate the pre-start stop race.
+        with self.loop_lock:
+            if self.loop is not None:
+                self.loop.quit()
+
+        self._task_thread.join(TASK_STOP_TIMEOUT)
+        if self._task_thread.is_alive():
+            logger.log_notice("MonitorSystemBusTask thread did not exit within timeout")
+            return False
         return True
 
     def task_notify(self, msg):

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -1330,6 +1330,48 @@ def test_monitor_sysbus_task():
     assert sysmon._task_thread is not None
     sysmon.task_stop()
 
+def _mock_sysbus_modules(fake_glib):
+    # subscribe_sysbus() imports dbus/gi lazily, so inject fakes via sys.modules.
+    return patch.dict('sys.modules', {
+        'dbus': MagicMock(),
+        'dbus.mainloop': MagicMock(),
+        'dbus.mainloop.glib': MagicMock(),
+        'gi': MagicMock(),
+        'gi.repository': MagicMock(GLib=fake_glib),
+    })
+
+def test_monitor_sysbus_stop_before_loop_start():
+    # A stop requested before the loop starts must prevent run() from being
+    # entered and must leave self.loop unassigned (stop-before-loop-start race).
+    sysmon = MonitorSystemBusTask(myQ)
+    fake_glib = MagicMock()
+    with _mock_sysbus_modules(fake_glib):
+        sysmon.task_stopping_event.set()
+        sysmon.subscribe_sysbus()
+    assert sysmon.loop is None
+    fake_glib.MainLoop.assert_not_called()
+
+def test_monitor_sysbus_runs_loop_when_not_stopping():
+    # Normal path: with no stop pending, the loop is assigned and run() entered.
+    sysmon = MonitorSystemBusTask(myQ)
+    fake_loop = MagicMock()
+    fake_glib = MagicMock()
+    fake_glib.MainLoop.return_value = fake_loop
+    with _mock_sysbus_modules(fake_glib):
+        sysmon.subscribe_sysbus()
+    assert sysmon.loop is fake_loop
+    fake_loop.run.assert_called_once()
+
+def test_monitor_sysbus_task_stop_quits_loop():
+    # task_stop() must set the stop flag and quit an already-assigned loop.
+    sysmon = MonitorSystemBusTask(myQ)
+    sysmon.loop = MagicMock()
+    sysmon._task_thread = MagicMock()
+    sysmon._task_thread.is_alive.return_value = False
+    assert sysmon.task_stop() is True
+    assert sysmon.task_stopping_event.is_set()
+    sysmon.loop.quit.assert_called_once()
+
 @patch('health_checker.sysmonitor.Sysmonitor._wait_for_monitor_subscriptions', MagicMock())
 @patch('health_checker.sysmonitor.MonitorSystemBusTask.subscribe_sysbus', MagicMock())
 @patch('health_checker.sysmonitor.MonitorStateDbTask.subscribe_statedb', MagicMock())


### PR DESCRIPTION
Fix for https://github.com/sonic-net/sonic-buildimage/issues/28166

#### Why I did it
MonitorSystemBusTask (in the system-health/healthd daemon) runs a GLib.MainLoop inside a worker thread. The previous task_stop() only set the stopping event and returned, assuming the worker thread was "daemon-like" and would die with the process. That assumption was wrong: the thread is not a daemon thread, so loop.run() keeps it alive and blocks Python interpreter shutdown.

As a result, healthd never exits on SIGTERM. systemd then waits the full default TimeoutStopSec (90s) before sending SIGKILL, which makes every reboot/shutdown unnecessarily slow (~90s delay).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Stored the GLib.MainLoop instance on the task object (self.loop) instead of a local variable.
In task_stop(), called self.loop.quit() (which is thread-safe) so that loop.run() returns and the worker thread exits cleanly instead of blocking interpreter shutdown.
Joined the worker thread with TASK_STOP_TIMEOUT and logged a notice + returned False if the thread fails to exit within the timeout.

#### How to verify it
Manual tests (systemctl stop system-health)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

