### PR TITLE
[dell/x86_64-dellemc_z9432f_c3758-r0] Increase syncd SHM size

### DIFF
--- a/device/dell/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf
+++ b/device/dell/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf
@@ -1,2 +1,2 @@
-SYNCD_SHM_SIZE=256m
+SYNCD_SHM_SIZE=1g
 is_ltsw_chip=1


### PR DESCRIPTION
- Increase the SHM size from `256m` to `1g` on Dell z9432f to prevent OOM in `syncd`

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

I was provisioning a Dell `Z9432F-ON` switch and ended up with a failing system.
After an investigation, I realized that the existing `SYNCD_SHM_SIZE` of `256m` is too low for `syncd` on Dell `z9432f` switches. It needs at least `436m`.
As a result, the container gets killed due to OOM and causes a chain reaction: `swss` times out -> `bgp` and other containers exit with an error, etc.

##### Work item tracking

#### How I did it

I inspected existing platform variables under [device/dell](https://github.com/sonic-net/sonic-buildimage/tree/master/device/dell), and noticed that `1g` is often the accepted `SYNCD_SHM_SIZE`. Setting it to `512m` would be risky since `syncd` is already pretty close to this limit.

As a result, I modified `/usr/share/sonic/device/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf` on the switch, made sure everything was operational, and edited `device/dell/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf` with the new limit in the repo.

#### How to verify it

- Boot the Z9432F with `SYNCD_SHM_SIZE=256m` in `/usr/share/sonic/device/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf`
- `swss/syncd` enter a restart loop: `docker ps | grep -E 'swss|syncd'`
- `syncd` crashes with `SIGBUS` during `create_switch`
-  watch the `syncd` shared memory usage during restarts `watch -n1 'docker exec syncd df -h /dev/shm'`.
- it will reach the limit after a few seconds, and `swss` will hang until the timeout limit and then restart
- Set `SYNCD_SHM_SIZE=1g` in `/usr/share/sonic/device/x86_64-dellemc_z9432f_c3758-r0/platform_env.conf` and restart `syncd`: `sudo systemctl reset-failed; sudo systemctl start syncd`
- The issue should be resolved 
 
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

Considering the scope and size of the change, I believe it needs to be backported to as many branches as possible. However, I'm most interested in `202605`

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] SONiC.202605.0-eaf24f49a
- [x] Tested for 202605 branch

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
- Increase the SHM size from `256m` to `1g` on Dell `z9432f` to prevent OOM in `syncd`
 
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

