### PR TITLE
Replace syslog crate with libc (replacing #26840 due to owner change)

### DIFF
--- a/src/sonic-ctrmgrd-rs/Cargo.lock
+++ b/src/sonic-ctrmgrd-rs/Cargo.lock
@@ -319,6 +319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cstr"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68523903c8ae5aacfa32a0d9ae60cadeb764e1da14ee0d26b1f3089f13a54636"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,15 +492,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.1",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -671,17 +672,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
 
 [[package]]
 name = "http"
@@ -1029,9 +1019,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -1067,15 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -1183,15 +1167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1636,8 +1611,10 @@ dependencies = [
 name = "sonic-rs-common"
 version = "0.1.0"
 dependencies = [
+ "cstr",
+ "libc",
+ "log",
  "swss-common",
- "syslog",
  "thiserror",
  "tracing",
 ]
@@ -1697,19 +1674,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "syslog"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7e95b5b795122fafe6519e27629b5ab4232c73ebb2428f568e82b1a457ad3"
-dependencies = [
- "error-chain",
- "hostname",
- "libc",
- "log",
- "time",
 ]
 
 [[package]]
@@ -1776,9 +1740,7 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -1976,12 +1938,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/src/sonic-rs-common/Cargo.toml
+++ b/src/sonic-rs-common/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2021"
 swss-common = { path = "../sonic-swss-common/crates/swss-common" }
 thiserror = "1"
 tracing = "0.1"
-syslog = "6.1"
+libc = "0.2.185"
+cstr = "0.2.12"
 
 [dev-dependencies]
 mockall = "0.12"

--- a/src/sonic-rs-common/Cargo.toml
+++ b/src/sonic-rs-common/Cargo.toml
@@ -13,6 +13,7 @@ swss-common = { path = "../sonic-swss-common/crates/swss-common" }
 thiserror = "1"
 tracing = "0.1"
 libc = "0.2.185"
+log = { version = "0.4.29", features = ["std"] }
 cstr = "0.2.12"
 
 [dev-dependencies]

--- a/src/sonic-rs-common/src/lib.rs
+++ b/src/sonic-rs-common/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod device_info;
 pub mod logger;
+pub mod simple_logger;
 
 pub use device_info::{DeviceInfoError, is_warm_restart_enabled, is_fast_reboot_enabled};
 pub use logger::{Logger, LoggerError, LoggerResult};
+pub use simple_logger::SimpleLogger;

--- a/src/sonic-rs-common/src/logger.rs
+++ b/src/sonic-rs-common/src/logger.rs
@@ -1,62 +1,92 @@
-use syslog::{Facility, Severity};
-use std::env;
-use std::path::Path;
+use std::ffi::CString;
+use std::sync::Mutex;
 
 #[derive(thiserror::Error, Debug)]
 pub enum LoggerError {
-    #[error("Syslog error")]
-    Syslog(#[from] syslog::Error),
+    #[error("Only one instance is allowed")]
+    MultipleInstances,
+    #[error("Invalid log identifier: {0}")]
+    InvalidIdentifier(String),
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone)]
+pub enum Facility {
+    Daemon = libc::LOG_DAEMON,
+    User = libc::LOG_USER,
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone)]
+pub enum Severity {
+    Emergency = libc::LOG_EMERG,
+    Alert = libc::LOG_ALERT,
+    Critical = libc::LOG_CRIT,
+    Error = libc::LOG_ERR,
+    Warning = libc::LOG_WARNING,
+    Notice = libc::LOG_NOTICE,
+    Info = libc::LOG_INFO,
+    Debug = libc::LOG_DEBUG,
 }
 
 pub type LoggerResult<T> = std::result::Result<T, LoggerError>;
 
 pub struct Logger {
-    writer: Option<syslog::Logger<syslog::LoggerBackend, syslog::Formatter3164>>,
+    log_facility: Facility,
     min_log_priority: Severity,
+    _ident: Option<CString>,
 }
 
+// Due to how libc::openlog() behaves, we can only have one instance of this class at any given time
+// This mutex ensures that
+static LOGGER_GUARD: Mutex<bool> = Mutex::new(false);
+
 impl Logger {
-    pub const LOG_FACILITY_DAEMON: Facility = Facility::LOG_DAEMON;
-    pub const LOG_FACILITY_USER: Facility = Facility::LOG_USER;
-
-    pub const LOG_PRIORITY_ERROR: Severity = Severity::LOG_ERR;
-    pub const LOG_PRIORITY_WARNING: Severity = Severity::LOG_WARNING;
-    pub const LOG_PRIORITY_NOTICE: Severity = Severity::LOG_NOTICE;
-    pub const LOG_PRIORITY_INFO: Severity = Severity::LOG_INFO;
-    pub const LOG_PRIORITY_DEBUG: Severity = Severity::LOG_DEBUG;
-
-    pub const DEFAULT_LOG_FACILITY: Facility = Self::LOG_FACILITY_USER;
+    const DEFAULT_LOG_FACILITY: Facility = Facility::User;
+    // Format specifier for libc::syslog()
+    const SYSLOG_FMT: &'static core::ffi::CStr = cstr::cstr!(b"%s");
 
     pub fn new(log_identifier: Option<String>) -> LoggerResult<Self> {
         Self::new_with_options(log_identifier, Self::DEFAULT_LOG_FACILITY)
     }
 
     pub fn new_with_options(log_identifier: Option<String>, log_facility: Facility) -> LoggerResult<Self> {
-        let identifier = match log_identifier {
-            Some(id) => id,
-            None => {
-                let args: Vec<String> = env::args().collect();
-                Path::new(args.first().unwrap_or(&String::new()))
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("")
-                    .to_string()
+        let mut guard = match LOGGER_GUARD.lock () {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                // This lock will only get poisoned if a panic occurs when creating or dropping the logger.
+                // It is safe to assume that if we panic when creating it, it was never created in the first place,
+                // thus we can call openlog() again.
+                *guard = false;
+                guard
+            },
+        };
+
+        if *guard {
+            return Err(LoggerError::MultipleInstances);
+        }
+
+        let ident = match log_identifier {
+            Some(id) => {
+                let c_ident = CString::new(id)
+                    .map_err(|e| LoggerError::InvalidIdentifier(e.to_string()))?;
+
+                unsafe {
+                    libc::openlog(c_ident.as_ptr(), 0, log_facility as i32);
+                }
+
+                Some(c_ident)
             }
+            None => None,
         };
 
-        let formatter = syslog::Formatter3164 {
-            facility: log_facility,
-            hostname: None,
-            process: identifier,
-            pid: std::process::id(),
-        };
-
-        // Try to create syslog writer, but don't fail if it doesn't work
-        let writer = syslog::unix(formatter).ok();
+        *guard = true;
 
         Ok(Logger {
-            writer,
-            min_log_priority: Self::LOG_PRIORITY_NOTICE,
+            log_facility,
+            min_log_priority: Severity::Notice,
+            _ident: ident,
         })
     }
 
@@ -65,63 +95,70 @@ impl Logger {
     }
 
     pub fn set_min_log_priority_error(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_ERROR);
+        self.set_min_log_priority(Severity::Error);
     }
 
     pub fn set_min_log_priority_warning(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_WARNING);
+        self.set_min_log_priority(Severity::Warning);
     }
 
     pub fn set_min_log_priority_notice(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_NOTICE);
+        self.set_min_log_priority(Severity::Notice);
     }
 
     pub fn set_min_log_priority_info(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_INFO);
+        self.set_min_log_priority(Severity::Info);
     }
 
     pub fn set_min_log_priority_debug(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_DEBUG);
+        self.set_min_log_priority(Severity::Debug);
     }
 
     pub fn log(&mut self, priority: Severity, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
         if self.min_log_priority as i32 >= priority as i32 {
-            // Only log to syslog if writer is available
-            if let Some(ref mut writer) = self.writer {
-                match priority {
-                    Severity::LOG_ERR => writer.err(msg)?,
-                    Severity::LOG_WARNING => writer.warning(msg)?,
-                    Severity::LOG_NOTICE => writer.notice(msg)?,
-                    Severity::LOG_INFO => writer.info(msg)?,
-                    Severity::LOG_DEBUG => writer.debug(msg)?,
-                    _ => writer.info(msg)?,
-                }
+            let c_msg = CString::new(msg).unwrap_or_default();
+
+            unsafe {
+                libc::syslog(self.log_facility as i32 | priority as i32, Self::SYSLOG_FMT.as_ptr(), c_msg.as_ptr());
             }
 
             if also_print_to_console {
                 println!("{}", msg);
             }
         }
+
         Ok(())
     }
 
     pub fn log_error(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_ERROR, msg, also_print_to_console)
+        self.log(Severity::Error, msg, also_print_to_console)
     }
 
     pub fn log_warning(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_WARNING, msg, also_print_to_console)
+        self.log(Severity::Warning, msg, also_print_to_console)
     }
 
     pub fn log_notice(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_NOTICE, msg, also_print_to_console)
+        self.log(Severity::Notice, msg, also_print_to_console)
     }
 
     pub fn log_info(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_INFO, msg, also_print_to_console)
+        self.log(Severity::Info, msg, also_print_to_console)
     }
 
     pub fn log_debug(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_DEBUG, msg, also_print_to_console)
+        self.log(Severity::Debug, msg, also_print_to_console)
+    }
+}
+
+impl Drop for Logger {
+    fn drop(&mut self) {
+        unsafe {
+            libc::closelog();
+        }
+
+        if let Ok(mut guard) = LOGGER_GUARD.lock() {
+            *guard = false;
+        }
     }
 }

--- a/src/sonic-rs-common/src/logger.rs
+++ b/src/sonic-rs-common/src/logger.rs
@@ -1,62 +1,92 @@
-use syslog::{Facility, Severity};
-use std::env;
-use std::path::Path;
+use std::ffi::CString;
+use std::sync::Mutex;
 
 #[derive(thiserror::Error, Debug)]
 pub enum LoggerError {
-    #[error("Syslog error")]
-    Syslog(#[from] syslog::Error),
+    #[error("Only one instance is allowed")]
+    MultipleInstances,
+    #[error("Invalid log identifier: {0}")]
+    InvalidIdentifier(String),
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone)]
+pub enum Facility {
+    Daemon = libc::LOG_DAEMON,
+    User = libc::LOG_USER,
+}
+
+#[repr(i32)]
+#[derive(Copy, Clone)]
+pub enum Severity {
+    Emergency = libc::LOG_EMERG,
+    Alert = libc::LOG_ALERT,
+    Critical = libc::LOG_CRIT,
+    Error = libc::LOG_ERR,
+    Warning = libc::LOG_WARNING,
+    Notice = libc::LOG_NOTICE,
+    Info = libc::LOG_INFO,
+    Debug = libc::LOG_DEBUG,
 }
 
 pub type LoggerResult<T> = std::result::Result<T, LoggerError>;
 
 pub struct Logger {
-    writer: Option<syslog::Logger<syslog::LoggerBackend, syslog::Formatter3164>>,
+    log_facility: Facility,
     min_log_priority: Severity,
+    _ident: Option<CString>,
 }
 
+// Due to how libc::openlog() behaves, we can only have one instance of this class at any given time
+// This mutex ensures that
+static LOGGER_GUARD: Mutex<bool> = Mutex::new(false);
+
 impl Logger {
-    pub const LOG_FACILITY_DAEMON: Facility = Facility::LOG_DAEMON;
-    pub const LOG_FACILITY_USER: Facility = Facility::LOG_USER;
-
-    pub const LOG_PRIORITY_ERROR: Severity = Severity::LOG_ERR;
-    pub const LOG_PRIORITY_WARNING: Severity = Severity::LOG_WARNING;
-    pub const LOG_PRIORITY_NOTICE: Severity = Severity::LOG_NOTICE;
-    pub const LOG_PRIORITY_INFO: Severity = Severity::LOG_INFO;
-    pub const LOG_PRIORITY_DEBUG: Severity = Severity::LOG_DEBUG;
-
-    pub const DEFAULT_LOG_FACILITY: Facility = Self::LOG_FACILITY_USER;
+    const DEFAULT_LOG_FACILITY: Facility = Facility::User;
+    // Format specifier for libc::syslog()
+    const SYSLOG_FMT: &'static core::ffi::CStr = cstr::cstr!(b"%s");
 
     pub fn new(log_identifier: Option<String>) -> LoggerResult<Self> {
         Self::new_with_options(log_identifier, Self::DEFAULT_LOG_FACILITY)
     }
 
     pub fn new_with_options(log_identifier: Option<String>, log_facility: Facility) -> LoggerResult<Self> {
-        let identifier = match log_identifier {
-            Some(id) => id,
-            None => {
-                let args: Vec<String> = env::args().collect();
-                Path::new(args.first().unwrap_or(&String::new()))
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("")
-                    .to_string()
+        let mut guard = match LOGGER_GUARD.lock () {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                let mut guard = poisoned.into_inner();
+                // This lock will only get poisoned if a panic occurs when creating or dropping the logger.
+                // It is safe to assume that if we panic when creating it, it was never created in the first place,
+                // thus we can call openlog() again.
+                *guard = false;
+                guard
+            },
+        };
+
+        if *guard {
+            return Err(LoggerError::MultipleInstances);
+        }
+
+        let ident = match log_identifier {
+            Some(id) => {
+                let c_ident = CString::new(id.replace('\0', ""))
+                    .map_err(|e| LoggerError::InvalidIdentifier(e.to_string()))?;
+
+                unsafe {
+                    libc::openlog(c_ident.as_ptr(), 0, log_facility as i32);
+                }
+
+                Some(c_ident)
             }
+            None => None,
         };
 
-        let formatter = syslog::Formatter3164 {
-            facility: log_facility,
-            hostname: None,
-            process: identifier,
-            pid: std::process::id(),
-        };
-
-        // Try to create syslog writer, but don't fail if it doesn't work
-        let writer = syslog::unix(formatter).ok();
+        *guard = true;
 
         Ok(Logger {
-            writer,
-            min_log_priority: Self::LOG_PRIORITY_NOTICE,
+            log_facility,
+            min_log_priority: Severity::Notice,
+            _ident: ident,
         })
     }
 
@@ -65,63 +95,70 @@ impl Logger {
     }
 
     pub fn set_min_log_priority_error(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_ERROR);
+        self.set_min_log_priority(Severity::Error);
     }
 
     pub fn set_min_log_priority_warning(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_WARNING);
+        self.set_min_log_priority(Severity::Warning);
     }
 
     pub fn set_min_log_priority_notice(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_NOTICE);
+        self.set_min_log_priority(Severity::Notice);
     }
 
     pub fn set_min_log_priority_info(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_INFO);
+        self.set_min_log_priority(Severity::Info);
     }
 
     pub fn set_min_log_priority_debug(&mut self) {
-        self.set_min_log_priority(Self::LOG_PRIORITY_DEBUG);
+        self.set_min_log_priority(Severity::Debug);
     }
 
     pub fn log(&mut self, priority: Severity, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
         if self.min_log_priority as i32 >= priority as i32 {
-            // Only log to syslog if writer is available
-            if let Some(ref mut writer) = self.writer {
-                match priority {
-                    Severity::LOG_ERR => writer.err(msg)?,
-                    Severity::LOG_WARNING => writer.warning(msg)?,
-                    Severity::LOG_NOTICE => writer.notice(msg)?,
-                    Severity::LOG_INFO => writer.info(msg)?,
-                    Severity::LOG_DEBUG => writer.debug(msg)?,
-                    _ => writer.info(msg)?,
-                }
+            let c_msg = CString::new(msg.replace('\0', "")).unwrap_or_default();
+
+            unsafe {
+                libc::syslog(self.log_facility as i32 | priority as i32, Self::SYSLOG_FMT.as_ptr(), c_msg.as_ptr());
             }
 
             if also_print_to_console {
                 println!("{}", msg);
             }
         }
+
         Ok(())
     }
 
     pub fn log_error(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_ERROR, msg, also_print_to_console)
+        self.log(Severity::Error, msg, also_print_to_console)
     }
 
     pub fn log_warning(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_WARNING, msg, also_print_to_console)
+        self.log(Severity::Warning, msg, also_print_to_console)
     }
 
     pub fn log_notice(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_NOTICE, msg, also_print_to_console)
+        self.log(Severity::Notice, msg, also_print_to_console)
     }
 
     pub fn log_info(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_INFO, msg, also_print_to_console)
+        self.log(Severity::Info, msg, also_print_to_console)
     }
 
     pub fn log_debug(&mut self, msg: &str, also_print_to_console: bool) -> LoggerResult<()> {
-        self.log(Self::LOG_PRIORITY_DEBUG, msg, also_print_to_console)
+        self.log(Severity::Debug, msg, also_print_to_console)
+    }
+}
+
+impl Drop for Logger {
+    fn drop(&mut self) {
+        unsafe {
+            libc::closelog();
+        }
+
+        if let Ok(mut guard) = LOGGER_GUARD.lock() {
+            *guard = false;
+        }
     }
 }

--- a/src/sonic-rs-common/src/simple_logger.rs
+++ b/src/sonic-rs-common/src/simple_logger.rs
@@ -1,0 +1,40 @@
+use log::{Record, Level, Metadata};
+use crate::logger::{Severity, Facility, Logger};
+use std::sync::Mutex;
+
+pub struct SimpleLogger {
+    logger: Mutex<Logger>
+}
+
+impl SimpleLogger {
+    pub fn new(log_facility: Facility) -> SimpleLogger {
+        let mut logger = Logger::new_with_options(None, log_facility).unwrap();
+        logger.set_min_log_priority(Severity::Debug);
+        SimpleLogger { logger: Mutex::new(logger) }
+    }
+}
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Info
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let severity = match record.metadata().level() {
+            Level::Error => Severity::Error,
+            Level::Warn => Severity::Warning,
+            Level::Info => Severity::Info,
+            Level::Debug => Severity::Debug,
+            Level::Trace => Severity::Debug,
+        };
+
+        let mut logger = self.logger.lock().unwrap();
+        logger.log(severity, record.args().to_string().as_ref(), false).unwrap();
+    }
+
+    fn flush(&self) {}
+}

--- a/src/sonic-rs-common/src/simple_logger.rs
+++ b/src/sonic-rs-common/src/simple_logger.rs
@@ -1,0 +1,47 @@
+use log::{Record, Level, Metadata};
+use crate::logger::{Severity, Facility, Logger};
+use std::sync::Mutex;
+
+pub struct SimpleLogger {
+    logger: Mutex<Logger>
+}
+
+impl SimpleLogger {
+    pub fn new(log_facility: Facility) -> Result<SimpleLogger, crate::logger::LoggerError> {
+        let mut logger = Logger::new_with_options(None, log_facility)?;
+        logger.set_min_log_priority(Severity::Debug);
+        Ok(SimpleLogger { logger: Mutex::new(logger) })
+    }
+
+    pub fn init(log_facility: Facility, level: log::LevelFilter) -> Result<(), String> {
+        let logger = Self::new(log_facility).map_err(|e| format!("Failed to create SimpleLogger: {:?}", e))?;
+        log::set_boxed_logger(Box::new(logger))
+            .map(|()| log::set_max_level(level))
+            .map_err(|e| format!("Failed to initialize logger: {}", e))
+    }
+}
+
+impl log::Log for SimpleLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= log::max_level()
+    }
+
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        let severity = match record.metadata().level() {
+            Level::Error => Severity::Error,
+            Level::Warn => Severity::Warning,
+            Level::Info => Severity::Info,
+            Level::Debug => Severity::Debug,
+            Level::Trace => Severity::Debug,
+        };
+
+        let mut logger = self.logger.lock().unwrap();
+        logger.log(severity, record.args().to_string().as_ref(), false).unwrap();
+    }
+
+    fn flush(&self) {}
+}

--- a/src/sonic-rs-common/tests/test_logger.rs
+++ b/src/sonic-rs-common/tests/test_logger.rs
@@ -1,14 +1,18 @@
 use sonic_rs_common::logger::*;
-use syslog::Severity;
 use gag::BufferRedirect;
 use std::io::Read;
 
 #[cfg(test)]
 mod test_logger {
+    use std::sync::Mutex;
     use super::*;
+
+    // This is required to prevent the tests using Logger from running in parallel by default
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_notice_log() {
+        let _unused = TEST_GUARD.lock();
         let mut logger = Logger::new(Some("test_logger".to_string()))
             .expect("Failed to create logger");
 
@@ -23,6 +27,7 @@ mod test_logger {
 
     #[test]
     fn test_basic() {
+        let _unused = TEST_GUARD.lock();
         let mut logger = Logger::new(Some("test_logger".to_string()))
             .expect("Failed to create logger");
 
@@ -32,15 +37,15 @@ mod test_logger {
         assert!(logger.log_notice("notice message", false).is_ok());
         assert!(logger.log_info("info message", false).is_ok());
         assert!(logger.log_debug("debug message", false).is_ok());
-        assert!(logger.log(Logger::LOG_PRIORITY_ERROR, "error msg", true).is_ok());
+        assert!(logger.log(Severity::Error, "error msg", true).is_ok());
     }
 
     #[test]
     fn test_log_priority() {
+        let _unused = TEST_GUARD.lock();
         let mut logger = Logger::new(Some("test_logger".to_string()))
             .expect("Failed to create logger");
-
-        logger.set_min_log_priority(Logger::LOG_PRIORITY_ERROR);
+        logger.set_min_log_priority(Severity::Error);
         // Note: In Rust version, we'd need to expose the min_log_priority field or add a getter
         // For now, test that the setter doesn't panic
     }
@@ -50,18 +55,18 @@ mod test_logger {
         // Note: The Python version has log_priority_from_str method
         // This would need to be implemented in the Rust Logger
         // Test that the constants are defined and accessible
-        let _error = Logger::LOG_PRIORITY_ERROR;
-        let _info = Logger::LOG_PRIORITY_INFO;
-        let _notice = Logger::LOG_PRIORITY_NOTICE;
-        let _warning = Logger::LOG_PRIORITY_WARNING;
-        let _debug = Logger::LOG_PRIORITY_DEBUG;
+        let _error = Severity::Error;
+        let _info = Severity::Info;
+        let _notice = Severity::Notice;
+        let _warning = Severity::Warning;
+        let _debug = Severity::Debug;
 
         // Test that we can compare the integer values
-        assert_eq!(Logger::LOG_PRIORITY_ERROR as i32, Severity::LOG_ERR as i32);
-        assert_eq!(Logger::LOG_PRIORITY_INFO as i32, Severity::LOG_INFO as i32);
-        assert_eq!(Logger::LOG_PRIORITY_NOTICE as i32, Severity::LOG_NOTICE as i32);
-        assert_eq!(Logger::LOG_PRIORITY_WARNING as i32, Severity::LOG_WARNING as i32);
-        assert_eq!(Logger::LOG_PRIORITY_DEBUG as i32, Severity::LOG_DEBUG as i32);
+        assert_eq!(Severity::Error as i32, Severity::Error as i32);
+        assert_eq!(Severity::Info as i32, Severity::Info as i32);
+        assert_eq!(Severity::Notice as i32, Severity::Notice as i32);
+        assert_eq!(Severity::Warning as i32, Severity::Warning as i32);
+        assert_eq!(Severity::Debug as i32, Severity::Debug as i32);
     }
 
     #[test]
@@ -71,19 +76,20 @@ mod test_logger {
         // Since Severity doesn't implement Debug, we test the integer values instead
 
         // Test that different priorities have different integer values
-        assert_ne!(Logger::LOG_PRIORITY_NOTICE as i32, Logger::LOG_PRIORITY_INFO as i32);
-        assert_ne!(Logger::LOG_PRIORITY_INFO as i32, Logger::LOG_PRIORITY_DEBUG as i32);
-        assert_ne!(Logger::LOG_PRIORITY_WARNING as i32, Logger::LOG_PRIORITY_ERROR as i32);
+        assert_ne!(Severity::Notice as i32, Severity::Info as i32);
+        assert_ne!(Severity::Info as i32, Severity::Debug as i32);
+        assert_ne!(Severity::Warning as i32, Severity::Error as i32);
 
         // Test that priorities are in expected order (lower number = higher priority)
-        assert!((Logger::LOG_PRIORITY_ERROR as i32) < (Logger::LOG_PRIORITY_WARNING as i32));
-        assert!((Logger::LOG_PRIORITY_WARNING as i32) < (Logger::LOG_PRIORITY_NOTICE as i32));
-        assert!((Logger::LOG_PRIORITY_NOTICE as i32) < (Logger::LOG_PRIORITY_INFO as i32));
-        assert!((Logger::LOG_PRIORITY_INFO as i32) < (Logger::LOG_PRIORITY_DEBUG as i32));
+        assert!((Severity::Error as i32) < (Severity::Warning as i32));
+        assert!((Severity::Warning as i32) < (Severity::Notice as i32));
+        assert!((Severity::Notice as i32) < (Severity::Info as i32));
+        assert!((Severity::Info as i32) < (Severity::Debug as i32));
     }
 
     #[test]
     fn test_runtime_config() {
+        let _unused = TEST_GUARD.lock();
         // Note: The Python version tests runtime config with SwSS database
         // This would require implementing runtime configuration in Rust Logger
         // For now, test basic logger creation with identifier
@@ -91,13 +97,14 @@ mod test_logger {
         assert!(logger.is_ok());
 
         let mut logger = logger.unwrap();
-        logger.set_min_log_priority(Logger::LOG_PRIORITY_DEBUG);
+        logger.set_min_log_priority(Severity::Debug);
         // Test that logger can be configured
         assert!(logger.log_debug("test message", false).is_ok());
     }
 
     #[test]
     fn test_runtime_config_negative() {
+        let _unused = TEST_GUARD.lock();
         // Note: The Python version tests error handling in runtime config
         // This would require implementing error handling for SwSS database operations
         // For now, test basic error handling in logger creation
@@ -105,23 +112,32 @@ mod test_logger {
         // Test that logger creation handles edge cases
         let logger_with_empty_id = Logger::new(Some("".to_string()));
         assert!(logger_with_empty_id.is_ok());
+    }
 
+    #[test]
+    fn test_runtime_config_negative_alt() {
+        let _unused = TEST_GUARD.lock();
         let logger_with_none = Logger::new(None);
         assert!(logger_with_none.is_ok());
     }
 
     // Test logger creation with different facilities
     #[test]
-    fn test_logger_facilities() {
+    fn test_logger_facility_daemon() {
+        let _unused = TEST_GUARD.lock();
         let daemon_logger = Logger::new_with_options(
             Some("daemon_test".to_string()),
-            Logger::LOG_FACILITY_DAEMON
+            Facility::Daemon
         );
         assert!(daemon_logger.is_ok());
+    }
 
+    #[test]
+    fn test_logger_facility_user() {
+        let _unused = TEST_GUARD.lock();
         let user_logger = Logger::new_with_options(
             Some("user_test".to_string()),
-            Logger::LOG_FACILITY_USER
+            Facility::User
         );
         assert!(user_logger.is_ok());
     }
@@ -129,6 +145,7 @@ mod test_logger {
     // Test logger priority setters
     #[test]
     fn test_priority_setters() {
+        let _unused = TEST_GUARD.lock();
         let mut logger = Logger::new(Some("priority_test".to_string()))
             .expect("Failed to create logger");
 
@@ -146,11 +163,27 @@ mod test_logger {
     // Test console output functionality
     #[test]
     fn test_console_output() {
+        let _unused = TEST_GUARD.lock();
         let mut logger = Logger::new(Some("console_test".to_string()))
             .expect("Failed to create logger");
 
         // Test logging with console output enabled
         assert!(logger.log_info("test console message", true).is_ok());
         assert!(logger.log_error("test console error", true).is_ok());
+    }
+
+    #[test]
+    fn test_double_logger_creation_fails() {
+        let _unused = TEST_GUARD.lock();
+
+        let logger1 = Logger::new(Some("First logger".to_string()));
+        assert!(logger1.is_ok(), "First logger created successfully");
+
+        let logger2 = Logger::new(Some("Second logger".to_string()));
+        assert!(logger2.is_err(), "Second logger should fail while first is alive");
+
+        drop(logger1.unwrap());
+        let logger3 = Logger::new(Some("Third logger".to_string()));
+        assert!(logger3.is_ok(), "Third logger created successfully after dropping the previous one");
     }
 }

--- a/src/sonic-supervisord-utilities-rs/Cargo.lock
+++ b/src/sonic-supervisord-utilities-rs/Cargo.lock
@@ -160,12 +160,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "deranged"
-version = "0.4.0"
+name = "cstr"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "68523903c8ae5aacfa32a0d9ae60cadeb764e1da14ee0d26b1f3089f13a54636"
 dependencies = [
- "powerfmt",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -182,15 +183,6 @@ checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -236,17 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
 name = "injectorpp"
 version = "0.4.0"
 source = "git+https://github.com/microsoft/injectorppforrust.git?rev=c7317906a1d514ef99bf2fbd4c943908c265d280#c7317906a1d514ef99bf2fbd4c943908c265d280"
@@ -283,9 +264,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -305,15 +286,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "matchers"
@@ -380,21 +355,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,12 +377,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "powerfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -609,6 +563,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "sonic-rs-common"
+version = "0.1.0"
+dependencies = [
+ "cstr",
+ "libc",
+ "log",
+ "swss-common",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "sonic-supervisord-utilities-rs"
 version = "1.0.0"
 dependencies = [
@@ -619,8 +585,8 @@ dependencies = [
  "nix",
  "scopeguard",
  "serde_json",
+ "sonic-rs-common",
  "swss-common",
- "syslog",
  "tempfile",
  "thiserror",
 ]
@@ -652,19 +618,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syslog"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc7e95b5b795122fafe6519e27629b5ab4232c73ebb2428f568e82b1a457ad3"
-dependencies = [
- "error-chain",
- "hostname",
- "libc",
- "log",
- "time",
 ]
 
 [[package]]
@@ -710,46 +663,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
-dependencies = [
- "deranged",
- "itoa",
- "libc",
- "num-conv",
- "num_threads",
- "powerfmt",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
-
-[[package]]
-name = "time-macros"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
-dependencies = [
- "num-conv",
- "time-core",
-]
-
-[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -809,12 +741,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/src/sonic-supervisord-utilities-rs/Cargo.toml
+++ b/src/sonic-supervisord-utilities-rs/Cargo.toml
@@ -16,11 +16,11 @@ path = "src/bin/supervisor_proc_exit_listener.rs"
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
 log = "0.4"
-syslog = "6.0"
 nix = { version = "0.27", features = ["signal", "process"] }
 thiserror = "1.0"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 swss-common = { path = "../sonic-swss-common/crates/swss-common" }
+sonic-rs-common = { path = "../sonic-rs-common" }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -3,7 +3,7 @@
 
 use crate::childutils;
 use clap::Parser;
-use log::{error, info, warn};
+use log::{error, info, warn, LevelFilter};
 use mio::{Events, Token};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::getppid;
@@ -15,8 +15,9 @@ use std::process;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use swss_common::{ConfigDBConnector, EventPublisher};
-use syslog::Severity;
 use thiserror::Error;
+use sonic_rs_common::logger::{Severity, Facility};
+use sonic_rs_common::simple_logger::SimpleLogger;
 
 // File paths
 const WATCH_PROCESSES_FILE: &str = "/etc/supervisor/watchdog_processes";
@@ -173,9 +174,9 @@ pub fn generate_alerting_message(process_name: &str, status: &str, dead_minutes:
 
     // Log with appropriate severity (matching syslog levels)
     match priority {
-        Severity::LOG_ERR => error!("{}", message),
-        Severity::LOG_WARNING => warn!("{}", message),
-        Severity::LOG_INFO => info!("{}", message),
+        Severity::Error => error!("{}", message),
+        Severity::Warning => warn!("{}", message),
+        Severity::Info => info!("{}", message),
         _ => error!("{}", message),
     }
 }
@@ -259,10 +260,8 @@ pub fn get_current_time() -> f64 {
 
 /// Main function with testable parameters
 pub fn main_with_args(args: Option<Vec<String>>) -> Result<()> {
-    // Initialize syslog logging to match Python version behavior
-    syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Info)
-        .map_err(|e| SupervisorError::Parse(format!("Failed to initialize syslog: {}", e)))?;
-
+    SimpleLogger::init(Facility::User, LevelFilter::Info)
+        .map_err(|e| SupervisorError::System(e))?;
     // Parse command line arguments
     let parsed_args = if let Some(args) = args {
         Args::try_parse_from(args).map_err(|e| SupervisorError::Parse(e.to_string()))?
@@ -506,7 +505,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                     let new_dead_minutes = current_dead_minutes + elapsed_mins as f64;
                     process_info.insert("dead_minutes".to_string(), new_dead_minutes);
 
-                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Severity::LOG_ERR);
+                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Severity::Error);
                 }
             }
         }
@@ -518,7 +517,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                 let threshold = get_heartbeat_alert_interval(process, &heartbeat_intervals);
                 if threshold > 0.0 && elapsed_secs >= threshold {
                     let elapsed_mins = (elapsed_secs / 60.0) as u64;
-                    generate_alerting_message(process, "stuck", elapsed_mins, Severity::LOG_WARNING);
+                    generate_alerting_message(process, "stuck", elapsed_mins, Severity::Warning);
                 }
             }
         }

--- a/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
+++ b/src/sonic-supervisord-utilities-rs/src/proc_exit_listener.rs
@@ -3,7 +3,7 @@
 
 use crate::childutils;
 use clap::Parser;
-use log::{error, info, warn};
+use log::{error, info, warn, LevelFilter};
 use mio::{Events, Token};
 use nix::sys::signal::{self, Signal};
 use nix::unistd::getppid;
@@ -15,8 +15,9 @@ use std::process;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use swss_common::{ConfigDBConnector, EventPublisher};
-use syslog::Severity;
 use thiserror::Error;
+use sonic_rs_common::logger::{Severity, Facility};
+use sonic_rs_common::simple_logger::SimpleLogger;
 
 // File paths
 const WATCH_PROCESSES_FILE: &str = "/etc/supervisor/watchdog_processes";
@@ -173,9 +174,9 @@ pub fn generate_alerting_message(process_name: &str, status: &str, dead_minutes:
 
     // Log with appropriate severity (matching syslog levels)
     match priority {
-        Severity::LOG_ERR => error!("{}", message),
-        Severity::LOG_WARNING => warn!("{}", message),
-        Severity::LOG_INFO => info!("{}", message),
+        Severity::Error => error!("{}", message),
+        Severity::Warning => warn!("{}", message),
+        Severity::Info => info!("{}", message),
         _ => error!("{}", message),
     }
 }
@@ -259,10 +260,8 @@ pub fn get_current_time() -> f64 {
 
 /// Main function with testable parameters
 pub fn main_with_args(args: Option<Vec<String>>) -> Result<()> {
-    // Initialize syslog logging to match Python version behavior
-    syslog::init_unix(syslog::Facility::LOG_USER, log::LevelFilter::Info)
-        .map_err(|e| SupervisorError::Parse(format!("Failed to initialize syslog: {}", e)))?;
-
+    let _ = log::set_boxed_logger(Box::new(SimpleLogger::new(Facility::User)))
+        .map(|()| log::set_max_level(LevelFilter::Info));
     // Parse command line arguments
     let parsed_args = if let Some(args) = args {
         Args::try_parse_from(args).map_err(|e| SupervisorError::Parse(e.to_string()))?
@@ -506,7 +505,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                     let new_dead_minutes = current_dead_minutes + elapsed_mins as f64;
                     process_info.insert("dead_minutes".to_string(), new_dead_minutes);
 
-                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Severity::LOG_ERR);
+                    generate_alerting_message(process_name, "not running", new_dead_minutes as u64, Severity::Error);
                 }
             }
         }
@@ -518,7 +517,7 @@ pub fn main_with_parsed_args_and_stdin<S: Read + AsRawFd, P: Poller>(args: Args,
                 let threshold = get_heartbeat_alert_interval(process, &heartbeat_intervals);
                 if threshold > 0.0 && elapsed_secs >= threshold {
                     let elapsed_mins = (elapsed_secs / 60.0) as u64;
-                    generate_alerting_message(process, "stuck", elapsed_mins, Severity::LOG_WARNING);
+                    generate_alerting_message(process, "stuck", elapsed_mins, Severity::Warning);
                 }
             }
         }

--- a/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
+++ b/src/sonic-supervisord-utilities-rs/tests/integration_tests.rs
@@ -5,7 +5,7 @@ use sonic_supervisord_utilities_rs::{
     proc_exit_listener::*,
 };
 use swss_common::ConfigDBConnector;
-use syslog::Severity;
+use sonic_rs_common::logger::Severity;
 use std::io::Write;
 use tempfile::NamedTempFile;
 use std::time::Duration;
@@ -69,13 +69,13 @@ fn test_generate_alerting_message() {
     // Test generate_alerting_message function
     // This function should log the message (we can't easily test the actual logging)
     // but we can test that it doesn't panic and follows the expected format
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
-    generate_alerting_message("heartbeat_process", "stuck", 2, Severity::LOG_WARNING);
+    generate_alerting_message("test_process", "not running", 5, Severity::Error);
+    generate_alerting_message("heartbeat_process", "stuck", 2, Severity::Warning);
 
     // Test with namespace environment variables
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::set_var("NAMESPACE_ID", "0");
-    generate_alerting_message("test_process", "not running", 10, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 10, Severity::Error);
     
     // Clean up
     std::env::remove_var("NAMESPACE_PREFIX");
@@ -155,17 +155,17 @@ fn test_namespace_detection() {
     // Test default namespace (host) - should not panic
     std::env::remove_var("NAMESPACE_PREFIX");
     std::env::remove_var("NAMESPACE_ID");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Severity::Error);
 
     // Test asic namespace - should not panic
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::set_var("NAMESPACE_ID", "0");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Severity::Error);
 
     // Test partial namespace (should fallback to host) - should not panic
     std::env::set_var("NAMESPACE_PREFIX", "asic");
     std::env::remove_var("NAMESPACE_ID");
-    generate_alerting_message("test_process", "not running", 5, Severity::LOG_ERR);
+    generate_alerting_message("test_process", "not running", 5, Severity::Error);
 
     // Cleanup
     std::env::remove_var("NAMESPACE_PREFIX");
@@ -194,10 +194,10 @@ fn test_autorestart_state_checking() {
 fn test_alerting_message_generation() {
     // Test different message types and priorities - function logs but doesn't return string
     // Main test is that it doesn't panic with various inputs
-    generate_alerting_message("orchagent", "not running", 5, Severity::LOG_ERR);
-    generate_alerting_message("portsyncd", "stuck", 10, Severity::LOG_WARNING);
-    generate_alerting_message("test", "status", 0, Severity::LOG_INFO);
-    generate_alerting_message("", "", 999, Severity::LOG_ALERT); // Edge case
+    generate_alerting_message("orchagent", "not running", 5, Severity::Error);
+    generate_alerting_message("portsyncd", "stuck", 10, Severity::Warning);
+    generate_alerting_message("test", "status", 0, Severity::Info);
+    generate_alerting_message("", "", 999, Severity::Alert); // Edge case
 }
 
 #[test]
@@ -280,9 +280,9 @@ fn test_function_robustness() {
     // Test that functions handle edge cases without panicking
 
     // Test generate_alerting_message with various inputs
-    generate_alerting_message("test", "status", 0, Severity::LOG_ERR);
-    generate_alerting_message("", "", 999, Severity::LOG_DEBUG);
-    generate_alerting_message("very_long_process_name_that_should_work", "some status", 60, Severity::LOG_WARNING);
+    generate_alerting_message("test", "status", 0, Severity::Error);
+    generate_alerting_message("", "", 999, Severity::Debug);
+    generate_alerting_message("very_long_process_name_that_should_work", "some status", 60, Severity::Warning);
     
     // Test get_current_time multiple calls
     let times: Vec<f64> = (0..5).map(|_| {


### PR DESCRIPTION


#### Why I did it

The Rust syslog crate does not attempt to reconnect when its connection to the socket is lost, nor does it provide a way to detect that the connection was broken. This causes the Rust listener to fail if it starts before the syslog daemon is initialized, since it attempts to connect to the socket without retrying on failure. Additionally, should an established syslog connection drop at any point, no reconnection is attempted. Messages sent after the disconnection are quietly lost, with no indication of failure to the application.

This PR plans to replace https://github.com/sonic-net/sonic-buildimage/pull/26840 and tackle the current open comments, due to ownership change. 


#### How I did it

-     Replaced the syslog crate with libc’s syslog in the Logger struct in sonic-rs-common

-     Added a SimpleLogger struct in sonic-rs-common which implements the log::Log trait using the Logger struct

-     Updated sonic-supervisord-utilities-rs to use SimpleLogger


#### How to verify it



1. Run cargo test for sonic-rs-common and sonic-supervisord-utilities-rs

1. To reproduce the original issue (before this fix):

On a DUT open three separate shells.

On the first one run:
sudo tail -F /var/log/syslog

On the second one run:
sudo docker exec -it syncd /usr/bin/supervisor-proc-exit-listener-rs –container-name syncd

Here, type “abcd” and press Enter
Notice how in the first shell the following is printed:
WARNING syncd#supervisor-proc-exit-listener-rs[668]: Missing ‘len’ in headers: {}

On the third one run:
sudo docker exec -it syncd bash -c 'kill $(pidof rsyslogd)

If this is tested against Prestera you'll also need to run:
sudo docker exec -it syncd bash -c '/usr/sbin/rsyslogd -n -iNONE'

Lastly, on the second shell, type “abcd” again and press Enter
The same message as before should be printed. Without this fix the message will not make it to syslog.


#### Which release branch to backport (provide reason below if selected)


- [x] 202511
This was introduced with https://github.com/sonic-net/sonic-buildimage/pull/24698.

#### Tested branch (Please provide the tested image version)
- [x] 202511



#### Description for the changelog


Replaced the syslog Rust crate with libc’s syslog to fix logging failures when the syslog daemon is unavailable or restarts.



#### A picture of a cute animal (not mandatory but encouraged)
![koala](https://placebear.com/300/300)


Fixes: https://github.com/sonic-net/sonic-buildimage/issues/26976
Fixes: https://github.com/sonic-net/sonic-buildimage/issues/26978