### PR TITLE
[Nvidia-Bluefield] Change installer to detect issues during bfb install

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_bfb_installer/dump_receiver.py
+++ b/platform/mellanox/platform-utils/mellanox_bfb_installer/dump_receiver.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Ephemeral HTTP server that receives diagnostic dump uploads from DPUs over the
+per-install tmfifo bridge during a sonic-bfb-installer run.
+
+Endpoint shape (PUT or POST, with the file as the raw request body):
+    /<dpu_name>/<filename>
+
+Files are saved to ``<output_dir>/<dpu_name>/<filename>``. ``<dpu_name>`` must
+match ``dpu<digits>`` and ``<filename>`` must be a single safe basename
+(no path separators, no parent refs). Anything else returns HTTP 400.
+
+The server is intentionally minimal:
+    * No authentication. It is meant to listen only on the internal tmfifo
+      bridge IP (e.g. 192.168.100.254), reachable solely by attached DPUs
+      during installation.
+    * Single-process, threaded request handler.
+    * Bounded by ``--max-bytes`` per upload (default 256 MiB) to avoid
+      runaway writes on bad input.
+    * SIGTERM / SIGINT trigger a clean shutdown.
+
+Run as a module:
+    python3 -m mellanox_bfb_installer.dump_receiver \\
+        --bind-ip 192.168.100.254 --port 8090 \\
+        --output-dir /var/log/sonic-bfb-installer/dumps
+"""
+
+import argparse
+import logging
+import os
+import re
+import signal
+import socket
+import sys
+import threading
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Optional, Tuple
+
+
+DEFAULT_BIND_IP = "192.168.100.254"
+DEFAULT_PORT = 8090
+DEFAULT_OUTPUT_DIR = "/var/log/sonic-bfb-installer/dumps"
+DEFAULT_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB
+READ_CHUNK_SIZE = 64 * 1024
+# Per-read socket timeout for the request body. Prevents a client that sends
+# headers and then stalls from blocking a handler thread indefinitely.
+BODY_READ_TIMEOUT_SEC = 30
+
+# A DPU name like "dpu0", "dpu12". This must match the convention used by
+# device_selection / main._dpu_name_to_id.
+_DPU_NAME_RE = re.compile(r"^dpu\d+$")
+# A filename must be a single basename: no path separators, no parent refs,
+# no leading dot. Allow letters, digits, dot, dash, underscore.
+_FILENAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+
+
+logger = logging.getLogger("dump_receiver")
+
+
+def _parse_target_path(url_path: str) -> Tuple[str, str]:
+    """Validate and split ``/<dpu_name>/<filename>`` from the request URL.
+
+    Returns (dpu_name, filename). Raises ValueError on any malformed input.
+    """
+    # Strip query string / fragment defensively even though we don't use them.
+    path = url_path.split("?", 1)[0].split("#", 1)[0]
+    if not path.startswith("/"):
+        raise ValueError("path must start with '/'")
+    parts = path.lstrip("/").split("/")
+    if len(parts) != 2:
+        raise ValueError("expected /<dpu_name>/<filename>")
+    dpu_name, filename = parts
+    if not _DPU_NAME_RE.match(dpu_name):
+        raise ValueError(f"invalid dpu name: {dpu_name!r}")
+    if not _FILENAME_RE.match(filename):
+        raise ValueError(f"invalid filename: {filename!r}")
+    return dpu_name, filename
+
+
+class _DumpReceiverConfig:
+    """Server-wide config that the handler instances read."""
+
+    def __init__(self, output_dir: str, max_bytes: int) -> None:
+        self.output_dir = output_dir
+        self.max_bytes = max_bytes
+
+
+class _DumpReceiverHandler(BaseHTTPRequestHandler):
+    # Attached by the server factory below.
+    receiver_config: Optional[_DumpReceiverConfig] = None
+
+    # Keep the canned protocol so 1.1 keepalive isn't attempted; each upload
+    # is a one-shot connection from curl in the BFB installer's ex_chroot.
+    protocol_version = "HTTP/1.0"
+
+    server_version = "sonic-bfb-installer-dump-receiver/1.0"
+
+    # ---- Logging ----------------------------------------------------------
+
+    def log_message(self, format: str, *args) -> None:  # noqa: A002 - stdlib API
+        # Route the access log through the module logger so the parent
+        # process's logging pipeline picks it up via stdout/stderr.
+        logger.info("%s - - %s", self.client_address[0], format % args)
+
+    # ---- Helpers ----------------------------------------------------------
+
+    def _reply(self, status: HTTPStatus, body: str = "") -> None:
+        body_bytes = body.encode("utf-8") if body else b""
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(body_bytes)))
+            self.send_header("Connection", "close")
+            self.end_headers()
+            if body_bytes:
+                self.wfile.write(body_bytes)
+        except (BrokenPipeError, ConnectionResetError):
+            # Client (DPU curl) hung up. Nothing actionable.
+            pass
+
+    def _save_upload(self) -> None:
+        cfg = self.receiver_config
+        assert cfg is not None  # set by server factory
+
+        try:
+            dpu_name, filename = _parse_target_path(self.path)
+        except ValueError as e:
+            self._reply(HTTPStatus.BAD_REQUEST, f"bad target path: {e}\n")
+            return
+
+        # Content-Length is required so we can enforce the size cap up front
+        # and read exactly the right number of bytes.
+        cl_header = self.headers.get("Content-Length")
+        if cl_header is None:
+            self._reply(HTTPStatus.LENGTH_REQUIRED, "Content-Length required\n")
+            return
+        try:
+            content_length = int(cl_header)
+        except ValueError:
+            self._reply(HTTPStatus.BAD_REQUEST, "invalid Content-Length\n")
+            return
+        if content_length < 0:
+            self._reply(HTTPStatus.BAD_REQUEST, "negative Content-Length\n")
+            return
+        if content_length > cfg.max_bytes:
+            self._reply(
+                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                f"upload too large ({content_length} > {cfg.max_bytes})\n",
+            )
+            return
+
+        dest_dir = os.path.join(cfg.output_dir, dpu_name)
+        try:
+            os.makedirs(dest_dir, mode=0o755, exist_ok=True)
+        except OSError as e:
+            logger.error("mkdir failed for %s: %s", dest_dir, e)
+            self._reply(HTTPStatus.INTERNAL_SERVER_ERROR, "mkdir failed\n")
+            return
+
+        dest_path = os.path.join(dest_dir, filename)
+        # Belt-and-suspenders: confirm the resolved destination stays under
+        # the configured output directory.
+        out_real = os.path.realpath(cfg.output_dir)
+        dest_real = os.path.realpath(dest_path)
+        if not (dest_real == out_real or dest_real.startswith(out_real + os.sep)):
+            logger.error("rejecting escape attempt: dest=%s base=%s", dest_real, out_real)
+            self._reply(HTTPStatus.BAD_REQUEST, "invalid destination\n")
+            return
+
+        tmp_path = dest_path + ".part"
+        bytes_remaining = content_length
+        # Bound each body read so a stalled client can't hold a handler thread forever.
+        self.connection.settimeout(BODY_READ_TIMEOUT_SEC)
+        try:
+            with open(tmp_path, "wb") as f:
+                while bytes_remaining > 0:
+                    chunk = self.rfile.read(min(READ_CHUNK_SIZE, bytes_remaining))
+                    if not chunk:
+                        raise ConnectionError("short read from client")
+                    f.write(chunk)
+                    bytes_remaining -= len(chunk)
+                f.flush()
+                try:
+                    os.fsync(f.fileno())
+                except OSError:
+                    pass
+            os.replace(tmp_path, dest_path)
+        except (ConnectionError, OSError, socket.timeout) as e:
+            logger.error(
+                "upload failed dpu=%s file=%s client=%s err=%s",
+                dpu_name,
+                filename,
+                self.client_address[0],
+                e,
+            )
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            self._reply(HTTPStatus.INTERNAL_SERVER_ERROR, f"write failed: {e}\n")
+            return
+
+        logger.info(
+            "saved upload dpu=%s file=%s bytes=%d client=%s dest=%s",
+            dpu_name,
+            filename,
+            content_length,
+            self.client_address[0],
+            dest_path,
+        )
+        self._reply(HTTPStatus.CREATED, f"ok: {dest_path}\n")
+
+    # ---- HTTP method dispatch --------------------------------------------
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib API
+        self._save_upload()
+
+    def do_PUT(self) -> None:  # noqa: N802 - stdlib API
+        self._save_upload()
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API
+        # Allow a trivial GET / for liveness checks. We don't expose listings.
+        if self.path == "/" or self.path == "":
+            self._reply(HTTPStatus.OK, "dump-receiver ok\n")
+            return
+        self._reply(HTTPStatus.NOT_FOUND, "not found\n")
+
+
+class _ReuseAddrThreadingHTTPServer(ThreadingHTTPServer):
+    """Bind to AF_INET with SO_REUSEADDR so quick restarts (test/CI, retries)
+    don't fail with EADDRINUSE on the previous socket's TIME_WAIT.
+
+    Avoids mutating ``ThreadingHTTPServer`` class attributes globally.
+    """
+
+    address_family = socket.AF_INET
+    allow_reuse_address = True
+
+
+def _build_server(
+    *, bind_ip: str, port: int, output_dir: str, max_bytes: int
+) -> ThreadingHTTPServer:
+    """Construct the HTTP server. Output dir is created if missing."""
+    os.makedirs(output_dir, mode=0o755, exist_ok=True)
+
+    handler_cls = type(
+        "DumpReceiverHandlerInstance",
+        (_DumpReceiverHandler,),
+        {"receiver_config": _DumpReceiverConfig(output_dir, max_bytes)},
+    )
+    return _ReuseAddrThreadingHTTPServer((bind_ip, port), handler_cls)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="sonic-bfb-installer dump-receiver",
+        description="HTTP receiver for DPU diagnostic dumps over tmfifo (ephemeral, used by sonic-bfb-installer).",
+    )
+    parser.add_argument("--bind-ip", default=DEFAULT_BIND_IP)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument(
+        "--max-bytes",
+        type=int,
+        default=DEFAULT_MAX_BYTES,
+        help="Per-upload size cap in bytes (default 256 MiB).",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="dump-receiver: %(message)s",
+        stream=sys.stderr,
+    )
+
+    try:
+        server = _build_server(
+            bind_ip=args.bind_ip,
+            port=args.port,
+            output_dir=args.output_dir,
+            max_bytes=args.max_bytes,
+        )
+    except OSError as e:
+        logger.error(
+            "failed to bind %s:%d: %s", args.bind_ip, args.port, e
+        )
+        return 1
+
+    logger.info(
+        "listening on %s:%d, saving to %s (max %d bytes/upload)",
+        args.bind_ip,
+        args.port,
+        args.output_dir,
+        args.max_bytes,
+    )
+
+    stop_event = threading.Event()
+
+    def _shutdown(_signum=None, _frame=None) -> None:
+        if stop_event.is_set():
+            return
+        stop_event.set()
+        # serve_forever() must be stopped from a thread other than the
+        # request-handling thread.
+        threading.Thread(target=server.shutdown, daemon=True).start()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+    try:
+        signal.signal(signal.SIGHUP, _shutdown)
+    except (AttributeError, ValueError):
+        # Some environments (Windows, threaded reload) don't have SIGHUP.
+        pass
+
+    try:
+        server.serve_forever(poll_interval=0.5)
+    finally:
+        server.server_close()
+        logger.info("dump receiver stopped")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/mellanox/platform-utils/mellanox_bfb_installer/main.py
+++ b/platform/mellanox/platform-utils/mellanox_bfb_installer/main.py
@@ -26,10 +26,12 @@ import fcntl
 import logging
 import logging.handlers
 import os
+import re
+import subprocess
 import sys
 import tempfile
 import time
-from typing import Dict, List, Optional
+from typing import Iterator, List, Optional
 
 
 from mellanox_bfb_installer import bfb_file
@@ -37,9 +39,19 @@ from mellanox_bfb_installer import device_selection
 from mellanox_bfb_installer import install_executor
 from mellanox_bfb_installer import bfb_install_core
 from mellanox_bfb_installer import platform_dpu
+from mellanox_bfb_installer import tmfifo_bridge
 
 SCRIPT_NAME = "sonic-bfb-installer"
 LOCK_FILE = "/var/lock/sonic-bfb-installer.lock"
+
+# Ephemeral DPU diagnostic-dump receiver (over tmfifo). Constants used both
+# here (to start the receiver) and inside the per-DPU bf.cfg so the
+# in-installer recovery path knows where to POST its mstdump to.
+DUMP_BRIDGE_NAME = "bridge-tmfifo"
+DUMP_BRIDGE_CIDR = "192.168.100.254/24"
+DUMP_RECEIVER_BIND_IP = "192.168.100.254"
+DUMP_RECEIVER_PORT = 8090
+DUMP_OUTPUT_DIR_DEFAULT = "/var/log/sonic-bfb-installer/dumps"
 
 logger: Optional[logging.Logger] = logging.getLogger(SCRIPT_NAME)
 
@@ -129,6 +141,7 @@ USAGE_ARGUMENTS = """Arguments:
 -s|--skip-extract\tSkip extracting the bfb image
 -v|--verbose\t\tVerbose installation result output
 -c|--config\t\tConfig file
+--debug-shell\t\tOn DPU-side installer command failure, drop into an interactive recovery shell
 -h|--help\t\tHelp"""
 
 
@@ -138,27 +151,62 @@ def print_usage() -> None:
     click.echo(USAGE_ARGUMENTS)
 
 
-def _generate_additional_config_lines() -> str:
-    """Generate additional config lines."""
+def _dpu_name_to_id(dpu_name: str) -> int:
+    """Convert a DPU name (e.g. 'dpu0', 'dpu12') to its numeric DPU ID."""
+    match = re.fullmatch(r"dpu(\d+)", dpu_name)
+    if not match:
+        raise ValueError(f"Cannot extract DPU ID from DPU name: {dpu_name!r}")
+    return int(match.group(1))
+
+
+def _generate_additional_config_lines(
+    target: device_selection.TargetInfo,
+    debug_shell: bool = False,
+    collect_dump_on_failure: bool = False,
+    dump_upload_base_url: Optional[str] = None,
+) -> str:
+    """Generate additional config lines for a specific target DPU."""
+    lines = []
     # Used by DPU to roughly set the clock after installation to a recent value from the NPU.
-    return f"NPU_TIME={int(time.time())}\n"
+    lines.append(f"NPU_TIME={int(time.time())}\n")
+    # Used by the in-DPU installer to compute the per-DPU tmfifo0 recovery address
+    # (192.168.100.{1+DPU_ID}/24); see platform/nvidia-bluefield/installer/install.sh.j2.
+    lines.append(f"DPU_ID={_dpu_name_to_id(target.dpu)}\n")
+    if debug_shell:
+        # When set, the DPU-side installer drops into an interactive recovery bash on
+        # chroot command failure; see ex_chroot in install.sh.j2.
+        lines.append("DEBUG_SHELL=true\n")
+    if collect_dump_on_failure != bool(dump_upload_base_url):
+        raise ValueError(
+            "dump_upload_base_url is only allowed, and must be given, "
+            "when collect_dump_on_failure is True"
+        )
+    if collect_dump_on_failure and dump_upload_base_url:
+        # Tells the DPU-side ex_chroot failure handler to collect platform-dump.sh
+        # output (including mstdump) and PUT it to the NPU's ephemeral HTTP receiver
+        # over the tmfifo bridge; see ex_chroot in install.sh.j2.
+        lines.append("COLLECT_DUMP_ON_FAILURE=true\n")
+        lines.append(f"DUMP_UPLOAD_BASE_URL={dump_upload_base_url}\n")
+    return "".join(lines)
 
 
 def _add_additional_config_lines(
-    targets: List[device_selection.TargetInfo], temp_config_lines: str, tempdir: str
+    targets: List[device_selection.TargetInfo],
+    tempdir: str,
+    debug_shell: bool = False,
+    collect_dump_on_failure: bool = False,
+    dump_upload_base_url: Optional[str] = None,
 ) -> None:
     """Update the targets to use temporary copies of the config files with additional content.
 
-    For each config file encountered (by path), create a temp copy with original contents plus
-    temp_config_lines, and update the target to use the new path. If the config file at a given
-    path has already been processed, re-use the existing temp copy. If the config file is None,
-    create an empty temp copy and append the additional lines.
+    For each target, create a temp copy of its config file with the original contents plus
+    DPU-specific additional lines (from _generate_additional_config_lines), and update the
+    target to use the new path. If the config file is None, create an empty temp copy and
+    append the additional lines. Targets that share a config_path each get a distinct temp
+    file since the additional lines vary per-DPU.
     """
-    processed_configs: Dict[Optional[str], str] = {}
-    for target in targets:
+    for idx, target in enumerate(targets):
         config_path = target.config_path
-        if config_path in processed_configs:
-            continue
         base = os.path.basename(config_path) if config_path else "empty-config"
         fd, new_path = tempfile.mkstemp(suffix="", prefix=f"{base}.", dir=tempdir)
         with os.fdopen(fd, "w") as f:
@@ -166,17 +214,98 @@ def _add_additional_config_lines(
                 with open(config_path, "r") as orig:
                     f.write(orig.read())
             f.write("\n")
-            f.write(temp_config_lines)
+            f.write(
+                _generate_additional_config_lines(
+                    target,
+                    debug_shell=debug_shell,
+                    collect_dump_on_failure=collect_dump_on_failure,
+                    dump_upload_base_url=dump_upload_base_url,
+                )
+            )
             f.write("\n")
-        processed_configs[config_path] = new_path
-    for idx, target in enumerate(targets):
         targets[idx] = device_selection.TargetInfo(
             dpu=target.dpu,
             rshim=target.rshim,
             dpu_pci_bus_id=target.dpu_pci_bus_id,
             rshim_pci_bus_id=target.rshim_pci_bus_id,
-            config_path=processed_configs[target.config_path],  # Replacing
+            config_path=new_path,
         )
+
+
+@contextmanager
+def _dump_receiver_subprocess(
+    output_dir: str,
+    bind_ip: str = DUMP_RECEIVER_BIND_IP,
+    port: int = DUMP_RECEIVER_PORT,
+    verbose: bool = False,
+) -> Iterator[Optional[subprocess.Popen]]:
+    """Run the dump_receiver as a child process for the lifetime of the block.
+
+    Started after the tmfifo bridge is up so the bind IP exists. SIGTERMed on
+    exit; SIGKILL fallback after a short grace period. We never let receiver
+    issues abort the actual BFB install — we log and continue with proc=None.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "mellanox_bfb_installer.dump_receiver",
+        "--bind-ip",
+        bind_ip,
+        "--port",
+        str(port),
+        "--output-dir",
+        output_dir,
+    ]
+    if verbose:
+        cmd.append("--verbose")
+    logger.info("Starting DPU dump receiver: %s", " ".join(cmd))
+
+    proc: Optional[subprocess.Popen] = None
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            # Inherit our stdout/stderr so the receiver's logs flow through
+            # the same console + syslog pipeline as the parent.
+            stdout=None,
+            stderr=None,
+        )
+    except OSError as e:
+        logger.warning(
+            "Could not start DPU dump receiver: %s. Continuing without auto-dump collection.",
+            e,
+        )
+        yield None
+        return
+
+    # Give it a moment to bind so DPUs that fail their first ex_chroot don't
+    # race the receiver coming up.
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        logger.warning(
+            "DPU dump receiver exited immediately with code %s; continuing without it.",
+            proc.returncode,
+        )
+        yield None
+        return
+
+    try:
+        yield proc
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "DPU dump receiver did not exit after SIGTERM; sending SIGKILL"
+                )
+                proc.kill()
+                try:
+                    proc.wait(timeout=2.0)
+                except subprocess.TimeoutExpired:
+                    logger.error("DPU dump receiver process %s could not be killed", proc.pid)
+        logger.info("DPU dump receiver stopped")
 
 
 def _install_on_dpus(
@@ -187,10 +316,21 @@ def _install_on_dpus(
     verbose: bool,
     configs: Optional[str],
     temp_work_dir: str,
+    debug_shell: bool = False,
+    collect_dump_on_failure: bool = False,
+    dump_output_dir: str = DUMP_OUTPUT_DIR_DEFAULT,
 ) -> None:
     """Install BFB image on DPUs connected to the host, including all preparatory steps, reset, etc.
 
     bfb_path is the prepared BFB path; work_dir is used for per-device result files.
+
+    When ``collect_dump_on_failure`` is True, an ephemeral host bridge
+    (``bridge-tmfifo`` @ ``192.168.100.254/24``) and HTTP dump receiver are
+    started before the parallel install kicks off and torn down on the way
+    out, success or failure. The DPU-side installer (install.sh.j2) uses the
+    matching ``COLLECT_DUMP_ON_FAILURE`` / ``DUMP_UPLOAD_BASE_URL`` values in
+    its bf.cfg to POST mstdump-bearing tarballs back to that receiver if its
+    chroot install steps fail.
     """
     # Turn the user-provided parameters into a concrete list of dpus/devices/configs.
     # Then do the parallel installations.
@@ -203,8 +343,19 @@ def _install_on_dpus(
         print_usage_callback=print_usage,
     )
 
-    additional_config_lines = _generate_additional_config_lines()
-    _add_additional_config_lines(targets, additional_config_lines, temp_work_dir)
+    dump_upload_base_url: Optional[str] = None
+    if collect_dump_on_failure:
+        dump_upload_base_url = (
+            f"http://{DUMP_RECEIVER_BIND_IP}:{DUMP_RECEIVER_PORT}"
+        )
+
+    _add_additional_config_lines(
+        targets,
+        temp_work_dir,
+        debug_shell=debug_shell,
+        collect_dump_on_failure=collect_dump_on_failure,
+        dump_upload_base_url=dump_upload_base_url,
+    )
 
     def _install_one_dpu(idx: int, child_pids: install_executor.PidCollection) -> int:
         target = targets[idx]
@@ -222,6 +373,34 @@ def _install_on_dpus(
             child_pids=child_pids,
         )
 
+    # Stand up the tmfifo bridge + dump receiver only when feature is on and
+    # we actually have DPUs to install on; tear them down on exit.
+    if collect_dump_on_failure and targets:
+        bridge = tmfifo_bridge.TmfifoBridge(
+            bridge_name=DUMP_BRIDGE_NAME, bridge_cidr=DUMP_BRIDGE_CIDR
+        )
+        try:
+            bridge.setup()
+        except subprocess.CalledProcessError as e:
+            logger.warning(
+                "Could not bring up %s (%s). Proceeding without DPU dump collection.",
+                DUMP_BRIDGE_NAME,
+                e,
+            )
+            failed = install_executor.run_parallel(len(targets), _install_one_dpu)
+            if failed:
+                sys.exit(1)
+            return
+
+        try:
+            with _dump_receiver_subprocess(dump_output_dir, verbose=verbose):
+                failed = install_executor.run_parallel(len(targets), _install_one_dpu)
+        finally:
+            bridge.teardown()
+        if failed:
+            sys.exit(1)
+        return
+
     failed = install_executor.run_parallel(len(targets), _install_one_dpu)
     if failed:
         sys.exit(1)
@@ -234,6 +413,9 @@ def _main(
     skip_extract: bool,
     verbose: bool,
     config: Optional[str],
+    debug_shell: bool,
+    collect_dump_on_failure: bool,
+    dump_output_dir: str,
 ) -> None:
     set_logging_level(verbose=verbose)
     check_for_root()
@@ -263,6 +445,9 @@ def _main(
                 verbose=verbose,
                 configs=config,
                 temp_work_dir=temp_work_dir.name,
+                debug_shell=debug_shell,
+                collect_dump_on_failure=collect_dump_on_failure,
+                dump_output_dir=dump_output_dir,
             )
         finally:
             try:
@@ -298,6 +483,33 @@ def _main(
     "-v", "--verbose", is_flag=True, default=False, help="Verbose installation result output"
 )
 @click.option("-c", "--config", type=str, default=None, help="Config file")
+@click.option(
+    "--debug-shell",
+    is_flag=True,
+    default=False,
+    help="On DPU-side installer command failure, drop into an interactive recovery shell.",
+)
+@click.option(
+    "--collect-dump-on-failure/--no-collect-dump-on-failure",
+    "collect_dump_on_failure",
+    default=False,
+    show_default=True,
+    help=(
+        "Stand up an ephemeral tmfifo bridge ("
+        f"{DUMP_BRIDGE_NAME} @ {DUMP_BRIDGE_CIDR}) and HTTP receiver on "
+        f"{DUMP_RECEIVER_BIND_IP}:{DUMP_RECEIVER_PORT} for the duration of the "
+        "install so DPUs can upload diagnostic dumps if their installer "
+        "fails. Disable for environments where tmfifo network setup is "
+        "undesired (e.g. CI mocks)."
+    ),
+)
+@click.option(
+    "--dump-output-dir",
+    type=str,
+    default=DUMP_OUTPUT_DIR_DEFAULT,
+    show_default=True,
+    help="Where the dump receiver writes uploaded DPU dump files.",
+)
 def main(
     bfb: Optional[str],
     rshim: Optional[str],
@@ -305,10 +517,23 @@ def main(
     skip_extract: bool,
     verbose: bool,
     config: Optional[str],
+    debug_shell: bool,
+    collect_dump_on_failure: bool,
+    dump_output_dir: str,
 ) -> None:
     """SONiC BFB Installer - install BFB image on DPUs connected to the host."""
     setup_log_handlers()
-    _main(bfb=bfb, rshim=rshim, dpu=dpu, skip_extract=skip_extract, verbose=verbose, config=config)
+    _main(
+        bfb=bfb,
+        rshim=rshim,
+        dpu=dpu,
+        skip_extract=skip_extract,
+        verbose=verbose,
+        config=config,
+        debug_shell=debug_shell,
+        collect_dump_on_failure=collect_dump_on_failure,
+        dump_output_dir=dump_output_dir,
+    )
 
 
 if __name__ == "__main__":

--- a/platform/mellanox/platform-utils/mellanox_bfb_installer/tmfifo_bridge.py
+++ b/platform/mellanox/platform-utils/mellanox_bfb_installer/tmfifo_bridge.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Ephemeral Linux bridge that absorbs every ``tmfifo_net*`` interface on the
+host for the duration of a single ``sonic-bfb-installer`` run.
+
+Why this exists
+---------------
+Each DPU exposes itself to the host through a ``tmfifo_net<N>`` netdev that
+appears when its rshim daemon starts. During a BFB install we want a single,
+stable host-side IP that every DPU can reach over tmfifo so the DPU-side
+installer can POST diagnostic dumps to us on failure.
+
+Lifecycle (driven by ``sonic-bfb-installer`` main):
+    1. Before any rshim is started, ``setup()`` creates the bridge, gives it
+       a static IP, and starts a daemon thread that continuously enslaves
+       any ``tmfifo_net*`` it sees. Existing tmfifo_net interfaces (if any)
+       are enslaved immediately.
+    2. ``sonic-bfb-installer`` runs its per-DPU installs in parallel. As
+       each DPU's rshim daemon comes up, the corresponding ``tmfifo_net<N>``
+       appears and is auto-enslaved by the watcher.
+    3. ``teardown()`` (always called from ``finally``) stops the watcher,
+       releases any slaves, and deletes the bridge.
+
+Nothing here persists across the process; if ``sonic-bfb-installer`` is
+killed without running ``teardown()``, a stale ``bridge-tmfifo`` may remain
+but ``setup()`` on the next run replaces it idempotently.
+"""
+
+from contextlib import AbstractContextManager
+import logging
+import os
+import re
+import subprocess
+import threading
+import time
+from typing import Iterable, List, Optional, Set
+
+
+DEFAULT_BRIDGE_NAME = "bridge-tmfifo"
+DEFAULT_BRIDGE_CIDR = "192.168.100.254/24"
+TMFIFO_IFACE_RE = re.compile(r"^tmfifo_net\d+$")
+
+# How often to scan /sys/class/net for new tmfifo_net interfaces. Short enough
+# that rshim_daemon.wait_for_rshim_boot's 10s budget always covers it, but not
+# so short that we burn CPU during a multi-DPU install.
+_WATCHER_POLL_INTERVAL_SEC = 0.5
+
+logger = logging.getLogger(__name__)
+
+
+def _run_ip(args: List[str], *, check: bool, log_prefix: str = "ip") -> int:
+    """Run an ``ip``/``bridge`` command, logging any non-zero result.
+
+    Returns the exit code. When ``check`` is True, raises CalledProcessError
+    on failure; the caller uses this for the bridge create/delete operations
+    that we want to surface, and ``check=False`` for per-iface enslavement
+    that is allowed to fail (e.g. interface vanished mid-loop).
+    """
+    cmd = ["ip"] + args if not (args and args[0] == "bridge") else args
+    logger.debug("%s: running %s", log_prefix, " ".join(cmd))
+    try:
+        result = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=check,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.warning(
+            "%s: command failed (rc=%s): %s | stderr=%s",
+            log_prefix,
+            e.returncode,
+            " ".join(cmd),
+            (e.stderr or "").strip(),
+        )
+        raise
+    if result.returncode != 0:
+        logger.debug(
+            "%s: command non-zero (rc=%s): %s | stderr=%s",
+            log_prefix,
+            result.returncode,
+            " ".join(cmd),
+            (result.stderr or "").strip(),
+        )
+    return result.returncode
+
+
+def _list_tmfifo_ifaces() -> List[str]:
+    """Return current ``tmfifo_net*`` netdev names from ``/sys/class/net``."""
+    try:
+        names = os.listdir("/sys/class/net")
+    except OSError as e:
+        logger.warning("could not list /sys/class/net: %s", e)
+        return []
+    return sorted(n for n in names if TMFIFO_IFACE_RE.match(n))
+
+
+def _iface_master(iface: str) -> Optional[str]:
+    """Return the current master bridge of ``iface``, or None if unenslaved."""
+    master_link = f"/sys/class/net/{iface}/master"
+    try:
+        return os.path.basename(os.readlink(master_link))
+    except OSError:
+        return None
+
+
+class TmfifoBridge(AbstractContextManager):
+    """Manages an ephemeral host bridge that absorbs all ``tmfifo_net*`` ifaces.
+
+    Use as a context manager for proper teardown::
+
+        with TmfifoBridge() as bridge:
+            ... run installs ...
+
+    Or call ``setup()`` / ``teardown()`` directly.
+    """
+
+    def __init__(
+        self,
+        bridge_name: str = DEFAULT_BRIDGE_NAME,
+        bridge_cidr: str = DEFAULT_BRIDGE_CIDR,
+    ) -> None:
+        self.bridge_name = bridge_name
+        self.bridge_cidr = bridge_cidr
+        self._stop_evt: Optional[threading.Event] = None
+        self._watcher: Optional[threading.Thread] = None
+        # Track which interfaces *we* enslaved so teardown only releases ours.
+        self._enslaved_by_us: Set[str] = set()
+        self._enslaved_lock = threading.Lock()
+        self._setup_done = False
+
+    # ---- Public lifecycle -------------------------------------------------
+
+    def setup(self) -> None:
+        """Create the bridge, assign it the static IP, and start the watcher.
+
+        Safe to call once per instance. If the bridge already exists (stale
+        from a prior aborted run) it is deleted and recreated so the IP and
+        forwarding state are known-good.
+        """
+        if self._setup_done:
+            logger.debug("setup() already called; skipping")
+            return
+
+        # If there's a stale leftover bridge from a previous aborted run,
+        # remove it so we start from a clean state. ``ip link del`` of an
+        # already-absent device fails, which we ignore.
+        _run_ip(["link", "del", self.bridge_name], check=False, log_prefix="bridge-del-pre")
+
+        _run_ip(["link", "add", "name", self.bridge_name, "type", "bridge"], check=True)
+        # Bridge defaults are fine for a single broadcast domain between
+        # the host and its DPUs over tmfifo.
+        _run_ip(["addr", "add", self.bridge_cidr, "dev", self.bridge_name], check=True)
+        _run_ip(["link", "set", self.bridge_name, "up"], check=True)
+        logger.info(
+            "tmfifo bridge %s up with %s", self.bridge_name, self.bridge_cidr
+        )
+
+        # Enslave anything already present, then start the watcher for
+        # devices that show up later (i.e. when each rshim daemon starts).
+        self._enslave_existing()
+
+        self._stop_evt = threading.Event()
+        self._watcher = threading.Thread(
+            target=self._watcher_loop,
+            name=f"tmfifo-bridge-watcher-{self.bridge_name}",
+            daemon=True,
+        )
+        self._watcher.start()
+        self._setup_done = True
+
+    def teardown(self) -> None:
+        """Stop the watcher, release slaves we attached, and delete the bridge.
+
+        Safe to call multiple times and safe to call without a prior
+        ``setup()`` (no-op in that case). Always best-effort: it logs but
+        does not raise on individual command failures so an installer
+        finally-block can always reach completion.
+        """
+        if self._stop_evt is not None:
+            self._stop_evt.set()
+        if self._watcher is not None:
+            self._watcher.join(timeout=5.0)
+            if self._watcher.is_alive():
+                logger.warning(
+                    "tmfifo bridge watcher %s did not exit within 5s",
+                    self.bridge_name,
+                )
+            self._watcher = None
+
+        # Release the slaves we attached. We deliberately leave alone any
+        # tmfifo_net that some external actor enslaved elsewhere.
+        with self._enslaved_lock:
+            to_release = list(self._enslaved_by_us)
+            self._enslaved_by_us.clear()
+        for iface in to_release:
+            # Only unset master if we are still the master. If the iface
+            # vanished or moved, ignore.
+            if _iface_master(iface) == self.bridge_name:
+                _run_ip(
+                    ["link", "set", iface, "nomaster"],
+                    check=False,
+                    log_prefix=f"release-{iface}",
+                )
+
+        _run_ip(
+            ["link", "del", self.bridge_name],
+            check=False,
+            log_prefix="bridge-del",
+        )
+        self._setup_done = False
+        logger.info("tmfifo bridge %s torn down", self.bridge_name)
+
+    # ---- Context manager --------------------------------------------------
+
+    def __enter__(self) -> "TmfifoBridge":
+        self.setup()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.teardown()
+
+    # ---- Internals --------------------------------------------------------
+
+    def _enslave_existing(self) -> None:
+        self._enslave_iter(_list_tmfifo_ifaces())
+
+    def _enslave_iter(self, ifaces: Iterable[str]) -> None:
+        for iface in ifaces:
+            self._enslave_one(iface)
+
+    def _enslave_one(self, iface: str) -> None:
+        """Enslave a single ``tmfifo_net*`` to the bridge and bring it up.
+
+        Idempotent: if already enslaved to our bridge, just bring it up; if
+        enslaved to some other bridge, log and skip (don't tug-of-war).
+        """
+        current_master = _iface_master(iface)
+        if current_master == self.bridge_name:
+            # Already ours: just make sure it's up.
+            _run_ip(
+                ["link", "set", iface, "up"],
+                check=False,
+                log_prefix=f"reup-{iface}",
+            )
+            return
+        if current_master is not None:
+            # Someone else owns it.
+            logger.warning(
+                "%s is already enslaved to %s; not moving to %s",
+                iface,
+                current_master,
+                self.bridge_name,
+            )
+            return
+
+        rc = _run_ip(
+            ["link", "set", iface, "master", self.bridge_name],
+            check=False,
+            log_prefix=f"enslave-{iface}",
+        )
+        if rc != 0:
+            return
+        _run_ip(
+            ["link", "set", iface, "up"],
+            check=False,
+            log_prefix=f"up-{iface}",
+        )
+        with self._enslaved_lock:
+            self._enslaved_by_us.add(iface)
+        logger.info("enslaved %s to %s", iface, self.bridge_name)
+
+    def _watcher_loop(self) -> None:
+        """Background poller: enslave any tmfifo_net* that shows up.
+
+        Polls /sys/class/net at a coarse interval. Polling (vs. listening on
+        netlink) keeps this dependency-free and easy to reason about; the
+        tmfifo_net devices on a smart switch number in the single digits and
+        only appear/disappear at rshim daemon start/stop, so 0.5s latency is
+        fine.
+        """
+        assert self._stop_evt is not None
+        already_seen: Set[str] = set()
+        while not self._stop_evt.is_set():
+            current = set(_list_tmfifo_ifaces())
+            new_ifaces = current - already_seen
+            if new_ifaces:
+                logger.debug(
+                    "watcher discovered new tmfifo ifaces: %s",
+                    sorted(new_ifaces),
+                )
+                self._enslave_iter(sorted(new_ifaces))
+            # Forget interfaces that have gone away so we'll re-enslave them
+            # if they come back (e.g. rshim restart).
+            already_seen = current
+            self._stop_evt.wait(_WATCHER_POLL_INTERVAL_SEC)

--- a/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_dump_receiver.py
+++ b/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_dump_receiver.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Unit tests for mellanox_bfb_installer.dump_receiver.
+
+The HTTP-level tests bind a real ``_ReuseAddrThreadingHTTPServer`` to
+``127.0.0.1:0`` (ephemeral port) so we exercise the actual request handler
+and ``http.server``/``socketserver`` plumbing, not a mock of them. Each test
+gets a fresh temp output directory so file IO is isolated and cleaned up.
+"""
+
+import http.client
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests for _parse_target_path
+# ---------------------------------------------------------------------------
+
+
+class TestParseTargetPath(unittest.TestCase):
+    """Validates the URL parser that the request handler uses to figure out
+    where on disk an upload should go.
+
+    The handler relies on this function to reject anything that isn't a
+    canonical ``/<dpuN>/<safe-basename>`` URL before any FS I/O happens, so
+    it's important the rejection rules are tight.
+    """
+
+    def test_valid_simple_path(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        self.assertEqual(
+            dump_receiver._parse_target_path("/dpu0/x.tar.gz"),
+            ("dpu0", "x.tar.gz"),
+        )
+
+    def test_valid_higher_dpu_id_and_complex_basename(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        self.assertEqual(
+            dump_receiver._parse_target_path("/dpu12/install-recovery-dpu12-20260516T231500Z.tar.gz"),
+            ("dpu12", "install-recovery-dpu12-20260516T231500Z.tar.gz"),
+        )
+
+    def test_strips_query_string(self):
+        """``?foo=1`` must not appear in the saved filename."""
+        from mellanox_bfb_installer import dump_receiver
+
+        self.assertEqual(
+            dump_receiver._parse_target_path("/dpu0/x.bin?foo=1&bar=2"),
+            ("dpu0", "x.bin"),
+        )
+
+    def test_strips_fragment(self):
+        """Fragments are client-side only but we still defend against them."""
+        from mellanox_bfb_installer import dump_receiver
+
+        self.assertEqual(
+            dump_receiver._parse_target_path("/dpu0/x.bin#frag"),
+            ("dpu0", "x.bin"),
+        )
+
+    def test_must_start_with_slash(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        with self.assertRaises(ValueError):
+            dump_receiver._parse_target_path("dpu0/x.tar.gz")
+
+    def test_wrong_segment_count_rejected(self):
+        """We require exactly two non-empty segments: dpu name and filename."""
+        from mellanox_bfb_installer import dump_receiver
+
+        # 0 segments / 1 segment
+        for bad in ["/", "/dpu0"]:
+            with self.assertRaises(ValueError, msg=f"should reject {bad!r}"):
+                dump_receiver._parse_target_path(bad)
+        # 3+ segments (includes path-traversal attempts after we URL-decode)
+        for bad in ["/dpu0/sub/file", "/a/b/c/d", "/dpu0/../sneaky"]:
+            with self.assertRaises(ValueError, msg=f"should reject {bad!r}"):
+                dump_receiver._parse_target_path(bad)
+
+    def test_empty_filename_rejected(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        with self.assertRaises(ValueError):
+            dump_receiver._parse_target_path("/dpu0/")
+
+    def test_invalid_dpu_names_rejected(self):
+        """Anything not matching ``dpu<digits>``."""
+        from mellanox_bfb_installer import dump_receiver
+
+        for bad in ["DPU0", "rshim0", "dpu", "dpux", "dpu0a", "dpu-0", "0dpu"]:
+            with self.assertRaises(ValueError, msg=f"should reject {bad!r}"):
+                dump_receiver._parse_target_path(f"/{bad}/x.tar.gz")
+
+    def test_invalid_filenames_rejected(self):
+        """Filenames with disallowed chars or that start with a dot."""
+        from mellanox_bfb_installer import dump_receiver
+
+        for bad in [".hidden", "with spaces", "weird!", "%2F", "tab\there", "back\\slash"]:
+            with self.assertRaises(ValueError, msg=f"should reject {bad!r}"):
+                dump_receiver._parse_target_path(f"/dpu0/{bad}")
+
+    def test_filename_length_cap(self):
+        """The regex caps filenames at 255 chars (1 leading + 254 trailing)."""
+        from mellanox_bfb_installer import dump_receiver
+
+        ok_name = "a" + "b" * 254
+        self.assertEqual(
+            dump_receiver._parse_target_path(f"/dpu0/{ok_name}"),
+            ("dpu0", ok_name),
+        )
+        too_long = "a" + "b" * 255
+        with self.assertRaises(ValueError):
+            dump_receiver._parse_target_path(f"/dpu0/{too_long}")
+
+
+# ---------------------------------------------------------------------------
+# _build_server / _ReuseAddrThreadingHTTPServer
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServer(unittest.TestCase):
+    """Tests for the factory that constructs the receiver's HTTP server."""
+
+    def test_creates_missing_output_dir(self):
+        """_build_server should mkdir -p the configured output directory."""
+        from mellanox_bfb_installer import dump_receiver
+
+        with tempfile.TemporaryDirectory(prefix="dr_build_") as base:
+            output_dir = os.path.join(base, "new", "nested", "dir")
+            server = dump_receiver._build_server(
+                bind_ip="127.0.0.1", port=0, output_dir=output_dir, max_bytes=1024
+            )
+            try:
+                self.assertTrue(os.path.isdir(output_dir))
+            finally:
+                server.server_close()
+
+    def test_server_uses_ipv4_and_reuse(self):
+        """Server class binds IPv4 with SO_REUSEADDR for predictable rebinds."""
+        from mellanox_bfb_installer import dump_receiver
+
+        with tempfile.TemporaryDirectory(prefix="dr_attrs_") as out:
+            server = dump_receiver._build_server(
+                bind_ip="127.0.0.1", port=0, output_dir=out, max_bytes=1024
+            )
+            try:
+                self.assertEqual(server.address_family, socket.AF_INET)
+                self.assertTrue(server.allow_reuse_address)
+            finally:
+                server.server_close()
+
+    def test_handler_class_has_attached_config(self):
+        """The dynamically-built handler class carries a per-server config."""
+        from mellanox_bfb_installer import dump_receiver
+
+        with tempfile.TemporaryDirectory(prefix="dr_cfg_") as out:
+            server = dump_receiver._build_server(
+                bind_ip="127.0.0.1", port=0, output_dir=out, max_bytes=4321
+            )
+            try:
+                handler_cls = server.RequestHandlerClass
+                self.assertIsNotNone(handler_cls.receiver_config)
+                self.assertEqual(handler_cls.receiver_config.output_dir, out)
+                self.assertEqual(handler_cls.receiver_config.max_bytes, 4321)
+            finally:
+                server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# HTTP-level integration tests against a real in-process server
+# ---------------------------------------------------------------------------
+
+
+class _ReceiverServerFixture(unittest.TestCase):
+    """Common setUp/tearDown that brings up a real receiver on 127.0.0.1.
+
+    Subclasses can override ``max_bytes`` via the class attribute to test the
+    upload-size cap branch.
+    """
+
+    max_bytes = 1024 * 1024  # 1 MiB default
+    SOCKET_TIMEOUT_SEC = 5.0
+
+    def setUp(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        self.tmpdir = tempfile.mkdtemp(prefix="dump_receiver_test_")
+        self.server = dump_receiver._build_server(
+            bind_ip="127.0.0.1", port=0, output_dir=self.tmpdir, max_bytes=self.max_bytes
+        )
+        self.host, self.port = self.server.server_address[0], self.server.server_address[1]
+        self.thread = threading.Thread(
+            target=self.server.serve_forever, kwargs={"poll_interval": 0.05}, daemon=True
+        )
+        self.thread.start()
+
+    def tearDown(self):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    # -- helpers --
+
+    def _conn(self):
+        """Return a fresh HTTPConnection. The receiver advertises HTTP/1.0
+        with Connection: close, so each request uses a fresh socket."""
+        return http.client.HTTPConnection(self.host, self.port, timeout=self.SOCKET_TIMEOUT_SEC)
+
+    def _raw_request(self, raw_bytes: bytes) -> bytes:
+        """Send a hand-crafted HTTP request and return the full response.
+
+        Needed for cases ``http.client`` won't let us produce, like a PUT
+        without Content-Length or a Content-Length that mismatches the body.
+        """
+        with socket.create_connection((self.host, self.port), timeout=self.SOCKET_TIMEOUT_SEC) as s:
+            s.sendall(raw_bytes)
+            # The handler sets Connection: close, so server closes after replying.
+            chunks = []
+            while True:
+                try:
+                    chunk = s.recv(4096)
+                except socket.timeout:
+                    break
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b"".join(chunks)
+
+
+class TestDumpReceiverHttpHappyPath(_ReceiverServerFixture):
+    """201 paths: PUT / POST / GET liveness."""
+
+    def test_put_writes_file_under_output_dir(self):
+        body = b"hello dpu world"
+        conn = self._conn()
+        conn.request(
+            "PUT",
+            "/dpu0/upload.tar.gz",
+            body=body,
+            headers={"Content-Length": str(len(body))},
+        )
+        resp = conn.getresponse()
+        resp_body = resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 201, resp_body)
+        dest = os.path.join(self.tmpdir, "dpu0", "upload.tar.gz")
+        self.assertTrue(os.path.isfile(dest), f"missing dest: {dest}")
+        with open(dest, "rb") as f:
+            self.assertEqual(f.read(), body)
+        # The .part file must be gone after atomic rename.
+        self.assertFalse(os.path.exists(dest + ".part"))
+
+    def test_post_writes_file(self):
+        """POST and PUT share the upload handler."""
+        body = b"posted-bytes"
+        conn = self._conn()
+        conn.request("POST", "/dpu1/posted.bin", body=body)
+        resp = conn.getresponse()
+        conn.close()
+        self.assertEqual(resp.status, 201)
+        dest = os.path.join(self.tmpdir, "dpu1", "posted.bin")
+        self.assertTrue(os.path.isfile(dest))
+
+    def test_get_root_returns_liveness_ok(self):
+        conn = self._conn()
+        conn.request("GET", "/")
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 200)
+        self.assertIn(b"ok", body)
+
+    def test_get_non_root_returns_404(self):
+        """GET to anything other than ``/`` must 404, including valid upload paths."""
+        conn = self._conn()
+        conn.request("GET", "/dpu0/x.tar.gz")
+        resp = conn.getresponse()
+        conn.close()
+        self.assertEqual(resp.status, 404)
+
+    def test_response_includes_connection_close(self):
+        """HTTP/1.0 + Connection: close so curl with --retry can re-establish cleanly."""
+        conn = self._conn()
+        conn.request("PUT", "/dpu0/one.bin", body=b"x")
+        resp = conn.getresponse()
+        resp.read()
+        conn.close()
+        self.assertEqual(resp.getheader("Connection"), "close")
+
+
+class TestDumpReceiverHttpRejections(_ReceiverServerFixture):
+    """400 / 411 / 413 / 500 paths."""
+
+    def test_invalid_dpu_name_returns_400(self):
+        conn = self._conn()
+        conn.request("PUT", "/notadpu/x.bin", body=b"x")
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 400)
+        self.assertIn(b"bad target path", body)
+
+    def test_invalid_filename_dot_hidden_returns_400(self):
+        """Filename starting with a dot is rejected (no creation of hidden files)."""
+        conn = self._conn()
+        conn.request("PUT", "/dpu0/.hidden", body=b"x")
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 400, body)
+        self.assertFalse(
+            os.path.exists(os.path.join(self.tmpdir, "dpu0", ".hidden")),
+            "bad filename must not have created a file on disk",
+        )
+
+    def test_invalid_filename_with_space_returns_400(self):
+        """Filenames with spaces (or any byte outside the allowlist) are
+        rejected by the server. We send via raw socket because http.client
+        refuses spaces in the URL client-side."""
+        raw = (
+            b"PUT /dpu0/with%20space HTTP/1.0\r\n"
+            b"Content-Length: 1\r\n"
+            b"\r\n"
+            b"x"
+        )
+        # We intentionally URL-encode the space because http.client and many
+        # other clients would reject the raw form. The receiver doesn't decode
+        # percent-encoding, so the regex still rejects ``%`` in the basename.
+        resp = self._raw_request(raw)
+        first_line = resp.split(b"\r\n", 1)[0]
+        self.assertIn(b" 400 ", first_line, resp)
+
+    def test_missing_content_length_returns_411(self):
+        """Without Content-Length the handler refuses to read a body."""
+        raw = (
+            b"PUT /dpu0/x.bin HTTP/1.0\r\n"
+            b"Host: localhost\r\n"
+            b"\r\n"
+        )
+        resp = self._raw_request(raw)
+        # Status line is the first line of the response.
+        first_line = resp.split(b"\r\n", 1)[0]
+        self.assertIn(b" 411 ", first_line, resp)
+
+    def test_invalid_content_length_returns_400(self):
+        raw = (
+            b"PUT /dpu0/x.bin HTTP/1.0\r\n"
+            b"Content-Length: notanint\r\n"
+            b"\r\n"
+        )
+        resp = self._raw_request(raw)
+        first_line = resp.split(b"\r\n", 1)[0]
+        self.assertIn(b" 400 ", first_line, resp)
+
+    def test_negative_content_length_returns_400(self):
+        """``http.client`` won't let us produce a negative CL, so use raw bytes."""
+        raw = (
+            b"PUT /dpu0/x.bin HTTP/1.0\r\n"
+            b"Content-Length: -5\r\n"
+            b"\r\n"
+        )
+        resp = self._raw_request(raw)
+        first_line = resp.split(b"\r\n", 1)[0]
+        self.assertIn(b" 400 ", first_line, resp)
+
+    def test_mkdir_failure_returns_500(self):
+        """If os.makedirs for ``<output_dir>/<dpuN>`` fails, the handler must
+        return HTTP 500 with a clear ``mkdir failed`` body and write no file.
+        The base ``output_dir`` itself was already created in _build_server,
+        so we only patch makedirs for the duration of the request."""
+        from mellanox_bfb_installer import dump_receiver
+
+        with mock.patch.object(
+            dump_receiver.os, "makedirs", side_effect=OSError("EACCES")
+        ):
+            conn = self._conn()
+            conn.request("PUT", "/dpu0/x.bin", body=b"x")
+            resp = conn.getresponse()
+            body = resp.read()
+            conn.close()
+
+        self.assertEqual(resp.status, 500, body)
+        self.assertIn(b"mkdir failed", body)
+        # And: the file definitely didn't make it to disk.
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu0", "x.bin")))
+
+    def test_short_body_returns_500_and_cleans_part_file(self):
+        """If the client sends fewer bytes than Content-Length says, the
+        handler must respond 500 and remove the partial .part file so the
+        next retry from the DPU starts clean."""
+        # Send Content-Length: 100 but only 5 bytes of body, then close.
+        raw = (
+            b"PUT /dpu8/short.bin HTTP/1.0\r\n"
+            b"Content-Length: 100\r\n"
+            b"\r\n"
+            b"short"
+        )
+        resp = self._raw_request(raw)
+        # We may or may not get a response back; both behaviours mean the
+        # save failed. Crucially the .part file must not be left around.
+        if resp:
+            first_line = resp.split(b"\r\n", 1)[0]
+            self.assertIn(b" 500 ", first_line, resp)
+        # Give the handler a moment to unlink the .part on the io error path.
+        for _ in range(20):
+            if not os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin.part")):
+                break
+            time.sleep(0.05)
+        self.assertFalse(
+            os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin.part")),
+            "stale .part file left behind on short-body upload",
+        )
+        # The final file must not exist either.
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin")))
+
+
+class TestDumpReceiverHttpSizeCap(_ReceiverServerFixture):
+    """413 path: enforce ``max_bytes`` cap before reading the body."""
+
+    max_bytes = 16  # tiny cap to make the test obvious
+
+    def test_oversize_content_length_returns_413(self):
+        body = b"x" * 64
+        conn = self._conn()
+        conn.request("PUT", "/dpu0/too-big.bin", body=body)
+        resp = conn.getresponse()
+        msg = resp.read()
+        conn.close()
+        self.assertEqual(resp.status, 413, msg)
+        self.assertIn(b"too large", msg)
+        # Nothing must have been written.
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu0", "too-big.bin")))
+        self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu0", "too-big.bin.part")))
+
+
+# ---------------------------------------------------------------------------
+# main() CLI entrypoint smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestDumpReceiverMain(unittest.TestCase):
+    """Exercise the ``main()`` CLI wrapper. We mock the server so the test
+    doesn't bind a real socket or block in serve_forever."""
+
+    def _patch_argv(self, args):
+        return mock.patch.object(sys, "argv", ["dump_receiver"] + list(args))
+
+    def test_main_returns_zero_when_server_runs_and_stops(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        fake_server = mock.MagicMock()
+        # serve_forever returns immediately as if a signal was received.
+        fake_server.serve_forever.return_value = None
+
+        with tempfile.TemporaryDirectory(prefix="dr_main_") as out, \
+             self._patch_argv([
+                 "--bind-ip", "127.0.0.1",
+                 "--port", "0",
+                 "--output-dir", out,
+                 "--max-bytes", "1024",
+             ]), \
+             mock.patch.object(dump_receiver, "_build_server", return_value=fake_server), \
+             mock.patch.object(dump_receiver.signal, "signal"):
+            rc = dump_receiver.main()
+
+        self.assertEqual(rc, 0)
+        fake_server.serve_forever.assert_called_once()
+        fake_server.server_close.assert_called_once()
+
+    def test_main_returns_one_when_bind_fails(self):
+        """``_build_server`` may raise OSError if the bind IP is unreachable
+        or the port is already in use; main() must surface this as rc=1."""
+        from mellanox_bfb_installer import dump_receiver
+
+        with tempfile.TemporaryDirectory(prefix="dr_main_err_") as out, \
+             self._patch_argv([
+                 "--bind-ip", "127.0.0.1",
+                 "--port", "0",
+                 "--output-dir", out,
+             ]), \
+             mock.patch.object(
+                 dump_receiver, "_build_server", side_effect=OSError("EADDRINUSE")
+             ), \
+             mock.patch.object(dump_receiver.signal, "signal"):
+            rc = dump_receiver.main()
+
+        self.assertEqual(rc, 1)
+
+
+class TestDumpReceiverSymlinkEscape(_ReceiverServerFixture):
+    """Belt-and-suspenders test for the realpath check.
+
+    The URL regex already blocks ``..`` and ``/`` in filenames, but the
+    handler also checks ``realpath(dest)`` is under ``realpath(output_dir)``.
+    To exercise that branch we plant a symlink at ``<output_dir>/dpu0``
+    pointing outside the configured output directory and confirm the handler
+    refuses to write.
+    """
+
+    def test_symlinked_dpu_dir_rejected_with_400(self):
+        outside = tempfile.mkdtemp(prefix="dr_escape_target_")
+        self.addCleanup(shutil.rmtree, outside, True)
+
+        # Note: makedirs(...exist_ok=True) tolerates an existing path even if
+        # it's a symlink, so we can place the symlink first and the handler
+        # will not clobber it.
+        os.symlink(outside, os.path.join(self.tmpdir, "dpu0"))
+
+        conn = self._conn()
+        conn.request("PUT", "/dpu0/escape.bin", body=b"should-not-land")
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+
+        self.assertEqual(resp.status, 400)
+        self.assertIn(b"invalid destination", body)
+        # Nothing must have appeared in the escape-target directory.
+        self.assertFalse(
+            os.listdir(outside),
+            f"symlink escape produced files in {outside}: {os.listdir(outside)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_main.py
+++ b/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_main.py
@@ -163,30 +163,89 @@ class TestUsage(unittest.TestCase):
         self.assertIn("-s|--skip-extract", USAGE_ARGUMENTS)
         self.assertIn("-v|--verbose", USAGE_ARGUMENTS)
         self.assertIn("-c|--config", USAGE_ARGUMENTS)
+        self.assertIn("--debug-shell", USAGE_ARGUMENTS)
         self.assertIn("-h|--help", USAGE_ARGUMENTS)
         self.assertNotIn("--rshim", USAGE_ARGUMENTS)
+
+
+class TestDpuNameToId(unittest.TestCase):
+    """Tests for _dpu_name_to_id."""
+
+    def test_valid_names(self):
+        from mellanox_bfb_installer.main import _dpu_name_to_id
+
+        self.assertEqual(_dpu_name_to_id("dpu0"), 0)
+        self.assertEqual(_dpu_name_to_id("dpu1"), 1)
+        self.assertEqual(_dpu_name_to_id("dpu12"), 12)
+
+    def test_invalid_name_raises(self):
+        from mellanox_bfb_installer.main import _dpu_name_to_id
+
+        with self.assertRaises(ValueError):
+            _dpu_name_to_id("rshim0")
+        with self.assertRaises(ValueError):
+            _dpu_name_to_id("DPU0")
+        with self.assertRaises(ValueError):
+            _dpu_name_to_id("dpu")
 
 
 class TestGenerateAdditionalConfigLines(unittest.TestCase):
     """Tests for _generate_additional_config_lines."""
 
-    def test_npu_time_is_present_and_correct(self):
-        """Returned string contains NPU_TIME=<integer> and is correct."""
-        import re
-        import time
+    def _make_target(self, idx: int):
+        from mellanox_bfb_installer.device_selection import TargetInfo
 
+        return TargetInfo(
+            dpu=f"dpu{idx}",
+            rshim=f"rshim{idx}",
+            dpu_pci_bus_id=f"0000:0{idx}:00.0",
+            rshim_pci_bus_id=f"0000:0{idx}:00.1",
+            config_path=None,
+        )
+
+    def test_npu_time_and_dpu_id_present_and_correct(self):
+        """Returned string contains NPU_TIME=<integer> and DPU_ID=<dpu index> lines."""
         from mellanox_bfb_installer.main import _generate_additional_config_lines
 
+        target = self._make_target(3)
+
         t_before = int(time.time())
-        result = _generate_additional_config_lines()
+        result = _generate_additional_config_lines(target)
         t_after = int(time.time())
 
-        match = re.fullmatch(r"NPU_TIME=(\d+)\n", result)
-        self.assertIsNotNone(match, f"NPU_TIME=<integer>\\n not found in {result!r}")
+        match = re.fullmatch(r"NPU_TIME=(\d+)\nDPU_ID=(\d+)\n", result)
+        self.assertIsNotNone(
+            match, f"Expected 'NPU_TIME=<int>\\nDPU_ID=<int>\\n' but got {result!r}"
+        )
         npu_time = int(match.group(1))
+        dpu_id = int(match.group(2))
 
         self.assertGreaterEqual(npu_time, t_before)
         self.assertLessEqual(npu_time, t_after)
+        self.assertEqual(dpu_id, 3)
+
+    def test_debug_shell_flag_omits_line_when_false(self):
+        """When debug_shell=False (default), DEBUG_SHELL is not present in the output."""
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        target = self._make_target(0)
+        result = _generate_additional_config_lines(target)
+        self.assertNotIn("DEBUG_SHELL", result)
+
+    def test_debug_shell_flag_adds_line_when_true(self):
+        """When debug_shell=True, DEBUG_SHELL=true line is appended after DPU_ID."""
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        target = self._make_target(2)
+        result = _generate_additional_config_lines(target, debug_shell=True)
+        match = re.fullmatch(
+            r"NPU_TIME=(\d+)\nDPU_ID=(\d+)\nDEBUG_SHELL=true\n", result
+        )
+        self.assertIsNotNone(
+            match,
+            f"Expected NPU_TIME/DPU_ID/DEBUG_SHELL block but got {result!r}",
+        )
+        self.assertEqual(int(match.group(2)), 2)
 
 
 class TestAddAdditionalConfigLines(unittest.TestCase):
@@ -204,9 +263,14 @@ class TestAddAdditionalConfigLines(unittest.TestCase):
             config_path=config_path,
         )
 
+    def _assert_has_npu_time_and_dpu_id(self, content: str, expected_dpu_id: int):
+        match = re.search(r"NPU_TIME=(\d+)\nDPU_ID=(\d+)\n", content)
+        self.assertIsNotNone(match, f"NPU_TIME/DPU_ID lines not found in {content!r}")
+        self.assertEqual(int(match.group(2)), expected_dpu_id)
+
     def test_single_target_creates_temp_file_with_original_plus_additional_lines(self):
-        """Single target: creates new file with original contents + temp_config_lines."""
-        from mellanox_bfb_installer import device_selection, main
+        """Single target: creates new file with original contents + per-DPU additional lines."""
+        from mellanox_bfb_installer import main
 
         with tempfile.TemporaryDirectory(prefix="add_config_test_") as tempdir:
             config_path = os.path.join(tempdir, "config.json")
@@ -214,8 +278,7 @@ class TestAddAdditionalConfigLines(unittest.TestCase):
                 f.write("original_line\n")
             target = self._make_target(0, config_path)
             targets = [target]
-            additional = "line 1\nline 2\n"
-            main._add_additional_config_lines(targets, additional, tempdir)
+            main._add_additional_config_lines(targets, tempdir)
             self.assertEqual(len(targets), 1)
             self.assertEqual(targets[0].dpu, "dpu0")
             self.assertEqual(targets[0].rshim, "rshim0")
@@ -227,12 +290,11 @@ class TestAddAdditionalConfigLines(unittest.TestCase):
             with open(new_path, "r") as f:
                 content = f.read()
             self.assertIn("original_line\n", content)
-            self.assertIn("line 1\n", content)
-            self.assertIn("line 2\n", content)
+            self._assert_has_npu_time_and_dpu_id(content, expected_dpu_id=0)
 
-    def test_two_targets_same_config_create_one_file_both_updated(self):
-        """Two targets with same config: one temp file created, both targets point to it."""
-        from mellanox_bfb_installer import device_selection, main
+    def test_two_targets_same_config_create_distinct_files_with_per_dpu_ids(self):
+        """Two targets sharing a config get distinct temp files, each with its own DPU_ID."""
+        from mellanox_bfb_installer import main
 
         with tempfile.TemporaryDirectory(prefix="add_config_test_") as tempdir:
             config_path = os.path.join(tempdir, "shared.json")
@@ -242,27 +304,26 @@ class TestAddAdditionalConfigLines(unittest.TestCase):
                 self._make_target(0, config_path),
                 self._make_target(1, config_path),
             ]
-            additional = "extra\n"
-            main._add_additional_config_lines(targets, additional, tempdir)
+            main._add_additional_config_lines(targets, tempdir)
             self.assertEqual(len(targets), 2)
             self.assertEqual(targets[0].dpu, "dpu0")
-            self.assertEqual(targets[0].rshim, "rshim0")
-            self.assertEqual(targets[0].dpu_pci_bus_id, "0000:00:00.0")
-            self.assertEqual(targets[0].rshim_pci_bus_id, "0000:00:00.1")
             self.assertEqual(targets[1].dpu, "dpu1")
-            self.assertEqual(targets[1].rshim, "rshim1")
-            self.assertEqual(targets[1].dpu_pci_bus_id, "0000:01:00.0")
-            self.assertEqual(targets[1].rshim_pci_bus_id, "0000:01:00.1")
 
-            self.assertTrue(targets[0].config_path.startswith(os.path.join(tempdir, "shared.json.")))
-            with open(targets[0].config_path, "r") as f:
-                content = f.read()
-            self.assertEqual("shared_content\n\nextra\n\n", content)
-            self.assertEqual(targets[1].config_path, targets[0].config_path)
+            self.assertNotEqual(
+                targets[0].config_path,
+                targets[1].config_path,
+                "Each target must get its own temp file since DPU_ID differs",
+            )
+            for tgt, expected_dpu_id in [(targets[0], 0), (targets[1], 1)]:
+                self.assertTrue(tgt.config_path.startswith(os.path.join(tempdir, "shared.json.")))
+                with open(tgt.config_path, "r") as f:
+                    content = f.read()
+                self.assertIn("shared_content\n", content)
+                self._assert_has_npu_time_and_dpu_id(content, expected_dpu_id=expected_dpu_id)
 
     def test_two_targets_different_configs_create_two_files(self):
         """Two targets with different configs: two temp files, each target gets correct path."""
-        from mellanox_bfb_installer import device_selection, main
+        from mellanox_bfb_installer import main
 
         with tempfile.TemporaryDirectory(prefix="add_config_test_") as tempdir:
             config1 = os.path.join(tempdir, "cfg1.json")
@@ -275,35 +336,476 @@ class TestAddAdditionalConfigLines(unittest.TestCase):
                 self._make_target(1, config1),
                 self._make_target(2, config2),
             ]
-            additional = "extra\n"
-            main._add_additional_config_lines(targets, additional, tempdir)
+            main._add_additional_config_lines(targets, tempdir)
             self.assertNotEqual(targets[0].config_path, targets[1].config_path)
             self.assertIn("cfg1.json.", targets[0].config_path)
             self.assertIn("cfg2.json.", targets[1].config_path)
             with open(targets[0].config_path, "r") as f:
-                self.assertEqual("config1_content\n\nextra\n\n", f.read())
+                content1 = f.read()
             with open(targets[1].config_path, "r") as f:
-                self.assertEqual("config2_content\n\nextra\n\n", f.read())
+                content2 = f.read()
+            self.assertIn("config1_content\n", content1)
+            self.assertIn("config2_content\n", content2)
+            self._assert_has_npu_time_and_dpu_id(content1, expected_dpu_id=1)
+            self._assert_has_npu_time_and_dpu_id(content2, expected_dpu_id=2)
 
     def test_target_with_config_none_creates_empty_config_file(self):
-        """Two targets with config_path None: one file created with only additional lines."""
-        from mellanox_bfb_installer import device_selection, main
+        """Two targets with config_path None: each gets its own temp file with only additional lines."""
+        from mellanox_bfb_installer import main
 
         with tempfile.TemporaryDirectory(prefix="add_config_test_") as tempdir:
             targets = [
                 self._make_target(0, None),
                 self._make_target(1, None),
             ]
-            additional = "extra\n"
-            main._add_additional_config_lines(targets, additional, tempdir)
+            main._add_additional_config_lines(targets, tempdir)
             self.assertEqual(len(targets), 2)
-            new_path = targets[0].config_path
-            self.assertIsNotNone(new_path)
-            self.assertIn("empty-config.", new_path)
-            self.assertEqual(targets[1].config_path, new_path, "Both targets share same output file")
-            with open(new_path, "r") as f:
+            self.assertNotEqual(
+                targets[0].config_path,
+                targets[1].config_path,
+                "Each target must get its own temp file since DPU_ID differs",
+            )
+            for tgt, expected_dpu_id in [(targets[0], 0), (targets[1], 1)]:
+                self.assertIsNotNone(tgt.config_path)
+                self.assertIn("empty-config.", tgt.config_path)
+                with open(tgt.config_path, "r") as f:
+                    content = f.read()
+                self._assert_has_npu_time_and_dpu_id(content, expected_dpu_id=expected_dpu_id)
+                self.assertNotIn("DEBUG_SHELL", content)
+
+    def test_debug_shell_true_propagates_to_temp_config(self):
+        """debug_shell=True writes 'DEBUG_SHELL=true' into each target's temp config."""
+        from mellanox_bfb_installer import main
+
+        with tempfile.TemporaryDirectory(prefix="add_config_test_") as tempdir:
+            targets = [
+                self._make_target(0, None),
+                self._make_target(1, None),
+            ]
+            main._add_additional_config_lines(targets, tempdir, debug_shell=True)
+            for tgt, expected_dpu_id in [(targets[0], 0), (targets[1], 1)]:
+                with open(tgt.config_path, "r") as f:
+                    content = f.read()
+                self._assert_has_npu_time_and_dpu_id(content, expected_dpu_id=expected_dpu_id)
+                self.assertIn("DEBUG_SHELL=true\n", content)
+
+
+class TestGenerateAdditionalConfigLinesDumpReceiver(unittest.TestCase):
+    """Tests for _generate_additional_config_lines with the dump-receiver knobs."""
+
+    def _make_target(self, idx: int):
+        from mellanox_bfb_installer.device_selection import TargetInfo
+
+        return TargetInfo(
+            dpu=f"dpu{idx}",
+            rshim=f"rshim{idx}",
+            dpu_pci_bus_id=f"0000:0{idx}:00.0",
+            rshim_pci_bus_id=f"0000:0{idx}:00.1",
+            config_path=None,
+        )
+
+    def test_flag_without_url_raises(self):
+        """collect_dump_on_failure=True with dump_upload_base_url=None is inconsistent and must raise.
+
+        The DPU-side installer needs both pieces of info to be useful; a half-configured bf.cfg
+        is rejected up front rather than silently emitted.
+        """
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        with self.assertRaises(ValueError):
+            _generate_additional_config_lines(
+                self._make_target(0),
+                collect_dump_on_failure=True,
+                dump_upload_base_url=None,
+            )
+
+    def test_url_without_flag_raises(self):
+        """dump_upload_base_url given but collect_dump_on_failure=False is inconsistent and must raise."""
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        with self.assertRaises(ValueError):
+            _generate_additional_config_lines(
+                self._make_target(0),
+                collect_dump_on_failure=False,
+                dump_upload_base_url="http://192.168.100.254:8090",
+            )
+
+    def test_flag_and_url_together_add_both_lines_in_order(self):
+        """collect_dump_on_failure=True + URL: both lines appear, in order, after DPU_ID."""
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        result = _generate_additional_config_lines(
+            self._make_target(2),
+            collect_dump_on_failure=True,
+            dump_upload_base_url="http://192.168.100.254:8090",
+        )
+        match = re.fullmatch(
+            r"NPU_TIME=(\d+)\nDPU_ID=(\d+)\n"
+            r"COLLECT_DUMP_ON_FAILURE=true\n"
+            r"DUMP_UPLOAD_BASE_URL=http://192\.168\.100\.254:8090\n",
+            result,
+        )
+        self.assertIsNotNone(
+            match, f"Expected NPU_TIME/DPU_ID/COLLECT_DUMP/URL block but got {result!r}"
+        )
+        self.assertEqual(int(match.group(2)), 2)
+
+    def test_all_flags_combined_block(self):
+        """All flags together: NPU_TIME, DPU_ID, DEBUG_SHELL, COLLECT_DUMP, URL in that exact order."""
+        from mellanox_bfb_installer.main import _generate_additional_config_lines
+
+        result = _generate_additional_config_lines(
+            self._make_target(5),
+            debug_shell=True,
+            collect_dump_on_failure=True,
+            dump_upload_base_url="http://10.0.0.1:8090",
+        )
+        match = re.fullmatch(
+            r"NPU_TIME=(\d+)\nDPU_ID=5\nDEBUG_SHELL=true\n"
+            r"COLLECT_DUMP_ON_FAILURE=true\n"
+            r"DUMP_UPLOAD_BASE_URL=http://10\.0\.0\.1:8090\n",
+            result,
+        )
+        self.assertIsNotNone(
+            match,
+            f"Expected NPU_TIME/DPU_ID/DEBUG_SHELL/COLLECT_DUMP/URL block but got {result!r}",
+        )
+
+
+class TestAddAdditionalConfigLinesDumpReceiver(unittest.TestCase):
+    """Tests that _add_additional_config_lines threads the new args into per-target configs."""
+
+    def _make_target(self, idx: int, config_path):
+        from mellanox_bfb_installer.device_selection import TargetInfo
+
+        return TargetInfo(
+            dpu=f"dpu{idx}",
+            rshim=f"rshim{idx}",
+            dpu_pci_bus_id=f"0000:0{idx}:00.0",
+            rshim_pci_bus_id=f"0000:0{idx}:00.1",
+            config_path=config_path,
+        )
+
+    def test_collect_dump_propagates_to_each_target_temp_config(self):
+        """collect_dump_on_failure=True+URL: both lines appear in every target's temp config,
+        each with its own DPU_ID."""
+        from mellanox_bfb_installer import main
+
+        with tempfile.TemporaryDirectory(prefix="add_config_dr_") as tempdir:
+            targets = [
+                self._make_target(0, None),
+                self._make_target(1, None),
+            ]
+            main._add_additional_config_lines(
+                targets,
+                tempdir,
+                collect_dump_on_failure=True,
+                dump_upload_base_url="http://192.168.100.254:8090",
+            )
+            for tgt, expected_dpu_id in [(targets[0], 0), (targets[1], 1)]:
+                with open(tgt.config_path, "r") as f:
+                    content = f.read()
+                self.assertIn(f"DPU_ID={expected_dpu_id}\n", content)
+                self.assertIn("COLLECT_DUMP_ON_FAILURE=true\n", content)
+                self.assertIn(
+                    "DUMP_UPLOAD_BASE_URL=http://192.168.100.254:8090\n", content
+                )
+
+    def test_collect_dump_default_does_not_add_lines(self):
+        """Default kwargs (no collect_dump_on_failure) must not emit the new lines."""
+        from mellanox_bfb_installer import main
+
+        with tempfile.TemporaryDirectory(prefix="add_config_dr_default_") as tempdir:
+            targets = [self._make_target(0, None)]
+            main._add_additional_config_lines(targets, tempdir)
+            with open(targets[0].config_path, "r") as f:
                 content = f.read()
-            self.assertEqual("\nextra\n\n", content)
+            self.assertNotIn("COLLECT_DUMP_ON_FAILURE", content)
+            self.assertNotIn("DUMP_UPLOAD_BASE_URL", content)
+
+
+class TestDumpReceiverSubprocess(unittest.TestCase):
+    """Tests for the _dump_receiver_subprocess context manager.
+
+    These are pure unit tests: subprocess.Popen and time.sleep are mocked, so
+    no actual child process is spawned and no real socket is bound.
+    """
+
+    def test_popen_is_invoked_with_expected_argv(self):
+        """The child process is launched with -m mellanox_bfb_installer.dump_receiver
+        and the right CLI args."""
+        from mellanox_bfb_installer import main
+
+        mock_proc = mock.MagicMock()
+        # First poll() = None (alive after 0.5s sleep), second poll() = 0 (on teardown still alive)
+        mock_proc.poll.side_effect = [None, None]
+        mock_proc.wait.return_value = 0
+        mock_proc.pid = 4242
+
+        with (
+            mock.patch.object(main.subprocess, "Popen", return_value=mock_proc) as mock_popen,
+            mock.patch.object(main.time, "sleep"),
+        ):
+            with main._dump_receiver_subprocess(
+                output_dir="/var/log/dpu",
+                bind_ip="10.0.0.5",
+                port=9001,
+                verbose=True,
+            ) as proc:
+                self.assertIs(proc, mock_proc)
+
+        mock_popen.assert_called_once()
+        argv = mock_popen.call_args[0][0]
+        # Python interpreter, then -m, then module name.
+        self.assertEqual(argv[0], sys.executable)
+        self.assertIn("-m", argv)
+        self.assertIn("mellanox_bfb_installer.dump_receiver", argv)
+        self.assertIn("--bind-ip", argv)
+        self.assertIn("10.0.0.5", argv)
+        self.assertIn("--port", argv)
+        self.assertIn("9001", argv)
+        self.assertIn("--output-dir", argv)
+        self.assertIn("/var/log/dpu", argv)
+        self.assertIn("--verbose", argv)
+
+    def test_normal_lifecycle_terminates_proc_on_exit(self):
+        """Happy path: yields the proc, then SIGTERMs it on context exit."""
+        from mellanox_bfb_installer import main
+
+        mock_proc = mock.MagicMock()
+        # poll() after 0.5s sleep: still alive (None). On teardown: also alive (None) -> terminate.
+        mock_proc.poll.side_effect = [None, None]
+        mock_proc.wait.return_value = 0
+
+        with (
+            mock.patch.object(main.subprocess, "Popen", return_value=mock_proc),
+            mock.patch.object(main.time, "sleep"),
+        ):
+            with main._dump_receiver_subprocess("/tmp/out") as proc:
+                self.assertIs(proc, mock_proc)
+
+        mock_proc.terminate.assert_called_once()
+        mock_proc.wait.assert_called()
+        mock_proc.kill.assert_not_called()
+
+    def test_popen_oserror_yields_none_and_proceeds(self):
+        """OSError on Popen (e.g. exec failure) must not raise; context yields None."""
+        from mellanox_bfb_installer import main
+
+        with (
+            mock.patch.object(main.subprocess, "Popen", side_effect=OSError("no exec")),
+            mock.patch.object(main.time, "sleep"),
+        ):
+            with main._dump_receiver_subprocess("/tmp/out") as proc:
+                self.assertIsNone(proc)
+        # Nothing to assert on teardown: no proc was ever started.
+
+    def test_proc_exits_immediately_yields_none_no_teardown(self):
+        """If the child exits before the 0.5s readiness sleep, we yield None and
+        don't try to SIGTERM/SIGKILL it later."""
+        from mellanox_bfb_installer import main
+
+        mock_proc = mock.MagicMock()
+        # poll() = 1 right after Popen (process exited immediately).
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with (
+            mock.patch.object(main.subprocess, "Popen", return_value=mock_proc),
+            mock.patch.object(main.time, "sleep"),
+        ):
+            with main._dump_receiver_subprocess("/tmp/out") as proc:
+                self.assertIsNone(proc)
+
+        mock_proc.terminate.assert_not_called()
+        mock_proc.kill.assert_not_called()
+
+    def test_terminate_timeout_falls_back_to_kill(self):
+        """If proc.wait() after terminate() times out, we SIGKILL the child."""
+        from mellanox_bfb_installer import main
+
+        mock_proc = mock.MagicMock()
+        mock_proc.poll.side_effect = [None, None]
+        # First wait (after terminate) times out, second wait (after kill) succeeds.
+        mock_proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="dump_receiver", timeout=5.0),
+            0,
+        ]
+        mock_proc.pid = 1234
+
+        with (
+            mock.patch.object(main.subprocess, "Popen", return_value=mock_proc),
+            mock.patch.object(main.time, "sleep"),
+        ):
+            with main._dump_receiver_subprocess("/tmp/out"):
+                pass
+
+        mock_proc.terminate.assert_called_once()
+        mock_proc.kill.assert_called_once()
+
+
+class TestInstallOnDpusDumpLifecycle(unittest.TestCase):
+    """Tests that _install_on_dpus sets up and tears down the tmfifo bridge + receiver
+    when collect_dump_on_failure is True, and skips that wiring otherwise.
+
+    Heavy mocking: device_selection.get_targets, install_executor.run_parallel,
+    tmfifo_bridge.TmfifoBridge, and _dump_receiver_subprocess are all stubbed so
+    no real network/system state is touched.
+    """
+
+    def _make_targets(self, count: int):
+        from mellanox_bfb_installer.device_selection import TargetInfo
+
+        return [
+            TargetInfo(
+                dpu=f"dpu{i}",
+                rshim=f"rshim{i}",
+                dpu_pci_bus_id=f"0000:0{i}:00.0",
+                rshim_pci_bus_id=f"0000:0{i}:00.1",
+                config_path=None,
+            )
+            for i in range(count)
+        ]
+
+    @contextmanager
+    def _common_mocks(self, targets, run_parallel_failed=0, setup_side_effect=None):
+        """Patch the boundary modules that _install_on_dpus depends on.
+
+        Yields a dict of MagicMocks for assertions.
+        """
+        from mellanox_bfb_installer import main
+
+        bridge_inst = mock.MagicMock()
+        if setup_side_effect is not None:
+            bridge_inst.setup.side_effect = setup_side_effect
+        bridge_cls = mock.MagicMock(return_value=bridge_inst)
+
+        @contextmanager
+        def fake_dump_receiver(*args, **kwargs):
+            yield mock.MagicMock()
+
+        with (
+            mock.patch.object(main.device_selection, "get_targets", return_value=list(targets)),
+            mock.patch.object(
+                main, "_add_additional_config_lines", return_value=None
+            ) as mock_add_cfg,
+            mock.patch.object(main.tmfifo_bridge, "TmfifoBridge", bridge_cls),
+            mock.patch.object(
+                main, "_dump_receiver_subprocess", side_effect=fake_dump_receiver
+            ) as mock_recv,
+            mock.patch.object(
+                main.install_executor, "run_parallel", return_value=run_parallel_failed
+            ) as mock_run_parallel,
+        ):
+            yield {
+                "bridge_cls": bridge_cls,
+                "bridge_inst": bridge_inst,
+                "add_cfg": mock_add_cfg,
+                "receiver": mock_recv,
+                "run_parallel": mock_run_parallel,
+            }
+
+    def test_bridge_and_receiver_started_and_torn_down_on_success(self):
+        from mellanox_bfb_installer import main
+
+        targets = self._make_targets(1)
+        with self._common_mocks(targets) as m:
+            main._install_on_dpus(
+                bfb_path="/tmp/x.bfb",
+                work_dir="/tmp/work",
+                rshims=None,
+                dpus="all",
+                verbose=False,
+                configs=None,
+                temp_work_dir="/tmp/work",
+                debug_shell=False,
+                collect_dump_on_failure=True,
+                dump_output_dir="/tmp/dumps",
+            )
+            m["bridge_inst"].setup.assert_called_once()
+            m["bridge_inst"].teardown.assert_called_once()
+            m["receiver"].assert_called_once()
+            m["run_parallel"].assert_called_once()
+            # Per-target bf.cfg got the new args propagated.
+            add_kwargs = m["add_cfg"].call_args[1]
+            self.assertTrue(add_kwargs["collect_dump_on_failure"])
+            self.assertTrue(add_kwargs["dump_upload_base_url"].startswith("http://"))
+
+    def test_bridge_teardown_runs_even_when_install_fails(self):
+        """run_parallel returns non-zero -> sys.exit(1), but bridge.teardown MUST still run."""
+        from mellanox_bfb_installer import main
+
+        targets = self._make_targets(2)
+        with self._common_mocks(targets, run_parallel_failed=1) as m:
+            with self.assertRaises(SystemExit) as cm:
+                main._install_on_dpus(
+                    bfb_path="/tmp/x.bfb",
+                    work_dir="/tmp/work",
+                    rshims=None,
+                    dpus="all",
+                    verbose=False,
+                    configs=None,
+                    temp_work_dir="/tmp/work",
+                    debug_shell=False,
+                    collect_dump_on_failure=True,
+                    dump_output_dir="/tmp/dumps",
+                )
+            self.assertEqual(cm.exception.code, 1)
+            m["bridge_inst"].setup.assert_called_once()
+            m["bridge_inst"].teardown.assert_called_once()
+
+    def test_collect_dump_disabled_skips_bridge_and_receiver(self):
+        """collect_dump_on_failure=False -> no bridge, no receiver, but install still runs."""
+        from mellanox_bfb_installer import main
+
+        targets = self._make_targets(1)
+        with self._common_mocks(targets) as m:
+            main._install_on_dpus(
+                bfb_path="/tmp/x.bfb",
+                work_dir="/tmp/work",
+                rshims=None,
+                dpus="all",
+                verbose=False,
+                configs=None,
+                temp_work_dir="/tmp/work",
+                debug_shell=False,
+                collect_dump_on_failure=False,
+                dump_output_dir="/tmp/dumps",
+            )
+            m["bridge_cls"].assert_not_called()
+            m["bridge_inst"].setup.assert_not_called()
+            m["bridge_inst"].teardown.assert_not_called()
+            m["receiver"].assert_not_called()
+            m["run_parallel"].assert_called_once()
+            # And the new bf.cfg fields are NOT propagated.
+            add_kwargs = m["add_cfg"].call_args[1]
+            self.assertFalse(add_kwargs["collect_dump_on_failure"])
+            self.assertIsNone(add_kwargs["dump_upload_base_url"])
+
+    def test_bridge_setup_failure_degrades_gracefully(self):
+        """If bridge.setup() raises CalledProcessError, install proceeds without it
+        (and bridge.teardown is NOT called, since setup never succeeded)."""
+        from mellanox_bfb_installer import main
+
+        targets = self._make_targets(1)
+        setup_err = subprocess.CalledProcessError(returncode=1, cmd=["ip"])
+        with self._common_mocks(targets, setup_side_effect=setup_err) as m:
+            main._install_on_dpus(
+                bfb_path="/tmp/x.bfb",
+                work_dir="/tmp/work",
+                rshims=None,
+                dpus="all",
+                verbose=False,
+                configs=None,
+                temp_work_dir="/tmp/work",
+                debug_shell=False,
+                collect_dump_on_failure=True,
+                dump_output_dir="/tmp/dumps",
+            )
+            m["bridge_inst"].setup.assert_called_once()
+            m["bridge_inst"].teardown.assert_not_called()
+            m["receiver"].assert_not_called()
+            m["run_parallel"].assert_called_once()
 
 
 if __name__ == "__main__":

--- a/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_tmfifo_bridge.py
+++ b/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_tmfifo_bridge.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Unit tests for mellanox_bfb_installer.tmfifo_bridge.
+
+These are pure unit tests: ``subprocess.run`` (used to invoke ``ip``/``bridge``)
+and the relevant ``os`` filesystem APIs are mocked, so no real bridge or
+network namespace change happens. The watcher thread is exercised through
+``setup()``/``teardown()`` and via direct calls to its helpers; we never
+sleep for the real poll interval to keep tests fast.
+"""
+
+import os
+import subprocess
+import sys
+import threading
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+def _ok_run(returncode: int = 0, stderr: str = ""):
+    """Build a MagicMock subprocess.run return value."""
+    return mock.MagicMock(returncode=returncode, stdout="", stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# _run_ip
+# ---------------------------------------------------------------------------
+
+
+class TestRunIp(unittest.TestCase):
+    """The thin wrapper around subprocess.run for ip/bridge commands."""
+
+    def test_prepends_ip_when_first_arg_is_not_bridge(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(tmfifo_bridge.subprocess, "run", return_value=_ok_run()) as m:
+            rc = tmfifo_bridge._run_ip(["link", "add", "br0", "type", "bridge"], check=True)
+            self.assertEqual(rc, 0)
+            argv = m.call_args[0][0]
+            self.assertEqual(argv[0], "ip")
+            self.assertEqual(argv[1:], ["link", "add", "br0", "type", "bridge"])
+            # subprocess.run kwargs we care about for safety:
+            kwargs = m.call_args[1]
+            self.assertIs(kwargs.get("stdin"), tmfifo_bridge.subprocess.DEVNULL)
+            self.assertTrue(kwargs.get("text"))
+            self.assertTrue(kwargs.get("check"))
+
+    def test_does_not_prepend_ip_when_first_arg_is_bridge(self):
+        """If a caller ever passes `bridge ...` we trust them and don't add 'ip'."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(tmfifo_bridge.subprocess, "run", return_value=_ok_run()) as m:
+            tmfifo_bridge._run_ip(["bridge", "link", "show"], check=False)
+            argv = m.call_args[0][0]
+            self.assertEqual(argv[0], "bridge")
+
+    def test_returns_nonzero_when_check_false(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(tmfifo_bridge.subprocess, "run", return_value=_ok_run(returncode=2)):
+            rc = tmfifo_bridge._run_ip(["link", "del", "br0"], check=False)
+            self.assertEqual(rc, 2)
+
+    def test_called_process_error_propagates_when_check_true(self):
+        """check=True must let the CalledProcessError escape so setup() can fail."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        err = subprocess.CalledProcessError(returncode=1, cmd=["ip"], stderr="boom")
+        with mock.patch.object(tmfifo_bridge.subprocess, "run", side_effect=err):
+            with self.assertRaises(subprocess.CalledProcessError):
+                tmfifo_bridge._run_ip(["link", "add", "br0", "type", "bridge"], check=True)
+
+
+# ---------------------------------------------------------------------------
+# _list_tmfifo_ifaces / _iface_master
+# ---------------------------------------------------------------------------
+
+
+class TestListTmfifoIfaces(unittest.TestCase):
+    def test_filters_to_tmfifo_net_pattern(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(
+            tmfifo_bridge.os,
+            "listdir",
+            return_value=[
+                "lo",
+                "eth0",
+                "tmfifo_net0",
+                "tmfifo_net12",
+                "tmfifo_netX",  # must NOT match: not all digits
+                "tmfifo_net",  # must NOT match: missing digits
+                "bridge-midplane",
+            ],
+        ):
+            result = tmfifo_bridge._list_tmfifo_ifaces()
+            self.assertEqual(result, ["tmfifo_net0", "tmfifo_net12"])
+
+    def test_returns_empty_list_when_sysfs_unavailable(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(
+            tmfifo_bridge.os, "listdir", side_effect=OSError("not found")
+        ):
+            self.assertEqual(tmfifo_bridge._list_tmfifo_ifaces(), [])
+
+    def test_results_are_sorted(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(
+            tmfifo_bridge.os,
+            "listdir",
+            return_value=["tmfifo_net2", "tmfifo_net0", "tmfifo_net10", "tmfifo_net1"],
+        ):
+            self.assertEqual(
+                tmfifo_bridge._list_tmfifo_ifaces(),
+                # Lexicographic, matching the production code's `sorted(...)`.
+                ["tmfifo_net0", "tmfifo_net1", "tmfifo_net10", "tmfifo_net2"],
+            )
+
+
+class TestIfaceMaster(unittest.TestCase):
+    def test_returns_basename_of_master_symlink(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(
+            tmfifo_bridge.os, "readlink", return_value="/sys/class/net/bridge-tmfifo"
+        ):
+            self.assertEqual(tmfifo_bridge._iface_master("tmfifo_net0"), "bridge-tmfifo")
+
+    def test_returns_none_when_no_master_link(self):
+        """Interfaces without /sys/class/net/<iface>/master raise OSError on readlink."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        with mock.patch.object(
+            tmfifo_bridge.os, "readlink", side_effect=OSError("no such link")
+        ):
+            self.assertIsNone(tmfifo_bridge._iface_master("tmfifo_net0"))
+
+
+# ---------------------------------------------------------------------------
+# TmfifoBridge.setup() / teardown()
+# ---------------------------------------------------------------------------
+
+
+class _BridgeBaseTest(unittest.TestCase):
+    """Common helpers for TmfifoBridge tests.
+
+    Patches subprocess.run to a counter+returncode-controlled fake and
+    captures every command argv for downstream assertions.
+    """
+
+    def _install_subprocess_patch(self, returncodes_by_cmd=None, raise_for_argv=None):
+        """Patch tmfifo_bridge.subprocess.run.
+
+        returncodes_by_cmd: optional dict { argv_tuple: returncode } that
+            overrides the default rc=0. Tuples are tried with the leading 'ip'
+            stripped because _run_ip prepends it.
+        raise_for_argv: optional set of argv tuples for which CalledProcessError
+            should be raised (with check=True semantics).
+        """
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._calls = []
+
+        def fake_run(argv, **kwargs):
+            argv_tuple = tuple(argv)
+            self._calls.append(argv_tuple)
+            if raise_for_argv and argv_tuple in raise_for_argv:
+                raise subprocess.CalledProcessError(
+                    returncode=1, cmd=list(argv_tuple), stderr="forced"
+                )
+            rc = 0
+            if returncodes_by_cmd and argv_tuple in returncodes_by_cmd:
+                rc = returncodes_by_cmd[argv_tuple]
+            if kwargs.get("check") and rc != 0:
+                raise subprocess.CalledProcessError(
+                    returncode=rc, cmd=list(argv_tuple), stderr=""
+                )
+            return _ok_run(returncode=rc)
+
+        patcher = mock.patch.object(tmfifo_bridge.subprocess, "run", side_effect=fake_run)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def _commands(self):
+        """Return the list of argv tuples in call order."""
+        return list(self._calls)
+
+
+class TestTmfifoBridgeSetup(_BridgeBaseTest):
+    def test_setup_runs_expected_ip_commands_in_order(self):
+        """setup() must: pre-delete (best-effort), add bridge, add IP, set up."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            try:
+                br.setup()
+            finally:
+                # Stop the watcher thread so the test doesn't leave one running.
+                br.teardown()
+
+        # Find the four bridge-management commands by their leading tokens.
+        bridge_cmds = [c for c in self._commands() if "bridge-test" in c]
+        # The pre-delete is first, then add/addr/up.
+        self.assertEqual(bridge_cmds[0], ("ip", "link", "del", "bridge-test"))
+        self.assertEqual(
+            bridge_cmds[1], ("ip", "link", "add", "name", "bridge-test", "type", "bridge")
+        )
+        self.assertEqual(
+            bridge_cmds[2], ("ip", "addr", "add", "10.0.0.1/24", "dev", "bridge-test")
+        )
+        self.assertEqual(bridge_cmds[3], ("ip", "link", "set", "bridge-test", "up"))
+
+    def test_setup_pre_delete_is_best_effort(self):
+        """Pre-delete failure must NOT abort setup (no leftover bridge case)."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        # First call (`ip link del`) returns non-zero, all others succeed.
+        self._install_subprocess_patch(
+            returncodes_by_cmd={("ip", "link", "del", "bridge-test"): 1}
+        )
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            try:
+                br.setup()  # must not raise
+                self.assertTrue(br._setup_done)
+            finally:
+                br.teardown()
+
+    def test_setup_raises_when_bridge_add_fails(self):
+        """`ip link add ... type bridge` is check=True; failure must surface
+        so the caller in main.py can degrade gracefully."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        bad = ("ip", "link", "add", "name", "bridge-test", "type", "bridge")
+        self._install_subprocess_patch(raise_for_argv={bad})
+
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            with self.assertRaises(subprocess.CalledProcessError):
+                br.setup()
+            self.assertFalse(br._setup_done)
+            # No watcher should have been started since setup didn't complete.
+            self.assertIsNone(br._watcher)
+
+    def test_setup_is_idempotent_when_called_twice(self):
+        """A second setup() call on the same instance must be a no-op."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            try:
+                br.setup()
+                first_calls = len(self._commands())
+                br.setup()
+                self.assertEqual(
+                    len(self._commands()),
+                    first_calls,
+                    "second setup() must not run any new ip commands",
+                )
+            finally:
+                br.teardown()
+
+    def test_setup_starts_watcher_thread(self):
+        """A daemon watcher thread is spawned and stops cleanly via teardown."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            try:
+                br.setup()
+                self.assertIsNotNone(br._watcher)
+                self.assertTrue(br._watcher.is_alive())
+                self.assertTrue(br._watcher.daemon)
+            finally:
+                br.teardown()
+            self.assertIsNone(br._watcher)
+
+    def test_setup_enslaves_already_present_tmfifo_ifaces(self):
+        """If tmfifo_net interfaces exist before setup(), they must be enslaved."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        # Two pre-existing tmfifo_net ifaces, neither has a master yet.
+        with mock.patch.object(
+            tmfifo_bridge, "_list_tmfifo_ifaces", return_value=["tmfifo_net0", "tmfifo_net1"]
+        ), mock.patch.object(tmfifo_bridge, "_iface_master", return_value=None):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            try:
+                br.setup()
+            finally:
+                br.teardown()
+
+        # The enslave + set-up commands must have been issued for both.
+        cmds = self._commands()
+        self.assertIn(
+            ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds
+        )
+        self.assertIn(("ip", "link", "set", "tmfifo_net0", "up"), cmds)
+        self.assertIn(
+            ("ip", "link", "set", "tmfifo_net1", "master", "bridge-test"), cmds
+        )
+        self.assertIn(("ip", "link", "set", "tmfifo_net1", "up"), cmds)
+
+
+class TestTmfifoBridgeTeardown(_BridgeBaseTest):
+    def test_teardown_without_setup_is_noop_safe(self):
+        """teardown() before setup() must NOT crash and must NOT issue ip commands."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+        # Even with no setup, teardown attempts the `link del` (idempotent
+        # cleanup); that's fine. What must NOT happen is releasing any slaves.
+        br.teardown()
+        cmds = self._commands()
+        # No `nomaster` releases occurred.
+        self.assertFalse(
+            any("nomaster" in c for c in cmds),
+            "teardown without setup must not release any slaves",
+        )
+
+    def test_teardown_deletes_bridge(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            br.setup()
+            br.teardown()
+
+        cmds = self._commands()
+        # Two link dels happen: pre-delete during setup, and final delete in teardown.
+        # The teardown one must be after addr add.
+        del_indices = [i for i, c in enumerate(cmds) if c == ("ip", "link", "del", "bridge-test")]
+        self.assertGreaterEqual(len(del_indices), 2)
+        addr_index = cmds.index(("ip", "addr", "add", "10.0.0.1/24", "dev", "bridge-test"))
+        self.assertGreater(del_indices[-1], addr_index)
+
+    def test_teardown_releases_only_slaves_we_attached(self):
+        """teardown() must call `nomaster` for ifaces we attached, and only if
+        they're still our slaves (a moved/vanished iface must be skipped).
+
+        We stub out the watcher loop to avoid racing the test's
+        ``_iface_master`` mock from the background thread; the watcher itself
+        is covered by ``TestTmfifoBridgeWatcherDirect``.
+        """
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+
+        # Stateful fake so concurrent calls (if any) all see consistent values.
+        # tmfifo_net0: unenslaved at setup, owned by us during teardown.
+        # tmfifo_net1: owned by another bridge from the start.
+        master_state = {"tmfifo_net0": None, "tmfifo_net1": "some-other-bridge"}
+        teardown_phase = threading.Event()
+
+        def fake_master(iface):
+            if teardown_phase.is_set() and iface == "tmfifo_net0":
+                return "bridge-test"
+            return master_state.get(iface)
+
+        with mock.patch.object(
+            tmfifo_bridge, "_list_tmfifo_ifaces", return_value=["tmfifo_net0", "tmfifo_net1"]
+        ), mock.patch.object(
+            tmfifo_bridge, "_iface_master", side_effect=fake_master
+        ), mock.patch.object(
+            tmfifo_bridge.TmfifoBridge, "_watcher_loop", lambda self: None
+        ):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            br.setup()
+            # Sanity: only tmfifo_net0 should be tracked.
+            self.assertEqual(br._enslaved_by_us, {"tmfifo_net0"})
+
+            teardown_phase.set()
+            br.teardown()
+
+        cmds = self._commands()
+        # tmfifo_net0 must have been released; tmfifo_net1 must not have been
+        # touched by us at any point.
+        self.assertIn(
+            ("ip", "link", "set", "tmfifo_net0", "nomaster"), cmds
+        )
+        self.assertNotIn(
+            ("ip", "link", "set", "tmfifo_net1", "nomaster"), cmds
+        )
+        # And we never tried to enslave the one already owned elsewhere.
+        self.assertNotIn(
+            ("ip", "link", "set", "tmfifo_net1", "master", "bridge-test"), cmds
+        )
+
+    def test_teardown_skips_release_when_iface_moved_to_different_master(self):
+        """If an iface we enslaved was moved away by an external actor before
+        teardown, we must NOT call nomaster on it (would yank an unrelated
+        bridge's slave)."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+
+        teardown_phase = threading.Event()
+
+        def fake_master(iface):
+            # During setup: unenslaved; during teardown: hijacked by another.
+            return "someone-else" if teardown_phase.is_set() else None
+
+        with mock.patch.object(
+            tmfifo_bridge, "_list_tmfifo_ifaces", return_value=["tmfifo_net0"]
+        ), mock.patch.object(
+            tmfifo_bridge, "_iface_master", side_effect=fake_master
+        ), mock.patch.object(
+            tmfifo_bridge.TmfifoBridge, "_watcher_loop", lambda self: None
+        ):
+            br = tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+            br.setup()
+            teardown_phase.set()
+            br.teardown()
+
+        cmds = self._commands()
+        # Sanity: setup actually enslaved the iface first, so the teardown-skip
+        # below is exercising the real "moved away by an external actor" path.
+        self.assertIn(("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds)
+        self.assertNotIn(("ip", "link", "set", "tmfifo_net0", "nomaster"), cmds)
+
+
+# ---------------------------------------------------------------------------
+# TmfifoBridge._enslave_one  branch coverage
+# ---------------------------------------------------------------------------
+
+
+class TestTmfifoBridgeEnslaveOne(_BridgeBaseTest):
+    """Directly drive _enslave_one through each of its three branches."""
+
+    def _make_bridge(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        return tmfifo_bridge.TmfifoBridge(bridge_name="bridge-test", bridge_cidr="10.0.0.1/24")
+
+    def test_already_ours_only_brings_up(self):
+        """If master already == us, we only re-up (no second master attach,
+        no addition to tracking set since we don't own it via setup)."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_iface_master", return_value="bridge-test"):
+            br = self._make_bridge()
+            br._enslave_one("tmfifo_net0")
+
+        cmds = self._commands()
+        self.assertIn(("ip", "link", "set", "tmfifo_net0", "up"), cmds)
+        self.assertNotIn(
+            ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds
+        )
+        # We didn't attach it, so we don't claim it for teardown.
+        self.assertNotIn("tmfifo_net0", br._enslaved_by_us)
+
+    def test_owned_by_someone_else_is_skipped(self):
+        """Don't tug-of-war: leave the iface alone, log only."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_iface_master", return_value="other-bridge"):
+            br = self._make_bridge()
+            br._enslave_one("tmfifo_net0")
+
+        cmds = self._commands()
+        self.assertNotIn(
+            ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds
+        )
+        self.assertNotIn(("ip", "link", "set", "tmfifo_net0", "up"), cmds)
+        self.assertNotIn("tmfifo_net0", br._enslaved_by_us)
+
+    def test_unenslaved_attaches_and_brings_up_and_tracks(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_iface_master", return_value=None):
+            br = self._make_bridge()
+            br._enslave_one("tmfifo_net0")
+
+        cmds = self._commands()
+        self.assertIn(
+            ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds
+        )
+        self.assertIn(("ip", "link", "set", "tmfifo_net0", "up"), cmds)
+        self.assertIn("tmfifo_net0", br._enslaved_by_us)
+
+    def test_enslave_failure_does_not_track(self):
+        """If `ip link set ... master <br>` fails, we must NOT bring it up
+        and must NOT track it (since teardown would then try nomaster on
+        an iface we never owned)."""
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        bad = ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test")
+        self._install_subprocess_patch(returncodes_by_cmd={bad: 1})
+        with mock.patch.object(tmfifo_bridge, "_iface_master", return_value=None):
+            br = self._make_bridge()
+            br._enslave_one("tmfifo_net0")
+
+        cmds = self._commands()
+        # The attach was attempted but the follow-up `link set ... up` was NOT.
+        self.assertIn(bad, cmds)
+        self.assertNotIn(("ip", "link", "set", "tmfifo_net0", "up"), cmds)
+        self.assertNotIn("tmfifo_net0", br._enslaved_by_us)
+
+
+# ---------------------------------------------------------------------------
+# TmfifoBridge context-manager protocol
+# ---------------------------------------------------------------------------
+
+
+class TestTmfifoBridgeContextManager(_BridgeBaseTest):
+    def test_enter_calls_setup_exit_calls_teardown(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            with tmfifo_bridge.TmfifoBridge(
+                bridge_name="bridge-test", bridge_cidr="10.0.0.1/24"
+            ) as br:
+                self.assertTrue(br._setup_done)
+                self.assertIsNotNone(br._watcher)
+            self.assertFalse(br._setup_done)
+            self.assertIsNone(br._watcher)
+
+    def test_exit_runs_teardown_even_when_body_raises(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+        with mock.patch.object(tmfifo_bridge, "_list_tmfifo_ifaces", return_value=[]):
+            with self.assertRaises(RuntimeError):
+                with tmfifo_bridge.TmfifoBridge(
+                    bridge_name="bridge-test", bridge_cidr="10.0.0.1/24"
+                ) as br:
+                    raise RuntimeError("boom")
+            self.assertFalse(br._setup_done)
+
+
+# ---------------------------------------------------------------------------
+# Watcher loop: ensure new ifaces appearing post-setup get enslaved
+# ---------------------------------------------------------------------------
+
+
+class TestTmfifoBridgeWatcherDirect(_BridgeBaseTest):
+    """Exercise the watcher loop directly with mocked dependencies.
+
+    We don't rely on the real thread for this test: we instantiate a bridge,
+    set up the stop event, drive one iteration manually, then signal stop.
+    """
+
+    def test_watcher_picks_up_new_iface_and_enslaves_it(self):
+        from mellanox_bfb_installer import tmfifo_bridge
+
+        self._install_subprocess_patch()
+
+        # Sequence of /sys/class/net snapshots:
+        #   1st poll: nothing
+        #   2nd poll: tmfifo_net0 appears
+        # After 2 polls the stop event is set.
+        snapshots = [[], ["tmfifo_net0"]]
+        snapshot_iter = iter(snapshots)
+
+        def fake_list():
+            try:
+                return next(snapshot_iter)
+            except StopIteration:
+                return ["tmfifo_net0"]
+
+        with mock.patch.object(
+            tmfifo_bridge, "_list_tmfifo_ifaces", side_effect=fake_list
+        ), mock.patch.object(tmfifo_bridge, "_iface_master", return_value=None):
+            br = tmfifo_bridge.TmfifoBridge(
+                bridge_name="bridge-test", bridge_cidr="10.0.0.1/24"
+            )
+            # Bypass setup() to avoid the bridge-management commands;
+            # we're isolating the watcher behaviour here.
+            br._stop_evt = threading.Event()
+
+            # Run the watcher in this thread for a bounded number of polls.
+            done = threading.Event()
+
+            def stop_after_polls():
+                # Allow a couple of poll cycles, then stop.
+                for _ in range(60):  # up to ~3s at 0.05s poll
+                    if len(self._commands()) >= 3:  # attach + up at least
+                        break
+                    if br._enslaved_by_us:
+                        break
+                    if done.is_set():
+                        break
+                    # Speed up the wait by using a tiny poll interval.
+                    br._stop_evt.wait(0.05)
+                br._stop_evt.set()
+
+            # Tighten the poll interval so the test runs fast.
+            with mock.patch.object(tmfifo_bridge, "_WATCHER_POLL_INTERVAL_SEC", 0.01):
+                stopper = threading.Thread(target=stop_after_polls, daemon=True)
+                stopper.start()
+                try:
+                    br._watcher_loop()
+                finally:
+                    done.set()
+                    stopper.join(timeout=2)
+
+        # After running, the watcher should have enslaved tmfifo_net0.
+        self.assertIn("tmfifo_net0", br._enslaved_by_us)
+        cmds = self._commands()
+        self.assertIn(
+            ("ip", "link", "set", "tmfifo_net0", "master", "bridge-test"), cmds
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -120,17 +120,315 @@ fi
 # Flags that can be overwritten by the bf.cfg
 declare -r SKIP_FIRMWARE_UPGRADE="${SKIP_FIRMWARE_UPGRADE:-false}"
 declare -r FORCE_FW_CONFIG_RESET="${FORCE_FW_CONFIG_RESET:-false}"
+# When set to "true" (typically by the NPU-side bfb installer via --debug-shell),
+# drop into an interactive recovery bash in the chroot if ex_chroot's command fails.
+declare -r DEBUG_SHELL="${DEBUG_SHELL:-false}"
+# When set to "true" (by the NPU-side sonic-bfb-installer by default), on any
+# ex_chroot command failure collect platform-dump.sh (which includes mstdump)
+# inside the chroot and PUT it to the NPU's ephemeral HTTP dump receiver over
+# tmfifo. The NPU bridge address is ${DUMP_UPLOAD_BASE_URL}; this DPU's
+# tmfifo0 gets 192.168.100.$((1 + DPU_ID))/24, see ex_chroot_bring_up_tmfifo.
+declare -r COLLECT_DUMP_ON_FAILURE="${COLLECT_DUMP_ON_FAILURE:-false}"
+declare -r DUMP_UPLOAD_BASE_URL="${DUMP_UPLOAD_BASE_URL:-http://192.168.100.254:8090}"
+# How long (seconds) to wait for the install target block device to appear
+# before collecting a one-shot diagnostic dump (best-effort, only honoured when
+# COLLECT_DUMP_ON_FAILURE=true). The wait for the device continues afterwards.
+declare -r DEVICE_WAIT_DUMP_TIMEOUT="${DEVICE_WAIT_DUMP_TIMEOUT:-60}"
 
 ex() {
     echo "Executing command: $@" > /dev/ttyAMA0
 
     local rc=0
-    $@ 2>&1 > /dev/ttyAMA0
+    $@ > /dev/ttyAMA0 2>&1
     rc=$?
 
     if [[ $rc -ne 0 ]]; then
         echo "RC: $rc" > /dev/ttyAMA0
     fi
+}
+
+# Bring up tmfifo0 inside the chroot and assign this DPU's recovery address
+# (192.168.100.$((1 + DPU_ID))/24). Idempotent and best-effort: every step is
+# swallowed so callers can rely on it not failing the install/recovery path.
+# Used by both the auto-dump path and the DEBUG_SHELL interactive path.
+ex_chroot_bring_up_tmfifo() {
+    chroot $sonic_fs_mountpoint modprobe mlxbf-tmfifo 2>/dev/null || true
+    # Driver / rename may lag after modprobe; wait before bringing tmfifo0 up.
+    local _tmfifo_wait=0
+    while ! chroot $sonic_fs_mountpoint ip link show tmfifo0 >/dev/null 2>&1; do
+        sleep 0.2
+        _tmfifo_wait=$((_tmfifo_wait + 1))
+        [[ $_tmfifo_wait -ge 50 ]] && break
+    done
+    chroot $sonic_fs_mountpoint ip link set tmfifo0 up 2>/dev/null || true
+    # bf.cfg may set DPU_ID; last octet is 1 + DPU_ID (default DPU_ID 0 -> .1).
+    local tmfifo0_last_octet=$((1 + ${DPU_ID:-0}))
+    # Add the address only if it isn't already there; ignore EEXIST.
+    chroot $sonic_fs_mountpoint ip addr add "192.168.100.${tmfifo0_last_octet}/24" dev tmfifo0 \
+        2>/dev/null || true
+}
+
+# Inside the chroot, take 3 back-to-back mstdumps for every device that
+# appears under /dev/mst. Stored at /tmp/mstdumps/mstdump_<dev>_<i>. Each
+# step is best-effort; failure of one device's dump won't abort the others.
+ex_chroot_collect_three_mstdumps() {
+    local mstdump_iters=3
+    local mstdump_sleep_sec=1
+    chroot $sonic_fs_mountpoint /bin/bash -s -- "$mstdump_iters" "$mstdump_sleep_sec" \
+            >/dev/ttyAMA0 2>&1 <<'INNER_MSTDUMP_EOF' || true
+iters=$1
+sleep_sec=$2
+mkdir -p /tmp/mstdumps
+if [[ ! -d /dev/mst ]] || ! ls /dev/mst/mt* >/dev/null 2>&1; then
+    echo "No /dev/mst/mt* devices found; mstdump collection skipped." >&2
+    exit 0
+fi
+for i in $(seq 1 "$iters"); do
+    for dev_path in /dev/mst/mt*; do
+        [[ -e "$dev_path" ]] || continue
+        dev=$(basename "$dev_path")
+        out=/tmp/mstdumps/mstdump_${dev}_${i}
+        echo "mstdump iter=$i dev=$dev -> $out" >&2
+        # Bound each dump so a wedged device can't hang the recovery path.
+        timeout 20 mstdump -full "$dev_path" > "$out" 2>>/tmp/mstdumps/errors.log
+        rc=$?
+        if [[ $rc -ne 0 ]]; then
+            echo "  mstdump iter=$i dev=$dev failed (rc=$rc)" >&2
+        fi
+    done
+    if [[ "$i" -lt "$iters" ]]; then
+        sleep "$sleep_sec"
+    fi
+done
+INNER_MSTDUMP_EOF
+}
+
+# Best-effort: collect platform-dump.sh (mstdump etc.) + 3 successive
+# mstdumps per /dev/mst device inside the chroot, bundle them into one
+# tarball, and PUT it to the NPU's per-install HTTP receiver over tmfifo.
+# Never fails the caller; all output goes to /dev/ttyAMA0 for post-mortem.
+ex_chroot_collect_and_upload_dump() {
+    local failed_cmd="$1"
+    local dpu_id=${DPU_ID:-0}
+    local timestamp
+    timestamp=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo "unknown")
+    local dump_basename="install-recovery-dpu${dpu_id}-${timestamp}.tar.gz"
+    local dump_url="${DUMP_UPLOAD_BASE_URL}/dpu${dpu_id}/${dump_basename}"
+
+    echo "Collecting platform-dump for recovery upload (failed cmd: ${failed_cmd})" \
+        > /dev/ttyAMA0
+
+    if [[ ! -x "$sonic_fs_mountpoint/usr/bin/platform-dump.sh" ]]; then
+        echo "platform-dump.sh missing inside chroot; skipping auto-collect." > /dev/ttyAMA0
+        return 0
+    fi
+
+    ex_chroot_bring_up_tmfifo
+
+    # mst is required for mstdump; failure here is logged but not fatal.
+    chroot $sonic_fs_mountpoint /usr/bin/mst start >/dev/ttyAMA0 2>&1 || true
+
+    # Take 3 successive mstdumps per /dev/mst device before platform-dump.sh
+    # so we capture three near-simultaneous register snapshots while the
+    # device is still in its post-failure state. This is the extra evidence
+    # over and above what platform-dump.sh's single per-device mstdump gives.
+    ex_chroot_collect_three_mstdumps
+
+    # platform-dump.sh tar's into /tmp/platform-dump.tar.gz inside the chroot.
+    if ! chroot $sonic_fs_mountpoint /usr/bin/platform-dump.sh >/dev/ttyAMA0 2>&1; then
+        echo "platform-dump.sh returned non-zero; uploading whatever it produced." \
+            > /dev/ttyAMA0
+    fi
+
+    # Bundle platform-dump.tar.gz together with the 3-iteration mstdumps
+    # into a single tarball so the upload is a single PUT. If the inner
+    # platform-dump.tar.gz is missing we still ship the mstdumps.
+    local bundle_basename="${dump_basename}"
+    local bundle_in_chroot="/tmp/${bundle_basename}"
+    chroot $sonic_fs_mountpoint /bin/bash -s -- "$bundle_basename" \
+            >/dev/ttyAMA0 2>&1 <<'INNER_BUNDLE_EOF' || true
+bundle_name=$1
+bundle_path=/tmp/${bundle_name}
+rm -f "$bundle_path"
+mkdir -p /tmp/bundle-staging
+# Include platform-dump.tar.gz if produced.
+if [[ -s /tmp/platform-dump.tar.gz ]]; then
+    cp /tmp/platform-dump.tar.gz /tmp/bundle-staging/
+fi
+# Include the 3-iteration mstdumps, plus any errors.log captured along
+# the way (kept small).
+if [[ -d /tmp/mstdumps ]] && compgen -G "/tmp/mstdumps/*" >/dev/null; then
+    cp -r /tmp/mstdumps /tmp/bundle-staging/
+fi
+if compgen -G "/tmp/bundle-staging/*" >/dev/null; then
+    tar czf "$bundle_path" -C /tmp/bundle-staging .
+fi
+rm -rf /tmp/bundle-staging
+INNER_BUNDLE_EOF
+
+    local bundle_on_host="$sonic_fs_mountpoint${bundle_in_chroot}"
+    if [[ ! -s "$bundle_on_host" ]]; then
+        echo "No diagnostic bundle produced; nothing to upload." > /dev/ttyAMA0
+        return 0
+    fi
+    echo "Built diagnostic bundle ${bundle_on_host} ($(stat -c '%s' "$bundle_on_host" 2>/dev/null || echo '?') bytes)" \
+        > /dev/ttyAMA0
+
+    # Try curl from inside the chroot (we know openssl + curl were packaged
+    # into the BFB initramfs's chroot via create_sonic_image). Fall back to
+    # the initramfs's curl if the chroot one is unavailable.
+    local upload_ok=1
+    if chroot $sonic_fs_mountpoint test -x /usr/bin/curl; then
+        if chroot $sonic_fs_mountpoint /usr/bin/curl \
+                --silent --show-error --fail \
+                --max-time 120 --retry 3 --retry-delay 2 \
+                --request PUT \
+                --header "Content-Type: application/gzip" \
+                --upload-file "${bundle_in_chroot}" \
+                "$dump_url" >/dev/ttyAMA0 2>&1; then
+            upload_ok=0
+        fi
+    elif command -v curl >/dev/null 2>&1; then
+        if curl --silent --show-error --fail \
+                --max-time 120 --retry 3 --retry-delay 2 \
+                --request PUT \
+                --header "Content-Type: application/gzip" \
+                --upload-file "$bundle_on_host" \
+                "$dump_url" >/dev/ttyAMA0 2>&1; then
+            upload_ok=0
+        fi
+    else
+        echo "curl unavailable; cannot upload diagnostic bundle." > /dev/ttyAMA0
+    fi
+
+    if [[ $upload_ok -eq 0 ]]; then
+        echo "Uploaded diagnostic bundle to ${dump_url}" > /dev/ttyAMA0
+    else
+        echo "Failed to upload diagnostic bundle to ${dump_url}; tarball left at \
+${bundle_on_host}." > /dev/ttyAMA0
+    fi
+}
+
+ex_chroot() {
+    echo "Executing command (chroot): $@" > /dev/ttyAMA0
+
+    local rc=0
+    chroot $sonic_fs_mountpoint "$@" > /dev/ttyAMA0 2>&1
+    rc=$?
+
+    if [[ $rc -ne 0 ]]; then
+        echo "Command failed (RC: $rc): $@" > /dev/ttyAMA0
+
+        # Always attempt the dump upload first (independent of DEBUG_SHELL)
+        # so unattended installs still get diagnostics back to the NPU. The
+        # upload routine brings tmfifo0 up itself, so the DEBUG_SHELL path
+        # below can rely on it already being addressed.
+        if [[ "$COLLECT_DUMP_ON_FAILURE" == "true" ]]; then
+            ex_chroot_collect_and_upload_dump "$*" || true
+        fi
+
+        if [[ "$DEBUG_SHELL" == "true" ]]; then
+            echo "DEBUG_SHELL=true: dropping to bash session in writable chroot (overlayfs)." > /dev/ttyAMA0
+            echo "You can install .deb packages, run commands, etc." > /dev/ttyAMA0
+            echo "Type 'exit' to continue the installation." > /dev/ttyAMA0
+            # tmfifo may already be up from the auto-dump path above; this
+            # call is idempotent and cheap.
+            ex_chroot_bring_up_tmfifo
+            # script(1) needs devpts; bind-mounted /dev in the chroot is not enough for PTYs.
+            # script runs bash on a pseudo-terminal: serial I/O is bridged, INTR (^C) is reliable.
+            local recovery_devpts_mounted=0
+            ex mkdir -p $sonic_fs_mountpoint/dev/pts
+            mount -t devpts -o newinstance,ptmxmode=0666 devpts "$sonic_fs_mountpoint/dev/pts" >/dev/ttyAMA0 2>&1 \
+                && recovery_devpts_mounted=1
+            if [[ -x $sonic_fs_mountpoint/usr/bin/script && $recovery_devpts_mounted -eq 1 ]]; then
+                chroot $sonic_fs_mountpoint /usr/bin/script -qfec \
+                    'hostname -b sonic-installer-recovery 2>/dev/null; exec /bin/bash -i' /dev/null \
+                    </dev/ttyAMA0 >/dev/ttyAMA0 2>&1
+            else
+                chroot $sonic_fs_mountpoint /bin/bash -i </dev/ttyAMA0 >/dev/ttyAMA0 2>&1
+            fi
+            if [[ $recovery_devpts_mounted -eq 1 ]]; then
+                umount "$sonic_fs_mountpoint/dev/pts" >/dev/ttyAMA0 2>&1 || true
+            fi
+        fi
+    fi
+}
+
+# Overlay SONiC rootfs for chroot (fw-manager, recovery). Sets sonic_fs_* globals;
+# call sonic_fs_chroot_umount when done. Requires image_dir.
+sonic_fs_chroot_mount() {
+    # Optional arg: path to the rootfs squashfs to mount. Defaults to the copy
+    # extracted onto the target device. The early device-wait dump path passes a
+    # squashfs extracted straight from the in-initramfs INSTALLER_PAYLOAD, since
+    # the target device isn't available yet at that point.
+    sonic_fs_path="${1:-/mnt/$image_dir/fs.squashfs}"
+    sonic_fs_mountpoint="/tmp/$image_dir-fs"
+    sonic_fs_lower="/tmp/$image_dir-fs-lower"
+    sonic_fs_overlay="/tmp/$image_dir-fs-overlay"
+
+    ex mkdir -p $sonic_fs_mountpoint $sonic_fs_lower $sonic_fs_overlay
+    ex mount -t squashfs $sonic_fs_path $sonic_fs_lower
+    ex mount -t tmpfs tmpfs $sonic_fs_overlay
+    ex mkdir -p $sonic_fs_overlay/upper $sonic_fs_overlay/work
+    ex mount -t overlay overlay -o lowerdir=$sonic_fs_lower,upperdir=$sonic_fs_overlay/upper,workdir=$sonic_fs_overlay/work $sonic_fs_mountpoint
+
+    # Mount shared memory needed for FW manager. Only mount it if it isn't
+    # already mounted, and remember that we did so teardown doesn't unmount a
+    # pre-existing /dev/shm that we didn't create.
+    sonic_fs_mounted_dev_shm=false
+    if ! grep -q " /dev/shm " /proc/mounts; then
+        ex mkdir -m 1777 /dev/shm
+        ex mount -t tmpfs -o size=4G tmpfs /dev/shm
+        sonic_fs_mounted_dev_shm=true
+    fi
+
+    # Mount other filesystems needed for FW manager
+    ex mount -t proc /proc $sonic_fs_mountpoint/proc
+    ex mount -t sysfs /sys $sonic_fs_mountpoint/sys
+    ex mount --bind /dev $sonic_fs_mountpoint/dev
+    ex mount -t tmpfs -o rw tmpfs $sonic_fs_mountpoint/tmp
+    ex mount --bind /mnt $sonic_fs_mountpoint/host
+}
+
+sonic_fs_chroot_umount() {
+    ex umount $sonic_fs_mountpoint/host
+    ex umount $sonic_fs_mountpoint/tmp
+    ex umount $sonic_fs_mountpoint/proc
+    ex umount $sonic_fs_mountpoint/sys
+    ex umount $sonic_fs_mountpoint/dev
+    ex umount $sonic_fs_mountpoint
+	ex umount $sonic_fs_lower
+	ex umount $sonic_fs_overlay
+	if [ "$sonic_fs_mounted_dev_shm" = true ]; then
+		ex umount /dev/shm
+	fi
+}
+
+# Best-effort: collect a firmware/register dump when the install target block
+# device never appears. The normal failure-dump path (ex_chroot_collect_and_upload_dump)
+# needs the SONiC rootfs chroot, which is usually mounted off the target device
+# -- exactly what's missing here. Instead we extract the rootfs squashfs straight
+# from the in-initramfs INSTALLER_PAYLOAD into RAM, mount the chroot from it, run
+# the standard collect+upload, then tear everything down. Never fails the caller.
+collect_dump_for_missing_device() {
+    [[ "$COLLECT_DUMP_ON_FAILURE" == "true" ]] || return 0
+
+    local early_squashfs="/tmp/early-dump-$FILESYSTEM_SQUASHFS"
+
+    echo "Device $device not ready after ${DEVICE_WAIT_DUMP_TIMEOUT}s; collecting firmware dump from initramfs payload." \
+        > /dev/ttyAMA0
+
+    if ! unzip -op /debian/$INSTALLER_PAYLOAD "$FILESYSTEM_SQUASHFS" > "$early_squashfs" 2>/dev/ttyAMA0; then
+        echo "Failed to extract $FILESYSTEM_SQUASHFS from payload; skipping early dump." > /dev/ttyAMA0
+        rm -f "$early_squashfs"
+        return 0
+    fi
+
+    sonic_fs_chroot_mount "$early_squashfs"
+    ex_chroot_collect_and_upload_dump "device $device not ready" || true
+    sonic_fs_chroot_umount
+
+    rm -f "$early_squashfs"
 }
 
 if (lspci -n -d 15b3: | grep -wq 'a2dc'); then
@@ -167,9 +465,20 @@ log "Using $device device and $device_label device label"
 
 # We cannot use wait-for-root as it expects the device to contain a
 # known filesystem, which might not be the case here.
+device_wait_secs=0
+early_dump_collected=false
 while [ ! -b $device ]; do
     log "Waiting for $device to be ready"
     sleep 1
+    device_wait_secs=$((device_wait_secs + 1))
+    # If the device never enumerates (e.g. NVMe not coming up) we'd otherwise
+    # block here forever with no diagnostics. After a grace period grab a
+    # one-shot best-effort dump (firmware/mst registers etc.) so the failure is
+    # debuggable, then keep waiting for the device.
+    if [[ "$early_dump_collected" == "false" ]] && [[ $device_wait_secs -ge $DEVICE_WAIT_DUMP_TIMEOUT ]]; then
+        collect_dump_for_missing_device
+        early_dump_collected=true
+    fi
 done
 
 # Flash image
@@ -242,41 +551,20 @@ chmod a+r /mnt/machine.conf
 sync
 
 if [[ $SKIP_FIRMWARE_UPGRADE != "true" ]]; then
-	sonic_fs_path="/mnt/$image_dir/fs.squashfs"
-	sonic_fs_mountpoint="/tmp/$image_dir-fs"
-
-	ex mkdir -p $sonic_fs_mountpoint
-	ex mount -t squashfs $sonic_fs_path $sonic_fs_mountpoint
-
-	# Mount shared memory needed for FW manager
-	ex mkdir -m 1777 /dev/shm
-	ex mount -t tmpfs -o size=4G tmpfs /dev/shm
-
-	# Mount other filesystems needed for FW manager
-	ex mount -t proc /proc $sonic_fs_mountpoint/proc
-	ex mount -t sysfs /sys $sonic_fs_mountpoint/sys
-	ex mount --bind /dev $sonic_fs_mountpoint/dev
-	ex mount -t tmpfs -o rw tmpfs $sonic_fs_mountpoint/tmp
-	ex mount --bind /mnt $sonic_fs_mountpoint/host
+	sonic_fs_chroot_mount
 
 	if function_exists bfb_pre_fw_install; then
 		log "Running bfb_pre_fw_install from bf.cfg"
 		bfb_pre_fw_install
 	fi
 
-	ex chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager -m --nosyslog --verbose
+	ex_chroot /usr/local/bin/mlnx-fw-manager -m --nosyslog --verbose
 
 	if [[ $FORCE_FW_CONFIG_RESET == "true" ]]; then
-		ex chroot $sonic_fs_mountpoint /usr/local/bin/mlnx-fw-manager -m --reset --nosyslog --verbose
+		ex_chroot /usr/local/bin/mlnx-fw-manager -m --reset --nosyslog --verbose
 	fi
 
-	ex umount $sonic_fs_mountpoint/host
-	ex umount $sonic_fs_mountpoint/tmp
-	ex umount $sonic_fs_mountpoint/proc
-	ex umount $sonic_fs_mountpoint/sys
-	ex umount $sonic_fs_mountpoint/dev
-	ex umount $sonic_fs_mountpoint
-	ex umount /dev/shm
+	sonic_fs_chroot_umount
 fi
 
 if function_exists bfb_post_sonic_install; then


### PR DESCRIPTION
#### Why I did it
BlueField (DPU) firmware-update installs that fail mid-flight were hard to debug:
on a DPU-side installer failure there was no automatic way to capture
firmware/register state, and an unattended install would simply error out (or, with
a NVMe target that never enumerates, block forever) with no diagnostics returned to
the NPU.

This PR adds an end-to-end recovery/diagnostics path for the `sonic-bfb-installer`
flow:
- NPU side can request an interactive recovery shell and/or automatic diagnostic
  collection on the DPU.
- DPU side collects `platform-dump.sh` output plus successive `mstdump`s on any
  install/chroot command failure and uploads them back to the NPU over tmfifo.
- The same diagnostics are now also collected when the install target block device
  (e.g. NVMe) never appears, instead of waiting indefinitely with no information.

#### How I did it
NPU-side (`platform/mellanox/platform-utils/mellanox_bfb_installer/`):
- Added `--debug-shell` to drop into an interactive recovery shell on a DPU-side
  installer command failure.
- Per-DPU config generation now emits `DPU_ID` (used by the DPU to compute its
  tmfifo0 recovery address `192.168.100.{1+DPU_ID}/24`), and optionally
  `DEBUG_SHELL` / `COLLECT_DUMP_ON_FAILURE` / `DUMP_UPLOAD_BASE_URL`.
- Added an ephemeral HTTP dump receiver (`dump_receiver.py`) and a tmfifo bridge
  (`tmfifo_bridge.py`, `bridge-tmfifo` @ `192.168.100.254`) so each DPU can PUT its
  diagnostic bundle back to the NPU during install.
- Fixed the upgrade command and reworked per-target config handling; added unit
  tests (`test_main.py`, `test_dump_receiver.py`, `test_tmfifo_bridge.py`).

DPU-side (`platform/nvidia-bluefield/installer/install.sh.j2`):
- On any `ex_chroot` command failure (gated by `COLLECT_DUMP_ON_FAILURE`), bring up
  tmfifo0, run `mst start`, take 3 successive `mstdump`s per `/dev/mst` device, run
  `platform-dump.sh`, bundle everything into one tarball, and PUT it to the NPU's
  receiver. Optional `DEBUG_SHELL` drops into a writable-overlay chroot recovery
  bash on the serial console.
- New: when the install target block device never enumerates, after a grace period
  (`DEVICE_WAIT_DUMP_TIMEOUT`, default 60s) collect the same diagnostic bundle once
  by mounting the rootfs squashfs directly from the in-initramfs `INSTALLER_PAYLOAD`
  (the target device isn't available yet), then continue waiting. Best-effort and a
  no-op unless `COLLECT_DUMP_ON_FAILURE=true`.

#### How to verify it
- Run the unit tests:
  `pytest platform/mellanox/platform-utils/tests/mellanox_bfb_installer/`
- Functional: install a BFB onto a DPU with
  `sonic-bfb-installer ... --debug-shell` and with dump-on-failure enabled, force a
  chroot/firmware failure, and confirm a diagnostic tarball
  (`install-recovery-dpu<N>-<ts>.tar.gz`) arrives in the NPU receiver's output dir.
- Device-missing path: boot the installer with no/absent NVMe target and
  `COLLECT_DUMP_ON_FAILURE=true`; confirm a single dump is collected and uploaded
  after ~60s while the installer keeps waiting for the device.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

<!-- These are features (DPU install diagnostics/recovery), not fixes, so no backport. -->

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
Add DPU install diagnostics/recovery for sonic-bfb-installer: debug-shell, automatic mstdump/platform-dump collection and tmfifo upload on failure, and dump collection when the install target device is missing.

#### Link to config_db schema for YANG module changes
N/A — no YANG/config_db schema changes.
