### PR TITLE
Fix to copy the bmc.json file Early in First boot up after sonic install.

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -510,18 +510,6 @@ if [[ -f "$PLATFORM_ENV_CONF_FILE" ]]; then
     source $PLATFORM_ENV_CONF_FILE
 fi
 
-# On BMC/Switch-Host platforms, copy bmc.json to /etc/sonic/.
-# Platform-specific bmc.json takes priority over the image-wide template.
-if [[ "${switch_bmc}" == "1" || "${switch_host}" == "1" ]]; then
-    PLATFORM_BMC_JSON="/usr/share/sonic/device/$PLATFORM/bmc.json"
-    TEMPLATE_BMC_JSON="/usr/share/sonic/templates/bmc.json"
-    if [[ -f "$PLATFORM_BMC_JSON" ]]; then
-        cp "$PLATFORM_BMC_JSON" /etc/sonic/bmc.json
-    elif [[ -f "$TEMPLATE_BMC_JSON" ]]; then
-        cp "$TEMPLATE_BMC_JSON" /etc/sonic/bmc.json
-    fi
-fi
-
 CMD=$1
 # Default command is boot
 if [ "$CMD" = "" ] || [ "$CMD" = "help" ] || \

--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -219,6 +219,33 @@ request_dpu_midplane_ip()
     fi
 }
 
+# On Switch-BMC/Switch-Host systems, copy bmc.json to /etc/sonic.
+# docker-database-init.sh reads /etc/sonic/bmc.json to bind the BMC-side redis
+# instance to the BMC<->Switch-Host link IP. config-setup also copies this file,
+# but it runs *after* the database service, so on a fresh boot redis binds only
+# to loopback until the database is restarted (sonic-net/sonic-buildimage#28367).
+# rc-local.service runs before database.service, so doing the copy here ensures
+# the file is present before the database container starts.
+copy_bmc_json()
+{
+    PLATFORM_ENV_CONF="/usr/share/sonic/device/$platform/platform_env.conf"
+    if [ -f "$PLATFORM_ENV_CONF" ]; then
+        switch_bmc=""
+        switch_host=""
+        . "$PLATFORM_ENV_CONF"
+
+        if [ "$switch_bmc" = "1" ] || [ "$switch_host" = "1" ]; then
+            PLATFORM_BMC_JSON="/usr/share/sonic/device/$platform/bmc.json"
+            TEMPLATE_BMC_JSON="/usr/share/sonic/templates/bmc.json"
+            if [ -f "$PLATFORM_BMC_JSON" ]; then
+                cp "$PLATFORM_BMC_JSON" /etc/sonic/bmc.json
+            elif [ -f "$TEMPLATE_BMC_JSON" ]; then
+                cp "$TEMPLATE_BMC_JSON" /etc/sonic/bmc.json
+            fi
+        fi
+    fi
+}
+
 #### Begin Main Body ####
 
 logger "SONiC version ${SONIC_VERSION} starting up..."
@@ -265,6 +292,9 @@ if /usr/bin/jq -e 'has("DPU")' /usr/share/sonic/device/$platform/platform.json 2
     echo "DPU type detected. Requesting IP ..."
     request_dpu_midplane_ip
 fi
+
+# Copy bmc.json early enough so that services can use it
+copy_bmc_json
 
 if [ -f $FIRST_BOOT_FILE ]; then
 


### PR DESCRIPTION

#### Why I did it
Fixes race condition issue seen at random on first boot alone. The bmc.json is copied either from the file in **platform/bmc.json**  or from sonic wide global **files/image_config/constants/bmc.json**. This is used in database docker to bind the redis serer to this IP as well .. so that eg: switch-host can talk to BMC

Fixes issue #https://github.com/sonic-net/sonic-buildimage/issues/28367


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Moved the activity to copy bmc.json file from config-setup service (which could start at the same time as database service to rc.local service which starts early and gets completed before database.service starts.

#### How to verify it
Remove /etc/sonic/bmc.json file 
Reboot the BMC

Find that redis is listening on loopback abd internal bmc link IP 
```
admin@host1-remote-bmc:~$ docker exec database cat /etc/supervisor/conf.d/supervisord.conf | grep -A2 'program:redis'   
[program:redis]
command=/bin/bash -c "{ [[ -s /var/lib/redis/dump.rdb ]] || rm -f /var/lib/redis/dump.rdb; } && mkdir -p /var/lib/redis && for ((i=0; i<300; i++)); do ip -o -4 addr show dev bmc0 up 2>/dev/null | grep -q 'inet 169.254.100.1/' && break; sleep 1; done; ip -o -4 addr show dev bmc0 up 2>/dev/null | grep -q 'inet 169.254.100.1/' || { echo 'Timed out waiting for bmc0 to be configured with 169.254.100.1' >&2; exit 1; } && exec /usr/bin/redis-server /etc/redis/redis.conf --bind  127.0.0.1 169.254.100.1 --port 6379 --unixsocket /var/run/redis/redis.sock --pidfile /var/run/redis/redis.pid --dir /var/lib/redis --protected-mode no"
priority=2

admin@host1-remote-bmc:~$ ss -ltnp | grep :6379
LISTEN 0      511    169.254.100.1:6379      0.0.0.0:*          
LISTEN 0      511        127.0.0.1:6379      0.0.0.0:*          
admin@host1-remote-bmc:~$ 
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

