### PR TITLE
[Mellanox] Fix syncd heap-buffer-overflow from SAI metadata missing CPU_PORT

### DIFF
--- a/platform/mellanox/mlnx-sai-metadata.mk
+++ b/platform/mellanox/mlnx-sai-metadata.mk
@@ -1,0 +1,43 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mellanox-only hook: saitypescustom.h from mlnx-sai is copied into
+# sonic-sairedis/SAI/custom/ before parse.pl generates saimetadata.c so
+# SAI_ACL_BIND_POINT_TYPE_CPU_PORT is merged into libsaimetadata.so.
+
+MLNX_SAI_CUSTOM_HEADERS_SCRIPT = $(BUILD_WORKDIR)/$(PLATFORM_PATH)/scripts/sync_mlnx_sai_custom_headers.sh
+MLNX_SAI_CUSTOM_DIR = $(BUILD_WORKDIR)/$($(LIBSAIREDIS)_SRC_PATH)/SAI/custom
+
+# Ensure the mlnx-sai .deb is built before libsairedis so the sync hook can
+# extract saitypescustom.h from it (via dpkg-deb -x). Use _AFTER, not _DEPENDS:
+# the header is only read out of the .deb file, so mlnx-sai must NOT be
+# installed. Installing it here would leave mlnx-sai present (libsairedis has no
+# UNINSTALLS) and deadlock the later libsaivs-dev-install, which conflicts with
+# mlnx-sai. Per platform/mellanox/rules.mk, mlnx-sai is installed only for syncd
+# (which uninstalls it again).
+$(LIBSAIREDIS)_AFTER += $(MLNX_SAI)
+
+# libsairedis (rules/sairedis.mk) and syncd (rules/syncd.mk) each run their own
+# dpkg-buildpackage of the sonic-sairedis source, and both recompile SAI/meta, so
+# both must resolve the "#include <saicustom.h>" that parse.pl emits into the
+# generated saimetadata.h once SAI/custom is non-empty. The shared pre-build env
+# below syncs the vendor custom headers into SAI/custom/, then puts SAI/custom on
+# the include path for the two build steps that need it:
+#   - C/C++ compiles: dpkg-buildflags' CPPFLAGS is on every compile line, so
+#     DEB_CPPFLAGS_MAINT_APPEND appends -I<custom>.
+#   - the pysairedis SWIG step: swig takes its -I from SAIINC (configure.ac), not
+#     CPPFLAGS, but it also honours the SWIG_FEATURES env var, so we inject
+#     -I<custom> there too.
+# This keeps the include-path fix entirely in sonic-buildimage (no sonic-sairedis
+# source change). Absolute paths: the build runs after pushd into sonic-sairedis.
+MLNX_SAI_CUSTOM_BUILD_ENV = $(MLNX_SAI_CUSTOM_HEADERS_SCRIPT) $(BUILD_WORKDIR)/$(DEBS_PATH)/$(MLNX_SAI) $(MLNX_SAI_CUSTOM_DIR) && DEB_CPPFLAGS_MAINT_APPEND="-I$(MLNX_SAI_CUSTOM_DIR)" SWIG_FEATURES="-I$(MLNX_SAI_CUSTOM_DIR)"
+
+$(LIBSAIREDIS)_BUILD_ENV = $(MLNX_SAI_CUSTOM_BUILD_ENV)
+
+# syncd is a second, independent dpkg-buildpackage of the same source, so it
+# needs the identical handling. mlnx-sai is already a _DEPENDS of syncd (per
+# platform/mellanox/rules.mk it is installed for the syncd build, then
+# uninstalled), so its .deb is present for the sync hook to read.
+$(SYNCD)_BUILD_ENV = $(MLNX_SAI_CUSTOM_BUILD_ENV)

--- a/platform/mellanox/rules.mk
+++ b/platform/mellanox/rules.mk
@@ -22,6 +22,7 @@ include $(PLATFORM_PATH)/fw.mk
 include $(PLATFORM_PATH)/mft.mk
 include $(PLATFORM_PATH)/mft-fwtrace-cfg.mk
 include $(PLATFORM_PATH)/mlnx-sai.mk
+include $(PLATFORM_PATH)/mlnx-sai-metadata.mk
 include $(PLATFORM_PATH)/hw-management.mk
 include $(PLATFORM_PATH)/mlnx-platform-api.mk
 include $(PLATFORM_PATH)/docker-syncd-mlnx.mk

--- a/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
+++ b/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copy selected Mellanox vendor custom SAI headers into sonic-sairedis/SAI/custom/
+# before OCP saimetadata.c is generated for libsaimetadata.so.
+#
+# Only headers required for the libsaimetadata / libsai bind-point enum alignment
+# are synced (saitypescustom.h merges SAI_ACL_BIND_POINT_TYPE_CPU_PORT). Full vendor
+# custom headers are intentionally omitted until parse.pl can version them cleanly.
+
+set -euo pipefail
+
+usage()
+{
+    echo "Usage: $0 <mlnx-sai.deb|mlnx-sai.tar.gz> <sonic-sairedis/SAI/custom/>" >&2
+    exit 1
+}
+
+if [ "$#" -ne 2 ]; then
+    usage
+fi
+
+MLNX_SAI_PKG="$1"
+CUSTOM_DIR="$2"
+SAI_META_DIR="$(dirname "$CUSTOM_DIR")/meta"
+
+if [ ! -e "$MLNX_SAI_PKG" ]; then
+    echo "ERROR: mlnx-sai package not found: $MLNX_SAI_PKG" >&2
+    exit 1
+fi
+
+if [ ! -d "$CUSTOM_DIR" ]; then
+    echo "ERROR: custom header directory not found: $CUSTOM_DIR" >&2
+    exit 1
+fi
+
+TMPDIR="$(mktemp -d)"
+cleanup()
+{
+    rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+if [[ "$MLNX_SAI_PKG" == *.deb ]]; then
+    dpkg-deb -x "$MLNX_SAI_PKG" "$TMPDIR"
+    HEADER_SRC="$TMPDIR/usr/include/sai"
+elif [[ "$MLNX_SAI_PKG" == *.tar.gz ]]; then
+    tar -xzf "$MLNX_SAI_PKG" -C "$TMPDIR"
+    if [ -d "$TMPDIR/mlnx_sai/inc/custom" ]; then
+        HEADER_SRC="$TMPDIR/mlnx_sai/inc/custom"
+    elif [ -d "$TMPDIR/inc/custom" ]; then
+        HEADER_SRC="$TMPDIR/inc/custom"
+    else
+        echo "ERROR: could not locate custom headers in tarball: $MLNX_SAI_PKG" >&2
+        exit 1
+    fi
+else
+    echo "ERROR: unsupported mlnx-sai package type: $MLNX_SAI_PKG" >&2
+    exit 1
+fi
+
+# Bind-point fix only: merge sai_acl_bind_point_type_custom_t (CPU_PORT) into OCP metadata.
+MLNX_SAI_METADATA_HEADERS=(
+    saitypescustom.h
+)
+
+headers=()
+missing=()
+for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
+    if [ -f "$HEADER_SRC/$header" ]; then
+        headers+=( "$HEADER_SRC/$header" )
+    else
+        missing+=( "$header" )
+    fi
+done
+
+if [ "${#missing[@]}" -ne 0 ]; then
+    echo "ERROR: required custom SAI headers not found under $HEADER_SRC: ${missing[*]}" >&2
+    exit 1
+fi
+
+# Only now that all required headers are confirmed present, drop stale vendor
+# headers from a previous sync (keep upstream README) and install the new set.
+# Deleting earlier would leave $CUSTOM_DIR empty if validation above failed.
+find "$CUSTOM_DIR" -maxdepth 1 -type f -name '*custom*.h' -delete
+cp -f "${headers[@]}" "$CUSTOM_DIR"/
+
+# parse.pl always emits "#include <saicustom.h>" when custom/ is non-empty. Vendor
+# saicustom.h pulls in every *custom*.h header; write a minimal umbrella instead.
+# Include at least one @flags free enum so Doxygen/parse.pl get a valid sectiondef.
+cat > "$CUSTOM_DIR/saicustom.h" <<'EOF'
+#ifndef __SAICUSTOM_H_
+#define __SAICUSTOM_H_
+
+#include <sai.h>
+#include <saitypes.h>
+#include "saitypescustom.h"
+
+/**
+ * @brief Custom SAI APIs
+ *
+ * @flags free
+ */
+typedef enum _sai_api_custom_t {
+    SAI_API_CUSTOM_RANGE_START = SAI_API_CUSTOM_RANGE_BASE,
+
+    /* Add new custom APIs above this line */
+
+    SAI_API_CUSTOM_RANGE_END
+} sai_api_custom_t;
+
+#endif /* __SAICUSTOM_H_ */
+EOF
+
+echo "Synced ${#headers[@]} Mellanox custom SAI header(s) into $CUSTOM_DIR:"
+for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
+    echo "  $CUSTOM_DIR/$header"
+done
+echo "  $CUSTOM_DIR/saicustom.h (generated minimal umbrella)"
+
+# Force saimetadata regeneration when custom headers change.
+rm -f \
+    "$SAI_META_DIR/saimetadata.c" \
+    "$SAI_META_DIR/saimetadata.h" \
+    "$SAI_META_DIR/saimetadatasize.h" \
+    "$SAI_META_DIR/saimetadatatest.c"

--- a/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
+++ b/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
@@ -89,15 +89,23 @@ find "$CUSTOM_DIR" -maxdepth 1 -type f -name '*custom*.h' -delete
 cp -f "${headers[@]}" "$CUSTOM_DIR"/
 
 # parse.pl always emits "#include <saicustom.h>" when custom/ is non-empty. Vendor
-# saicustom.h pulls in every *custom*.h header; write a minimal umbrella instead.
+# saicustom.h pulls in every *custom*.h header, which OCP parse.pl cannot version
+# cleanly; write a minimal umbrella instead. The custom #include lines are generated
+# from MLNX_SAI_METADATA_HEADERS so the umbrella can never drift from the curated set
+# that is actually synced above (add a header to that array and it is included here).
 # Include at least one @flags free enum so Doxygen/parse.pl get a valid sectiondef.
-cat > "$CUSTOM_DIR/saicustom.h" <<'EOF'
+{
+    cat <<'EOF'
 #ifndef __SAICUSTOM_H_
 #define __SAICUSTOM_H_
 
 #include <sai.h>
 #include <saitypes.h>
-#include "saitypescustom.h"
+EOF
+    for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
+        echo "#include \"$header\""
+    done
+    cat <<'EOF'
 
 /**
  * @brief Custom SAI APIs
@@ -114,6 +122,7 @@ typedef enum _sai_api_custom_t {
 
 #endif /* __SAICUSTOM_H_ */
 EOF
+} > "$CUSTOM_DIR/saicustom.h"
 
 echo "Synced ${#headers[@]} Mellanox custom SAI header(s) into $CUSTOM_DIR:"
 for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do


### PR DESCRIPTION
#### Why I did it
ASAN-enabled `syncd` aborts with a heap-buffer-overflow when creating an ACL table on Mellanox
    AddressSanitizer: heap-buffer-overflow ... READ of size 24
      #0 memcpy
      #1 (libsai.so.0)
      #4 check_attribs_metadata              (libsai.so.0)
      #5 check_attribs_on_create_without_oid (libsai.so.0)
      #6 mlnx_create_acl_table              (libsai.so.0)
      #7 syncd::VendorSai::create           (syncd/VendorSai.cpp:223)
      #8 syncd::Syncd::processOidCreate     (syncd/Syncd.cpp:3742)
    0x... is located 0 bytes after 20-byte region allocated by calloc()
    in check_attribs_metadata (libsai.so.0)
**Root cause:** SONiC generates the SAI metadata (`libsaimetadata`) from the OCP headers only, dropping the vendor `SAI/custom` folder. As a result `sai_acl_bind_point_type_t` is emitted without `SAI_ACL_BIND_POINT_TYPE_CPU_PORT`:
    sai_metadata_enum_sai_acl_bind_point_type_t.valuescount == 5
        // PORT, LAG, VLAN, ROUTER_INTERFACE, SWITCH   (CPU_PORT missing)
The vendor SAI (36.0.14+) defines a sixth value, `CPU_PORT`, and the vendor `libsai` is linked against this SONiC-generated `libsaimetadata` inside `syncd`, so the two disagree on the enum size. `libsai` sizes a scratch array from the undersized metadata:
    dyn_attrs = calloc(enum_metadata->valuescount, sizeof(*dyn_attrs));
which reserves room for 5 entries (the 20-byte region above) but then walks the full vendor enum space including `CPU_PORT`, touching the 6th entry past the end of the allocation → heap-buffer-overflow. The defect is not a 1.17/1.18 header mix as first suspected; it is SONiC building its metadata without the custom headers, leaving it out of sync with the vendor SAI.

##### Work item tracking
- Microsoft ADO **(number only)**: <!-- add ADO number here -->
- 
#### How I did it
Compile the `sonic-sairedis` metadata WITH the Mellanox custom headers so the generated enum space matches the vendor SAI (6 values, including `CPU_PORT`). Keep the logic in `sonic-buildimage` and touch the `sonic-sairedis` submodule only where packaging genuinely requires it:
- Add a Mellanox-only build hook (`platform/mellanox/mlnx-sai-metadata.mk` and `scripts/sync_mlnx_sai_custom_headers.sh`) that, before `sonic-sairedis` is built, extracts `saitypescustom.h` from the `mlnx-sai` `.deb` into `sonic-sairedis/SAI/custom/` and generates a minimal `saicustom.h` umbrella, so `parse.pl` merges the custom enums into the generated `saimetadata`.
- Build `mlnx-sai` before `libsairedis` with `_AFTER`, not `_DEPENDS`: the header is only read out of the `.deb`, so `mlnx-sai` must not be installed here. Installing it would leave it resident (`libsairedis` has no `UNINSTALLS`) and deadlock the later `libsaivs-dev` install, which conflicts with `mlnx-sai`.
- Once `SAI/custom` is populated, `parse.pl` emits `#include <saicustom.h>` into the generated `saimetadata.h`. Put `SAI/custom` on the include path for the two build steps that consume it — C/C++ compiles via `DEB_CPPFLAGS_MAINT_APPEND` and the `pysairedis` SWIG step via `SWIG_FEATURES` (swig takes its `-I` from `SAIINC` and ignores `CPPFLAGS`) — for both the `libsairedis` and `syncd` `dpkg-buildpackage` runs, since `syncd` is a second, independent build of the same source. This avoids a build-time patch of `sonic-sairedis`' `configure.ac`.
- Ship the synced custom headers in `libsaivs-dev` (via `sonic-sairedis` `debian/rules`, pulled in through the submodule bump) so downstream consumers of the public `saimetadata.h`, e.g. `sonic-swss`, can resolve the include. `libsaivs-dev` conflicts with `mlnx-sai`, so there is no `/usr/include/sai/saicustom.h` overwrite clash, and the install is guarded on header presence so non-Mellanox builds are unaffected.
- 
#### How to verify it
This issue can be verified with the following test command (sonic-mgmt):

```
PYTHONPATH=/devts/ /ngts_venv/bin/pytest \
  ngts/tests/nightly/rocev2_acl_counter/test_rocev2_acl_counter.py::TestRocev2AclCounter::test_rocev2_acl_counter[physical] \
  --setup_name=<setup> \
  --rootdir=/root/mars/workspace/sonic-mgmt/ngts \
  -c /root/mars/workspace/sonic-mgmt/ngts/pytest.ini \
  --log-level=INFO --showlocals --timeout 3600 --session-timeout 3600
```

Additionally, simply running `sudo config acl add table ASAN_REPRO L3 -p Ethernet128 -s ingress` is enough to repro the issue. You can then check for ASAN results with `sudo cat /var/log/asan/syncd-asan.log.*`.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605

This is a memory issue that could lead to unpredictable behavior of our software, and potentially even security issues.

#### Tested branch (Please provide the tested image version)
- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
[mellanox] Build SAI metadata with vendor custom headers so `sai_acl_bind_point_type_t` includes `CPU_PORT`, fixing a `syncd` heap-buffer-overflow (ASAN) on ACL table create.
#### Link to config_db schema for YANG module changes
N/A — no YANG / config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)
