### PR TITLE
[build] install python3-lazy-object-proxy to fix command fallback issue

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -122,7 +122,8 @@ SONIC_COMMON_BASE_FILES_LIST  := sonic-slave-jessie/Dockerfile.j2 sonic-slave-je
                                  sonic-slave-stretch/Dockerfile.j2 sonic-slave-stretch/Dockerfile.user.j2 \
                                  sonic-slave-buster/Dockerfile.j2 sonic-slave-buster/Dockerfile.user.j2 \
                                  sonic-slave-bullseye/Dockerfile.j2 sonic-slave-bullseye/Dockerfile.user.j2 \
-                                 sonic-slave-bookworm/Dockerfile.j2 sonic-slave-bookworm/Dockerfile.user.j2
+                                 sonic-slave-bookworm/Dockerfile.j2 sonic-slave-bookworm/Dockerfile.user.j2 \
+								 sonic-slave-trixie/Dockerfile.j2 sonic-slave-trixie/Dockerfile.user.j2
 
 
 

--- a/files/build/versions-public/build/build-sonic-slave-trixie/versions-py3
+++ b/files/build/versions-public/build/build-sonic-slave-trixie/versions-py3
@@ -14,7 +14,6 @@ jsondiff==2.2.1
 jsonpatch==1.33
 jsonpointer==3.1.1
 jsonschema==2.6.0
-lazy-object-proxy==1.12.0
 libyang==3.1.0
 netaddr==0.8.0
 pddf-platform==1.0

--- a/files/build/versions-public/dockers/sonic-slave-trixie/versions-deb-trixie
+++ b/files/build/versions-public/dockers/sonic-slave-trixie/versions-deb-trixie
@@ -1994,6 +1994,7 @@ python3-jedi==0.19.1+ds1-1
 python3-jinja2==3.1.6-1
 python3-jsonpickle==4.0.2+dfsg-2
 python3-kiwisolver==1.4.7-3+b1
+python3-lazy-object-proxy==1.10.0-4+b1
 python3-legacy-cgi==2.6.3-1
 python3-llvmlite==0.44.0-1
 python3-logilab-common==2.1.0-1

--- a/files/build/versions-public/dockers/sonic-slave-trixie/versions-py3
+++ b/files/build/versions-public/dockers/sonic-slave-trixie/versions-py3
@@ -71,6 +71,7 @@ jinja2==3.1.6
 jsonpath-ng==1.7.0
 jsonpickle==4.0.2+dfsg
 kiwisolver==1.4.7
+lazy-object-proxy==1.10.0
 legacy-cgi==2.6.3
 llvmlite==0.44.0
 logilab-common==2.1.0

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -450,6 +450,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
 # For sonic-utilities build
         python3-cryptography \
         python3-deepdiff \
+        python3-lazy-object-proxy \
         python3-natsort \
         python3-netifaces \
         python3-paramiko \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Building sonic-utilities inside the sonic-slave-trixie container fails during installing sonic-utilities wheel which requires lazy-object-proxy as a dependency. Because the version-control hook adds `--no-build-isolation` to pip, the build is exposed to the system setuptools (78.1.1 in Debian trixie). That version enforces PEP 621 validation and rejects the bare string `license = "BSD-2-Clause"` in lazy-object-proxy's pyproject.toml (the correct form in PEP 621 is `license = {text = "BSD-2-Clause"}`), causing the constrained install to fail. So it falls back to an unconstrained install, which caused the regrex failure: https://github.com/sonic-net/sonic-buildimage/pull/28144. This also breaks the reproducible build principle.
only `setuptools(>=80.x)` support and accepts `license=BSD-2-Clause` as valid. The newest version of `python3-setuptools` in Trixie is `78.1.1`. we can install >=80.x using pip, but this only helps if it chooses pip version over Debian version. It may also break other things that depend on older setuptools behavior.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Install `python3-lazy-object-proxy` in slave container. Debian trixie ships `python3-lazy-object-proxy==1.10.0-4`, which pip recognises as already satisfying the lazy-object-proxy requirement and skips the source build entirely.
- Add `sonic-slave-trixie/Dockerfile.j2` and `sonic-slave-trixie/Dockerfile.user.j2` to `SONIC_COMMON_BASE_FILES_LIST` in `Makefile.cache`. These files were missing for trixie (all other slaves are listed), so changes to the trixie slave Dockerfile did not invalidate the DPKG build cache. Without this, builds could reuse stale cached artifacts and CI would not actually exercise the modified slave environment.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] <!-- image version 1 --> 202605
- [ ] <!-- image version 2 -->

#### Test result
202605: the command fallback issue for lazy-object-proxy is fixed

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

