### PR TITLE
[Mellanox] Fix /tmp/nv-syncd-shared created with 755 by determine-reboot-cause

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -56,8 +56,10 @@ class ModuleHostMgmtInitializer:
         self.lock = threading.Lock()
         self.asic_count = DeviceDataManager.get_asic_count()
         self.initialized_list = [False] * self.asic_count
+        nv_dir_existed = os.path.exists(NV_SYNCD_SHARED_DIR)
         os.makedirs(ASIC_READY_DIR, exist_ok=True)
-        if ASIC_READY_DIR.startswith(NV_SYNCD_SHARED_DIR):
+        # chmod only when we created the dir
+        if ASIC_READY_DIR.startswith(NV_SYNCD_SHARED_DIR) and not nv_dir_existed and os.getuid() == 0:
             # 0o777 is required: this directory is bind-mounted as /tmp into the syncd/pmon
             # containers, where apt (running as different users) must be able to write to it.
             # This is existing behaviour per: nv-syncd-shared.service

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -29,7 +29,8 @@ import fcntl
 MODULE_READY_MAX_WAIT_TIME = 300
 MODULE_READY_CHECK_INTERVAL = 5
 # pmon's /tmp is bind-mounted from host /tmp/nv-syncd-shared/, so pick the equivalent path per context.
-ASIC_READY_DIR = '/tmp/nv-syncd-shared/asic_ready' if utils.is_host() else '/tmp/asic_ready'
+NV_SYNCD_SHARED_DIR = '/tmp/nv-syncd-shared'
+ASIC_READY_DIR = os.path.join(NV_SYNCD_SHARED_DIR, 'asic_ready') if utils.is_host() else '/tmp/asic_ready'
 ASIC_READY_FILE_PREFIX = 'module_host_mgmt_asic_ready'
 DEDICATE_INIT_DAEMON = 'xcvrd'
 
@@ -56,6 +57,8 @@ class ModuleHostMgmtInitializer:
         self.asic_count = DeviceDataManager.get_asic_count()
         self.initialized_list = [False] * self.asic_count
         os.makedirs(ASIC_READY_DIR, exist_ok=True)
+        if ASIC_READY_DIR.startswith(NV_SYNCD_SHARED_DIR):
+            os.chmod(NV_SYNCD_SHARED_DIR, 0o777)
 
     def initialize(self, chassis):
         """Initialize all modules. Only applicable for module host management mode.

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -58,6 +58,10 @@ class ModuleHostMgmtInitializer:
         self.initialized_list = [False] * self.asic_count
         os.makedirs(ASIC_READY_DIR, exist_ok=True)
         if ASIC_READY_DIR.startswith(NV_SYNCD_SHARED_DIR):
+            # 0o777 is required: this directory is bind-mounted as /tmp into the syncd/pmon
+            # containers, where apt (running as different users) must be able to write to it.
+            # This is existing behaviour per: nv-syncd-shared.service
+            # nosemgrep: python.lang.security.audit.insecure-file-permissions.insecure-file-permissions
             os.chmod(NV_SYNCD_SHARED_DIR, 0o777)
 
     def initialize(self, chassis):


### PR DESCRIPTION
## Is it a bug?

- [x] Yes

## Is it platform specific?

- [x] Yes: **Mellanox**

## Importance / Severity

Medium — package installation (`apt install`) silently fails inside `syncd` and `pmon` containers after a normal cold boot preventing any container-side software installation.

## Description

**NOTE: This PR depends on https://github.com/sonic-net/sonic-buildimage/pull/26678**
`/tmp/nv-syncd-shared/` is bind-mounted as `/tmp` inside the `syncd` and `pmon` containers. If that directory is created with `755` permissions instead of `777`, non-root users inside those containers (e.g. `_apt`) cannot write to `/tmp`, and `apt` fails.

The directory ends up with `755` because of a boot-ordering race:

1. `determine-reboot-cause.service` is ordered at `multi-user.target` (early boot).  
   It calls `Platform().get_chassis()` on the **host**, which instantiates `ModuleHostMgmtInitializer` and calls `os.makedirs('/tmp/nv-syncd-shared/asic_ready', exist_ok=True)`.  
   `os.makedirs` applies the process umask: with root's default umask of `022`, the intended `0o777` is silently masked to `0755`, so `/tmp/nv-syncd-shared/` is created with **755**.

2. `nv-syncd-shared.service` is ordered at `sonic.target` (later). It runs:
   ```
   mkdir -m 777 -p /tmp/nv-syncd-shared/
   ```
   Because the directory already exists, `mkdir -p` is a no-op and the **755** permissions persist.

3. The `syncd`/`pmon` containers start with `/tmp/nv-syncd-shared/` bind-mounted as `/tmp`. Non-root users (e.g. `_apt`) cannot write to it, so package installation fails.

The root cause was introduced by https://github.com/sonic-net/sonic-buildimage/pull/26678 which changed `ASIC_READY_DIR` to use the host-side path `/tmp/nv-syncd-shared/asic_ready`, causing `determine-reboot-cause` to create the parent directory before `nv-syncd-shared.service` runs.


## Steps to Reproduce

1. Boot a Mellanox switch running a trixie image that includes the multi-asic asic-ready signal support.
2. After boot, observe `/tmp/nv-syncd-shared/` has permissions `755`.
3. Inside the `syncd` or `pmon` container, run `apt install <package>` — it fails because `_apt` cannot write to `/tmp`.

## Fix

After `os.makedirs(ASIC_READY_DIR, exist_ok=True)`, explicitly call `os.chmod(NV_SYNCD_SHARED_DIR, 0o777)` when on the host-side path. Unlike `os.makedirs`, `os.chmod` bypasses the umask and sets permissions directly, guaranteeing `777` regardless of boot order.


## Actual Behavior

`/tmp/nv-syncd-shared/` created with `755`; `apt` fails inside syncd/pmon containers.

## Expected Behavior

`/tmp/nv-syncd-shared/` has `777` permissions; containers can write to `/tmp` normally.

#### Which release branch to backport

- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Reason: The issue also affects the 202605 branch.

#### Tested branch

- [x] master
- [x] 202605


## Relevant Log Output

```
E: Can't drop privileges for downloading as file '/tmp/apt.conf.d' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
```
