### PR TITLE
[installer][arista]: Add platform override and trap priority

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -82,6 +82,12 @@ generate_onie_installer_image()
             if [ -f ./device/$VENDOR/$PLATFORM/installer.conf ]; then
                 cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/platforms/$PLATFORM
             fi
+            # Optional per-platform override drop-in. When present it is sourced by
+            # install.sh right after installer.conf, so it can extend (not replace)
+            # the base values. Absent for all platforms upstream (no-op by default).
+            if [ -f ./device/$VENDOR/$PLATFORM/installer.conf.override ]; then
+                cp ./device/$VENDOR/$PLATFORM/installer.conf.override ./installer/platforms/$PLATFORM.override
+            fi
 
         done
     done

--- a/build_image.sh
+++ b/build_image.sh
@@ -82,9 +82,8 @@ generate_onie_installer_image()
             if [ -f ./device/$VENDOR/$PLATFORM/installer.conf ]; then
                 cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/platforms/$PLATFORM
             fi
-            # Optional per-platform override drop-in. When present it is sourced by
-            # install.sh right after installer.conf, so it can extend (not replace)
-            # the base values. Absent for all platforms upstream (no-op by default).
+            # Optional per-platform override drop-in. When present it is sourced
+            # after installer.conf so it can override or extend the base values.
             if [ -f ./device/$VENDOR/$PLATFORM/installer.conf.override ]; then
                 cp ./device/$VENDOR/$PLATFORM/installer.conf.override ./installer/platforms/$PLATFORM.override
             fi

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-C32/config.bcm.j2
@@ -20,6 +20,7 @@ sai_verify_incoming_chksum=0
 {{ map_prio }}
 {{ pfcwd_sock }}
 host_as_route_disable=1
+sai_trap_group_priority=1000
 use_all_splithorizon_groups=1
 riot_enable=1
 sai_tunnel_support=1

--- a/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
+++ b/device/arista/x86_64-arista_7050cx3_32s/Arista-7050CX3-32S-D48C8/config.bcm.j2
@@ -20,6 +20,7 @@ sai_verify_incoming_chksum=0
 {{ map_prio }}
 {{ pfcwd_sock }}
 host_as_route_disable=1
+sai_trap_group_priority=1000
 use_all_splithorizon_groups=1
 riot_enable=1
 sai_tunnel_support=1

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -107,6 +107,10 @@ ONIE_IMAGE_PART_SIZE="%%ONIE_IMAGE_PART_SIZE%%"
 VAR_LOG_SIZE=4096
 
 [ -r platforms/$onie_platform ] && . platforms/$onie_platform
+# Optional per-platform override drop-in, sourced after installer.conf so it can
+# extend the base values (e.g. append to $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX)
+# without diverging installer.conf itself. Absent for all platforms upstream.
+[ -r platforms/$onie_platform.override ] && . platforms/$onie_platform.override
 
 # Verify image platform is inside devices list
 if [ "$install_env" = "onie" ]; then

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -106,11 +106,8 @@ ONIE_IMAGE_PART_SIZE="%%ONIE_IMAGE_PART_SIZE%%"
 # Default var/log device size in MB
 VAR_LOG_SIZE=4096
 
-[ -r platforms/$onie_platform ] && . platforms/$onie_platform
-# Optional per-platform override drop-in, sourced after installer.conf so it can
-# extend the base values (e.g. append to $ONIE_PLATFORM_EXTRA_CMDLINE_LINUX)
-# without diverging installer.conf itself. Absent for all platforms upstream.
-[ -r platforms/$onie_platform.override ] && . platforms/$onie_platform.override
+[ -r "platforms/$onie_platform" ] && . "platforms/$onie_platform"
+[ -r "platforms/$onie_platform.override" ] && . "platforms/$onie_platform.override"
 
 # Verify image platform is inside devices list
 if [ "$install_env" = "onie" ]; then


### PR DESCRIPTION
#### Why I did it

Platform `installer.conf` files often keep kernel command-line parameters on one line. Downstream builds that append a platform-specific option must modify that shared line, causing recurring merge conflicts.

The Arista 7050CX3 C32 and D48C8 HwSKUs also require an explicit SAI trap group priority so trap handling uses the intended priority.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added an optional per-platform `installer.conf.override` drop-in.
- Copied the drop-in into the installer when present and sourced it after the base `installer.conf`, allowing it to override or extend base values.
- Quoted the platform configuration paths when testing and sourcing them.
- Set `sai_trap_group_priority=1000` for the Arista 7050CX3 C32 and D48C8 HwSKUs.

No override files are added upstream, so public platform behavior remains unchanged unless a downstream platform supplies one.

#### How to verify it

- Build scripts pass shell syntax validation.
- Builds without `installer.conf.override` continue to use only the base platform configuration.
- A drop-in can append to `ONIE_PLATFORM_EXTRA_CMDLINE_LINUX` after the base configuration is sourced.
- Generated BCM configuration for both Arista HwSKUs includes `sai_trap_group_priority=1000`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: shell syntax validation passed; installer override append behavior verified locally.

#### Description for the changelog

Add an optional platform installer override and configure Arista 7050CX3 SAI trap priority.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A