### PR TITLE
[Mellanox] Implement get_midplane_down_reason for DPU module

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -278,18 +278,33 @@ class DpuModule(ModuleBase):
         self.CONFIG_DB_NAME = "CONFIG_DB"
         self.midplane_interface = None
         self.bus_info = None
-        self.reboot_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"
+        self.reset_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"
+        # Two dedicated maps keyed by the hw-management reset-cause file. Each value is
+        # a (reason_code, description) tuple, so within each map index 0 is always the
+        # reason code and index 1 the description (no cross-purpose index reuse).
         self.reboot_cause_map = {
-            f'{self.reboot_base_path}reset_aux_pwr_or_reload':
+            f'{self.reset_base_path}reset_aux_pwr_or_reload':
                 (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'power auxiliary outage or reload'),
-            f'{self.reboot_base_path}reset_comex_pwr_fail':
+            f'{self.reset_base_path}reset_comex_pwr_fail':
                 (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'Power failed to comex module'),
-            f'{self.reboot_base_path}reset_from_main_board':
+            f'{self.reset_base_path}reset_from_main_board':
                 (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset from Main board'),
-            f'{self.reboot_base_path}reset_dpu_thermal':
+            f'{self.reset_base_path}reset_dpu_thermal':
                 (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-            f'{self.reboot_base_path}reset_pwr_off':
+            f'{self.reset_base_path}reset_pwr_off':
                 (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
+        }
+        self.midplane_down_reason_map = {
+            f'{self.reset_base_path}reset_aux_pwr_or_reload':
+                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'power auxiliary outage or reload'),
+            f'{self.reset_base_path}reset_comex_pwr_fail':
+                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'Power failed to comex module'),
+            f'{self.reset_base_path}reset_from_main_board':
+                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset from Main board'),
+            f'{self.reset_base_path}reset_dpu_thermal':
+                (ModuleBase.MIDPLANE_DOWN_REASON_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
+            f'{self.reset_base_path}reset_pwr_off':
+                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset due to Power off'),
         }
         self.MLX_DPU_REBOOT_CAUSE_WARM = 0
         self.MLX_DPU_REBOOT_CAUSE_COLD = 1
@@ -482,6 +497,16 @@ class DpuModule(ModuleBase):
                 logger.log_notice(f"Reset reason for {self._name} is {rd[0]}")
                 return rd
         return ChassisBase.REBOOT_CAUSE_NON_HARDWARE, ''
+
+    def get_midplane_down_reason(self):
+        """
+        Retrieves the reason for the midplane down
+        """
+        for f, rd in self.midplane_down_reason_map.items():
+            if utils.read_int_from_file(f) == 1:
+                logger.log_notice(f"Midplane down reason for {self._name} is {rd[0]}")
+                return rd
+        return ModuleBase.MIDPLANE_DOWN_REASON_HARDWARE_OTHER, ''
 
     def get_midplane_ip(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -485,7 +485,8 @@ class DpuModule(ModuleBase):
 
     def get_midplane_down_reason(self):
         """
-        Retrieves the reason for the midplane down
+        Retrieves the reason for the midplane down.
+        Using the reboot cause sysfs files to indicate the midplane down reason.
 
         Returns:
             A tuple (string, string) where the first element is one of the

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -278,33 +278,18 @@ class DpuModule(ModuleBase):
         self.CONFIG_DB_NAME = "CONFIG_DB"
         self.midplane_interface = None
         self.bus_info = None
-        self.reset_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"
-        # Two dedicated maps keyed by the hw-management reset-cause file. Each value is
-        # a (reason_code, description) tuple, so within each map index 0 is always the
-        # reason code and index 1 the description (no cross-purpose index reuse).
+        self.reboot_base_path = f"/var/run/hw-management/{self.dpuctl_obj._name}/system/"
         self.reboot_cause_map = {
-            f'{self.reset_base_path}reset_aux_pwr_or_reload':
+            f'{self.reboot_base_path}reset_aux_pwr_or_reload':
                 (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'power auxiliary outage or reload'),
-            f'{self.reset_base_path}reset_comex_pwr_fail':
+            f'{self.reboot_base_path}reset_comex_pwr_fail':
                 (ChassisBase.REBOOT_CAUSE_POWER_LOSS, 'Power failed to comex module'),
-            f'{self.reset_base_path}reset_from_main_board':
+            f'{self.reboot_base_path}reset_from_main_board':
                 (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset from Main board'),
-            f'{self.reset_base_path}reset_dpu_thermal':
+            f'{self.reboot_base_path}reset_dpu_thermal':
                 (ChassisBase.REBOOT_CAUSE_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-            f'{self.reset_base_path}reset_pwr_off':
+            f'{self.reboot_base_path}reset_pwr_off':
                 (ChassisBase.REBOOT_CAUSE_NON_HARDWARE, 'Reset due to Power off'),
-        }
-        self.midplane_down_reason_map = {
-            f'{self.reset_base_path}reset_aux_pwr_or_reload':
-                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'power auxiliary outage or reload'),
-            f'{self.reset_base_path}reset_comex_pwr_fail':
-                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'Power failed to comex module'),
-            f'{self.reset_base_path}reset_from_main_board':
-                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset from Main board'),
-            f'{self.reset_base_path}reset_dpu_thermal':
-                (ModuleBase.MIDPLANE_DOWN_REASON_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-            f'{self.reset_base_path}reset_pwr_off':
-                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset due to Power off'),
         }
         self.MLX_DPU_REBOOT_CAUSE_WARM = 0
         self.MLX_DPU_REBOOT_CAUSE_COLD = 1
@@ -501,12 +486,17 @@ class DpuModule(ModuleBase):
     def get_midplane_down_reason(self):
         """
         Retrieves the reason for the midplane down
+
+        Returns:
+            A tuple (string, string) where the first element is one of the
+            ChassisBase.REBOOT_CAUSE_* strings and the second element is a
+            description of the midplane down reason.
         """
-        for f, rd in self.midplane_down_reason_map.items():
+        for f, rd in self.reboot_cause_map.items():
             if utils.read_int_from_file(f) == 1:
                 logger.log_notice(f"Midplane down reason for {self._name} is {rd[0]}")
                 return rd
-        return ModuleBase.MIDPLANE_DOWN_REASON_HARDWARE_OTHER, ''
+        return ChassisBase.REBOOT_CAUSE_NON_HARDWARE, ''
 
     def get_midplane_ip(self):
         """

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module.py
@@ -119,7 +119,7 @@ class Module(ModuleBase):
         if state != self.current_state:
             self._re_init()
         elif seq_no != self.seq_no:
-            if state == Module.STATE_ACTIVATED: # LC has been replaced, need re-initialize
+            if state == Module.STATE_ACTIVATED:  # LC has been replaced, need re-initialize
                 self._re_init()
         self.current_state = state
         self.seq_no = seq_no
@@ -145,7 +145,6 @@ class Module(ModuleBase):
         self._thermal_list = []
         self._sfp_list = []
         self._sfp_count = 0
-
 
     ##############################################
     # THERMAL methods
@@ -473,7 +472,7 @@ class DpuModule(ModuleBase):
                     # Extract the value after the '|'
                     reset_reason_value = line.split('|')[1].strip()
                     break
-            if reset_reason_value and int(reset_reason_value,16) == self.MLX_DPU_REBOOT_CAUSE_WATCHDOG:
+            if reset_reason_value and int(reset_reason_value, 16) == self.MLX_DPU_REBOOT_CAUSE_WATCHDOG:
                 logger.log_notice(f"Reset reason for {self._name} is {ChassisBase.REBOOT_CAUSE_WATCHDOG}")
                 return ChassisBase.REBOOT_CAUSE_WATCHDOG, 'Watchdog reboot'
         # Check for other reboot causes

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -344,6 +344,20 @@ class TestModule:
                 for index, file_name in enumerate(file_name_list):
                     test_file_path = file_name
                     assert m.get_reboot_cause() == reboot_cause_list[index]
+
+            # get_midplane_down_reason() uses midplane_down_reason_map and must return MIDPLANE_DOWN_REASON_* codes.
+            midplane_down_reason_list = [
+                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'power auxiliary outage or reload'),
+                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'Power failed to comex module'),
+                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset from Main board'),
+                (ModuleBase.MIDPLANE_DOWN_REASON_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
+                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset due to Power off'),
+                (ModuleBase.MIDPLANE_DOWN_REASON_HARDWARE_OTHER, ''),
+            ]
+            with patch("sonic_platform.utils.read_int_from_file", wraps=mock_read_int_from_file):
+                for index, file_name in enumerate(file_name_list):
+                    test_file_path = file_name
+                    assert m.get_midplane_down_reason() == midplane_down_reason_list[index]
             
             # Test subprocess exception case
             mock_check_output.side_effect = subprocess.CalledProcessError(1, 'mlxreg')

--- a/platform/mellanox/mlnx-platform-api/tests/test_module.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_module.py
@@ -345,19 +345,12 @@ class TestModule:
                     test_file_path = file_name
                     assert m.get_reboot_cause() == reboot_cause_list[index]
 
-            # get_midplane_down_reason() uses midplane_down_reason_map and must return MIDPLANE_DOWN_REASON_* codes.
-            midplane_down_reason_list = [
-                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'power auxiliary outage or reload'),
-                (ModuleBase.MIDPLANE_DOWN_REASON_POWER_LOSS, 'Power failed to comex module'),
-                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset from Main board'),
-                (ModuleBase.MIDPLANE_DOWN_REASON_THERMAL_OVERLOAD_OTHER, 'Thermal shutdown of the DPU'),
-                (ModuleBase.MIDPLANE_DOWN_REASON_NON_HARDWARE, 'Reset due to Power off'),
-                (ModuleBase.MIDPLANE_DOWN_REASON_HARDWARE_OTHER, ''),
-            ]
+            # get_midplane_down_reason() shares reboot_cause_map, so it reports the same
+            # (cause, description) pairs as get_reboot_cause() for every reset-cause file.
             with patch("sonic_platform.utils.read_int_from_file", wraps=mock_read_int_from_file):
                 for index, file_name in enumerate(file_name_list):
                     test_file_path = file_name
-                    assert m.get_midplane_down_reason() == midplane_down_reason_list[index]
+                    assert m.get_midplane_down_reason() == reboot_cause_list[index]
             
             # Test subprocess exception case
             mock_check_output.side_effect = subprocess.CalledProcessError(1, 'mlxreg')


### PR DESCRIPTION
#### Why I did it
Mellanox `DpuModule` did not implement the pmon `ModuleBase.get_midplane_down_reason()`
interface, so it fell back to the generic base behavior instead of reporting the actual DPU
hardware reset cause. As a result, when a DPU's midplane went down there was no way for pmon to
surface whether it was caused by a power loss, a thermal shutdown, or a reset from the main board.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Implemented `DpuModule.get_midplane_down_reason()` in
  `platform/mellanox/mlnx-platform-api/sonic_platform/module.py`.
- The implementation scans the existing `reboot_cause_map` (the per-DPU
  `/var/run/hw-management/<dpu>/system/reset_*` sysfs files) and returns the
  `(ChassisBase.REBOOT_CAUSE_*, description)` tuple of the first file that reads `1`.
- Falls back to `(ChassisBase.REBOOT_CAUSE_NON_HARDWARE, '')` when no reset-cause file is
  asserted, matching the existing `get_reboot_cause()` contract.
- Logs a notice with the resolved reason so the cause is recoverable from syslog.
- Reuses the existing `ChassisBase.REBOOT_CAUSE_*` constants rather than introducing new
  midplane-specific constants.

#### How to verify it
Run the Mellanox platform API unit tests:

```bash
cd platform/mellanox/mlnx-platform-api
python3 -m pytest tests/test_module.py::TestModule::test_dpu_module -v
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411

#### Description for the changelog
Implement get_midplane_down_reason for Mellanox DPU module
