### PR TITLE
[ci] stop publishing docker-ptf in official vs build

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -113,14 +113,7 @@ jobs:
           BRANCH=$(Build.SourceBranchName)
           echo "Branch = $BRANCH"
           PUSH_DOCKER="False"
-          if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
-          then
-            LABELS="$BRANCH"
-            [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
-            DOCKERS=$(ls target/docker-ptf.gz)
-            PUSH_DOCKER="True"
-          elif [[ "$PTF_MODIFIED_IN_PR" == "True" ]]
-          then
+          if [[ "$PTF_MODIFIED_IN_PR" == "True" ]]; then
             LABELS="ptf-$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER"
             DOCKERS=$(ls target/docker-ptf.gz)
             PUSH_DOCKER="True"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We now have a dedicated pipeline (`.azure-pipelines/docker-ptf.yml`) that builds, tests and publishes docker-ptf. 
Previously, the official VS build (`Azure.sonic-buildimage.official.vs`) also published docker-ptf (tagged with the branch name, plus  latest  on master) as a side effect of the image build — without any testing. That path can publish a broken docker-ptf and silently break the downstream test stage that consumes it.
This PR removes that untested publish path from the official VS build so docker-ptf is only ever published through the dedicated, tested pipeline.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
In `.azure-pipelines/azure-pipelines-image-template.yml`, dropped the branch of the publish logic that pushed `target/docker-ptf.gz` when `BUILD_REASON != PullRequest` and `BUILD_DEFINITIONNAME == Azure.sonic-buildimage.official.vs`
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
N/A - pipeline change, no test needed
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

