### PR TITLE
Enable SRv6 support on Arista-7060X6-64DE devices 

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-256x200G/th5-a7060x6-64de.config.bcm
@@ -40,7 +40,7 @@ bcm_device:
             #l3_intf_vlan_split_egress for MTU at L3IF
             l3_intf_vlan_split_egress : 1
             pfc_deadlock_seq_control : 1
-            sai_tunnel_support: 2
+            sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
             stat_custom_receive0_management_mode: 1

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE-O128S2/th5-a7060x6-64de.config.bcm
@@ -40,7 +40,7 @@ bcm_device:
             #l3_intf_vlan_split_egress for MTU at L3IF
             l3_intf_vlan_split_egress : 1
             pfc_deadlock_seq_control : 1
-            sai_tunnel_support: 2
+            sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
             stat_custom_receive0_management_mode: 1

--- a/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64de/Arista-7060X6-64DE/th5-a7060x6-64de.config.bcm
@@ -40,7 +40,7 @@ bcm_device:
             #l3_intf_vlan_split_egress for MTU at L3IF
             l3_intf_vlan_split_egress : 1
             pfc_deadlock_seq_control : 1
-            sai_tunnel_support: 2
+            sai_tunnel_support: 0x12
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 12288
             stat_custom_receive0_management_mode: 1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The SRv6 is not enabled on the following Arista devices using TH5 chipset,
 - Arista-7060X6-64DE
 - Arista-7060X6-64DE-256x200G
 - Arista-7060X6-64DE-64x400G
 - Arista-7060X6-64DE-O128S2

The following SRv6 tests failed,
- generic_config_updater/test_srv6.py
- srv6/test_srv6_dataplane.py

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Enable SRv6 in the corresponding config.bcm file.

#### How to verify it
Run the SRv6 tests and verify no failure.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [X] 202511
- [X] 202512
- [X] 202605
- [X] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

