### PR TITLE
Update grub2 version from 2.06-13 to 2.12-9

### DIFF
--- a/rules/grub2.mk
+++ b/rules/grub2.mk
@@ -1,6 +1,6 @@
 # grub2 package
 
-GRUB2_VERSION := 2.06-13+deb13u1
+GRUB2_VERSION := 2.12-9+deb13u1
 
 export GRUB2_VERSION
 
@@ -23,12 +23,18 @@ $(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_AMD64)))
 
 GRUB_EFI_AMD64_BIN = grub-efi-amd64-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_AMD64_BIN)))
+
+GRUB_EFI_AMD64_UNSIGNED = grub-efi-amd64-unsigned_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_AMD64_UNSIGNED)))
 else ifeq ($(CONFIGURED_ARCH),arm64)
 GRUB_EFI_ARM64 = grub-efi-arm64_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARM64)))
 
 GRUB_EFI_ARM64_BIN = grub-efi-arm64-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 $(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARM64_BIN)))
+
+GRUB_EFI_ARM64_UNSIGNED = grub-efi-arm64-unsigned_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+$(eval $(call add_derived_package,$(GRUB2_COMMON),$(GRUB_EFI_ARM64_UNSIGNED)))
 endif
 
 # The .c, .cpp, .h & .hpp files under src/{$DBG_SRC_ARCHIVE list}

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -507,6 +507,7 @@ RUN apt-get update && apt-get install -y eatmydata && eatmydata apt-get install 
         libefiboot-dev \
         libefivar-dev \
         dosfstools \
+        libfuse3-dev \
 # For nvidia-bluefield sdk compilation
         cython3 \
         pandoc \

--- a/src/grub2/Makefile
+++ b/src/grub2/Makefile
@@ -10,9 +10,11 @@ ifeq ($(CONFIGURED_ARCH),amd64)
 DERIVED_TARGETS += grub-pc-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS += grub-efi-amd64_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS += grub-efi-amd64-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS += grub-efi-amd64-unsigned_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 else ifeq ($(CONFIGURED_ARCH),arm64)
 DERIVED_TARGETS += grub-efi-arm64_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS += grub-efi-arm64-bin_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS += grub-efi-arm64-unsigned_$(GRUB2_VERSION)_$(CONFIGURED_ARCH).deb
 endif
 
 SUFFIX := $(shell date +%Y%m%d\.%H%M%S)

--- a/src/grub2/patch/adjust-build-rules-for-debian.patch
+++ b/src/grub2/patch/adjust-build-rules-for-debian.patch
@@ -3,34 +3,19 @@ Adjust build rules for Debian Trixie
 From: Saikrishna Arcot <sarcot@microsoft.com>
 
 
----
- debian/control |   23 +----------------------
- debian/rules   |    2 --
- 2 files changed, 1 insertion(+), 24 deletions(-)
-
 diff --git a/debian/control b/debian/control
-index 1c48f28e2..976040a8c 100644
+index 11e9e7e57..a059c4063 100644
 --- a/debian/control
 +++ b/debian/control
-@@ -11,8 +11,7 @@ Build-Depends: debhelper-compat (= 13),
-  po-debconf,
-  help2man,
-  texinfo,
-- gcc-12,
-- gcc-12-multilib [i386 kopensolaris-i386 any-amd64 any-ppc64 any-sparc],
-+ gcc-multilib [i386 kopensolaris-i386 any-amd64 any-ppc64 any-sparc],
-  xfonts-unifont,
-  libfreetype6-dev,
-  gettext,
-@@ -20,7 +19,6 @@ Build-Depends: debhelper-compat (= 13),
+@@ -20,7 +20,6 @@ Build-Depends: debhelper-compat (= 13),
   libgeom-dev (>= 8.2+ds1-1~) [kfreebsd-any] | libgeom-dev (<< 8.2) [kfreebsd-any],
-  libsdl1.2-dev [!hurd-any],
+  libsdl2-dev [!hurd-any],
   xorriso,
 - qemu-system [i386 kfreebsd-i386 kopensolaris-i386 any-amd64],
   cpio [i386 kopensolaris-i386 amd64 x32],
   parted [!hurd-any],
-  libfuse-dev (>= 2.8.4-1.4) [linux-any kfreebsd-any],
-@@ -578,25 +576,6 @@ Description: GRand Unified Bootloader, version 2 (Open Firmware version)
+  libfuse3-dev [linux-any kfreebsd-any],
+@@ -841,25 +840,6 @@ Description: GRand Unified Bootloader, version 2 (Open Firmware version)
   use with Open Firmware implementations.  Installing this package indicates
   that this version of GRUB should be the active boot loader.
  
@@ -56,16 +41,3 @@ index 1c48f28e2..976040a8c 100644
  Package: grub-uboot-bin
  Architecture: any-arm
  Depends: ${shlibs:Depends}, ${misc:Depends}, grub-common (= ${binary:Version})
-diff --git a/debian/rules b/debian/rules
-index d974316dc..2ed556351 100755
---- a/debian/rules
-+++ b/debian/rules
-@@ -37,8 +37,6 @@ else
- with_check := yes
- endif
- 
--CC := gcc-12
--
- confflags = \
- 	PACKAGE_VERSION="$(deb_version)" PACKAGE_STRING="GRUB $(deb_version)" \
- 	CC=$(CC) TARGET_CC=$(CC) \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix issue #28442 

#### How I did it

- Updated grub version to 2.12-9
- Updated `src/grub2/patch/adjust-build-rules-for-debian.patch` so it applies cleanly to the new grub (no functional changes)
- Added libfuse3-dev to the sonic-slave-trixie build container because the newer grub build requires it.
- Added grub-efi-amd64-unsigned deb as a grub derived package/output because newer grub-efi-amd64-bin depends on grub-efi-amd64-unsigned at the exact same version. Same for arm64 deb files.

#### How to verify it

The new image now passes the secure boot checking on startup.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch

- [x] master
- [ ]  202305
- [ ]  202311
- [ ]  202405
- [ ]  202411
- [ ]  202505
- [x]  202511
- [ ]  202512
- [x]  202605
- [ ]  202608

#### Test result

Booting a signed image passes the grub stage and continues booting normally.