### PR TITLE
Fix database_config.json race condition instead of increasing sleep

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -51,11 +51,15 @@ mkdir -p /etc/supervisor/conf.d/
 if [ -f /etc/sonic/database_config$NAMESPACE_ID.json ]; then
     cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json
 else
+    # Render into a temp file first and atomically move it into place, so that any
+    # process racing to read database_config.json (e.g. waitForAllInstanceDatabaseConfigJsonFilesReady)
+    # never observes a truncated/partially-rendered file.
     if [ -f /etc/sonic/enable_multidb ]; then
-        HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE BMP_DB_PORT=$BMP_DB_PORT include_system_eventd=$INCLUDE_SYSTEM_EVENTD jinjanate /usr/share/sonic/templates/multi_database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json
+        HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE BMP_DB_PORT=$BMP_DB_PORT include_system_eventd=$INCLUDE_SYSTEM_EVENTD jinjanate /usr/share/sonic/templates/multi_database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json.tmp
     else
-        HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE BMP_DB_PORT=$BMP_DB_PORT include_system_eventd=$INCLUDE_SYSTEM_EVENTD jinjanate /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json
+        HOST_IP=$host_ip REDIS_PORT=$redis_port DATABASE_TYPE=$DATABASE_TYPE BMP_DB_PORT=$BMP_DB_PORT include_system_eventd=$INCLUDE_SYSTEM_EVENTD jinjanate /usr/share/sonic/templates/database_config.json.j2 > $REDIS_DIR/sonic-db/database_config.json.tmp
     fi
+    mv $REDIS_DIR/sonic-db/database_config.json.tmp $REDIS_DIR/sonic-db/database_config.json
 fi
 
 # on VoQ system, we only publish redis_chassis instance and CHASSIS_APP_DB when
@@ -102,7 +106,10 @@ then
     if [ -f /etc/sonic/database_global.json ]; then
         cp /etc/sonic/database_global.json $REDIS_DIR/sonic-db/database_global.json
     else
-        jinjanate /usr/share/sonic/templates/database_global.json.j2 > $REDIS_DIR/sonic-db/database_global.json
+        # Render into a temp file first and atomically move it into place, so that any
+        # process racing to read database_global.json never observes a truncated file.
+        jinjanate /usr/share/sonic/templates/database_global.json.j2 > $REDIS_DIR/sonic-db/database_global.json.tmp
+        mv $REDIS_DIR/sonic-db/database_global.json.tmp $REDIS_DIR/sonic-db/database_global.json
     fi
 fi
 # delete chassisdb config to generate supervisord config

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -156,12 +156,36 @@ function setPlatformLagIdBoundaries()
         redis.call('rpush','SYSTEM_LAG_IDS_FREE_LIST', tostring(id))
     end" 0 $lag_id_start $lag_id_end
 }
+function waitForFileToBeValidJson()
+{
+    # Waits for $1 to exist AND contain valid, fully-rendered JSON, instead of blindly
+    # sleeping. The file is written by another process via a plain '>' redirect from a
+    # jinja2/j2 render, so a consumer can observe the file after it has been created
+    # (truncated to 0 bytes) but before rendering has finished writing to it. Polling for
+    # existence alone is therefore not sufficient and led to intermittent
+    # "unexpected end of input" json parse errors on slower devices.
+    file=$1
+    max_wait_seconds=30
+    poll_interval_seconds=0.2
+    cnt=0
+    max_cnt=$(python -c "print(int($max_wait_seconds / $poll_interval_seconds))")
+    while [ ! -f "$file" ] || ! python -c "import sys, json; json.load(open(sys.argv[1]))" "$file" >/dev/null 2>&1
+    do
+        sleep $poll_interval_seconds
+        cnt=$(( $cnt + 1))
+        if [ $cnt -ge $max_cnt ]; then
+            echo "Error: $file not found or not valid JSON after ${max_wait_seconds}s"
+            return 1
+        fi
+    done
+    return 0
+}
+
 function waitForAllInstanceDatabaseConfigJsonFilesReady()
 {
     if [ ! -z "$DEV" ]; then
-	cnt=0
 	SONIC_DB_GLOBAL_JSON="/var/run/redis/sonic-db/database_global.json"
-	if [ -f "$SONIC_DB_GLOBAL_JSON" ]; then
+	if waitForFileToBeValidJson "$SONIC_DB_GLOBAL_JSON"; then
             # Create a separate python script to get a list of location of all instance database_config.json file
             redis_database_cfg_list=`/usr/bin/python -c "import sys; import os; import json; f=open(sys.argv[1]); \
             		    global_db_dir = os.path.dirname(sys.argv[1]); data=json.load(f); \
@@ -169,21 +193,9 @@ function waitForAllInstanceDatabaseConfigJsonFilesReady()
                             for elem in data['INCLUDES'] if 'namespace' in elem])); f.close()" $SONIC_DB_GLOBAL_JSON`
             for file  in $redis_database_cfg_list
             do
-		while [ ! -f $file ]
-		do
-                    sleep 1
-                    cnt=$(( $cnt + 1))
-                    if [ $cnt -ge 60 ]; then
-			echo "Error: $file not found"
-			break
-                    fi
-		done
+		waitForFileToBeValidJson "$file"
             done
         fi
-        # Delay 5 seconds to allow all instance database_config.json files to be completely generated and fully accessible.
-        # This delay is needed to make sure that the database_config.json files are correctly rendered from j2 template
-        # files ( rendering takes some time )
-        sleep 5
     fi
 }
 {%- endif %}


### PR DESCRIPTION
#### Why I did it
Follow-up to #25121, which bumped the fixed delay in `waitForAllInstanceDatabaseConfigJsonFilesReady()` from 1s to 5s to work around:

```
sonic-db-cli: :- parseDatabaseConfig: Sonic database config file syntax error >> [json.exception.parse_error.101] parse error at line 1, column 1: syntax error while parsing value - unexpected end of input; expected '[', '{', or a literal
```

We are still seeing this failure on some devices even after the 5 second delay, since a fixed sleep only narrows the race window rather than eliminating it.

**Root cause**: `docker-database-init.sh` renders `database_config.json` / `database_global.json` with:
```
jinjanate template.j2 > $REDIS_DIR/sonic-db/database_config.json
```
The `>` redirect truncates/creates the destination file *before* the renderer produces any output. `waitForAllInstanceDatabaseConfigJsonFilesReady()` only checks `[ -f $file ]`, so it can observe the file as "ready" while it's still empty or partially written, causing the JSON parse error. A longer sleep just makes the window rarer, not impossible.

#### How I did it
1. `dockers/docker-database/docker-database-init.sh`: render `database_config.json` and `database_global.json` to a `.tmp` file first, then atomically `mv` into place. Readers can never observe a truncated/partial file.
2. `files/build_templates/docker_image_ctl.j2`: replace the fixed `sleep 5` with `waitForFileToBeValidJson()`, which polls (0.2s interval, 30s cap) until each file exists **and** parses as valid JSON, rather than assuming a fixed delay is long enough. This removes the wasted delay on fast devices and removes the failure on slow devices.

#### How to verify it
Built and booted a multi-ASIC image with an artificially slowed-down j2 render (`sleep` inserted before the template renders) and confirmed `database.sh`/`sonic-db-cli` no longer log the JSON parse error, and that the wait exits as soon as the files are valid instead of always waiting the full delay.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202411
- [ ] 202505
- [ ] 202511

Backport reason: fixes an intermittent syslog error on slow-NPU devices seen on release branches after #25121.