### PR TITLE
[Mellanox][SmartSwitch] bfb-installer: retry rshim daemon start with backoff

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_bfb_installer/bfb_install_core.py
+++ b/platform/mellanox/platform-utils/mellanox_bfb_installer/bfb_install_core.py
@@ -41,6 +41,12 @@ logger = logging.getLogger(__name__)
 
 BFB_INSTALL_TIMEOUT_SEC = 1200
 
+# Backoff (seconds) between rshim-daemon start retries. A previous failed
+# deployment can leave the rshim in a state where the first start attempt
+# fails; stop and retry with increasing backoff before giving up. Only the
+# rshim-daemon start is retried here -- no DPU reset or other recovery.
+RSHIM_START_RETRY_BACKOFF_SEC = (3, 5, 10)
+
 
 def _run_bfb_install_image_delivery(
     *,
@@ -129,6 +135,32 @@ def _run_bfb_install_image_delivery(
     return exit_status
 
 
+def _start_rshim_daemon_with_retries(rshim_id: str, rshim_pci_bus_id: str) -> bool:
+    """Start the rshim daemon, retrying with backoff if the start fails.
+
+    Only the rshim-daemon start is retried (stop, wait, start again); no DPU
+    reset or other recovery is attempted. Retries use RSHIM_START_RETRY_BACKOFF_SEC.
+
+    Returns True once the daemon starts, False if every attempt fails.
+    """
+    if rshim_daemon.start_rshim_daemon(rshim_id, rshim_pci_bus_id):
+        return True
+    total = len(RSHIM_START_RETRY_BACKOFF_SEC)
+    for attempt, backoff in enumerate(RSHIM_START_RETRY_BACKOFF_SEC, start=1):
+        logger.info(
+            "%s: Rshim couldn't start; stopping and retrying in %ds (retry %d/%d).",
+            rshim_id,
+            backoff,
+            attempt,
+            total,
+        )
+        rshim_daemon.stop_rshim_daemon(rshim_id)
+        time.sleep(backoff)
+        if rshim_daemon.start_rshim_daemon(rshim_id, rshim_pci_bus_id):
+            return True
+    return False
+
+
 def full_install_bfb_on_device(
     *,
     rshim_name: str,
@@ -158,18 +190,13 @@ def full_install_bfb_on_device(
         # Should not happen. Handled by caller.
         logger.error("Error: Could not find rshim PCI bus ID for DPU %s", dpu_name)
         return 1
-    if not rshim_daemon.start_rshim_daemon(rshim_id, rshim_pci_bus_id):
-        logger.info(
-            "%s: Rshim couldn't start. Attempting to stop it and then start it again.", rshim_id
+    if not _start_rshim_daemon_with_retries(rshim_id, rshim_pci_bus_id):
+        logger.error(
+            "%s: Rshim couldn't start after %d attempts. Giving up.",
+            rshim_id,
+            len(RSHIM_START_RETRY_BACKOFF_SEC) + 1,
         )
-        stop_ret = rshim_daemon.stop_rshim_daemon(rshim_id)
-        if not rshim_daemon.start_rshim_daemon(rshim_id, rshim_pci_bus_id):
-            logger.error(
-                "%s: Rshim couldn't start after stopping. (Stopping returned %s.) Giving up.",
-                rshim_id,
-                stop_ret,
-            )
-            return 1
+        return 1
     try:
         if not rshim_daemon.wait_for_rshim_boot(rshim_name):
             return 1

--- a/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_bfb_install_core.py
+++ b/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_bfb_install_core.py
@@ -183,14 +183,19 @@ class TestBfBInstallCore(unittest.TestCase):
             shutil.rmtree(work_dir, ignore_errors=True)
 
     def test_full_install_bfb_on_device_returns_one_when_start_rshim_daemon_fails(self):
-        """full_install_bfb_on_device returns 1 when start_rshim_daemon returns False."""
+        """full_install_bfb_on_device returns 1 and retries start with backoff when start always fails."""
         from mellanox_bfb_installer import bfb_install_core
 
         work_dir = tempfile.mkdtemp()
         try:
+            mock_start = mock.MagicMock(return_value=False)
+            mock_stop = mock.MagicMock()
+            mock_sleep = mock.MagicMock()
             with (
                 mock.patch.object(bfb_install_core.reset_dpu, "wait_for_module_transition_to_complete"),
-                mock.patch.object(bfb_install_core.rshim_daemon, "start_rshim_daemon", return_value=False),
+                mock.patch.object(bfb_install_core.rshim_daemon, "start_rshim_daemon", mock_start),
+                mock.patch.object(bfb_install_core.rshim_daemon, "stop_rshim_daemon", mock_stop),
+                mock.patch.object(bfb_install_core.time, "sleep", mock_sleep),
             ):
                 status = bfb_install_core.full_install_bfb_on_device(
                     rshim_name="rshim0",
@@ -205,6 +210,56 @@ class TestBfBInstallCore(unittest.TestCase):
                     child_pids=install_executor.PidCollection(),
                 )
             self.assertEqual(status, 1)
+            # 1 initial attempt + one per backoff entry.
+            self.assertEqual(
+                mock_start.call_count, len(bfb_install_core.RSHIM_START_RETRY_BACKOFF_SEC) + 1
+            )
+            # A stop precedes each retry, and each retry waits its backoff.
+            self.assertEqual(mock_stop.call_count, len(bfb_install_core.RSHIM_START_RETRY_BACKOFF_SEC))
+            self.assertEqual(
+                [c.args[0] for c in mock_sleep.call_args_list],
+                list(bfb_install_core.RSHIM_START_RETRY_BACKOFF_SEC),
+            )
+        finally:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    def test_full_install_bfb_on_device_start_rshim_succeeds_on_retry(self):
+        """A start that fails once then succeeds is retried (no give-up) and proceeds."""
+        from mellanox_bfb_installer import bfb_install_core
+
+        work_dir = tempfile.mkdtemp()
+        try:
+            mock_start = mock.MagicMock(side_effect=[False, True])
+            mock_stop = mock.MagicMock(return_value=False)
+            mock_sleep = mock.MagicMock()
+            with (
+                mock.patch.object(bfb_install_core.reset_dpu, "wait_for_module_transition_to_complete"),
+                mock.patch.object(bfb_install_core.rshim_daemon, "start_rshim_daemon", mock_start),
+                mock.patch.object(bfb_install_core.rshim_daemon, "stop_rshim_daemon", mock_stop),
+                mock.patch.object(bfb_install_core.time, "sleep", mock_sleep),
+                # Short-circuit after the successful start so we only exercise the retry path.
+                mock.patch.object(bfb_install_core.rshim_daemon, "wait_for_rshim_boot", return_value=False),
+                mock.patch.object(bfb_install_core.reset_dpu, "reset_dpu"),
+            ):
+                bfb_install_core.full_install_bfb_on_device(
+                    rshim_name="rshim0",
+                    rshim_id="0",
+                    dpu_name="dpu0",
+                    rshim_pci_bus_id="0000:08:00.0",
+                    dpu_pci_bus_id=None,
+                    config_path=None,
+                    bfb_path="/x.bfb",
+                    work_dir=work_dir,
+                    verbose=False,
+                    child_pids=install_executor.PidCollection(),
+                )
+            # Started twice (initial fail + one retry that succeeds), with one backoff sleep.
+            # stop_rshim_daemon is called twice: once in the retry loop, and once more in
+            # full_install_bfb_on_device's outer finally block (reached because
+            # wait_for_rshim_boot returns False and execution falls through to return 1).
+            self.assertEqual(mock_start.call_count, 2)
+            self.assertEqual(mock_stop.call_count, 2)
+            mock_sleep.assert_called_once_with(bfb_install_core.RSHIM_START_RETRY_BACKOFF_SEC[0])
         finally:
             shutil.rmtree(work_dir, ignore_errors=True)
 


### PR DESCRIPTION
#### Why I did it

The BFB image installer starts a background rshim-daemon that must come up before the boot image can be delivered to the target device. Occasionally — most often when a previous install attempt left the device in a bad state — that daemon fails to start on the first try. The installer only attempted a single stop-and-restart, which was not always enough, so it gave up and the whole install failed intermittently (the expected boot interface never appeared).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a bounded retry with backoff around starting the daemon: on a failed start, stop it, wait a short increasing interval (3s, then 5s, then 10s), and try again, up to a few attempts before giving up. Only the daemon start is retried — no device reset or other recovery is performed, and the existing pre-start wait and post-start steps are unchanged. Added/updated unit tests covering the retry-with-backoff path (all-fail and succeeds-on-retry).

#### How to verify it

- Unit tests for the installer pass (they run with full dependencies in the build container).
- Functionally: trigger an install where the daemon start initially fails (e.g. run an install right after a previously failed one that left the device in a bad state) and confirm the installer now recovers on a retry and completes, instead of aborting on the first failed start.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ]

#### Description for the changelog

Retry starting the rshim-daemon with increasing backoff (3 s, 5 s, 10 s) so a transient or bad-state failure from a previous install attempt recovers instead of aborting the install.

#### Link to config_db schema for YANG module changes

N/A