### PR TITLE
[config-engine] Parse single-ASIC BGP router ID from minigraph

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2100,7 +2100,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     local_devices = parse_asic_meta_get_devices(root)
 
     for child in root:
-        if child.tag == str(QName(ns, "CpgDec")):
+        if not is_multi_asic() and child.tag == str(QName(ns, "CpgDec")):
             bgp_router_id = parse_bgp_router_id(child, hostname)
 
         if asic_hostname is None:

--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1294,6 +1294,24 @@ def parse_host_loopback(dpg, hname):
         return lo_intfs
 
 
+def parse_bgp_router_id(cpg, hname):
+    routers = cpg.find(str(QName(ns, "Routers")))
+    if routers is None:
+        return None
+
+    for router in routers.findall(str(QName(ns1, "BGPRouterDeclaration"))):
+        hostname = router.find(str(QName(ns1, "Hostname")))
+        if hostname is None or not hostname.text or hostname.text.lower() != hname.lower():
+            continue
+
+        router_id = router.find(str(QName(ns1, "RouterID")))
+        if router_id is not None and router_id.text:
+            return router_id.text.strip() or None
+        return None
+
+    return None
+
+
 def parse_cpg(cpg, hname, local_devices=[]):
     bgp_sessions = {}
     bgp_internal_sessions = {}
@@ -1986,6 +2004,7 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     bgp_sessions = None
     bgp_monitors = []
     bgp_asn = None
+    bgp_router_id = None
     intfs = None
     dpg_ecmp_content = {}
     png_ecmp_content = {}
@@ -2081,6 +2100,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
     local_devices = parse_asic_meta_get_devices(root)
 
     for child in root:
+        if child.tag == str(QName(ns, "CpgDec")):
+            bgp_router_id = parse_bgp_router_id(child, hostname)
+
         if asic_hostname is None:
             if child.tag == str(QName(ns, "DpgDec")):
                 (intfs, lo_intfs, mvrf, mgmt_intf, voq_inband_intfs, vlans, vlan_members, dhcp_relay_table, pcs, pc_members, acls, acl_table_types, vni, tunnel_intfs, dpg_ecmp_content, static_routes, tunnel_intfs_qos_remap_config) = parse_dpg(child, hostname)
@@ -2157,6 +2179,9 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
 
     if bgp_asn:
         results['DEVICE_METADATA']['localhost']['bgp_asn'] = bgp_asn
+
+    if bgp_router_id:
+        results['DEVICE_METADATA']['localhost']['bgp_router_id'] = bgp_router_id
 
     if chassis_hostname:
         results['DEVICE_METADATA']['localhost']['chassis_hostname'] = chassis_hostname

--- a/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
+++ b/src/sonic-config-engine/tests/multi_npu_data/sample-minigraph.xml
@@ -142,6 +142,7 @@
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
+        <a:RouterID>11.22.33.44</a:RouterID>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
         <a:ASN>65100</a:ASN>

--- a/src/sonic-config-engine/tests/sample_graph.xml
+++ b/src/sonic-config-engine/tests/sample_graph.xml
@@ -38,6 +38,7 @@
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
+        <a:RouterID>11.22.33.44</a:RouterID>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
         <a:ASN>64542</a:ASN>

--- a/src/sonic-config-engine/tests/simple-sample-graph.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph.xml
@@ -128,6 +128,7 @@
           </BGPPeer>
         </a:Peers>
         <a:RouteMaps/>
+        <a:RouterID i:nil="true"/>
       </a:BGPRouterDeclaration>
       <a:BGPRouterDeclaration>
         <a:ASN>64600</a:ASN>

--- a/src/sonic-config-engine/tests/test_cfggen.py
+++ b/src/sonic-config-engine/tests/test_cfggen.py
@@ -103,6 +103,16 @@ class TestCfgGen(TestCase):
         output = self.run_script(argument)
         self.assertEqual(output.strip(), 'Force10-Z9100')
 
+    def test_minigraph_bgp_router_id(self):
+        argument = ['-v', "DEVICE_METADATA['localhost']['bgp_router_id']", '-m', self.sample_graph, '-p', self.port_config]
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '11.22.33.44')
+
+    def test_minigraph_empty_bgp_router_id(self):
+        argument = ['-v', "DEVICE_METADATA['localhost'].get('bgp_router_id', '')", '-m', self.sample_graph_simple, '-p', self.port_config]
+        output = self.run_script(argument)
+        self.assertEqual(output.strip(), '')
+
     def test_minigraph_region(self):
         argument = ['-v', "DEVICE_METADATA[\'localhost\'][\'region\']", '-m', self.sample_graph_metadata, '-p', self.port_config]
         output = self.run_script(argument)
@@ -1169,5 +1179,3 @@ class TestCfgGen(TestCase):
         config_json = utils.to_dict(output.strip())
         os.environ["PLATFORM"] = ""
         self.assertEqual(config_json['ASIC_SENSORS'], utils.to_dict("{'ASIC_SENSORS_POLLER_INTERVAL': {'interval': '10'}, 'ASIC_SENSORS_POLLER_STATUS': {'admin_status': 'enable'}}"))
-
-

--- a/src/sonic-config-engine/tests/test_multinpu_cfggen.py
+++ b/src/sonic-config-engine/tests/test_multinpu_cfggen.py
@@ -343,6 +343,16 @@ class TestMultiNpuCfgGen(TestCase):
                 self.assertEqual(output['localhost']['sub_role'], 'BackEnd')
             self.assertEqual(output['localhost']['deployment_id'], "1")
 
+    def test_bgp_router_id_not_generated(self):
+        argument = ["-m", self.sample_graph, "-p", self.sample_port_config, "--var-json", "DEVICE_METADATA"]
+        output = json.loads(self.run_script(argument))
+        self.assertNotIn('bgp_router_id', output['localhost'])
+
+        argument = ["-m", self.sample_graph, "--var-json", "DEVICE_METADATA"]
+        for asic in range(NUM_ASIC):
+            output = json.loads(self.run_script_for_asic(argument, asic, self.port_config[asic]))
+            self.assertNotIn('bgp_router_id', output['localhost'])
+
     def test_global_asic_acl(self):
         argument = ["-m", self.sample_graph, "-p", self.sample_port_config, "--var-json", "ACL_TABLE"]
         output = json.loads(self.run_script(argument))


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Some single-ASIC minigraphs explicitly define the local BGP router ID in the matching `BGPRouterDeclaration`. This value should be available in `DEVICE_METADATA` so BGP configuration can use the explicitly assigned router ID.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added minigraph parsing that:

- Reads the device hostname from the root `Hostname` element.
- Finds the case-insensitive matching `BGPRouterDeclaration/Hostname` under `CpgDec/Routers`.
- Adds a non-empty `RouterID` to `DEVICE_METADATA|localhost` as `bgp_router_id`.
- Ignores missing, nil, and whitespace-only `RouterID` values.
- Skips router ID generation for multi-ASIC configurations because their BGP metadata is ASIC-specific.

Added cfggen test coverage for populated, nil, and multi-ASIC router ID cases.

#### How to verify it

- Verified a minigraph with a populated local `RouterID` produces `DEVICE_METADATA|localhost/bgp_router_id`.
- Verified a minigraph with `RouterID i:nil="true"` does not produce `bgp_router_id`.
- Verified multi-ASIC host and ASIC configurations do not produce `bgp_router_id`.
- Verified the supplied production samples parse as expected: one produces `241.136.0.1`, and the sample with a nil local router ID produces no value.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Parse an explicitly configured BGP router ID from single-ASIC minigraphs into `DEVICE_METADATA`.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

Not applicable. No YANG module changes.

#### A picture of a cute animal (not mandatory but encouraged)
