### PR TITLE
Install pygnmi==0.8.15 for docker-sonic-mgmt

### DIFF
--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -103,6 +103,7 @@ RUN uv pip install --no-cache \
     pexpect \
     prettytable \
     "protobuf>=5.29.6,<6" \
+    "pygnmi==0.8.15" \
     psutil \
     ptf==0.10.0 \
     pyasn1 \


### PR DESCRIPTION
#### Why I did it

The new native `pygnmi`-based gNMI client for sonic-mgmt (see sonic-net/sonic-mgmt#26015 and sonic-net/sonic-mgmt#26013) talks gRPC directly to the DUT's gNMI server from the sonic-mgmt orchestrator, replacing the `gnmic` CLI binary that is being removed from `docker-ptf`. That client depends on the `pygnmi` Python package, which is not currently installed in the `docker-sonic-mgmt` image.

This PR adds `pygnmi==0.8.15` to the `docker-sonic-mgmt` image so the new client and the gNMI tests that use it (`tests/common/pygnmi_client.py`, `tests/gnmi/test_pygnmi_client.py`) can run.

Related to sonic-net/sonic-mgmt#26015
Companion PR: sonic-net/sonic-mgmt#26013

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `"pygnmi==0.8.15"` to the `uv pip install` package list in `dockers/docker-sonic-mgmt/Dockerfile.j2`. The version is pinned for reproducible builds and to match the version validated by the sonic-mgmt changes.

#### How to verify it

1. Build the docker-sonic-mgmt image:
    make target/docker-sonic-mgmt.gz
2. Confirm the package is present and pinned inside the image:
 docker run --rm docker-sonic-mgmt python3 -c "import pygnmi; print(pygnmi.version)" expects 0.8.15

3. Run the pygnmi client tests from sonic-mgmt (sonic-net/sonic-mgmt#26013) inside the built container and confirm they no longer fail on `import pygnmi`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [x] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [x] 202505:  PASS Manual cherry-pick PR: #28690
- [x] 202511:  PASS  Manual cherry-pick PR: #28691
- [x] 202605:  PASS, included here https://github.com/sonic-net/sonic-buildimage/pull/28536

#### Description for the changelog

Install pygnmi==0.8.15 in docker-sonic-mgmt for the native gNMI test client

#### Link to config_db schema for YANG module changes

N/A - no YANG/config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

![otter](https://octodex.github.com/images/daftpunktocat-thomas.gif)




