### PR TITLE
Fix docker-orchagent/docker-init.j2 ENABLE_ASAN templating.

### DIFF
--- a/dockers/docker-orchagent/docker-init.j2
+++ b/dockers/docker-orchagent/docker-init.j2
@@ -8,9 +8,10 @@ mkdir -p /dev/shm/supervisor/
 CFGGEN_PARAMS=" \
     -d \
 {% if ENABLE_ASAN == "y" %}
-     -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\"}" \
-{% endif %}
+    -a "{\"ENABLE_ASAN\":\"{{ENABLE_ASAN}}\",\"ASIC_VENDOR\":\"${ASIC_VENDOR:-unknown}\"}" \
+{% else %}
     -a "{\"ASIC_VENDOR\":\"${ASIC_VENDOR:-unknown}\"}" \
+{% endif %}
     -y /etc/sonic/constants.yml \
     -t /usr/share/sonic/templates/orch_zmq_tables.conf.j2,/etc/swss/orch_zmq_tables.conf \
     -t /usr/share/sonic/templates/switch.json.j2,/etc/swss/config.d/switch.json \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

On ASAN images, `docker-orchagent/docker-init.j2` passed separate `-a` JSON blobs to `sonic-cfggen`; the `ASIC_VENDOR` argument overwrote `ENABLE_ASAN`, so supervisord never rendered the `ASAN_OPTIONS` log paths for swss processes. ASAN-instrumented binaries still ran, but reports did not land under `/var/log/asan/`, making failures hard to detect.

Tracked in https://github.com/sonic-net/sonic-buildimage/issues/28279

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
- Merge `ENABLE_ASAN` and `ASIC_VENDOR` into a single `-a` JSON object when ASAN is enabled; pass only `ASIC_VENDOR` otherwise.

#### How to verify it
1. Build or deploy an ASAN image (`ENABLE_ASAN=y`).
2. Start the swss/orchagent container and inspect `/etc/supervisor/conf.d/supervisord.conf`.
3. Confirm swss programs include `ASAN_OPTIONS` with `log_path=/var/log/asan/...` entries.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] 202605

#### Description for the changelog
Fix orchagent docker ENABLE_ASAN templating so ASAN logs are written to `/var/log/asan/`.

Fixes bug mentioned in https://github.com/sonic-net/sonic-buildimage/issues/28279

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->
