### PR TITLE
[Arista] Update sensor labels for x86_64-arista_7280dr3a_36

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
@@ -1,5 +1,7 @@
 bus "i2c-21" "SCD 0000:01:00.0 SMBus master 0 bus 0"
 bus "i2c-22" "SCD 0000:01:00.0 SMBus master 0 bus 1"
+bus "i2c-28" "SCD 0000:01:00.0 SMBus master 0 bus 7"
+bus "i2c-9" "SCD 0000:00:18.7 SMBus master 0 bus 0"
 
 chip "nvme-pci-0500"
     ignore temp2
@@ -17,6 +19,14 @@ chip "dps800-i2c-21-58"
     ignore fan3
     ignore fan4
 
+chip "pmbus-i2c-21-58"
+    label temp1 "Power supply 1 inlet temp sensor"
+    label temp2 "Power supply 1 secondary hotspot sensor"
+    label temp3 "Power supply 1 primary hotspot temp sensor"
+
+    ignore fan3
+    ignore fan4
+
 chip "dps800-i2c-22-58"
     label temp1 "Power supply 2 inlet temp sensor"
     label temp2 "Power supply 2 secondary hotspot sensor"
@@ -25,3 +35,28 @@ chip "dps800-i2c-22-58"
     ignore fan3
     ignore fan4
 
+chip "pmbus-i2c-22-58"
+    label temp1 "Power supply 2 inlet temp sensor"
+    label temp2 "Power supply 2 secondary hotspot sensor"
+    label temp3 "Power supply 2 primary hotspot temp sensor"
+
+    ignore fan3
+    ignore fan4
+
+chip "tmp464-i2c-28-48"
+    label temp1 "JE0 Front Side"
+    label temp2 "Air Inlet"
+    label temp3 "Board Temp"
+    label temp4 "JE1_C Diode"
+    label temp5 "JE0_C Diode"
+    ignore temp6
+    ignore temp7
+    ignore temp8
+    ignore temp9
+
+chip "max6658-i2c-9-4c"
+    label temp1 "CPU board"
+    label temp2 "Back-panel"
+
+chip "k10temp-pci-00c3"
+    label temp1 "CPU"


### PR DESCRIPTION
#### Why I did it
Update labels for the temperature sensors on `x86_64-arista_7280dr3a_36`

#### How I did it
Updated sensors.conf for the `x86_64-arista_7280dr3a_36` sku

#### How to verify it
Confirmed all labels appear in the output of `sensors` on the `x86_64-arista_7280dr3a_36` sku

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

- [x] 202511

#### Description for the changelog
Update labels for the temperature sensors on `x86_64-arista_7280dr3a_36`

