### PR TITLE
wire ENABLE_DIALOUT flag to have the option to disable dialout

### DIFF
--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -27,6 +27,15 @@ COPY ["telemetry_vars.j2", "/usr/share/sonic/templates/"]
 COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["critical_processes", "/etc/supervisor"]
 
+{% if ENABLE_DIALOUT == "n" %}
+# ENABLE_DIALOUT=n: remove the [program:dialout] block from supervisord.conf and drop the now-unused
+# launcher. The COPY lines above stay unchanged; only this build-flag-gated step is added.
+# Default (flag unset) keeps dialout enabled.
+RUN sed -i '/^\[program:dialout\]$/,$d' /etc/supervisor/conf.d/supervisord.conf \
+ && sed -i -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' /etc/supervisor/conf.d/supervisord.conf \
+ && rm -f /usr/bin/dialout.sh
+{% endif %}
+
 FROM $BASE
 
 ARG image_version

--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -28,10 +28,10 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["critical_processes", "/etc/supervisor"]
 
 {% if ENABLE_DIALOUT == "n" %}
-# ENABLE_DIALOUT=n: remove the [program:dialout] block from supervisord.conf and drop the now-unused
-# launcher. The COPY lines above stay unchanged; only this build-flag-gated step is added.
-# Default (flag unset) keeps dialout enabled.
-RUN sed -i '/^\[program:dialout\]$/,$d' /etc/supervisor/conf.d/supervisord.conf \
+# ENABLE_DIALOUT=n: remove only the [program:dialout] supervisor section (up to the next INI
+# header) and drop the now-unused launcher. The COPY lines above stay unchanged; only this
+# build-flag-gated step is added. Default (flag unset) keeps dialout enabled.
+RUN sed -i '/^\[program:dialout\]$/,/^\[/{/^\[program:dialout\]$/d; /^\[/!d}' /etc/supervisor/conf.d/supervisord.conf \
  && sed -i -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' /etc/supervisor/conf.d/supervisord.conf \
  && rm -f /usr/bin/dialout.sh
 {% endif %}

--- a/dockers/docker-sonic-gnmi/Dockerfile.j2
+++ b/dockers/docker-sonic-gnmi/Dockerfile.j2
@@ -36,6 +36,8 @@ RUN sed -i '/^\[program:dialout\]$/,$d' /etc/supervisor/conf.d/supervisord.conf 
  && rm -f /usr/bin/dialout.sh
 {% endif %}
 
+{% include "Dockerfile.gnmi.custom.j2" ignore missing %}
+
 FROM $BASE
 
 ARG image_version

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -28,6 +28,15 @@ COPY ["supervisord.conf", "/etc/supervisor/conf.d/"]
 COPY ["critical_processes", "/etc/supervisor"]
 COPY ["docker-telemetry-entry.sh", "/usr/local/bin/"]
 
+{% if ENABLE_DIALOUT == "n" %}
+# ENABLE_DIALOUT=n: remove the [program:dialout] block from supervisord.conf and drop the now-unused
+# launcher. The COPY lines above stay unchanged; only this build-flag-gated step is added.
+# Default (flag unset) keeps dialout enabled.
+RUN sed -i '/^\[program:dialout\]$/,$d' /etc/supervisor/conf.d/supervisord.conf \
+ && sed -i -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' /etc/supervisor/conf.d/supervisord.conf \
+ && rm -f /usr/bin/dialout.sh
+{% endif %}
+
 FROM $BASE
 
 ARG image_version

--- a/dockers/docker-sonic-telemetry/Dockerfile.j2
+++ b/dockers/docker-sonic-telemetry/Dockerfile.j2
@@ -29,10 +29,10 @@ COPY ["critical_processes", "/etc/supervisor"]
 COPY ["docker-telemetry-entry.sh", "/usr/local/bin/"]
 
 {% if ENABLE_DIALOUT == "n" %}
-# ENABLE_DIALOUT=n: remove the [program:dialout] block from supervisord.conf and drop the now-unused
-# launcher. The COPY lines above stay unchanged; only this build-flag-gated step is added.
-# Default (flag unset) keeps dialout enabled.
-RUN sed -i '/^\[program:dialout\]$/,$d' /etc/supervisor/conf.d/supervisord.conf \
+# ENABLE_DIALOUT=n: remove only the [program:dialout] supervisor section (up to the next INI
+# header) and drop the now-unused launcher. The COPY lines above stay unchanged; only this
+# build-flag-gated step is added. Default (flag unset) keeps dialout enabled.
+RUN sed -i '/^\[program:dialout\]$/,/^\[/{/^\[program:dialout\]$/d; /^\[/!d}' /etc/supervisor/conf.d/supervisord.conf \
  && sed -i -e :a -e '/^[[:space:]]*$/{$d;N;ba' -e '}' /etc/supervisor/conf.d/supervisord.conf \
  && rm -f /usr/bin/dialout.sh
 {% endif %}

--- a/slave.mk
+++ b/slave.mk
@@ -427,6 +427,7 @@ export FRR_USER_UID
 export FRR_USER_GID
 export INCLUDE_FIPS
 export ENABLE_FIPS
+export ENABLE_DIALOUT
 
 ###############################################################################
 ## Build Options


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `ENABLE_DIALOUT` build flag was added in PR17715 and is plumbed through `Makefile.work` and `slave.mk`, but nothing consumes it -- the dial-out client is always built into the telemetry and gnmi containers regardless of the flag.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Complete the wiring so ENABLE_DIALOUT=n actually disables dial-out:
- slave.mk: export `ENABLE_DIALOUT` so it is available to the docker Dockerfile.j2 render environment (j2cli reads os.environ).
 - docker-sonic-telemetry/Dockerfile.j2, docker-sonic-gnmi/Dockerfile.j2: add an append-only `{% if ENABLE_DIALOUT == "n" %}` build step that strips the `[program:dialout]` block from the copied `supervisord.conf` and removes the now-unused launcher. The block runs in the builder stage, so the edit is propagated to the final image by `rsync_from_builder_stage()`.
Default behavior is unchanged: with ENABLE_DIALOUT unset the templates render byte-identical to before and dial-out stays enabled.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)



---

**Update — additional commit:** Also adds a generic no-op downstream include hook to `docker-sonic-gnmi/Dockerfile.j2`:
`{% include "Dockerfile.gnmi.custom.j2" ignore missing %}`. This lets downstream forks inject extra gnmi build steps without diverging from the shared template (mirrors the existing `Dockerfile.common.j2` include pattern). With `ignore missing` and no such file upstream, it renders to nothing — no functional change to the upstream image.
