### PR TITLE
Add CLI knob to expose and configure LACP mode per port channel

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2275,23 +2275,18 @@ name as object key and member list as attribute.
         "mtu": "9100",
         "fallback": "false",
         "fast_rate": "true",
-<<<<<<< HEAD
-        "system_mac": "aa:bb:cc:dd:ee:ff"
-=======
+        "system_mac": "aa:bb:cc:dd:,
         "lacp_mode": "independent"
->>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
     }
   }
 }
 ```
 
-<<<<<<< HEAD
 The optional **system_mac** field overrides the LACP actor system MAC for the PortChannel. When unset, the device system MAC is used. EVPN multihoming deployments can set this field when peer devices must advertise a shared LACP system identifier.
-=======
+
 The optional **lacp_mode** field configures the LACP operating mode for the
 PortChannel. Valid values are `couple` and `independent`. The default is
 `couple`.
->>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
 
 
 ### Portchannel member

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -2275,13 +2275,23 @@ name as object key and member list as attribute.
         "mtu": "9100",
         "fallback": "false",
         "fast_rate": "true",
+<<<<<<< HEAD
         "system_mac": "aa:bb:cc:dd:ee:ff"
+=======
+        "lacp_mode": "independent"
+>>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
     }
   }
 }
 ```
 
+<<<<<<< HEAD
 The optional **system_mac** field overrides the LACP actor system MAC for the PortChannel. When unset, the device system MAC is used. EVPN multihoming deployments can set this field when peer devices must advertise a shared LACP system identifier.
+=======
+The optional **lacp_mode** field configures the LACP operating mode for the
+PortChannel. Valid values are `couple` and `independent`. The default is
+`couple`.
+>>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
 
 
 ### Portchannel member

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -34,6 +34,14 @@
         "eStrKey" : "Pattern",
         "eStr": ["false|true|False|True"]
     },
+    "PORT_CHANNEL_VALID_LACP_MODE": {
+        "desc": "Configure valid value for PortChannel lacp_mode."
+    },
+    "PORT_CHANNEL_INVALID_LACP_MODE": {
+        "desc": "INCORRECT PORTCHANNEL LACP_MODE IN PORT_CHANNEL TABLE.",
+        "eStrKey" : "Pattern",
+        "eStr": ["independent|couple"]
+    },
     "PORTCHANNEL_INTERFACE_IP_ADDR_TEST": {
         "desc": "Configure IP address on PORTCHANNEL_INTERFACE table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -171,6 +171,36 @@
             }
         }
     },
+    "PORT_CHANNEL_VALID_LACP_MODE": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "tpid": "0x9100",
+                        "name": "PortChannel0001",
+                        "lacp_mode": "independent"
+                    }
+                ]
+            }
+        }
+    },
+    "PORT_CHANNEL_INVALID_LACP_MODE": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "tpid": "0x9100",
+                        "name": "PortChannel0001",
+                        "lacp_mode": "off"
+                    }
+                ]
+            }
+        }
+    },
     "PORTCHANNEL_INTERFACE_IP_ADDR_TEST": {
         "sonic-portchannel:sonic-portchannel": {
             "sonic-portchannel:PORTCHANNEL": {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,17 +24,16 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
-<<<<<<< HEAD
-    revision 2025-06-24 {
-        description "Add LACP System MAC address";
-=======
+
     revision 2025-06-28 {
         description "Add lacp_mode (independent|couple) attribute to PortChannel.";
     }
 
+    revision 2025-06-24 {
+        description "Add LACP System MAC address";
+
     revision 2025-05-20 {
         description "A port-channel member must be a switchport; reject any port with an INTERFACE row (routed port).";
->>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
     }
 
     revision 2021-06-13 {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,8 +24,17 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
+<<<<<<< HEAD
     revision 2025-06-24 {
         description "Add LACP System MAC address";
+=======
+    revision 2025-06-28 {
+        description "Add lacp_mode (independent|couple) attribute to PortChannel.";
+    }
+
+    revision 2025-05-20 {
+        description "A port-channel member must be a switchport; reject any port with an INTERFACE row (routed port).";
+>>>>>>> bf113ebd1 (NOS-10747: Add CLI knob to expose and configure LACP mode per port channel (#6123))
     }
 
     revision 2021-06-13 {
@@ -126,6 +135,12 @@ module sonic-portchannel {
                     description "Enable LACP fast rate";
                     type stypes:boolean_type;
                 }
+                leaf lacp_mode {
+                    description "PortChannel LACP Mode possible values are independent|couple. Default value for LACP mode is couple.";
+                    type stypes:lacp_mode;
+                    default "couple";
+                }
+
 
                 leaf system_mac {
                     description

--- a/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
+++ b/src/sonic-yang-models/yang-templates/sonic-types.yang.j2
@@ -249,6 +249,14 @@ module sonic-types {
             "SwitchPort Modes for Port & PortChannel";
     }
 
+    typedef lacp_mode {
+        type string {
+            pattern "independent|couple";
+        }
+        description
+            "LACP Modes for PortChannel";
+    }
+
     typedef meter_type {
         description "Policer metering unit: packets or bytes";
         type enumeration {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
There are 2 LACP modes: independent and coupled. SONiC as of today only implements coupled mode as default, but this is being changes. SONiC will start implementing independent mode.

Once successfully completed, the user would need a CLI knob to configure the LACP mode for a port channel. This PR exposes --lacp-mode as a per port channel configuration.

Modified YANG model to accept lacp_mode as a valid config option.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

