### PR TITLE
Implement RTC persistence on BMC

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -436,8 +436,17 @@ install_deb_package $debs_path/openssh-server_${OPENSSH_VERSION_FULL}_*.deb $deb
 install_deb_package $debs_path/flashrom_*.deb
 {% endif %}
 
+{% if sonic_asic_platform == "aspeed" %}
+# Create /usr/lib/clock-epoch for systemd
+sudo touch $FILESYSTEM_ROOT/usr/lib/clock-epoch
+sudo cp $IMAGE_CONFIGS/chrony/bmc-rtc-epoch-save $FILESYSTEM_ROOT/usr/local/bin/
+sudo cp $IMAGE_CONFIGS/chrony/bmc-clock-epoch-sync.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM/
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable bmc-clock-epoch-sync.service
+sudo cp -f $IMAGE_CONFIGS/cron.d/bmc/* $FILESYSTEM_ROOT/etc/cron.d/
+{% endif %}
+
 # Copy crontabs
-sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/
+sudo find $IMAGE_CONFIGS/cron.d/ -maxdepth 1 -type f -exec cp -ft $FILESYSTEM_ROOT/etc/cron.d/ {} +
 
 # Copy NTP configuration files and templates
 sudo cp $IMAGE_CONFIGS/chrony/chrony-config.sh $FILESYSTEM_ROOT/usr/bin/

--- a/files/image_config/chrony/bmc-clock-epoch-sync.service
+++ b/files/image_config/chrony/bmc-clock-epoch-sync.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Sync clock-epoch immediately after first NTP sync
+BindsTo=sonic.target
+After=sonic.target
+After=chrony.service
+Requires=chrony.service
+
+[Service]
+Type=simple
+# waitsync: poll every 10s until chrony syncs within 1.0s offset.
+# On success, persist the accurate NTP time if it is ahead of the saved value.
+ExecStart=/usr/bin/bash -c 'chronyc waitsync 0 1.0 0 && /usr/local/bin/bmc-rtc-epoch-save'
+Restart=on-failure
+RestartSec=60
+
+[Install]
+WantedBy=sonic.target

--- a/files/image_config/chrony/bmc-rtc-epoch-save
+++ b/files/image_config/chrony/bmc-rtc-epoch-save
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Only persist system time if it is strictly ahead of the saved timestamp.
+saved=$(stat -c %Y /usr/lib/clock-epoch 2>/dev/null || echo 0) 
+[ "$(date +%s)" -gt "$saved" ] && touch /usr/lib/clock-epoch
+exit 0

--- a/files/image_config/chrony/chrony-config.sh
+++ b/files/image_config/chrony/chrony-config.sh
@@ -6,6 +6,11 @@ if [ $? -ne 0 ]; then
     hwclock --systohc
 fi
 
-sonic-cfggen -d -t /usr/share/sonic/templates/chrony.conf.j2 >/etc/chrony/chrony.conf
+# Detect whether this platform is a switch BMC (declared via switch_bmc=1 in the
+# platform's platform_env.conf). Used to gate BMC-specific chrony behavior such as
+# stepping the clock and falling back to public NTP servers.
+is_switch_bmc=$(python3 -c 'from sonic_py_common import device_info; print(int(device_info.is_switch_bmc()))' 2>/dev/null || echo 0)
+
+sonic-cfggen -d -a "{\"is_switch_bmc\": $is_switch_bmc}" -t /usr/share/sonic/templates/chrony.conf.j2 >/etc/chrony/chrony.conf
 sonic-cfggen -d -t /usr/share/sonic/templates/chrony.keys.j2 >/etc/chrony/chrony.keys
 chmod o-r /etc/chrony/chrony.keys

--- a/files/image_config/chrony/chrony.conf.j2
+++ b/files/image_config/chrony/chrony.conf.j2
@@ -161,8 +161,13 @@ rtcautotrim 15
 # Step the system clock instead of slewing it if the adjustment is larger than
 # one second, but only in the first three clock updates.
 #
+{% if is_switch_bmc %}
+# Enabled for the first 3 chrony updates
+makestep 1 3
+{% else %}
 # Disabled because we don't want chrony to do any clock steps; it should only slew
 #makestep 1 3
+{% endif %}
 
 # Get TAI-UTC offset and leap seconds from the system tz database.
 # This directive must be commented out when using time sources serving

--- a/files/image_config/cron.d/bmc/bmc-rtc-persist
+++ b/files/image_config/cron.d/bmc/bmc-rtc-persist
@@ -1,0 +1,3 @@
+# Persist system time to clock-epoch every 12 hours so BMC can reseed its clock
+# after a hard power cycle. Edit the schedule here to change the interval.
+0 */12 * * * root /usr/local/bin/bmc-rtc-epoch-save


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BMC loses wall-clock time across power cycles because it has no battery-backed RTC. This adds a simple persisted timestamp so the system can reseed time on boot until NTP synchronizes.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added /usr/lib/clock-epoch as a persisted timestamp marker, a periodic job to refresh it, and a one-shot service that updates it after the first successful NTP synchronization following boot.

#### How to verify it
After a power cycle, verify that:
- system time is restored from the persisted timestamp instead of resetting to build time
- bmc-clock-epoch-sync.service waits for the first successful NTP sync and then exits successfully
- when network is available, chrony synchronizes the clock and the persisted timestamp is refreshed

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

