### PR TITLE
[tacacs]: Add optional downstream extension hooks (DeviceType attr + local patch series)

### DIFF
--- a/src/tacacs/.gitignore
+++ b/src/tacacs/.gitignore
@@ -7,6 +7,15 @@ audisp/*
 nsm/*
 !nsm/Makefile
 !nsm/*.patch
+!nss/
+nss/*
+!nss/Makefile
+!nss/patch/
+nss/patch/*
+!nss/patch/*.patch
+!nss/patch/series.local
+!pam/
 pam/*
 !pam/Makefile
 !pam/*.patch
+!pam/series.local

--- a/src/tacacs/bash_tacplus/Makefile.am
+++ b/src/tacacs/bash_tacplus/Makefile.am
@@ -13,7 +13,7 @@ moduledir = @plugindir@
 module_LTLIBRARIES = bash_tacplus.la
 bash_tacplus_la_SOURCES = bash_tacplus.h \
 bash_tacplus.c
-bash_tacplus_la_CFLAGS = $(AM_CFLAGS) -I $(top_srcdir)/libtac/include
+bash_tacplus_la_CFLAGS = $(AM_CFLAGS) $(TACACS_DEVICE_TYPE_CFLAGS) -I $(top_srcdir)/libtac/include
 bash_tacplus_la_LDFLAGS = -module -avoid-version
 
 EXTRA_DIST = bash_tacplus.spec

--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -155,6 +155,14 @@ int send_authorization_message(
         tac_add_attrib(&attr, "cmd-arg", (char *)arg);
     }
 
+#ifdef TACACS_DEVICE_TYPE
+    /* Optionally advertise a device type attribute so AAA services can match
+       authorization rules on it. The value is provided at build time via
+       -DTACACS_DEVICE_TYPE='"..."'; when the macro is undefined (the default)
+       this is a no-op and no attribute is sent. */
+    tac_add_attrib_pair(&attr, "DeviceType", '*', TACACS_DEVICE_TYPE);
+#endif
+
     re.msg = NULL;
     output_debug("send authorizatiom message with user: %s, tty: %s, remote: %s\n", user, tty, remote);
     retval = tac_author_send(tac_fd, (char *)user, (char *)tty, (char *)remote, attr);

--- a/src/tacacs/bash_tacplus/bash_tacplus.c
+++ b/src/tacacs/bash_tacplus/bash_tacplus.c
@@ -164,7 +164,7 @@ int send_authorization_message(
 #endif
 
     re.msg = NULL;
-    output_debug("send authorizatiom message with user: %s, tty: %s, remote: %s\n", user, tty, remote);
+    output_debug("send authorization message with user: %s, tty: %s, remote: %s\n", user, tty, remote);
     retval = tac_author_send(tac_fd, (char *)user, (char *)tty, (char *)remote, attr);
     output_debug("authorization result: %d\n", retval);
 

--- a/src/tacacs/bash_tacplus/unittest/Makefile.am
+++ b/src/tacacs/bash_tacplus/unittest/Makefile.am
@@ -10,9 +10,9 @@ CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werr
 CFLAGS_TEST = -Wno-parentheses -Wno-format-security -Wno-implicit-function-declaration -Wno-int-to-pointer-cast
 IFLAGS_TEST = -I.. -I../include -I../lib
 DBGFLAGS = -DDEBUG -DBASH_PLUGIN_UT
-DEVICE_TYPE_TEST_FLAG = -DTACACS_DEVICE_TYPE=\"Test\\040Device\\040Type\"
+TACACS_DEVICE_TYPE_CFLAGS = -DTACACS_DEVICE_TYPE=\"Test\\040Device\\040Type\"
 
 plugin_test_SOURCES = plugin_test.c mock_helper.c ../bash_tacplus.c
 
-plugin_test_CFLAGS = $(DBGFLAGS) $(DEVICE_TYPE_TEST_FLAG) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
+plugin_test_CFLAGS = $(DBGFLAGS) $(TACACS_DEVICE_TYPE_CFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
 plugin_test_LDADD = -lc -lcunit

--- a/src/tacacs/bash_tacplus/unittest/Makefile.am
+++ b/src/tacacs/bash_tacplus/unittest/Makefile.am
@@ -10,8 +10,9 @@ CFLAGS = -g -O2 -fstack-protector-strong -fstack-clash-protection -Wformat -Werr
 CFLAGS_TEST = -Wno-parentheses -Wno-format-security -Wno-implicit-function-declaration -Wno-int-to-pointer-cast
 IFLAGS_TEST = -I.. -I../include -I../lib
 DBGFLAGS = -DDEBUG -DBASH_PLUGIN_UT
+DEVICE_TYPE_TEST_FLAG = -DTACACS_DEVICE_TYPE=\"Test\\040Device\\040Type\"
 
 plugin_test_SOURCES = plugin_test.c mock_helper.c ../bash_tacplus.c
 
-plugin_test_CFLAGS = $(DBGFLAGS) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
+plugin_test_CFLAGS = $(DBGFLAGS) $(DEVICE_TYPE_TEST_FLAG) $(AM_CFLAGS) $(CFLAGS_COMMON) $(CFLAGS_TEST) $(IFLAGS_TEST)
 plugin_test_LDADD = -lc -lcunit

--- a/src/tacacs/bash_tacplus/unittest/mock_helper.c
+++ b/src/tacacs/bash_tacplus/unittest/mock_helper.c
@@ -24,6 +24,12 @@
 /* Mock syslog buffer */
 char mock_syslog_message_buffer[1024];
 
+/* Mock tac_add_attrib_pair state */
+int mock_attrib_pair_count;
+char mock_attrib_pair_name[128];
+char mock_attrib_pair_separator;
+char mock_attrib_pair_value[128];
+
 /* define test scenarios for mock functions return different value by scenario. */
 int test_scenario;
 
@@ -101,6 +107,14 @@ int get_memory_allocate_count()
   return memory_allocate_count;
 }
 
+void reset_mock_attrib_pair()
+{
+	mock_attrib_pair_count = 0;
+	mock_attrib_pair_name[0] = '\0';
+	mock_attrib_pair_separator = '\0';
+	mock_attrib_pair_value[0] = '\0';
+}
+
 /* Mock xcalloc method */
 void *xcalloc(size_t count, size_t size)
 {
@@ -113,6 +127,16 @@ void *xcalloc(size_t count, size_t size)
 void tac_add_attrib(struct tac_attrib **attr, char *attrname, char *attrvalue)
 {
 	debug_printf("MOCK: tac_add_attrib add attribute: %s, value: %s\n", attrname, attrvalue);
+}
+
+/* Mock tac_add_attrib_pair method */
+void tac_add_attrib_pair(struct tac_attrib **attr, char *attrname, char separator, char *attrvalue)
+{
+	mock_attrib_pair_count++;
+	snprintf(mock_attrib_pair_name, sizeof(mock_attrib_pair_name), "%s", attrname);
+	mock_attrib_pair_separator = separator;
+	snprintf(mock_attrib_pair_value, sizeof(mock_attrib_pair_value), "%s", attrvalue);
+	debug_printf("MOCK: tac_add_attrib_pair add attribute: %s%c%s\n", attrname, separator, attrvalue);
 }
 
 /* Mock tac_free_attrib method */

--- a/src/tacacs/bash_tacplus/unittest/mock_helper.h
+++ b/src/tacacs/bash_tacplus/unittest/mock_helper.h
@@ -24,6 +24,12 @@
 /* Mock syslog buffer */
 extern char mock_syslog_message_buffer[1024];
 
+/* Mock tac_add_attrib_pair state */
+extern int mock_attrib_pair_count;
+extern char mock_attrib_pair_name[128];
+extern char mock_attrib_pair_separator;
+extern char mock_attrib_pair_value[128];
+
 #define TEST_SCEANRIO_CONNECTION_ALL_FAILED                 1
 #define TEST_SCEANRIO_CONNECTION_SEND_FAILED_RESULT         2
 #define TEST_SCEANRIO_CONNECTION_SEND_SUCCESS_READ_FAILED   3
@@ -47,5 +53,7 @@ void set_memory_allocate_count(int count);
 /* Get memory allocate count for test*/
 int get_memory_allocate_count();
 
+/* Reset the captured tac_add_attrib_pair state. */
+void reset_mock_attrib_pair();
 
 #endif /* _MOCK_HELPER_H_ */

--- a/src/tacacs/bash_tacplus/unittest/plugin_test.c
+++ b/src/tacacs/bash_tacplus/unittest/plugin_test.c
@@ -93,10 +93,15 @@ void testcase_tacacs_authorization_success() {
 
 	// test connection success case
 	set_test_scenario(TEST_SCEANRIO_CONNECTION_SEND_SUCCESS_RESULT);
+	reset_mock_attrib_pair();
 	int result = tacacs_authorization("test_user","tty0","test_host","test_command",testargv,2);
 
 	// wuthorization success
 	CU_ASSERT_EQUAL(result, 0);
+	CU_ASSERT_EQUAL(mock_attrib_pair_count, 1);
+	CU_ASSERT_STRING_EQUAL(mock_attrib_pair_name, "DeviceType");
+	CU_ASSERT_EQUAL(mock_attrib_pair_separator, '*');
+	CU_ASSERT_STRING_EQUAL(mock_attrib_pair_value, "Test Device Type");
 }
 
 /* Test authorization_with_host_and_tty get success case */

--- a/src/tacacs/nss/Makefile
+++ b/src/tacacs/nss/Makefile
@@ -16,6 +16,13 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	stg init
 	stg import -s ../patch/series
 
+	# Import optional local patch series ../patch/series.local, if present.
+	# No-op upstream (no series.local is shipped); lets downstreams add local
+	# patches without editing the shared series.
+	if [ -f ../patch/series.local ]; then
+		stg import -s ../patch/series.local
+	fi
+
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -rfakeroot -b -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/tacacs/pam/Makefile
+++ b/src/tacacs/pam/Makefile
@@ -27,6 +27,13 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	git apply ../0009-Add-setting-flag-for-authorization-and-accounting.patch
 	git apply ../0010-handle-bad-password-set-by-sshd.patch
 
+	# Apply optional local patches listed in ../series.local, if present.
+	# No-op upstream (no series.local is shipped); lets downstreams add local
+	# patches without editing this recipe.
+	if [ -f ../series.local ]; then
+		while read -r p; do echo $$p; git apply ../$$p; done < ../series.local
+	fi
+
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -rfakeroot -b -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)
 else

--- a/src/tacacs/pam/Makefile
+++ b/src/tacacs/pam/Makefile
@@ -31,7 +31,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# No-op upstream (no series.local is shipped); lets downstreams add local
 	# patches without editing this recipe.
 	if [ -f ../series.local ]; then
-		while read -r p; do echo $$p; git apply ../$$p; done < ../series.local
+		sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$$/d' ../series.local | \
+			while IFS= read -r p; do echo "$$p"; git apply "../$$p"; done
 	fi
 
 ifeq ($(CROSS_BUILD_ENVIRON), y)


### PR DESCRIPTION
#### Why I did it

Deployment-specific TACACS customizations currently require edits to shared
authorization code and PAM/NSS patch lists. Those edits repeatedly conflict
when downstream branches synchronize with public `master`.

This change provides dormant extension hooks so downstreams can add an
authorization `DeviceType` and private PAM/NSS patches without modifying the
shared implementation. The default public build remains unchanged.

#### How I did it

- Added an optional `TACACS_DEVICE_TYPE` compile-time hook to
  `send_authorization_message()`.
- Added the attribute with `tac_add_attrib_pair(..., "DeviceType", '*', ...)`;
  `*` marks the TACACS argument as optional.
- Added `TACACS_DEVICE_TYPE_CFLAGS` to the bash plugin target so downstream
  definitions are applied only during the libtool build and do not affect
  configure compiler checks.
- Added optional local patch-series hooks for PAM and NSS. No local series is
  shipped publicly, so these hooks are no-ops by default.
- Made the PAM local-series reader ignore blank lines and comments.
- Added unit coverage that compiles the hook with a DeviceType containing
  spaces and verifies the attribute name, separator, value, and call count.

A downstream can enable the attribute without embedding literal spaces in
`CFLAGS`, for example:

```make
$(BASH_TACPLUS)_BUILD_ENV += TACACS_DEVICE_TYPE_CFLAGS='-DTACACS_DEVICE_TYPE=\"Example\\040Device\\040Type\"'
```

When `TACACS_DEVICE_TYPE` is undefined, no DeviceType attribute is emitted.

#### How to verify it

1. Build normally and confirm the plugin remains a no-op for DeviceType.
2. Build with `TACACS_DEVICE_TYPE_CFLAGS` defined and confirm the flag retains
   its C string quotes through libtool and adds one optional `DeviceType` pair.
3. Add blank lines and comments to a downstream PAM `series.local` and confirm
   only patch paths are applied.

#### Description for the changelog

[tacacs]: Add optional downstream DeviceType and local patch-series hooks.