### PR TITLE
[SuperMicro] Use --no-block to start sfp-max-temp-updater.service in SSE-T8164/SSE-T8196 postinst files

### DIFF
--- a/platform/broadcom/sonic-platform-modules-supermicro/debian/platform-modules-sse-t8164.postinst
+++ b/platform/broadcom/sonic-platform-modules-supermicro/debian/platform-modules-sse-t8164.postinst
@@ -4,7 +4,7 @@ depmod -a
 systemctl enable pddf-platform-init.service
 systemctl start pddf-platform-init.service
 systemctl enable sfp-max-temp-updater.service
-systemctl start sfp-max-temp-updater.service
+systemctl start --no-block sfp-max-temp-updater.service
 systemctl enable system-health.service
 systemctl start --no-block system-health.service
 

--- a/platform/broadcom/sonic-platform-modules-supermicro/debian/platform-modules-sse-t8196.postinst
+++ b/platform/broadcom/sonic-platform-modules-supermicro/debian/platform-modules-sse-t8196.postinst
@@ -4,7 +4,7 @@ depmod -a
 systemctl enable pddf-platform-init.service
 systemctl start pddf-platform-init.service
 systemctl enable sfp-max-temp-updater.service
-systemctl start sfp-max-temp-updater.service
+systemctl start --no-block sfp-max-temp-updater.service
 systemctl enable system-health.service
 systemctl start --no-block system-health.service
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Resolve a service deadlock during the first boot,
which is caused by the commit https://github.com/sonic-net/sonic-buildimage/commit/ccb568930f3c1995ec29258a76f4d6ccd72426f8:

gnoi-shutdown adds Requires=gnmi and Wants/After=pmon
    ↓
When multi-user.target activates, systemd queues gnmi/pmon start jobs early for gnoi
    ↓
The pmon start job enters "waiting" while rc.local is still running
    ↓
rc.local executes the platform postinst which runs a blocking "systemctl start sfp-max-temp-updater" (After=pmon)
    ↓
sfp-max-temp waits for pmon, pmon waits for rc.local, rc.local waits for postinst
    ↓
deadlock


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Add --no-block for starting  sfp-max-temp-updater.service in platform-modules-sse-t8164.postinst and platform-modules-sse-t8196.postinst

#### How to verify it
Install sonic-broadcom.bin on SSE-T8164/SSE-T8196, check the first boot doesn't get blocked
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)
- [x] master
Verified the first boot with the image built by the Azure pipeline for this PR
[T8164_master_PR28444.log](https://github.com/user-attachments/files/30440345/T8164_master_PR28444.log)
[T8196_master_PR28444.log](https://github.com/user-attachments/files/30440351/T8196_master_PR28444.log)
- [x] 202605
Verified the first boot with the image built with cherry-picking this commit to the 202605 branch:
commit 32fe728bdbae653b69b52c1c85e80f43390c926d (HEAD -> 202605)
Author: Robert Hong <roberth@supermicro.com.tw>
Date:   Thu Jul 16 01:22:56 2026 +0000

    [SuperMicro] Use --no-block to start sfp-max-temp-updater.service in SSE-T8164/SSE-T8196 postinst files

    Signed-off-by: Robert Hong <roberth@supermicro.com.tw>
commit ba3fb8d5f5cd01431b26bcb3f302500c704a9037 (origin/202605)
Author: ShiyanWangMS <shiyanwang@microsoft.com>
Date:   Mon Jul 27 08:03:43 2026 +1000

    [cisco-8000]: Update platform ref to 202605.1.0.2 (#28574)

    Signed-off-by: Shiyan Wang <shiyanwang@microsoft.com>
    Signed-off-by: Copilot <223556219+Copilot@users.noreply.github.com>
    Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
[T8164_202605_PR28444.log](https://github.com/user-attachments/files/30440377/T8164_202605_PR28444.log)
[T8196_202605_PR28444.log](https://github.com/user-attachments/files/30440380/T8196_202605_PR28444.log)



#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use --no-block to start sfp-max-temp-updater.service in SSE-T8164/SSE-T8196 postinst files
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

