### PR TITLE
Enable BMP feature when included in image

### DIFF
--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -104,6 +104,7 @@
 {%- if include_macsec == "y" %}{% do features.append(("macsec", "{% if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type'] in ['SpineRouter', 'UpperSpineRouter', 'LowerRegionalHub'] and DEVICE_RUNTIME_METADATA['MACSEC_SUPPORTED'] %}enabled{% else %}disabled{% endif %}", false, "enabled")) %}{% endif %}
 {%- if include_system_gnmi == "y" %}{% do features.append(("gnmi", "enabled", true, "enabled")) %}{% endif %}
 {%- if include_system_telemetry == "y" %}{% do features.append(("telemetry", "enabled", true, "enabled")) %}{% endif %}
+{%- if include_system_bmp == "y" %}{% do features.append(("bmp", "enabled", false, "enabled")) %}{% endif %}
 {%- if include_system_otel == "y" %}{% do features.append(("otel", "disabled", false, "enabled")) %}{% endif %}
 {%- if include_system_eventd == "y" and BUILD_REDUCE_IMAGE_SIZE == "y" %}
     {% do features.append(("eventd","disabled", false, "enabled")) %}


### PR DESCRIPTION
BMP can be built into the image with `INCLUDE_SYSTEM_BMP=y`, but it is
  not added to the generated `FEATURE` table. As a result, the `bmp`
  container is absent and `bmp.service` is masked.

  Add `bmp` to `init_cfg.json.j2` when `include_system_bmp` is enabled so
  the feature is present and enabled in `CONFIG_DB`.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`bmp/test_docker_restart.py::test_restart_bmp_docker` expects the BMP
  service/container to be present when BMP is included in the image. The
  image already sets `INCLUDE_SYSTEM_BMP=y`, but the generated
  `init_cfg.json` does not include `FEATURE|bmp`, so starting `bmp.service`
  fails with:
 
 ```
 Error: No such object: bmp
  Failed to start bmp.service: Unit bmp.service is masked.
```

##### Work item tracking
- Microsoft ADO **(number only)**:
- Fixes : https://github.com/sonic-net/sonic-mgmt/issues/26162

#### How I did it
Added bmp to the features list in files/build_templates/init_cfg.json.j2
  when include_system_bmp == "y".

#### How to verify it
Verified on Arista DUTs that /etc/sonic/init_cfg.json contains
  FEATURE|bmp with state=enabled when BMP is included in the image.

 Also verified the BMP container/service is present and running:

  ```
show feature status bmp
  bmp enabled

  docker inspect -f '{{.State.Running}}' bmp
  true

  systemctl is-active bmp
  active

```
  bmp/test_docker_restart.py::test_restart_bmp_docker passed after the
  change.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->
- [x] 202605: SONiC.branch.202605-ars.32bfd92c-buildimage.9c84048a4240ea5d358f74b0821d2d51bba9a3b5-nightly-2026.07.08.14.43


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Enable BMP in generated init config when BMP is included in the image.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
N/A

#### A picture of a cute animal (not mandatory but encouraged)

