### PR TITLE
[YANG] Add new attributes in CONSOLE_PORT to support Console Logging feature

### DIFF
--- a/platform/aspeed/aspeed-platform-services/scripts/sonic-switchcpu-console-init.sh
+++ b/platform/aspeed/aspeed-platform-services/scripts/sonic-switchcpu-console-init.sh
@@ -72,24 +72,23 @@ udevadm control --reload-rules
 udevadm trigger
 log "Udev rules reloaded and triggered"
 
-# Configure CONSOLE_PORT|0 with platform settings
+# Configure CONSOLE_PORT|0 with platform settings (preserve user config such as logging)
 log "Configuring CONSOLE_PORT|0 in CONFIG_DB..."
 
-# Check if entry exists
-if sonic-db-cli CONFIG_DB HGETALL "CONSOLE_PORT|0" >/dev/null 2>&1; then
-    log "CONSOLE_PORT|0 already exists, deleting to ensure correct settings..."
-    sonic-db-cli CONFIG_DB DEL "CONSOLE_PORT|0"
+existing_logging=$(sonic-db-cli CONFIG_DB HGET "CONSOLE_PORT|0" logging_enabled 2>/dev/null || true)
+existing_log_file=$(sonic-db-cli CONFIG_DB HGET "CONSOLE_PORT|0" log_file 2>/dev/null || true)
+if [ -n "$existing_logging" ] || [ -n "$existing_log_file" ]; then
+    log "Preserving existing user config: logging_enabled=${existing_logging:-unset}, log_file=${existing_log_file:-unset}"
 fi
 
-# Create with platform-specific settings
-log "Creating CONSOLE_PORT|0 with baud=$CONSOLE_BAUD_RATE, flow=$CONSOLE_FLOW_CONTROL, device=$CONSOLE_REMOTE_DEVICE"
+log "Updating CONSOLE_PORT|0 platform settings: baud=$CONSOLE_BAUD_RATE, flow=$CONSOLE_FLOW_CONTROL, device=$CONSOLE_REMOTE_DEVICE"
 if sonic-db-cli CONFIG_DB HMSET "CONSOLE_PORT|0" \
     baud_rate "$CONSOLE_BAUD_RATE" \
     flow_control "$CONSOLE_FLOW_CONTROL" \
     remote_device "$CONSOLE_REMOTE_DEVICE"; then
-    log "Created CONSOLE_PORT|0 successfully"
+    log "CONSOLE_PORT|0 configured successfully"
 else
-    log "ERROR: Failed to create CONSOLE_PORT|0"
+    log "ERROR: Failed to configure CONSOLE_PORT|0"
     exit 1
 fi
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/console.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/console.json
@@ -108,5 +108,37 @@
         "desc": "CONSOLE_PORT invalid escape_char with empty string.",
         "eStrKey": "Pattern",
         "eStr": ["escape_char"]
+    },
+    "CONSOLE_PORT_DEFAULT_LOGGING_ENABLED": {
+        "desc": "CONSOLE_PORT default value for logging_enabled field.",
+        "eStrKey": "Verify",
+        "verify": {
+            "xpath": "/sonic-console:sonic-console/CONSOLE_PORT/CONSOLE_PORT_LIST[name='1']/logging_enabled",
+            "key": "sonic-console:logging_enabled",
+            "value": "no"
+        }
+    },
+    "CONSOLE_PORT_VALID_LOGGING": {
+        "desc": "CONSOLE_PORT valid logging configuration."
+    },
+    "CONSOLE_PORT_VALID_LOGGING_DEFAULT_LOGROTATE": {
+        "desc": "CONSOLE_PORT valid logging with log_file configured and default logrotate parameters."
+    },
+    "CONSOLE_PORT_VALID_LOGGING_DEFAULT_ALL": {
+        "desc": "CONSOLE_PORT valid logging with default log_file and logrotate parameters."
+    },
+    "CONSOLE_PORT_INVALID_LOGGING_ENABLED": {
+        "desc": "CONSOLE_PORT invalid logging_enabled pattern failure.",
+        "eStrKey": "Pattern",
+        "eStr": ["logging_enabled"]
+    },
+    "CONSOLE_PORT_INVALID_LOGROTATE_SIZE": {
+        "desc": "CONSOLE_PORT invalid logrotate_size pattern failure.",
+        "eStrKey": "Pattern",
+        "eStr": ["logrotate_size"]
+    },
+    "CONSOLE_PORT_INVALID_LOGROTATE_COUNT": {
+        "desc": "CONSOLE_PORT invalid logrotate_count range failure.",
+        "eStrKey": "Range"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/console.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/console.json
@@ -257,5 +257,104 @@
                 ]
             }
         }
+    },
+    "CONSOLE_PORT_DEFAULT_LOGGING_ENABLED": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_VALID_LOGGING": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "logging_enabled": "yes",
+                        "log_file": "/var/log/console1.log",
+                        "logrotate_size": "10M",
+                        "logrotate_count": "5"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_VALID_LOGGING_DEFAULT_LOGROTATE": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "logging_enabled": "yes",
+                        "log_file": "/var/log/console1.log"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_VALID_LOGGING_DEFAULT_ALL": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "logging_enabled": "yes"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_INVALID_LOGGING_ENABLED": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "logging_enabled": "true",
+                        "log_file": "/var/log/console1.log"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_INVALID_LOGROTATE_SIZE": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "log_file": "/var/log/console1.log",
+                        "logrotate_size": "big",
+                        "logrotate_count": "5"
+                    }
+                ]
+            }
+        }
+    },
+    "CONSOLE_PORT_INVALID_LOGROTATE_COUNT": {
+        "sonic-console:sonic-console": {
+            "sonic-console:CONSOLE_PORT": {
+                "CONSOLE_PORT_LIST": [
+                    {
+                        "name": "1",
+                        "baud_rate": "9600",
+                        "log_file": "/var/log/console1.log",
+                        "logrotate_size": "10M",
+                        "logrotate_count": "0"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-console.yang
+++ b/src/sonic-yang-models/yang-models/sonic-console.yang
@@ -9,6 +9,10 @@ module sonic-console {
 
     description "Console port switch and management YANG module for SONiC OS.";
 
+    revision 2026-06-29 {
+        description "Add console port logging and logrotate config";
+    }
+
     revision 2026-02-12 {
         description "Add escape_char config";
     }
@@ -35,6 +39,13 @@ module sonic-console {
         description "Configuration to set if enable flow control on a console port";
         type string {
             pattern "0|1";
+        }
+    }
+
+    typedef console-logrotate-size {
+        description "Logrotate size threshold (e.g. 10M, 100k).";
+        type string {
+            pattern '[0-9]+[kKmMgG]?';
         }
     }
 
@@ -70,6 +81,29 @@ module sonic-console {
                 leaf escape_char {
                     description "Per-port escape character overriding the global default.";
                     type console-mgmt-escape-char;
+                }
+
+                leaf logging_enabled {
+                    description "Enable (yes) or disable (no) I/O logging for this console port.";
+                    type console-mgmt-enabled;
+                    default "no";
+                }
+
+                leaf log_file {
+                    description "File path to store console I/O when logging is enabled.";
+                    type string;
+                }
+
+                leaf logrotate_size {
+                    description "Maximum log file size before rotation (e.g. 10M, 100k).";
+                    type console-logrotate-size;
+                }
+
+                leaf logrotate_count {
+                    description "Number of rotated log files to retain.";
+                    type uint8 {
+                        range "1..100";
+                    }
                 }
             }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
[YANG] Support logging_enabled, log_file, logrotate_count and logrotate_size attributes  in CONSOLE_PORT table to enable/diable console logging feature on SONiC BMC/console switch.

YANG schema added: 

- logging_enabled (default "no")
- log_file
- logrotate_size (pattern [0-9]+[kKmMgG]?)
- logrotate_count (range 1..100)


Sample config:

```
   "CONSOLE_PORT": {
        "0": {
            "baud_rate": "115200",
            "flow_control": "0",
            "log_file": "/var/log/console-0.log",
            "logging_enabled": "yes",
            "logrotate_count": "10",
            "logrotate_size": "10K",
            "remote_device": "SwitchCpu"
        }
    },

```

platform/aspeed/aspeed-platform-services/scripts/sonic-switchcpu-console-init.sh is modified to skip deleting CONSOLE_PORT|0 and keeps the previously  saved CONSOLE_PORT|0 configuration.


Related PR from other submodules:
https://github.com/sonic-net/sonic-host-services/pull/409
https://github.com/sonic-net/sonic-utilities/pull/4685
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
 Update Yang model for sonic-console and add corresponding unit tests:
    - Added logging_enabled attribute in CONSOLE_PORT
    - Added test cases for default value verification
    - Added test cases for valid configuration
    - Added test cases for valid configuration with optional parameters as default
    - Added test cases for invalid pattern detection

#### How to verify it
Verified by manual testing on testbed and unit test.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

