### PR TITLE
Gate rsyslog service to ensure RELP TCP port binding

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -488,6 +488,8 @@ j2 $IMAGE_CONFIGS/rsyslog/rsyslog.d/00-sonic.conf.j2 | sudo tee $FILESYSTEM_ROOT
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/*.conf $FILESYSTEM_ROOT/etc/rsyslog.d/
 sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.d/*.json $FILESYSTEM_ROOT/etc/rsyslog.d/
 echo "rsyslog-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
+sudo mkdir -p $FILESYSTEM_ROOT/etc/systemd/system/rsyslog.service.d
+sudo cp $IMAGE_CONFIGS/rsyslog/rsyslog.service.d/override.conf $FILESYSTEM_ROOT/etc/systemd/system/rsyslog.service.d/override.conf
 
 # Copy containercfgd configuration files
 sudo cp $IMAGE_CONFIGS/containercfgd/containercfgd.conf $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/

--- a/files/image_config/rsyslog/rsyslog.service.d/override.conf
+++ b/files/image_config/rsyslog/rsyslog.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=docker.service
+Wants=docker.service


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
We observed a race condition during boot on a multi-ASIC platform that may cause rsyslog to fail when binding to the RELP TCP socket:
```
2026 Jun 26 00:49:58.767175 dut101 ERR rsyslogd: imrelp[2514]: error 'error while binding relp tcp socket on port '2514'', object  'lstn 2514' - input may not work as intended [v8.2504.0 try https://www.rsyslog.com/e/2353 ]
2026 Jun 26 00:49:58.767425 dut101 ERR rsyslogd: imrelp: could not activate relp listener, code 10005 [v8.2504.0 try https://www.rsyslog.com/e/2291 ]
```
As a result, all the logs from containers like swss are not recorded correctly until a manual restart of rsyslog service.


We expect that rsyslog service can start only after all its dependencies are ready. In this case, rsyslog service should start only after the port '2514' is created so it can bind this port correctly and then receive the logs from containers.

Introduced by: #18113 
Fixes: #28170 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Type of change
- [X] Bug fix
- [ ] Testbed and Framework(new/improvement)
- [ ] New Test case
  - [ ] Skipped for non-supported platforms
- [ ] Test case improvement

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [X] 202608

#### How did you do it?
This changes adds dependency so that rsyslog service can always start with the port created.
#### How did you verify/test it?
This can be reproduced by just booting a multi-ASIC platform. Note that this is a race condition so it's not reproducible 100% of time.
