### PR TITLE
[otel] Disable debug exporter in default pipeline

### DIFF
--- a/files/image_config/otel/otel_config.yml
+++ b/files/image_config/otel/otel_config.yml
@@ -12,8 +12,9 @@ processors:
     send_batch_size: 1000
 
 exporters:
-  debug:
-    verbosity: basic
+  # debug:
+  #   verbosity: detailed
+  nop: {}
   
 service:
   telemetry:
@@ -24,15 +25,17 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug]
+      # exporters: [debug]
+      exporters: [nop]
 
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug]
+      # exporters: [debug]
+      exporters: [nop]
 
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug]
-
+      # exporters: [debug]
+      exporters: [nop]

--- a/files/image_config/otel/otel_config.yml
+++ b/files/image_config/otel/otel_config.yml
@@ -13,7 +13,7 @@ processors:
 
 exporters:
   debug:
-    verbosity: detailed
+    verbosity: basic
   
 service:
   telemetry:

--- a/files/image_config/otel/otel_config.yml
+++ b/files/image_config/otel/otel_config.yml
@@ -1,3 +1,7 @@
+# Telemetry is discarded by default. For debug output, replace `nop: {}` under
+# exporters with `debug: {verbosity: detailed}`, then replace `[nop]` with
+# `[debug]` in the desired pipelines. Verbosity may be basic, normal, or detailed.
+
 receivers:
   otlp:
     protocols:
@@ -12,8 +16,6 @@ processors:
     send_batch_size: 1000
 
 exporters:
-  # debug:
-  #   verbosity: detailed
   nop: {}
   
 service:
@@ -25,17 +27,14 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      # exporters: [debug]
       exporters: [nop]
 
     logs:
       receivers: [otlp]
       processors: [batch]
-      # exporters: [debug]
       exporters: [nop]
 
     traces:
       receivers: [otlp]
       processors: [batch]
-      # exporters: [debug]
       exporters: [nop]


### PR DESCRIPTION
#### Why I did it

Fixes #28407.

The default SONiC OTEL configuration explicitly sets the debug exporter to `verbosity: detailed`. OpenTelemetry documents `basic` as the default; `detailed` writes all fields for every telemetry record, usually across multiple lines.

During HFT validation with a 10 ms polling interval, this produced a 101 MB `otel.log.1` in one test module and overwhelmed host rsyslog. The DUT repeatedly reported rate-limit drops, including 46,462 lost messages in one five-second window, which caused LogAnalyzer markers to be dropped.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Disable the debug exporter in the default configuration and route the existing metrics, logs, and traces pipelines to the built-in no-op exporter. The Collector requires every configured pipeline to have at least one exporter, so simply removing the debug exporter would make the default configuration invalid.

The original `debug` exporter with `verbosity: detailed` and its pipeline references remain commented in the YAML as an explicit troubleshooting option. Operators can uncomment them in deployment-specific `/etc/sonic/otel_config.yml` when full payload output is needed.

The HFT end-to-end test is unaffected: it overwrites `/etc/sonic/otel_config.yml` with its dedicated InfluxDB exporter configuration and validates data by querying InfluxDB, not by reading debug exporter output.

#### How to verify it

- Parsed `files/image_config/otel/otel_config.yml` with PyYAML and verified the active exporter is `nop` while `debug/detailed` remains commented.
- Confirmed `sonic_debian_extension.j2` copies this file to `/etc/sonic/otel_config.yml` and `docker-sonic-otel/otel.sh` loads that path directly.
- Confirmed the affected `docker-sonic-otel:latest` image contains both `debug` and `nop` exporter components.
- Validated the candidate YAML with the affected DUT's actual `otelcol-contrib validate` command.
- Confirmed the HFT end-to-end test installs a separate InfluxDB exporter configuration and does not assert on debug exporter output.
- Failure evidence: https://elastictest.org/scheduler/testplan/6a55b5880b7e95197e91debe

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Reason: both release branches ship the same `verbosity: detailed` default and are affected by HFT log amplification.

#### Tested branch (Please provide the tested image version)

- [x] 20251110.38 - validated the failure mechanism and the existing runtime `basic` mitigation on Mellanox-SN5640-C512S2
- [ ] master image build pending CI

#### Description for the changelog

Disable the OTEL debug exporter by default to prevent telemetry log amplification.

#### Link to config_db schema for YANG module changes

N/A - no YANG or Config DB schema changes.

#### A picture of a cute animal (not mandatory but encouraged)

N/A
