### PR TITLE
[docker-fpm-frr]: Restrict rvtysh to read-only commands

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -1,22 +1,36 @@
 #!/bin/bash
 
-# The command rvtysh can be run as root priviledge by any user without password, only allow to execute readonly commands.
+QUOTED_OUTPUT=''
+for var in "$@"; do
+    if [ "$var" == "-c" ]
+    then
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} ${var}"
+    elif [ "$var" == "-n" ]
+    then
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var}#"
+    else
+        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var:Q}#"
+    fi
+done
 
-# The options in the show command cannot contains any charactors to run multiple sub-commands potentially, such as "\n", "\r", "|", "&", "$" and ";".
-if printf -- "$*" | grep -qPz '[\n\r|&$;]'; then
-    echo "Not allow to run the command, please use the comand 'sudo vtysh' instead." 1>&2
+SHOW_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "\-[c][ ]+#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#"|grep -Eo "#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#" |sed -e 's/#//g'`
+if [ "${SHOW_MATCHED_PATTERN}" == "" ]
+then
+    echo "Not allowed to run command. Please run sudo vtysh instead."
     exit 1
 fi
 
-# The sub commands must start with "show"
-LAST_PARAM=
-for param in "$@"
-do
-    if [ "$LAST_PARAM" == "-c" ] && [[ "$param" != show*  ]]; then
-        echo "Not allow to run the command '$param', please use the comand 'sudo vtysh' instead." 1>&2
-        exit 1
-    fi
-    LAST_PARAM=$param
-done
+# The command includes '-c' option (required) and '-n' option (optional)
+# '-c' option must start with show and the subcommand only allows a specific number of special characters.
+ARGUMENTS=()
+N_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "#-[n]#[ ]+#[0-9]#" |grep -Eo "#[0-9]#" |sed -e 's/#//g'`
+if [ "${N_MATCHED_PATTERN}" != "" ]
+then
+    ARGUMENTS+=('-n')
+    ARGUMENTS+=(${N_MATCHED_PATTERN})
+fi
+ARGUMENTS+=('-c')
+ARGUMENTS+=("${SHOW_MATCHED_PATTERN}")
 
-vtysh "$@"
+vtysh "${ARGUMENTS[@]}"
+

--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-readonly SHOW_COMMAND_PATTERN='^show($| [a-zA-Z0-9%()*+,./:<=>@^_~ -]+$)'
+readonly SHOW_COMMAND_PATTERN='^show($| [a-zA-Z0-9%()*+,./:<=>?@^_~ -]+$)'
 readonly VTYSH=/usr/bin/vtysh
 
 reject_command()
@@ -17,7 +17,7 @@ while (( $# > 0 )); do
     case "$1" in
         -n)
             (( $# >= 2 && namespace_set == 0 )) || reject_command
-            [[ "$2" =~ ^[0-9]$ ]] || reject_command
+            [[ "$2" =~ ^[0-9]+$ ]] || reject_command
             namespace="$2"
             namespace_set=1
             shift 2

--- a/dockers/docker-fpm-frr/base_image_files/rvtysh
+++ b/dockers/docker-fpm-frr/base_image_files/rvtysh
@@ -1,36 +1,49 @@
 #!/bin/bash
 
-QUOTED_OUTPUT=''
-for var in "$@"; do
-    if [ "$var" == "-c" ]
-    then
-        QUOTED_OUTPUT="${QUOTED_OUTPUT} ${var}"
-    elif [ "$var" == "-n" ]
-    then
-        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var}#"
-    else
-        QUOTED_OUTPUT="${QUOTED_OUTPUT} #${var:Q}#"
-    fi
+readonly SHOW_COMMAND_PATTERN='^show($| [a-zA-Z0-9%()*+,./:<=>@^_~ -]+$)'
+readonly VTYSH=/usr/bin/vtysh
+
+reject_command()
+{
+    echo "Not allowed to run command. Please run sudo vtysh instead." >&2
+    exit 1
+}
+
+namespace=
+namespace_set=0
+commands=()
+
+while (( $# > 0 )); do
+    case "$1" in
+        -n)
+            (( $# >= 2 && namespace_set == 0 )) || reject_command
+            [[ "$2" =~ ^[0-9]$ ]] || reject_command
+            namespace="$2"
+            namespace_set=1
+            shift 2
+            ;;
+        -c)
+            (( $# >= 2 )) || reject_command
+            [[ "$2" =~ $SHOW_COMMAND_PATTERN ]] || reject_command
+            commands+=("$2")
+            shift 2
+            ;;
+        *)
+            reject_command
+            ;;
+    esac
 done
 
-SHOW_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "\-[c][ ]+#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#"|grep -Eo "#show[ a-zA-Z0-9!%()*+,./:<=>@^_~ -]+#" |sed -e 's/#//g'`
-if [ "${SHOW_MATCHED_PATTERN}" == "" ]
-then
-    echo "Not allowed to run command. Please run sudo vtysh instead."
-    exit 1
+(( ${#commands[@]} > 0 )) || reject_command
+
+arguments=()
+if (( namespace_set == 1 )); then
+    arguments+=("-n" "$namespace")
 fi
 
-# The command includes '-c' option (required) and '-n' option (optional)
-# '-c' option must start with show and the subcommand only allows a specific number of special characters.
-ARGUMENTS=()
-N_MATCHED_PATTERN=`echo ${QUOTED_OUTPUT}|grep -Eo "#-[n]#[ ]+#[0-9]#" |grep -Eo "#[0-9]#" |sed -e 's/#//g'`
-if [ "${N_MATCHED_PATTERN}" != "" ]
-then
-    ARGUMENTS+=('-n')
-    ARGUMENTS+=(${N_MATCHED_PATTERN})
-fi
-ARGUMENTS+=('-c')
-ARGUMENTS+=("${SHOW_MATCHED_PATTERN}")
+for command in "${commands[@]}"; do
+    arguments+=("-c" "$command")
+done
 
-vtysh "${ARGUMENTS[@]}"
-
+unset VTYSH_PAGER PAGER
+exec "$VTYSH" "${arguments[@]}"

--- a/dockers/docker-fpm-frr/tests/test_rvtysh.py
+++ b/dockers/docker-fpm-frr/tests/test_rvtysh.py
@@ -1,0 +1,142 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+RVTYSH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', 'base_image_files', 'rvtysh')
+)
+
+
+@pytest.fixture
+def vtysh_stub(tmp_path):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    capture_path = tmp_path / 'argv'
+    stub_path = bin_dir / 'vtysh'
+    stub_path.write_text(
+        '#!/bin/bash\n'
+        'printf "%s\\0" "$@" > "$VTYSH_CAPTURE"\n'
+        'printf "%s" "${VTYSH_PAGER-unset}" > "$VTYSH_CAPTURE.pager"\n'
+        'printf "%s" "${PAGER-unset}" > "$VTYSH_CAPTURE.pager_fallback"\n'
+    )
+    stub_path.chmod(0o755)
+
+    wrapper_path = tmp_path / 'rvtysh'
+    wrapper_path.write_text(
+        Path(RVTYSH).read_text().replace(
+            'readonly VTYSH=/usr/bin/vtysh',
+            'readonly VTYSH={}'.format(stub_path),
+        )
+    )
+    wrapper_path.chmod(0o755)
+
+    env = os.environ.copy()
+    env['VTYSH_CAPTURE'] = str(capture_path)
+    env['VTYSH_PAGER'] = 'malicious pager'
+    env['PAGER'] = 'malicious fallback pager'
+    return env, capture_path, wrapper_path
+
+
+def run_rvtysh(arguments, vtysh_stub, cwd=None):
+    env, capture_path, wrapper_path = vtysh_stub
+    result = subprocess.run(
+        [str(wrapper_path)] + arguments,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    captured_arguments = []
+    if capture_path.exists():
+        captured_arguments = [
+            value.decode()
+            for value in capture_path.read_bytes().split(b'\0')
+            if value
+        ]
+    return result, captured_arguments
+
+
+@pytest.mark.parametrize(
+    'arguments, expected',
+    [
+        (['-c', 'show version'], ['-c', 'show version']),
+        (
+            ['-n', '0', '-c', 'show ip bgp summary'],
+            ['-n', '0', '-c', 'show ip bgp summary'],
+        ),
+        (
+            ['-c', 'show version', '-c', 'show ip route'],
+            ['-c', 'show version', '-c', 'show ip route'],
+        ),
+    ],
+)
+def test_allows_only_valid_show_commands(vtysh_stub, arguments, expected):
+    result, captured_arguments = run_rvtysh(arguments, vtysh_stub)
+
+    assert result.returncode == 0
+    assert result.stdout == ''
+    assert result.stderr == ''
+    assert captured_arguments == expected
+
+
+@pytest.mark.parametrize(
+    'arguments',
+    [
+        [],
+        ['-f', '/tmp/config'],
+        ['-b'],
+        ['-d', 'bgpd', '-c', 'show version'],
+        ['-c'],
+        ['-c', 'configure terminal'],
+        ['-c', 'showfoo'],
+        ['-c', 'show version; configure terminal'],
+        ['-c', 'show run | include password'],
+        ['-c', 'show version\nconfigure terminal'],
+        ['-c', 'show version', '-c', 'configure terminal'],
+        ['-n'],
+        ['-n', '10', '-c', 'show version'],
+        ['-n', 'x', '-c', 'show version'],
+        ['-n', '0', '-n', '1', '-c', 'show version'],
+        ['-c', 'show version', 'unexpected'],
+    ],
+)
+def test_rejects_invalid_or_ambiguous_arguments(vtysh_stub, arguments):
+    result, captured_arguments = run_rvtysh(arguments, vtysh_stub)
+
+    assert result.returncode == 1
+    assert result.stdout == ''
+    assert result.stderr == (
+        'Not allowed to run command. Please run sudo vtysh instead.\n'
+    )
+    assert captured_arguments == []
+
+
+def test_preserves_whitespace_and_glob_characters(vtysh_stub, tmp_path):
+    (tmp_path / 'ip').touch()
+    command = 'show  *'
+
+    result, captured_arguments = run_rvtysh(
+        ['-c', command],
+        vtysh_stub,
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert captured_arguments == ['-c', command]
+
+
+def test_removes_pager_environment(vtysh_stub):
+    result, captured_arguments = run_rvtysh(
+        ['-c', 'show version'],
+        vtysh_stub,
+    )
+    _, capture_path, _ = vtysh_stub
+
+    assert result.returncode == 0
+    assert captured_arguments == ['-c', 'show version']
+    assert capture_path.with_suffix('.pager').read_text() == 'unset'
+    assert capture_path.with_suffix('.pager_fallback').read_text() == 'unset'

--- a/dockers/docker-fpm-frr/tests/test_rvtysh.py
+++ b/dockers/docker-fpm-frr/tests/test_rvtysh.py
@@ -72,6 +72,18 @@ def run_rvtysh(arguments, vtysh_stub, cwd=None):
             ['-c', 'show version', '-c', 'show ip route'],
             ['-c', 'show version', '-c', 'show ip route'],
         ),
+        (
+            ['-c', 'show ip route ?'],
+            ['-c', 'show ip route ?'],
+        ),
+        (
+            ['-c', 'show ip route summ?'],
+            ['-c', 'show ip route summ?'],
+        ),
+        (
+            ['-n', '10', '-c', 'show version'],
+            ['-n', '10', '-c', 'show version'],
+        ),
     ],
 )
 def test_allows_only_valid_show_commands(vtysh_stub, arguments, expected):
@@ -98,7 +110,6 @@ def test_allows_only_valid_show_commands(vtysh_stub, arguments, expected):
         ['-c', 'show version\nconfigure terminal'],
         ['-c', 'show version', '-c', 'configure terminal'],
         ['-n'],
-        ['-n', '10', '-c', 'show version'],
         ['-n', 'x', '-c', 'show version'],
         ['-n', '0', '-n', '1', '-c', 'show version'],
         ['-c', 'show version', 'unexpected'],

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -31,7 +31,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog, /bin/cat /var/log/sys
                                  /usr/bin/lldpctl, \
                                  /usr/bin/sensors, \
                                  /usr/bin/tail -F /var/log/syslog, \
-                                 /usr/bin/rvtysh -c show *, /usr/bin/rvtysh -n [0-9] -c show *, \
+                                 /usr/bin/rvtysh -c show *, /usr/bin/rvtysh -n [0-9]* -c show *, \
                                  /usr/bin/vtysh -c show version, \
                                  /usr/bin/vtysh -c show bgp ipv[46] summary json, \
                                  /usr/bin/vtysh -n [0-9] -c show version, \

--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -31,7 +31,7 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog, /bin/cat /var/log/sys
                                  /usr/bin/lldpctl, \
                                  /usr/bin/sensors, \
                                  /usr/bin/tail -F /var/log/syslog, \
-                                 /usr/bin/rvtysh *, \
+                                 /usr/bin/rvtysh -c show *, /usr/bin/rvtysh -n [0-9] -c show *, \
                                  /usr/bin/vtysh -c show version, \
                                  /usr/bin/vtysh -c show bgp ipv[46] summary json, \
                                  /usr/bin/vtysh -n [0-9] -c show version, \
@@ -71,4 +71,3 @@ Defaults passwd_timeout=5
 # See sudoers(5) for more information on "#include" directives:
 
 #includedir /etc/sudoers.d
-


### PR DESCRIPTION
#### Why I did it

`rvtysh` is granted passwordless root access so operators can run read-only FRR `show` commands. The previous wrapper validated only arguments following `-c` and then forwarded the complete original argument list. Commands such as `rvtysh -f <file>` therefore bypassed validation and could load FRR configuration as root.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Parse only optional `-n <single digit>` and one or more `-c <command>` pairs.
- Validate each complete command against an anchored `show` command allow-list.
- Reject missing values, duplicate namespaces, unknown options, extra arguments, and mixed valid/invalid commands.
- Preserve validated commands literally in a Bash array without word splitting or pathname expansion.
- Remove pager environment variables and invoke `/usr/bin/vtysh` directly.
- Restrict the sudoers `READ_ONLY_CMDS` entry to the validated `rvtysh -c show *` and `rvtysh -n [0-9] -c show *` forms.
- Send rejection messages to stderr and return a non-zero status.
- Add regression tests covering valid commands, namespace selection, multiple commands, configuration-file bypasses, command separators, invalid namespaces, glob preservation, and pager sanitization.

#### How to verify it

```text
pytest -q dockers/docker-fpm-frr/tests/test_rvtysh.py
bash -n dockers/docker-fpm-frr/base_image_files/rvtysh
visudo -cf files/image_config/sudoers/sudoers
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

21 `rvtysh` regression tests passed. The wrapper and sudoers files passed syntax validation.

#### Description for the changelog

Restrict passwordless `rvtysh` access to validated read-only FRR commands.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
