### PR TITLE
[mellanox][logrotate] Add sdk_dbg and sai_failure_dump to logrotate

### DIFF
--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -4,12 +4,7 @@
 /var/log/sai_failure_dump/*
 /var/log/sai_failure_dump/*/*
 /var/log/mellanox/sdk-dumps/*
-/var/log/sdk_dbg/sdk_dump_ext_*
-/var/log/sdk_dbg/sai_sdk_dump_before_shutdown_vlan_ports
-/var/log/sdk_dbg/sai_sdk_dump_before_shutdown_vlan_ports.json
-/var/log/sdk_dbg/sai_sdk_dump_after_shutdown_vlan_ports
-/var/log/sdk_dbg/sai_sdk_dump_after_shutdown_vlan_ports.json
-/var/log/sdk_dbg/sx_sdk_*
+/var/log/sdk_dbg/*
 /var/log/sdk_dbg/*/*
 /var/log/sdk_dbg/*/*/*
 {

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -1,0 +1,23 @@
+# Mellanox diagnostic dump artifacts are collected by techsupport, but live
+# under /var/log tmpfs and can accumulate enough data to starve syslog.
+# Treat non-empty dump artifacts as disposable after one day.
+/var/log/sai_failure_dump/*
+/var/log/sai_failure_dump/*/*
+/var/log/mellanox/sdk-dumps/*
+/var/log/sdk_dbg/sdk_dump_ext_*
+/var/log/sdk_dbg/sai_sdk_dump_before_shutdown_vlan_ports
+/var/log/sdk_dbg/sai_sdk_dump_before_shutdown_vlan_ports.json
+/var/log/sdk_dbg/sai_sdk_dump_after_shutdown_vlan_ports
+/var/log/sdk_dbg/sai_sdk_dump_after_shutdown_vlan_ports.json
+/var/log/sdk_dbg/sx_sdk_*
+/var/log/sdk_dbg/*/*
+/var/log/sdk_dbg/*/*/*
+{
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -1,12 +1,23 @@
 # Mellanox diagnostic dump artifacts are collected by techsupport, but live
 # under /var/log tmpfs and can accumulate enough data to starve syslog.
 # Treat non-empty dump artifacts as disposable after one day.
-/var/log/sai_failure_dump/*
-/var/log/sai_failure_dump/*/*
-/var/log/mellanox/sdk-dumps/*
-/var/log/sdk_dbg/*
-/var/log/sdk_dbg/*/*
-/var/log/sdk_dbg/*/*/*
+/var/log/sai_failure_dump/sai_sdk_dump_*.tar.gz
+/var/log/sai_failure_dump/*/sai_sdk_dump_*.tar.gz
+/var/log/sai_failure_dump/*/*/sai_sdk_dump_*.tar.gz
+/var/log/mellanox/sdk-dumps/sai_sdk_dump_*.tar.gz
+/var/log/mellanox/sdk-dumps/*/sai_sdk_dump_*.tar.gz
+/var/log/sdk_dbg/sdk_dump_ext_*
+/var/log/sdk_dbg/*/sdk_dump_ext_*
+/var/log/sdk_dbg/*/*/sdk_dump_ext_*
+/var/log/sdk_dbg/sai_sdk_dump_*_shutdown_vlan_ports
+/var/log/sdk_dbg/*/sai_sdk_dump_*_shutdown_vlan_ports
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_shutdown_vlan_ports
+/var/log/sdk_dbg/sai_sdk_dump_*_extras/*
+/var/log/sdk_dbg/*/sai_sdk_dump_*_extras/*
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_extras/*
+/var/log/sdk_dbg/sx_sdk_*
+/var/log/sdk_dbg/*/sx_sdk_*
+/var/log/sdk_dbg/*/*/sx_sdk_*
 {
     missingok
     notifempty

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -1,24 +1,231 @@
 # Mellanox diagnostic dump artifacts are collected by techsupport, but live
 # under /var/log tmpfs and can accumulate enough data to starve syslog.
 # Treat non-empty dump artifacts as disposable after one day.
-/var/log/sai_failure_dump/sai_sdk_dump_*.tar.gz
-/var/log/sai_failure_dump/*/sai_sdk_dump_*.tar.gz
-/var/log/sai_failure_dump/*/*/sai_sdk_dump_*.tar.gz
-/var/log/mellanox/sdk-dumps/sai_sdk_dump_*.tar.gz
-/var/log/mellanox/sdk-dumps/*/sai_sdk_dump_*.tar.gz
-/var/log/sdk_dbg/sdk_dump_ext_*
-/var/log/sdk_dbg/*/sdk_dump_ext_*
-/var/log/sdk_dbg/*/*/sdk_dump_ext_*
-/var/log/sdk_dbg/sai_sdk_dump_*_shutdown_vlan_ports
-/var/log/sdk_dbg/*/sai_sdk_dump_*_shutdown_vlan_ports
-/var/log/sdk_dbg/*/*/sai_sdk_dump_*_shutdown_vlan_ports
-/var/log/sdk_dbg/sai_sdk_dump_*_extras/*
-/var/log/sdk_dbg/*/sai_sdk_dump_*_extras/*
-/var/log/sdk_dbg/*/*/sai_sdk_dump_*_extras/*
-/var/log/sdk_dbg/sx_sdk_*
-/var/log/sdk_dbg/*/sx_sdk_*
-/var/log/sdk_dbg/*/*/sx_sdk_*
-{
+#
+# Each glob intentionally has its own stanza. Logrotate requires the opening
+# brace on the same line as the file pattern, does not support multiline
+# pattern lists, and fails if a broad glob also matches a directory.
+/var/log/sai_failure_dump/sai_sdk_dump_*.tar.gz {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sai_failure_dump/*/sai_sdk_dump_*.tar.gz {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sai_failure_dump/*/*/sai_sdk_dump_*.tar.gz {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/mellanox/sdk-dumps/sai_sdk_dump_*.tar.gz {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/mellanox/sdk-dumps/*/sai_sdk_dump_*.tar.gz {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sdk_dump_ext_* {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sdk_dump_ext_* {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sdk_dump_ext_* {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sai_sdk_dump_*_shutdown_vlan_ports {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sai_sdk_dump_*_shutdown_vlan_ports {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_shutdown_vlan_ports {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sai_sdk_dump_*_shutdown_vlan_ports.json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sai_sdk_dump_*_shutdown_vlan_ports.json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_shutdown_vlan_ports.json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sai_sdk_dump_*_extras/*_[0-9] {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sai_sdk_dump_*_extras/*_[0-9] {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_extras/*_[0-9] {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sai_sdk_dump_*_extras/*_[0-9].json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sai_sdk_dump_*_extras/*_[0-9].json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sai_sdk_dump_*_extras/*_[0-9].json {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/sx_sdk_* {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/sx_sdk_* {
+    missingok
+    notifempty
+    size 1
+    minage 1
+    rotate 0
+    nocreate
+    nocompress
+}
+
+/var/log/sdk_dbg/*/*/sx_sdk_* {
     missingok
     notifempty
     size 1

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -6,10 +6,19 @@
 #  * Globs do not recurse, hence one pattern per depth. Keep them depth
 #    separated: two patterns expanding to the same file abort the whole stanza
 #    with "duplicate log entry". Directory matches are fine, logrotate skips
-#    them silently.
+#    them silently. Four levels covers every root uniformly; the deepest
+#    observed on a DUT is three (sai_failure_dump/<dump>/<dump>_extras/<file>).
 #  * `minage` is ignored when a `size` criterion is used, so `hourly` is used
 #    to get age based cleanup. `rotate 0` plus `nocreate` makes rotation a
 #    delete, and `su` avoids failures on group/world writable dump directories.
+#  * `rotate 0` deletes by renaming to a rotated name first, so with the
+#    default numeric suffix a dump named `X.1` alongside `X` is clobbered by
+#    the rotation of `X`: the run exits 1 and orphans `X.2`. `dateext` puts a
+#    timestamp in the rotated name instead, which removes the collision.
+#  * `notifempty` is deliberately not set. Cleanup here is a delete, not a
+#    rotation, and a truncated dump left behind by a crashed collection is
+#    exactly what should be reclaimed. `minage` already keeps a dump that is
+#    still being written out of scope.
 
 /var/log/sdk_dbg/*
 /var/log/sdk_dbg/*/*
@@ -21,15 +30,20 @@
 /var/log/sai_failure_dump/*/*/*/*
 /var/log/mellanox/sdk-dumps/*
 /var/log/mellanox/sdk-dumps/*/*
+/var/log/mellanox/sdk-dumps/*/*/*
+/var/log/mellanox/sdk-dumps/*/*/*/*
 /var/log/bluefield/sdk-dumps/*
 /var/log/bluefield/sdk-dumps/*/*
+/var/log/bluefield/sdk-dumps/*/*/*
+/var/log/bluefield/sdk-dumps/*/*/*/*
 {
     su root root
     hourly
     minage 1
     missingok
-    notifempty
     rotate 0
     nocreate
     nocompress
+    dateext
+    dateformat -%Y%m%d%H%M%S
 }

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -21,6 +21,8 @@
 /var/log/sai_failure_dump/*/*/*/*
 /var/log/mellanox/sdk-dumps/*
 /var/log/mellanox/sdk-dumps/*/*
+/var/log/bluefield/sdk-dumps/*
+/var/log/bluefield/sdk-dumps/*/*
 {
     su root root
     hourly

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -1,0 +1,33 @@
+# NVIDIA/Mellanox SDK diagnostic dumps are not covered by any other logrotate
+# config and have been seen to accumulate over 1GB on long running DUTs,
+# starving /var/log. They are collected by techsupport, so delete after a day.
+#
+# Gotchas (verified on logrotate 3.14.0/3.18.0/3.21.0/3.22.0):
+#  * Globs do not recurse, hence one pattern per depth. Keep them depth
+#    separated: two patterns expanding to the same file abort the whole stanza
+#    with "duplicate log entry". Directory matches are fine, logrotate skips
+#    them silently.
+#  * `minage` is ignored when a `size` criterion is used, so `hourly` is used
+#    to get age based cleanup. `rotate 0` plus `nocreate` makes rotation a
+#    delete, and `su` avoids failures on group/world writable dump directories.
+
+/var/log/sdk_dbg/*
+/var/log/sdk_dbg/*/*
+/var/log/sdk_dbg/*/*/*
+/var/log/sdk_dbg/*/*/*/*
+/var/log/sai_failure_dump/*
+/var/log/sai_failure_dump/*/*
+/var/log/sai_failure_dump/*/*/*
+/var/log/sai_failure_dump/*/*/*/*
+/var/log/mellanox/sdk-dumps/*
+/var/log/mellanox/sdk-dumps/*/*
+{
+    su root root
+    hourly
+    minage 1
+    missingok
+    notifempty
+    rotate 0
+    nocreate
+    nocompress
+}

--- a/files/image_config/logrotate/logrotate.d/sdk-dump
+++ b/files/image_config/logrotate/logrotate.d/sdk-dump
@@ -1,24 +1,35 @@
-# NVIDIA/Mellanox SDK diagnostic dumps are not covered by any other logrotate
-# config and have been seen to accumulate over 1GB on long running DUTs,
-# starving /var/log. They are collected by techsupport, so delete after a day.
-#
-# Gotchas (verified on logrotate 3.14.0/3.18.0/3.21.0/3.22.0):
-#  * Globs do not recurse, hence one pattern per depth. Keep them depth
-#    separated: two patterns expanding to the same file abort the whole stanza
-#    with "duplicate log entry". Directory matches are fine, logrotate skips
-#    them silently. Four levels covers every root uniformly; the deepest
-#    observed on a DUT is three (sai_failure_dump/<dump>/<dump>_extras/<file>).
-#  * `minage` is ignored when a `size` criterion is used, so `hourly` is used
-#    to get age based cleanup. `rotate 0` plus `nocreate` makes rotation a
-#    delete, and `su` avoids failures on group/world writable dump directories.
-#  * `rotate 0` deletes by renaming to a rotated name first, so with the
-#    default numeric suffix a dump named `X.1` alongside `X` is clobbered by
-#    the rotation of `X`: the run exits 1 and orphans `X.2`. `dateext` puts a
-#    timestamp in the rotated name instead, which removes the collision.
-#  * `notifempty` is deliberately not set. Cleanup here is a delete, not a
-#    rotation, and a truncated dump left behind by a crashed collection is
-#    exactly what should be reclaimed. `minage` already keeps a dump that is
-#    still being written out of scope.
+# Compress NVIDIA/Mellanox SDK dumps after one day and delete the compressed
+# files after 30 days. The .gz stanza must come first: ignoreduplicates
+# prevents the broader stanza from processing compressed files again.
+
+/var/log/sdk_dbg/*.gz
+/var/log/sdk_dbg/*/*.gz
+/var/log/sdk_dbg/*/*/*.gz
+/var/log/sdk_dbg/*/*/*/*.gz
+/var/log/sai_failure_dump/*.gz
+/var/log/sai_failure_dump/*/*.gz
+/var/log/sai_failure_dump/*/*/*.gz
+/var/log/sai_failure_dump/*/*/*/*.gz
+/var/log/mellanox/sdk-dumps/*.gz
+/var/log/mellanox/sdk-dumps/*/*.gz
+/var/log/mellanox/sdk-dumps/*/*/*.gz
+/var/log/mellanox/sdk-dumps/*/*/*/*.gz
+/var/log/bluefield/sdk-dumps/*.gz
+/var/log/bluefield/sdk-dumps/*/*.gz
+/var/log/bluefield/sdk-dumps/*/*/*.gz
+/var/log/bluefield/sdk-dumps/*/*/*/*.gz
+{
+    su root root
+    hourly
+    minage 30
+    missingok
+    rotate 0
+    nocreate
+    nocompress
+    dateext
+    dateformat -%Y%m%d%H%M%S
+    ignoreduplicates
+}
 
 /var/log/sdk_dbg/*
 /var/log/sdk_dbg/*/*
@@ -41,9 +52,9 @@
     hourly
     minage 1
     missingok
-    rotate 0
+    rotate -1
     nocreate
-    nocompress
+    compress
     dateext
     dateformat -%Y%m%d%H%M%S
 }


### PR DESCRIPTION
#### Why I did it
We have seen failures where tests cannot write to `/var/log` due to an ENOSPC error. NVIDIA/Mellanox SDK diagnostic dumps are not covered by the existing logrotate configuration and have accumulated to approximately 1.6 GB on a DUT after six days.

The dumps are useful for techsupport, so deleting them after one day is undesirable. Compression is effective for at least some of these artifacts: a representative 296 MB SDK PCAP compressed to 6.4 MB. This change therefore compresses dumps after one day and retains the compressed files for 30 days.

##### Work item tracking
- Microsoft ADO **38614040,38099232**

#### How I did it
Added two ordered logrotate stanzas covering:

- `/var/log/sdk_dbg`
- `/var/log/sai_failure_dump`
- `/var/log/mellanox/sdk-dumps`
- `/var/log/bluefield/sdk-dumps`

The first stanza matches existing `*.gz` files and deletes them after 30 days. It comes first and uses `ignoreduplicates` so the broader second stanza does not process or recompress those files.

The second stanza compresses uncompressed files after one day. It uses `rotate -1` so recurring basenames retain every dated archive until the `*.gz` stanza expires it. `dateext` with second-resolution timestamps prevents rotated-name collisions, `nocreate` avoids recreating dump files, and `su root root` handles the writable directories created by the SDK.

Logrotate globs do not recurse, so each stanza has one pattern per directory depth. Four levels cover all 323 files from the observed dump tree without overlapping patterns.

No `size` criterion is used: it applies to each file rather than aggregate directory usage, and its rotation decision bypasses the required `minage` behavior.

The target host images support `ignoreduplicates`:

| Branch | Host logrotate package |
|---|---|
| 202511 | `3.22.0-1+b2` |
| 202605 | `3.22.0-1` |

These versions come from the generated host-image manifests, which collect installed package versions from the completed root filesystem.

#### How to verify it
A local fake tree covering all four roots and every configured depth was tested with Debian's packaged `logrotate 3.22.0-1+b2`. The test confirmed that:

- Raw files older than one day are compressed
- Fresh raw files remain unchanged
- Compressed files younger than 30 days are retained
- Compressed files older than 30 days are deleted
- Existing compressed files are not recompressed
- Repeated basenames retain distinct dated archives
- Dump directories remain intact

On a Mellanox DUT:

```
sudo /usr/sbin/logrotate -v --state /dev/shm/logrotate/status /etc/logrotate.conf; echo "exit=$?"
```

[sonic-net/sonic-mgmt#27190](https://github.com/sonic-net/sonic-mgmt/pull/27190) contains the fake-tree coverage for this config. It will be updated for the compression and 30-day retention behavior before the release-branch tests are rerun.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

The earlier one-day deletion behavior passed on both requested branches:

- 202511: `SONiC.20251110.47`, `Mellanox-SN4600C-C64` (`t0-64`). Test plan [`6a87fd8b5585d0b8ab0a7fa9`](https://elastictest.org/scheduler/testplan/6a87fd8b5585d0b8ab0a7fa9), both tests passed.
- 202605: `SONiC.20260510.11`, same testbed and hwsku. Test plan [`6a8e5e36a2b56b54e48a0692`](https://elastictest.org/scheduler/testplan/6a8e5e36a2b56b54e48a0692), both tests passed.

The new compression and 30-day retention behavior has been validated locally; release-branch reruns are pending the sonic-mgmt test update.

#### Description for the changelog

Compress NVIDIA/Mellanox SDK diagnostic dumps after one day and remove compressed dumps after 30 days.