### PR TITLE
[Pensando] Add SmartSwitch chassis APIs and fix container health check

### DIFF
--- a/platform/pensando/sonic-platform-modules-dpu/dpu/utils/fetch_dpu_status
+++ b/platform/pensando/sonic-platform-modules-dpu/dpu/utils/fetch_dpu_status
@@ -36,13 +36,12 @@ STATE_DB = 6
 REDIS_LOCALHOST_SERVER_PORT = 6379
 REDIS_LOCALHOST_SERVER_IP = '127.0.0.1'
 NOT_AVAILABLE = 'N/A'
-STARTUP_CONTAINER_LIST = ['swss', 'syncd', 'database']
-CONTAINERS_TO_IGNORE = ['macsec']
+CONTAINERS_TO_CHECK = ['swss', 'syncd', 'database']
 try:
     apiHelper = APIHelper()
     chassis = Chassis()
     dpu_docker_name = apiHelper.get_dpu_docker_container_name()
-    STARTUP_CONTAINER_LIST.append(dpu_docker_name)
+    CONTAINERS_TO_CHECK.append(dpu_docker_name)
 except Exception as e:
     log_err(f'failed to fetch dpu docker name due to {e}')
 
@@ -135,39 +134,34 @@ class DPUHealthUpdater():
         try:
             client = docker.from_env()
             containers = client.containers.list(all=True)
-            all_container_status = True
-            startup_container_status = True
+            container_status = True
             swss_container_uptime = 0
             container_not_running = []
             container_restarting = []
             reason = ""
             for container in containers:
                 container_name = container.name
-                container_status = container.status
-                if container_name in CONTAINERS_TO_IGNORE:
+                container_state = container.status
+                if container_name not in CONTAINERS_TO_CHECK:
                     continue
-                if container_status == 'restarting':
-                    if container_name in STARTUP_CONTAINER_LIST:
-                        startup_container_status &= False
-                    all_container_status &= False
+                if container_state == 'restarting':
+                    container_status &= False
                     container_restarting.append(container_name)
-                elif container_status == 'exited':
-                    if container_name in STARTUP_CONTAINER_LIST:
-                        startup_container_status &= False
-                    all_container_status &= False
+                elif container_state == 'exited':
+                    container_status &= False
                     container_not_running.append(container_name)
-                if container_name == "swss" and startup_container_status:
+                if container_name == "swss" and container_status:
                     swss_container_uptime = datetime.now(timezone.utc) - parse_docker_time(container.attrs['State']['StartedAt'])
-            if startup_container_status and swss_container_uptime < timedelta(minutes=2):
+            if container_status and swss_container_uptime < timedelta(minutes=2):
                 reason = "Early stage containers (swss, syncd, database) are up and running"
-                return startup_container_status, reason
+                return container_status, reason
             if container_not_running:
                 reason += "Container not running : " + ', '.join(container_not_running)
             if container_restarting:
                 reason += "Container restarting : " + ', '.join(container_restarting)
             if reason == "":
                 reason = "All containers are up and running"
-            return all_container_status, reason
+            return container_status, reason
         except Exception as e:
             log_err(f"failed to fetch dpu docker running status due to {e}")
             return False, f"failed to fetch dpu docker running status due to {e}"

--- a/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
+++ b/platform/pensando/sonic-platform-modules-dpu/sonic_platform/chassis.py
@@ -15,6 +15,7 @@ try:
     import subprocess
     from sonic_platform_base.chassis_base import ChassisBase
     from .helper import APIHelper
+    import redis
     import syslog
     import inspect
     from sonic_py_common import syslogger
@@ -32,6 +33,11 @@ REBOOT_CAUSE_EXTERNAL = "External causes"
 RESET_CAUSE_PATH = "/sys/firmware/pensando/rstcause/this_cause"
 DOCKER_HWSKU_PATH = '/usr/share/sonic/platform'
 SLOT_ID_MASK = 0x7
+
+REDIS_CHASSIS_SERVER_PORT = 6380
+REDIS_CHASSIS_SERVER_IP = '169.254.200.254'
+CHASSIS_STATE_DB_ID = 13
+DPU_HEALTH_INFO_TABLE_NAME = 'DPU_STATE'
 
 #cpld masks for system led
 SYSTEM_LED_GREEN   = 0x7
@@ -432,4 +438,48 @@ class Chassis(ChassisBase):
 
     def get_revision(self):
         return self._api_helper.get_board_rev()
+
+    ##############################################
+    # SmartSwitch methods
+    ##############################################
+
+    def _get_chassis_state_db(self):
+        if not hasattr(self, '_chassis_state_db') or self._chassis_state_db is None:
+            try:
+                self._chassis_state_db = redis.Redis(
+                    host=REDIS_CHASSIS_SERVER_IP,
+                    port=REDIS_CHASSIS_SERVER_PORT,
+                    decode_responses=True,
+                    db=CHASSIS_STATE_DB_ID)
+                self._chassis_state_db.ping()
+            except Exception:
+                self._chassis_state_db = None
+        return self._chassis_state_db
+
+    def is_smartswitch(self):
+        return True
+
+    def is_dpu(self):
+        return True
+
+    def get_dpu_id(self, **kwargs):
+        return self.get_my_slot()
+
+    def get_dataplane_state(self):
+        db = self._get_chassis_state_db()
+        if db is None:
+            return False
+        slot_id = self.get_my_slot()
+        table = f'{DPU_HEALTH_INFO_TABLE_NAME}|DPU{slot_id}'
+        state = db.hget(table, 'dpu_data_plane_state')
+        return state == 'up'
+
+    def get_controlplane_state(self):
+        db = self._get_chassis_state_db()
+        if db is None:
+            return False
+        slot_id = self.get_my_slot()
+        table = f'{DPU_HEALTH_INFO_TABLE_NAME}|DPU{slot_id}'
+        state = db.hget(table, 'dpu_control_plane_state')
+        return state == 'up'
 


### PR DESCRIPTION
Implement missing SmartSwitch chassis APIs for Pensando DPU platform (arm64-elba-asic-flash128-r0) and tighten control plane container health monitoring in fetch_dpu_status.

- Add is_smartswitch() and is_dpu() returning True for Mt Fuji/Lipari SmartSwitch boards
- Add get_dpu_id() mapping to hardware slot ID via get_my_slot()
- Add get_dataplane_state() and get_controlplane_state() reading from CHASSIS_STATE_DB, populated by the dpu-db-util service using pdsctl, pdsagent status, container health, and uplink checks via gRPC events
- Add _get_chassis_state_db() helper for lazy Redis connection to the switch host chassis state DB at 169.254.200.254:6380
- Replace container denylist approach in fetch_dpu_status with an explicit allowlist (swss, syncd, database, polaris) to avoid false positives from unrelated containers; remove pmon from check since it starts after swss and is covered by the 2-minute grace period

#### Why I did it
smartswitch related APIs were missing in chassis.py. So added missing APIs and enabled chassisd for Pensando-elba platform. Also tighten the logic for data_plane_status by removing unnecessary container checks which are irrelevant for dpu container data plane functionality.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Add is_smartswitch() and is_dpu() returning True for Mt Fuji/Lipari SmartSwitch boards
- Add get_dpu_id() mapping to hardware slot ID via get_my_slot()
- Add get_dataplane_state() and get_controlplane_state() reading from CHASSIS_STATE_DB, populated by the dpu-db-util service using pdsctl, pdsagent status, container health, and uplink checks via gRPC events
- Add _get_chassis_state_db() helper for lazy Redis connection to the switch host chassis state DB at 169.254.200.254:6380
- Replace container denylist approach in fetch_dpu_status with an explicit allowlist (swss, syncd, database, polaris) to avoid false positives from unrelated containers; remove pmon from check since it starts after swss and is covered by the 2-minute grace period

#### How to verify it

Make sure chassis.py apis are returning correct values
```
root@sonic:/home/admin# python3
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import sonic_platform
>>> p = sonic_platform.platform.Platform()
>>> c = p.get_chassis()
>>> c.get_controlplane_state()
True
>>> c.get_dataplane_state()
True
>>> c.is_smartswitch()
True
>>> c.is_dpu()
True
>>>
```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [x] 20251106.23
- [x] 20260510.09

#### Test result
 202605: 
 ```
 root@sonic:/home/admin#
root@sonic:/home/admin# show version | head

SONiC Software Version: SONiC.20260510.09
SONiC OS Version: 13
Distribution: Debian 13.5
Kernel: 6.12.41+deb13-sonic-arm64
Build commit: ed7a797580
Build date: Mon Aug 3 17:40:45 UTC 2026
Built by: azureuser@c1875dbcc000002

Platform: arm64-elba-asic-flash128-r0
root@sonic:/home/admin#
root@sonic:/home/admin#
root@sonic:/home/admin# python3
Python 3.13.5 (tags/v3.13.5-dirty:6cb20a219a8, Jun 26 2025, 18:55:22) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.

import sonic_platform
p=sonic_platform.platform.Platform()
c=p.get_chassis()

c.get_controlplane_state()
True

c.get_dataplane_state()
True

c.is_smartswitch()
True

c.is_dpu()
True
```
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

