### PR TITLE
Correct the psu hardware checker wrong condition

### DIFF
--- a/src/system-health/health_checker/hardware_checker.py
+++ b/src/system-health/health_checker/hardware_checker.py
@@ -171,7 +171,7 @@ class HardwareChecker(HealthChecker):
         :param config: Health checker configuration
         :return:
         """
-        if config.ignore_devices and 'psu' in config.ignore_devices and 'pdb' in config.ignore_devices:
+        if config.ignore_devices and ('psu' in config.ignore_devices or 'pdb' in config.ignore_devices):
             return
 
         keys = self._db.keys(self._db.STATE_DB, HardwareChecker.PSU_TABLE_NAME + '*')

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -863,6 +863,52 @@ def test_hardware_checker():
     assert 'missing' in checker._info['PDB 3'][HealthChecker.INFO_FIELD_OBJECT_MSG].lower()
 
 
+_PSU_PDB_MOCK_DATA = {
+    'PSU_INFO|PSU 1': {
+        'presence': 'True',
+        'status': 'True',
+        'temp': '55',
+        'temp_threshold': '100',
+        'voltage': '10',
+        'voltage_min_threshold': '8',
+        'voltage_max_threshold': '15',
+    },
+    'PSU_INFO|PDB 1': {
+        'presence': 'True',
+        'status': 'True',
+        'temp': '55',
+        'temp_threshold': '100',
+        'voltage': '10',
+        'voltage_min_threshold': '8',
+        'voltage_max_threshold': '15',
+    },
+}
+
+
+def test_hardware_checker_ignore_psu_skips_psu_info_check():
+    """When 'psu' is in ignore_devices, _check_psu_status returns without checking PSU_INFO."""
+    MockConnector.data.clear()
+    MockConnector.data.update(_PSU_PDB_MOCK_DATA)
+    config = Config()
+    config.ignore_devices = ['psu']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PSU 1' not in checker._info
+    assert 'PDB 1' not in checker._info
+
+
+def test_hardware_checker_ignore_pdb_skips_psu_info_check():
+    """When 'pdb' is in ignore_devices, _check_psu_status returns without checking PSU_INFO."""
+    MockConnector.data.clear()
+    MockConnector.data.update(_PSU_PDB_MOCK_DATA)
+    config = Config()
+    config.ignore_devices = ['pdb']
+    checker = HardwareChecker()
+    checker.check(config)
+    assert 'PSU 1' not in checker._info
+    assert 'PDB 1' not in checker._info
+
+
 def test_hardware_checker_pdb_ignore():
     """PSU_INFO rows are skipped when the key name is listed in ignore_devices."""
     MockConnector.data.clear()
@@ -887,22 +933,13 @@ def test_hardware_checker_pdb_ignore():
 def test_hardware_checker_psu_pdb_ignore_both_skips_psu_check():
     """When both 'psu' and 'pdb' are in ignore_devices, _check_psu_status returns without entries."""
     MockConnector.data.clear()
-    MockConnector.data.update({
-        'PSU_INFO|PSU 1': {
-            'presence': 'True',
-            'status': 'True',
-            'temp': '55',
-            'temp_threshold': '100',
-            'voltage': '10',
-            'voltage_min_threshold': '8',
-            'voltage_max_threshold': '15',
-        },
-    })
+    MockConnector.data.update(_PSU_PDB_MOCK_DATA)
     config = Config()
     config.ignore_devices = ['psu', 'pdb']
     checker = HardwareChecker()
     checker.check(config)
     assert 'PSU 1' not in checker._info
+    assert 'PDB 1' not in checker._info
 
 
 def test_config():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
_check_psu_status only skipped PSU/PDB checks when both psu and pdb were in ignore_devices, so ignoring just one still triggered incorrect health checks.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the skip condition from and to or, and added unit tests for ignoring psu only, pdb only, or both.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->
run the UT and manually test on device while setting the psu or pdb as ignored.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

