### PR TITLE
[docker-restapi-sidecar] Fix systemd_stub start ordering (autostart=false)

### DIFF
--- a/dockers/docker-restapi-sidecar/supervisord.conf
+++ b/dockers/docker-restapi-sidecar/supervisord.conf
@@ -26,7 +26,7 @@ dependent_startup=true
 [program:systemd_stub]
 command=python3 /usr/bin/systemd_stub.py
 priority=3
-autostart=true
+autostart=false
 autorestart=false
 startsecs=0
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
#### Why I did it

The `systemd_stub` program in the restapi-sidecar container is supposed to wait for `rsyslogd` before it starts, so its early output actually makes it into the logs. It already has the right directives for that:

```
dependent_startup=true
dependent_startup_wait_for=rsyslogd:running
```

but it *also* had `autostart=true`. With `autostart=true`, supervisord starts the program immediately at boot and the `dependent_startup` ordering never kicks in — so `systemd_stub` races ahead of `rsyslogd` and its first log lines (e.g. `IS_V1_ENABLED=...`) get dropped until `rsyslogd` finally comes up. In practice that shows up as a ~15 minute gap before the initial log line appears.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Set `autostart=false` on `[program:systemd_stub]` so the `dependent_startup` plugin owns its lifecycle and starts it only after `rsyslogd` is running — which is what the existing `dependent_startup_wait_for=rsyslogd:running` line was always meant to do.

#### How to verify it

On a device running the restapi-sidecar container, restart the container and watch the logs: `systemd_stub`'s initial output (such as `IS_V1_ENABLED=...`) should show up right after `rsyslogd` starts, instead of only appearing minutes later.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->

#### Description for the changelog

Fix restapi-sidecar systemd_stub start ordering so it waits for rsyslogd (autostart=false).
