### PR TITLE
Upgrade containerd to 2.2.5

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -28,7 +28,7 @@ CONFIGURED_ARCH=$([ -f .arch ] && cat .arch || echo amd64)
 
 ## docker engine version (with platform)
 DOCKER_VERSION=5:28.5.2-1~debian.13~$IMAGE_DISTRO
-CONTAINERD_IO_VERSION=1.7.28-2~debian.13~$IMAGE_DISTRO
+CONTAINERD_IO_VERSION=2.2.5-1~debian.13~$IMAGE_DISTRO
 LINUX_KERNEL_VERSION=6.12.41+deb13
 
 ## Working directory to prepare the file system


### PR DESCRIPTION
#### Why I did it
After config reload, a container can fail to stop cleanly and get force-killed, leaving a stale containerd task. The container then appears running but is unreachable via `docker exec` and health checks fail. This is a known transient bug in runc 1.3.3 (bundled with containerd.io 1.7.28-2), tracked at [opencontainers/runc#5007](https://github.com/opencontainers/runc/issues/5007). Upgrading containerd pulls in a fixed runc version. Fixes sonic-net/sonic-buildimage#27672.
#### How I did it
- Bump `CONTAINERD_IO_VERSION` in `build_debian.sh` from `1.7.28-2` to `2.2.5-1`.
#### How to verify it
- Build and install an image from this branch.
- Bring up a switch and repeatedly perform config reload.
- Confirm containers stop cleanly and remain accessible via `docker exec` after reload.
#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605
#### Tested branch (Please provide the tested image version)
- [x] master
#### Description for the changelog
Upgrade containerd to 2.2.5