### PR TITLE
marvell-prestera: P8.0.0 sai-1.18.1-1

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 else
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Update marvell-prestera SAI version from 1.17.1-13 onto 1.18.1-1

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update the version index in the
        platform/marvell-prestera/sai.mk

#### How to verify it
Build marvell-prestera
Check
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb.log
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb-install.log

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)

