### PR TITLE
Updated flexcounter yang model for icmp stats

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1420,6 +1420,8 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
 
 ### FLEX_COUNTER_TABLE
 
+`ICMP_SESSION` controls ICMP echo session counter polling. `POLL_INTERVAL` for `ICMP_SESSION` is in milliseconds with allowed range `1000..30000`.
+
 ```
 {
 	"FLEX_COUNTER_TABLE": {
@@ -1446,6 +1448,10 @@ The FG_NHG_PREFIX table provides the FG_NHG_PREFIX for which FG behavior is desi
 		"WRED_ECN_PORT": {
 			"FLEX_COUNTER_STATUS": "enable",
 			"POLL_INTERVAL": "1000"
+		},
+		"ICMP_SESSION": {
+			"FLEX_COUNTER_STATUS": "enable",
+			"POLL_INTERVAL": "10000"
 		},
 		"SWITCH": {
 			"FLEX_COUNTER_STATUS": "enable",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/flex_counter.json
@@ -13,6 +13,20 @@
         "desc": "Out of range bulk chunk size.",
         "eStrKey": "Range"
     },
+    "FLEX_COUNTER_TABLE_WITH_VALID_ICMP_SESSION_POLL_INTERVAL_LOWER_BOUND": {
+        "desc": "ICMP_SESSION poll interval lower bound is accepted."
+    },
+    "FLEX_COUNTER_TABLE_WITH_VALID_ICMP_SESSION_POLL_INTERVAL_UPPER_BOUND": {
+        "desc": "ICMP_SESSION poll interval upper bound is accepted."
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_ICMP_SESSION_POLL_INTERVAL_LOWER_BOUND": {
+        "desc": "ICMP_SESSION poll interval below lower bound is rejected.",
+        "eStrKey": "Range"
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_ICMP_SESSION_POLL_INTERVAL_UPPER_BOUND": {
+        "desc": "ICMP_SESSION poll interval above upper bound is rejected.",
+        "eStrKey": "Range"
+    },
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
         "desc": "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF no failure."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/flex_counter.json
@@ -298,6 +298,46 @@
             }
         }
     },
+    "FLEX_COUNTER_TABLE_WITH_VALID_ICMP_SESSION_POLL_INTERVAL_LOWER_BOUND": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "ICMP_SESSION": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 1000
+                }
+            }
+        }
+    },
+    "FLEX_COUNTER_TABLE_WITH_VALID_ICMP_SESSION_POLL_INTERVAL_UPPER_BOUND": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "ICMP_SESSION": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 30000
+                }
+            }
+        }
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_ICMP_SESSION_POLL_INTERVAL_LOWER_BOUND": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "ICMP_SESSION": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 999
+                }
+            }
+        }
+    },
+    "FLEX_COUNTER_TABLE_WITH_INVALID_ICMP_SESSION_POLL_INTERVAL_UPPER_BOUND": {
+        "sonic-flex_counter:sonic-flex_counter": {
+            "sonic-flex_counter:FLEX_COUNTER_TABLE": {
+                "ICMP_SESSION": {
+                    "FLEX_COUNTER_STATUS": "enable",
+                    "POLL_INTERVAL": 30001
+                }
+            }
+        }
+    },
     "FLOW_COUNTER_ROUTE_PATTERN_TABLE_WITH_VRF": {
         "sonic-vrf:sonic-vrf":{
             "sonic-vrf:VRF": {

--- a/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
+++ b/src/sonic-yang-models/yang-models/sonic-flex_counter.yang
@@ -44,6 +44,13 @@ module sonic-flex_counter {
                 }
             }
 
+            typedef icmp_poll_interval {
+                description "ICMP echo session counter polling interval in milliseconds";
+                type uint32 {
+                    range 1000..30000;
+                }
+            }
+
             typedef bulk_chunk_size {
                 description "Number of counter entries processed per SAI bulk counter API call";
                 type uint32 {
@@ -134,6 +141,19 @@ module sonic-flex_counter {
                 }
                 leaf POLL_INTERVAL {
                     type poll_interval;
+                }
+            }
+
+            container ICMP_SESSION {
+                description "Polling configuration for ICMP echo session counters";
+                /* ICMP_SESSION_STAT_COUNTER_FLEX_COUNTER_GROUP */
+                leaf FLEX_COUNTER_STATUS {
+                    description "Enable or disable ICMP echo session counter polling";
+                    type flex_status;
+                }
+                leaf POLL_INTERVAL {
+                    description "ICMP echo session counter polling interval in milliseconds";
+                    type icmp_poll_interval;
                 }
             }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Added ICMP_SESSION support to sonic-flex_counter.yang under FLEX_COUNTER_TABLE, including FLEX_COUNTER_STATUS and a bounded POLL_INTERVAL range of 1000..30000 ms to align with counterpoll icmp behavior.
Updated YANG validation tests and Configuration.md with positive/negative interval coverage and configuration examples/documentation for the new ICMP session counter entry.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

