### PR TITLE
[system-health]: Make optional-container checks data-driven (generalize otel special-case)

### DIFF
--- a/src/system-health/health_checker/config.py
+++ b/src/system-health/health_checker/config.py
@@ -45,6 +45,7 @@ class Config(object):
         self.ignore_devices = None
         self.user_defined_checkers = None
         self.include_devices = None
+        self.optional_containers = {}
     def config_file_exists(self):
         return os.path.exists(self._config_file)
 
@@ -73,6 +74,7 @@ class Config(object):
                 self.ignore_devices = self._get_list_data('devices_to_ignore')
                 self.user_defined_checkers = self._get_list_data('user_defined_checkers')
                 self.include_devices = self._get_list_data('include_devices')
+                self.optional_containers = self.config_data.get('optional_containers', {})
             except Exception as e:
                 self._reset()
 
@@ -88,6 +90,7 @@ class Config(object):
         self.ignore_devices = None
         self.user_defined_checkers = None
         self.include_devices = None
+        self.optional_containers = {}
 
     def get_led_color(self, status):
         """

--- a/src/system-health/health_checker/config.py
+++ b/src/system-health/health_checker/config.py
@@ -4,6 +4,18 @@ import os
 from sonic_py_common import device_info
 
 
+def sanitize_optional_containers(optional_containers):
+    if not isinstance(optional_containers, dict):
+        return {}
+
+    return {
+        container_name: image_name
+        for container_name, image_name in optional_containers.items()
+        if isinstance(container_name, str) and container_name
+        and isinstance(image_name, str) and image_name
+    }
+
+
 class Config(object):
     """
     Manage configuration of system health.
@@ -74,7 +86,9 @@ class Config(object):
                 self.ignore_devices = self._get_list_data('devices_to_ignore')
                 self.user_defined_checkers = self._get_list_data('user_defined_checkers')
                 self.include_devices = self._get_list_data('include_devices')
-                self.optional_containers = self.config_data.get('optional_containers', {})
+                self.optional_containers = sanitize_optional_containers(
+                    self.config_data.get('optional_containers', {})
+                )
             except Exception as e:
                 self._reset()
 

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -55,6 +55,15 @@ class ServiceChecker(HealthChecker):
     # These containers will be excluded from both expected and running container sets.
     CONTAINER_K8S_WHITELIST = {'telemetry', 'acms', 'restapi'}
 
+    # Containers that are only present in some images. When the docker image that
+    # backs such a container is not part of the build, the container is not
+    # expected to run and is skipped. Maps container name -> docker image name.
+    # Deployments can declare additional optional containers via the
+    # 'optional_containers' object in system_health_monitoring_config.json.
+    OPTIONAL_CONTAINERS = {
+        'otel': 'docker-sonic-otel',
+    }
+
     def __init__(self):
         HealthChecker.__init__(self)
         self.container_critical_processes = {}
@@ -69,11 +78,13 @@ class ServiceChecker(HealthChecker):
 
         self.load_critical_process_cache()
 
-    def get_expected_running_containers(self, feature_table):
+    def get_expected_running_containers(self, feature_table, config=None):
         """Get a set of containers that are expected to running on SONiC
 
         Args:
             feature_table (object): FEATURE table in CONFIG_DB
+            config (object): Health checker configuration (optional). Used to
+                pick up deployment-declared optional containers.
 
         Returns:
             expected_running_containers: A set of container names that are expected running
@@ -81,6 +92,12 @@ class ServiceChecker(HealthChecker):
         """
         expected_running_containers = set()
         container_feature_dict = {}
+
+        # Build the effective optional-container map: the built-in defaults plus
+        # any extras declared by the deployment configuration.
+        optional_containers = dict(ServiceChecker.OPTIONAL_CONTAINERS)
+        if config is not None and getattr(config, 'optional_containers', None):
+            optional_containers.update(config.optional_containers)
 
         # Get current asic presence list. For multi_asic system, multi instance containers
         # should be checked only for asics present.
@@ -116,10 +133,11 @@ class ServiceChecker(HealthChecker):
                     else:
                         container_list.append("gnmi")
                     continue
-            # Some platforms may not include the OTEL container; skip expecting it when image absent
-            if container_name == "otel":
-                if not check_docker_image("docker-sonic-otel"):
-                    logger.log_debug("Ignoring otel container check on image which has no corresponding docker image")
+            # Some platforms may not include an optional container; skip
+            # expecting it when its docker image is absent from this build.
+            if container_name in optional_containers:
+                if not check_docker_image(optional_containers[container_name]):
+                    logger.log_debug("Ignoring {} container check on image which has no corresponding docker image".format(container_name))
                     continue
 
             container_list.append(container_name)
@@ -321,7 +339,7 @@ class ServiceChecker(HealthChecker):
             self.config_db = swsscommon.ConfigDBConnector(use_unix_socket_path=True)
             self.config_db.connect()
         feature_table = self.config_db.get_table("FEATURE")
-        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table)
+        expected_running_containers, self.container_feature_dict = self.get_expected_running_containers(feature_table, config)
         current_running_containers = self.get_current_running_containers()
 
         newly_disabled_containers = set(self.container_critical_processes.keys()).difference(expected_running_containers)

--- a/src/system-health/health_checker/service_checker.py
+++ b/src/system-health/health_checker/service_checker.py
@@ -6,6 +6,7 @@ import re
 from swsscommon import swsscommon
 from sonic_py_common import multi_asic, device_info
 from sonic_py_common.logger import Logger
+from .config import sanitize_optional_containers
 from .health_checker import HealthChecker
 from . import utils
 
@@ -96,8 +97,10 @@ class ServiceChecker(HealthChecker):
         # Build the effective optional-container map: the built-in defaults plus
         # any extras declared by the deployment configuration.
         optional_containers = dict(ServiceChecker.OPTIONAL_CONTAINERS)
-        if config is not None and getattr(config, 'optional_containers', None):
-            optional_containers.update(config.optional_containers)
+        if config is not None:
+            optional_containers.update(
+                sanitize_optional_containers(getattr(config, 'optional_containers', {}))
+            )
 
         # Get current asic presence list. For multi_asic system, multi instance containers
         # should be checked only for asics present.

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -32,7 +32,7 @@ scripts_path = os.path.join(modules_path, 'scripts')
 sys.path.insert(0, modules_path)
 sys.path.insert(0, scripts_path)
 from health_checker import utils
-from health_checker.config import Config
+from health_checker.config import Config, sanitize_optional_containers
 from health_checker.hardware_checker import HardwareChecker
 from health_checker.health_checker import HealthChecker
 from health_checker.manager import HealthCheckerManager
@@ -69,6 +69,54 @@ def no_op(*args, **kwargs):
 def setup():
     if os.path.exists(ServiceChecker.CRITICAL_PROCESS_CACHE):
         os.remove(ServiceChecker.CRITICAL_PROCESS_CACHE)
+
+
+def test_sanitize_optional_containers():
+    assert sanitize_optional_containers(None) == {}
+    assert sanitize_optional_containers(['docker-image']) == {}
+    assert sanitize_optional_containers({
+        'valid': 'docker-valid',
+        'empty-image': '',
+        'null-image': None,
+        '': 'docker-empty-name',
+    }) == {'valid': 'docker-valid'}
+
+
+@patch('sonic_py_common.device_info.is_disaggregated_chassis', MagicMock(return_value=False))
+@patch('sonic_py_common.device_info.is_supervisor', MagicMock(return_value=False))
+@patch('sonic_py_common.multi_asic.is_multi_asic', MagicMock(return_value=False))
+@patch('sonic_py_common.multi_asic.get_asic_presence_list', MagicMock(return_value=[]))
+@patch('health_checker.service_checker.ServiceChecker.load_critical_process_cache', MagicMock())
+@patch('health_checker.service_checker.check_docker_image')
+def test_optional_containers(mock_check_docker_image):
+    feature_table = {
+        container_name: {'state': 'enabled'}
+        for container_name in ('otel', 'missing', 'present', 'invalid', 'regular')
+    }
+    config = Config()
+    config.optional_containers = {
+        'missing': 'docker-missing',
+        'present': 'docker-present',
+        'invalid': None,
+    }
+    mock_check_docker_image.side_effect = lambda image_name: image_name == 'docker-present'
+
+    checker = ServiceChecker()
+    expected, _ = checker.get_expected_running_containers(feature_table, config)
+
+    assert expected == {'present', 'invalid', 'regular'}
+    assert mock_check_docker_image.call_args_list == [
+        call('docker-sonic-otel'),
+        call('docker-missing'),
+        call('docker-present'),
+    ]
+
+    config.optional_containers = ['invalid']
+    expected, _ = checker.get_expected_running_containers(
+        {'configured': {'state': 'enabled'}},
+        config
+    )
+    assert expected == {'configured'}
 
 
 @patch('health_checker.utils.run_command')


### PR DESCRIPTION
#### Why I did it

`ServiceChecker.get_expected_running_containers()` currently hardcodes special
handling for the optional `otel` container. Deployments with another optional
container must add another control-flow block to this shared method, creating
recurring downstream divergence and synchronization conflicts.

This change makes optional-container handling data-driven while preserving the
existing public behavior.

#### How I did it

- Added `ServiceChecker.OPTIONAL_CONTAINERS`, mapping a container name to the
  docker image that indicates whether the container is included:

  ```python
  OPTIONAL_CONTAINERS = {
      'otel': 'docker-sonic-otel',
  }
  ```

- Replaced the hardcoded `otel` branch with a generic lookup in the effective
  optional-container map.
- Added an `optional_containers` object to
  `system_health_monitoring_config.json` through `Config`.
- Merged deployment-configured entries over the built-in defaults and passed
  the active health-monitor configuration into the expected-container lookup.
- Reset `optional_containers` to an empty map when configuration is absent or
  cannot be loaded.

With no new configuration, behavior is unchanged: `otel` is skipped only when
`docker-sonic-otel` is absent. A deployment can add another optional container
without changing `service_checker.py`, for example:

```json
{
  "optional_containers": {
    "example": "docker-sonic-example"
  }
}
```

#### How to verify it

1. Confirm `otel` is skipped when `docker-sonic-otel` is absent and expected
   when the image is present.
2. Configure an additional optional container and confirm it is skipped only
   when its mapped docker image is absent.
3. Confirm containers not present in the effective map are unaffected.
4. Confirm an empty or missing `optional_containers` configuration preserves
   the built-in defaults.

#### Description for the changelog

[system-health]: Make optional-container checks data-driven while preserving
the existing `otel` behavior.