### PR TITLE
Harden EEPROM text decode to handle non-UTF8 padding bytes

### DIFF
--- a/device/celestica/x86_64-cel_e1031-r0/sonic_platform/eeprom.py
+++ b/device/celestica/x86_64-cel_e1031-r0/sonic_platform/eeprom.py
@@ -19,6 +19,7 @@ try:
 
     from sonic_platform_base.sonic_eeprom import eeprom_tlvinfo
     from sonic_platform_base.sonic_eeprom.eeprom_base import EepromDecoder
+    from sonic_py_common.eeprom_utils import safe_decode_eeprom_text
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -173,12 +174,12 @@ class DeviceEEPROM(eeprom_tlvinfo.TlvInfoDecoder):
 
         (valid, data) = self._get_eeprom_field("Model")
         if valid:
-            self.model_str = data.decode()
+            self.model_str = safe_decode_eeprom_text(data)
 
         try:
             (valid, data) = self._get_eeprom_field("Serial Number")
             if valid:
-                self.serial_number = data.decode()
+                self.serial_number = safe_decode_eeprom_text(data)
         except Exception as e:
             return
 

--- a/platform/marvell-prestera/sonic-platform-nokia/7215/sonic_platform/eeprom.py
+++ b/platform/marvell-prestera/sonic-platform-nokia/7215/sonic_platform/eeprom.py
@@ -17,6 +17,7 @@ try:
     from sonic_platform_base.sonic_eeprom.eeprom_base import EepromDecoder
     from sonic_platform_base.sonic_eeprom.eeprom_tlvinfo import TlvInfoDecoder
     from sonic_py_common import logger
+    from sonic_py_common.eeprom_utils import safe_decode_eeprom_text
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -159,17 +160,17 @@ class Eeprom(TlvInfoDecoder):
 
             (valid, data) = self._get_eeprom_field("Model")
             if valid:
-                self.model_str = data.decode()
+                self.model_str = safe_decode_eeprom_text(data)
 
             (valid, data) = self._get_eeprom_field("Part Number")
             if valid:
-                self.part_number = data.decode()
+                self.part_number = safe_decode_eeprom_text(data)
 
             # Early PSU device eeproms were not programmed with serial #
             try:
                 (valid, data) = self._get_eeprom_field("Serial Number")
                 if valid:
-                    self.serial_number = data.decode()
+                    self.serial_number = safe_decode_eeprom_text(data)
             except Exception as e:
                 sonic_logger.log_warning("Unable to read serial# of PSU#{}".format(self.index))
                 return

--- a/src/sonic-py-common/sonic_py_common/eeprom_utils.py
+++ b/src/sonic-py-common/sonic_py_common/eeprom_utils.py
@@ -14,8 +14,9 @@ def safe_decode_eeprom_text(raw, default="NA"):
 
     :param raw: The value to decode.  Accepts ``bytes``, ``bytearray``,
                 ``str``, or ``None``.
-    :param default: Value returned when *raw* is empty, ``None``, or cannot
-                    be decoded.  Defaults to ``"NA"``.
+    :param default: Value returned when *raw* is empty, ``None``, an
+                    unsupported type, or an unexpected decoding error.
+                    Defaults to ``"NA"``.
     :returns: Decoded, stripped string or *default*.
 
     Behaviour:
@@ -43,11 +44,6 @@ def safe_decode_eeprom_text(raw, default="NA"):
     # Prefer strict UTF-8
     try:
         return stripped.decode('utf-8')
-    except (UnicodeDecodeError, ValueError):
-        pass
-
-    # latin-1 is a lossless single-byte encoding that never raises
-    try:
+    except UnicodeDecodeError:
+        # latin-1 is a lossless single-byte encoding for bytes input.
         return stripped.decode('latin-1')
-    except Exception:
-        return default

--- a/src/sonic-py-common/sonic_py_common/eeprom_utils.py
+++ b/src/sonic-py-common/sonic_py_common/eeprom_utils.py
@@ -1,0 +1,53 @@
+"""
+Utilities for safely decoding raw EEPROM text fields.
+
+EEPROM data from PSU/Fan modules often contains non-UTF-8 padding bytes
+(e.g., 0xFF, 0x00) that cause UnicodeDecodeError when decoded with the
+default UTF-8 codec.  Use :func:`safe_decode_eeprom_text` instead of
+``bytes.decode()`` in platform EEPROM drivers.
+"""
+
+
+def safe_decode_eeprom_text(raw, default="NA"):
+    """
+    Safely decode a raw EEPROM text field to a str.
+
+    :param raw: The value to decode.  Accepts ``bytes``, ``bytearray``,
+                ``str``, or ``None``.
+    :param default: Value returned when *raw* is empty, ``None``, or cannot
+                    be decoded.  Defaults to ``"NA"``.
+    :returns: Decoded, stripped string or *default*.
+
+    Behaviour:
+    * Strips common EEPROM padding bytes (``0x00``, ``0xFF``) and ASCII
+      spaces before and after the payload.
+    * Attempts strict UTF-8 decoding first.
+    * Falls back to latin-1 (which never raises) if UTF-8 fails.
+    * Never raises a decoding exception; returns *default* on any error.
+    """
+    if raw is None:
+        return default
+
+    if isinstance(raw, str):
+        result = raw.strip('\x00\xff ')
+        return result if result else default
+
+    if not isinstance(raw, (bytes, bytearray)):
+        return default
+
+    # Strip common EEPROM padding before decoding
+    stripped = raw.strip(b'\x00\xff ')
+    if not stripped:
+        return default
+
+    # Prefer strict UTF-8
+    try:
+        return stripped.decode('utf-8')
+    except (UnicodeDecodeError, ValueError):
+        pass
+
+    # latin-1 is a lossless single-byte encoding that never raises
+    try:
+        return stripped.decode('latin-1')
+    except Exception:
+        return default

--- a/src/sonic-py-common/tests/test_eeprom_utils.py
+++ b/src/sonic-py-common/tests/test_eeprom_utils.py
@@ -2,8 +2,6 @@
 Unit tests for sonic_py_common.eeprom_utils.safe_decode_eeprom_text.
 """
 
-import pytest
-
 from sonic_py_common.eeprom_utils import safe_decode_eeprom_text
 
 

--- a/src/sonic-py-common/tests/test_eeprom_utils.py
+++ b/src/sonic-py-common/tests/test_eeprom_utils.py
@@ -77,6 +77,10 @@ class TestSafeDecodeEepromText:
         result = safe_decode_eeprom_text(b"\x00Caf\xe9\xff")
         assert result == "Café"
 
+    def test_latin1_fallback_with_bytearray(self):
+        result = safe_decode_eeprom_text(bytearray(b"\x00Caf\xe9\xff"))
+        assert result == "Café"
+
     # ------------------------------------------------------------------
     # Custom default value
     # ------------------------------------------------------------------

--- a/src/sonic-py-common/tests/test_eeprom_utils.py
+++ b/src/sonic-py-common/tests/test_eeprom_utils.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for sonic_py_common.eeprom_utils.safe_decode_eeprom_text.
+"""
+
+import pytest
+
+from sonic_py_common.eeprom_utils import safe_decode_eeprom_text
+
+
+class TestSafeDecodeEepromText:
+    """Tests for safe_decode_eeprom_text()."""
+
+    # ------------------------------------------------------------------
+    # Basic str/None/invalid input passthrough
+    # ------------------------------------------------------------------
+
+    def test_none_returns_default(self):
+        assert safe_decode_eeprom_text(None) == "NA"
+
+    def test_none_custom_default(self):
+        assert safe_decode_eeprom_text(None, default="Unknown") == "Unknown"
+
+    def test_invalid_type_returns_default(self):
+        assert safe_decode_eeprom_text(12345) == "NA"
+        assert safe_decode_eeprom_text([0x41, 0x42]) == "NA"
+
+    def test_str_passthrough(self):
+        assert safe_decode_eeprom_text("DPS-200PB") == "DPS-200PB"
+
+    def test_str_strips_padding(self):
+        assert safe_decode_eeprom_text("\x00\x00DPS-200PB \x00") == "DPS-200PB"
+
+    def test_str_all_padding_returns_default(self):
+        assert safe_decode_eeprom_text("\x00\xff  \x00") == "NA"
+
+    # ------------------------------------------------------------------
+    # bytes / bytearray – clean ASCII
+    # ------------------------------------------------------------------
+
+    def test_clean_ascii_bytes(self):
+        assert safe_decode_eeprom_text(b"DPS-200PB-204") == "DPS-200PB-204"
+
+    def test_clean_ascii_bytearray(self):
+        assert safe_decode_eeprom_text(bytearray(b"DPS-200PB-204")) == "DPS-200PB-204"
+
+    def test_leading_trailing_spaces_stripped(self):
+        assert safe_decode_eeprom_text(b"  DPS-200PB  ") == "DPS-200PB"
+
+    # ------------------------------------------------------------------
+    # Padding bytes stripped
+    # ------------------------------------------------------------------
+
+    def test_null_padded_bytes(self):
+        assert safe_decode_eeprom_text(b"DPS-200PB\x00\x00\x00") == "DPS-200PB"
+
+    def test_ff_padded_bytes(self):
+        """Simulate the observed crash: b'DPS-200PB-204 \\xff'"""
+        assert safe_decode_eeprom_text(b"DPS-200PB-204 \xff") == "DPS-200PB-204"
+
+    def test_all_null_bytes_returns_default(self):
+        assert safe_decode_eeprom_text(b"\x00\x00\x00") == "NA"
+
+    def test_all_ff_bytes_returns_default(self):
+        assert safe_decode_eeprom_text(b"\xff\xff\xff") == "NA"
+
+    def test_empty_bytes_returns_default(self):
+        assert safe_decode_eeprom_text(b"") == "NA"
+
+    # ------------------------------------------------------------------
+    # Non-UTF-8 interior bytes (latin-1 fallback)
+    # ------------------------------------------------------------------
+
+    def test_latin1_interior_bytes(self):
+        """Byte 0xE9 is valid latin-1 ('é') but cannot appear in UTF-8 alone."""
+        result = safe_decode_eeprom_text(b"Caf\xe9")
+        assert result == "Café"
+
+    def test_mixed_padding_and_latin1(self):
+        result = safe_decode_eeprom_text(b"\x00Caf\xe9\xff")
+        assert result == "Café"
+
+    # ------------------------------------------------------------------
+    # Custom default value
+    # ------------------------------------------------------------------
+
+    def test_custom_default_on_empty(self):
+        assert safe_decode_eeprom_text(b"", default="N/A") == "N/A"
+
+    def test_custom_default_on_all_padding(self):
+        assert safe_decode_eeprom_text(b"\xff\xff", default="Unknown") == "Unknown"


### PR DESCRIPTION
#### Why I did it

PSU/Fan EEPROM text fields can contain trailing 0xFF or 0x00 padding bytes that cause UnicodeDecodeError in PMON daemons (xcvrd, thermalctld, psud) when raw bytes are decoded with default UTF-8 codec.

Example seen in the field:

```python
UnicodeDecodeError('utf-8', b'DPS-200PB-204 \xff', 14, 15, 'invalid start byte')
```

Bare data.decode() calls in platform EEPROM drivers can crash PMON daemons on hardware whose EEPROM text includes non-UTF8 padding bytes. Two platform drivers were confirmed vulnerable.

##### Work item tracking

- Microsoft ADO: 38789399
#### How I did it

New shared helper:

- src/sonic-py-common/sonic_py_common/eeprom_utils.py
```python
from sonic_py_common.eeprom_utils import safe_decode_eeprom_text
```

safe_decode_eeprom_text(raw, default="NA") behavior:

- Accepts bytes / bytearray / str / None
- - Strips 0x00, 0xFF, and space padding before decoding
- - Tries strict UTF-8 first; falls back to latin-1 (never raises)
- - Returns default ("NA") on empty or undecodable input (never throws)
Platform driver fixes (replace data.decode() with safe_decode_eeprom_text(data)):

- device/celestica/x86_64-cel_e1031-r0/sonic_platform/eeprom.py
-   - Model, Serial Number
- - platform/marvell-prestera/sonic-platform-nokia/7215/sonic_platform/eeprom.py
-   - Model, Part Number, Serial Number
Before (crashes on 0xFF padding):

```python
self.model_str = data.decode()
```

After (safe):

```python
self.model_str = safe_decode_eeprom_text(data)
```

Tests:

- src/sonic-py-common/tests/test_eeprom_utils.py
- - 18 unit tests covering:
-   - None/invalid input
-   - clean ASCII
-   - null/0xFF padding
-   - all-padding -> default
-   - latin-1 fallback
-   - custom default
#### How to verify it

```python
from sonic_py_common.eeprom_utils import safe_decode_eeprom_text

assert safe_decode_eeprom_text(b'DPS-200PB-204 \xff') == 'DPS-200PB-204'
assert safe_decode_eeprom_text(b'\xff\xff\xff') == 'NA'
assert safe_decode_eeprom_text(None) == 'NA'
```

Run unit tests:

```bash
cd src/sonic-py-common
pytest tests/test_eeprom_utils.py -v
```

## Backport Information

### Release Branch

Which release branch should be backported?

- [x] `202605`

### Reason

Bug fix and stability hardening to prevent `UnicodeDecodeError` crashes caused by non-UTF-8 EEPROM padding bytes.

## Testing Information

**Tested branch:** `202605`  
**Backport method:** Cherry-picked PR commits onto `origin/202605`  
**Cherry-pick result:** Success; no conflicts  
**Base revision tested:** `80d8c0e58cf4b0de6c13a4652832f460013a0970`

### Cherry-Picked Commits

- `3635946a5` — Harden EEPROM text decode to handle non-UTF-8 padding bytes
- `46dfc01ee` — Potential fix for pull request finding “Unused import”
- `70f5a4e3a` — Address PR review nits in EEPROM decode helper

## Test Output

### Unit Tests

```text
python -m pytest -q src/sonic-py-common/tests/test_eeprom_utils.py

19 passed in 1.50s
exit code 0
```

### EEPROM Decode Fallback Smoke Checks

```text
CASE1 DPS-200PB-204
CASE2 NA
CASE3 NA
CASE4 abc
exit code 0
```

## Image Version

No built image was used in this validation run. Code-level backport verification was performed directly on the `202605` branch at the revision specified above.

## Change Classification

- [x] Bug fix / regression hardening
- [ ] New feature
- [ ] Platform configuration change
- [ ] Dependency update
- [ ] Infrastructure update

#### Description for the changelog

Add sonic_py_common.eeprom_utils.safe_decode_eeprom_text helper and use it in Celestica E1031 and Nokia 7215 EEPROM drivers to prevent UnicodeDecodeError crashes from non-UTF8 EEPROM padding bytes.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A