### PR TITLE
[Micas] W6940: fix incorrect static threshold configs for buffer profiles

### DIFF
--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128qc-r0/M2-W6940-128QC/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-128X1-FR4/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-pure-pd-r0/M2-W6940-64X1-FR4/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-128X1-FR4/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-128x1-fr4-r0/M2-W6940-64X1-FR4/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_ft2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_ft2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_lt2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_lt2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t0.j2
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t0.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t1.j2
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t1.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",

--- a/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t2.j2
+++ b/device/micas/x86_64-micas_m2-w6940-64oc-r0/M2-W6940-64OC/buffers_defaults_t2.j2
@@ -20,12 +20,12 @@
         "ingress_lossy_profile": {
             "pool":"ingress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossless_profile": {
             "pool":"egress_lossless_pool",
             "size":"0",
-            "static_th":"165867080"
+            "dynamic_th":"3"
         },
         "egress_lossy_profile": {
             "pool":"egress_lossless_pool",


### PR DESCRIPTION
Switch ingress_lossy_profile and egress_lossless_profile from incorrect static watermarks to dynamic threshold

Change-Id: I9d32372b9d45850f887935026cc464fd575847e0

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The W6940 buffer profiles used incorrect static thresholds. Switch to dynamic threshold for proper operation.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Change threshold mode from static to dynamic for ingress_lossy_profile and egress_lossless_profile in buffer template.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
[Micas] W6940: fix incorrect static threshold configs for buffer profiles
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

