### PR TITLE
[dhcp_server] Revert container-side docker0 syslog iptables add/del (#26637); caclmgrd to own the rule

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -131,12 +131,6 @@ function preStartAction()
         echo "Cannot fetch system eeprom information. Setting chassis serial number to N/A."
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
     fi
-{%- elif docker_container_name == "dhcp_server" %}
-    # dhcp_server is the only bridge-mode container. caclmgrd's catch-all DROP
-    # on the INPUT chain blocks its syslog (UDP 514) to host rsyslog.
-    # Restrict to docker0 interface to minimize security impact.
-    iptables -C INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog" 2>/dev/null || \
-        iptables -I INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog"
 {%- else %}
     : # nothing
 {%- endif %}
@@ -894,10 +888,6 @@ stop() {
         /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}
     fi
-{%- if docker_container_name == "dhcp_server" %}
-    # Remove syslog iptables exception added during start
-    iptables -D INPUT -i docker0 -p udp --dport 514 -j ACCEPT -m comment --comment "dhcp_server_syslog" 2>/dev/null || true
-{%- endif %}
     {%- endif %}
 }
 


### PR DESCRIPTION
#### Why I did it
Reverts sonic-net/sonic-buildimage#26637.

This is **step 1 of 3** of moving the `dhcp_server` `docker0` syslog (UDP 514) `INPUT` exception out of the container start/stop script so that **`caclmgrd` owns it**. `caclmgrd` will re-install the rule on every control-plane ACL flush-and-rebuild, keyed on `FEATURE|dhcp_server`, so the rebuild never drops it — the root cause of sonic-net/sonic-buildimage#27584.

Plan (parent ADO 38699922):
1. **(this PR)** revert the container-side `iptables -I` / `-D` add/del.
2. `caclmgrd` installs/removes the rule based on `FEATURE|dhcp_server` (sonic-host-services#412 — must reach the image before this repo relies on it).
3. replace the removed add/del with feature-gated bounded waits that synchronize with `caclmgrd` (sonic-net/sonic-buildimage#28580).

##### Work item tracking
- Microsoft ADO (number only): 38745010

#### How I did it
`git revert` of 933d908a65 (#26637). Removes the two `dhcp_server`-specific blocks in `files/build_templates/docker_image_ctl.j2` (the `iptables -I` in `preStartAction` and the `iptables -D` in `stop`). No other change.

#### How to verify it
1. `grep dhcp_server_syslog files/build_templates/docker_image_ctl.j2` returns nothing.
2. The rendered `dhcp_server` container ctl script no longer adds/removes the `docker0` UDP 514 `iptables` rule on start/stop.

##### Hardware validation

Validated as part of the 3-PR set (revert here + caclmgrd ownership + container waits) by hand-patching the changes onto a running DUT (no image rebuild).

- **DUT / topology:** `bjw-can-720dt-2` (720dt, `mx`), `dhcp_server` enabled.
- **Transport:** RELP tcp/2514 (host `rsyslogd` listens on `240.127.1.1:2514`, the `docker0` IP).
- **This PR's effect on the DUT:** the `dhcp_server` container ctl script no longer adds/removes the `docker0` syslog `iptables` rule on start/stop — the rule is instead owned and re-installed by `caclmgrd`.

Results:

1. **caclmgrd owns the rule, above the catch-all DROP** (feature enabled):
   ```
   3:-A INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment dhcp_server_syslog -j ACCEPT
   46:-A INPUT -j DROP
   ```
2. **End-to-end syslog delivery** — `docker exec dhcp_server logger ...` reached host `/var/log/syslog`; the `docker0` ACCEPT rule showed packet hits (2 pkts / 214 B).
3. **Feature toggle** — `config feature state dhcp_server disabled` removes the rule; `enabled` re-adds it (caclmgrd logs both transitions).
4. **Survives control-plane ACL re-walk** (the root regression, #27584) — after modifying an unrelated control-plane ACL rule (forcing caclmgrd to flush + rebuild `INPUT`), the `docker0`/2514 ACCEPT rule is still present at position 3, above the catch-all DROP. With the container-side add/del removed by this PR, this only holds because `caclmgrd` now owns the rule.

> Note: this hardware validation was performed on a 202605 image (identical container ctl / caclmgrd flush-rebuild path); the code change under test is the same logic.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Backporting the revert in isolation would leave the branch with neither the container nor caclmgrd owning the rule; the 202605 backport is handled together with the caclmgrd change (sonic-host-services#412) and the container-waits change (#28580) as a coordinated set.
Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 38745010
Failure type: day-one issue (the container-owned docker0 syslog rule never survived a caclmgrd control-plane ACL rebuild)

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Test result

- 202605: 20260510.07 — hand-patched HW validation on `bjw-can-720dt-2` (720dt, `mx`) as part of the 3-PR set; see "Hardware validation" above (caclmgrd owns the docker0 tcp/2514 rule above the catch-all DROP, end-to-end RELP syslog delivered, feature toggle add/remove, survives an unrelated control-plane ACL re-walk — bug #27584 fix).
- master: validation pending — the rendered `dhcp_server` ctl script and `caclmgrd` code path are identical to 202605; a master-image run is the only remaining validation step.

#### Description for the changelog
Revert the dhcp_server container-side docker0 syslog iptables add/del; ownership of that INPUT exception moves to caclmgrd.
