### PR TITLE
[Mellanox] Disable warm reboot on ACS-SN6600_LD

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/sai_6600.xml
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/sai_6600.xml
@@ -24,7 +24,7 @@
         <device-mac-address>00:02:03:04:05:00</device-mac-address>
 
         <!-- ISSU enabled -->
-        <issu-enabled>1</issu-enabled>
+        <issu-enabled>0</issu-enabled>
 
     </platform_info>
 </root>


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Disable warm reboot/ISSU for the ACS-SN6600_LD platform configuration.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated `device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/sai_6600.xml` to set:

`<issu-enabled>0</issu-enabled>`

instead of enabling ISSU with value `1`.

#### How to verify it

- Confirm the XML contains `<issu-enabled>0</issu-enabled>`.
- Build or package the Mellanox platform image/config that includes `ACS-SN6600_LD`.
- On the target image or DUT, verify the installed `sai_6600.xml` under the SN6600_LD device directory has ISSU disabled.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

