### PR TITLE
[interfaces] Enable IPv6 on the mgmt port before assigning its IPv6 address

### DIFF
--- a/files/image_config/interfaces/interfaces.j2
+++ b/files/image_config/interfaces/interfaces.j2
@@ -92,6 +92,10 @@ iface {{ name }} {{ 'inet' if prefix | ipv4 else 'inet6' }} static
 {% if prefix | broadcast %}
     broadcast {{ prefix | broadcast }}
 {% endif %}
+{% if prefix | ipv6 %}
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.{{ name }}.disable_ipv6=0
+{% endif %}
 {%     set vrf_table = 'default' %}
 {% if (MGMT_VRF_CONFIG) and (MGMT_VRF_CONFIG['vrf_global']['mgmtVrfEnabled'] == "true") %}
 {%     set vrf_table = '6000' %}

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces
@@ -35,6 +35,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_mgmt31
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_mgmt31
@@ -34,6 +34,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog
@@ -37,6 +37,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog_vrf
+++ b/src/sonic-config-engine/tests/sample_output/py2/interfaces_syslog_vrf
@@ -35,6 +35,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/mvrf_interfaces
@@ -49,6 +49,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules

--- a/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py2/two_mgmt_interfaces
@@ -52,6 +52,8 @@ iface eth1 inet6 static
     netmask 64
     network 2603:10e2:0:abcd::
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth1.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default
@@ -69,6 +71,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces
@@ -35,6 +35,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_mgmt31
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_mgmt31
@@ -34,6 +34,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog
@@ -37,6 +37,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog_vrf
+++ b/src/sonic-config-engine/tests/sample_output/py3/interfaces_syslog_vrf
@@ -35,6 +35,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default

--- a/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/mvrf_interfaces
@@ -49,6 +49,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     vrf mgmt
     ########## management network policy routing rules
     # management port up rules

--- a/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
+++ b/src/sonic-config-engine/tests/sample_output/py3/two_mgmt_interfaces
@@ -36,6 +36,8 @@ iface eth0 inet6 static
     netmask 64
     network 2603:10e2:0:2902::
     broadcast 2603:10e2:0:2902:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth0.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:2902::/64 dev eth0 table default
@@ -69,6 +71,8 @@ iface eth1 inet6 static
     netmask 64
     network 2603:10e2:0:abcd::
     broadcast 2603:10e2:0:abcd:ffff:ffff:ffff:ffff
+    # IPv6 may be disabled on the mgmt port (inherited default); re-enable it so the address can be assigned
+    pre-up sysctl -w net.ipv6.conf.eth1.disable_ipv6=0
     ########## management network policy routing rules
     # management port up rules
     up ip -6 route add 2603:10e2:0:abcd::/64 dev eth1 table default


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/sonic-net/SONiC/blob/gh-pages/CONTRIBUTING.md
-->

Fixes #28317

#### Why I did it

When `MGMT_INTERFACE` has an IPv6 address, `ifup` writes the `eth0 inet6 static` stanza, but IPv6 can be **disabled on the mgmt port** — `net.ipv6.conf.eth0.disable_ipv6=1`, inherited from the runtime per-interface default. `90-sonic.conf` only clears `net.ipv6.conf.all.disable_ipv6`, not `default`/`eth0`. With IPv6 disabled on the port, `ifup` cannot assign the mgmt IPv6 address, so eth0 ends up with **no IPv6 at all** (not even a link-local) even though CONFIG_DB and `/etc/network/interfaces` list one.

Observed command output: `IPv6 is disabled on this device`; and, as a concrete downstream symptom, `snmpd` fails to bind the mgmt IPv6 address (`failed to bind ... 99 Cannot assign requested address` → `Server Exiting with code 1`), exits on every start, hits the systemd start-limit, so the `snmp` container stays down and `monit container_checker` logs `Expected containers not running: snmp` every minute → trips LogAnalyzer in gated tests.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

In the mgmt-interface stanza of `interfaces.j2`, when the prefix is IPv6, add a `pre-up sysctl -w net.ipv6.conf.<name>.disable_ipv6=0` before the address is assigned. This mirrors the existing per-interface `disable_ipv6=0` pattern already used in the tree (e.g. `usb-network-init.sh`). IPv4-only mgmt stanzas are unaffected.

#### How to verify it

- **Template render:** the new `pre-up` line appears only on the IPv6 (`inet6`) mgmt stanza; IPv4-only mgmt config is byte-for-byte unchanged.
- **Live:** starting from a broken baseline (IPv6 disabled on eth0, `ifup` unable to assign the mgmt IPv6 address), `ifdown eth0 && ifup eth0` now re-enables IPv6 on the port and assigns the address; `snmpd` binds successfully, the `snmp` container stays Up, and the per-minute `monit container_checker` noise stops.

#### Which release branch to backport (provide reason below if selected)

<!-- 202xxx -->
- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Description for the changelog

Enable IPv6 on the mgmt interface before assigning its IPv6 address, so it is programmed even when IPv6 was disabled on the port by the inherited per-interface default.

#### Link to config_db schema for YANG module changes
<!-- N/A -->

#### A picture of a cute animal (not mandatory but encouraged)
