### PR TITLE
[installer] Install UEFI Secure Boot db certificate during SONiC installation

### DIFF
--- a/Makefile.work
+++ b/Makefile.work
@@ -417,6 +417,10 @@ endif
 ifneq ($(SECURE_UPGRADE_KERNEL_CAFILE),)
     DOCKER_RUN += -v $(SECURE_UPGRADE_KERNEL_CAFILE):$(SECURE_UPGRADE_KERNEL_CAFILE):ro
 endif
+# Mount the Secure Boot db certificate (DB.auth) file into the slave container
+ifneq ($(SECURE_BOOT_DB_CERT),)
+    DOCKER_RUN += -v $(abspath $(SECURE_BOOT_DB_CERT)):$(abspath $(SECURE_BOOT_DB_CERT)):ro
+endif
 # Mount the Signing prod tool in the slave container
 $(info "SECURE_UPGRADE_PROD_SIGNING_TOOL": "$(SECURE_UPGRADE_PROD_SIGNING_TOOL)")
 ifneq ($(SECURE_UPGRADE_PROD_SIGNING_TOOL),)
@@ -648,6 +652,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            SECURE_UPGRADE_SIGNING_CERT=$(SECURE_UPGRADE_SIGNING_CERT) \
                            SECURE_UPGRADE_KERNEL_CAFILE=$(SECURE_UPGRADE_KERNEL_CAFILE) \
                            SECURE_UPGRADE_PROD_SIGNING_TOOL=$(SECURE_UPGRADE_PROD_SIGNING_TOOL) \
+                           SECURE_BOOT_DB_CERT=$(SECURE_BOOT_DB_CERT) \
                            SONIC_DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
                            ENABLE_HOST_SERVICE_ON_START=$(ENABLE_HOST_SERVICE_ON_START) \
                            SLAVE_DIR=$(SLAVE_DIR) \

--- a/Makefile.work
+++ b/Makefile.work
@@ -417,6 +417,10 @@ endif
 ifneq ($(SECURE_UPGRADE_KERNEL_CAFILE),)
     DOCKER_RUN += -v $(SECURE_UPGRADE_KERNEL_CAFILE):$(SECURE_UPGRADE_KERNEL_CAFILE):ro
 endif
+# Mount the Secure Boot db certificate (DB.auth) file into the slave container
+ifneq ($(SECURE_BOOT_DB_CERT),)
+    DOCKER_RUN += -v $(abspath $(SECURE_BOOT_DB_CERT)):$(abspath $(SECURE_BOOT_DB_CERT)):ro
+endif
 # Mount the Signing prod tool in the slave container
 $(info "SECURE_UPGRADE_PROD_SIGNING_TOOL": "$(SECURE_UPGRADE_PROD_SIGNING_TOOL)")
 ifneq ($(SECURE_UPGRADE_PROD_SIGNING_TOOL),)
@@ -648,6 +652,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            SECURE_UPGRADE_SIGNING_CERT=$(SECURE_UPGRADE_SIGNING_CERT) \
                            SECURE_UPGRADE_KERNEL_CAFILE=$(SECURE_UPGRADE_KERNEL_CAFILE) \
                            SECURE_UPGRADE_PROD_SIGNING_TOOL=$(SECURE_UPGRADE_PROD_SIGNING_TOOL) \
+                           SECURE_BOOT_DB_CERT=$(if $(SECURE_BOOT_DB_CERT),$(abspath $(SECURE_BOOT_DB_CERT))) \
                            SONIC_DEFAULT_CONTAINER_REGISTRY=$(DEFAULT_CONTAINER_REGISTRY) \
                            ENABLE_HOST_SERVICE_ON_START=$(ENABLE_HOST_SERVICE_ON_START) \
                            SLAVE_DIR=$(SLAVE_DIR) \

--- a/build_debian.sh
+++ b/build_debian.sh
@@ -767,6 +767,18 @@ if [[ $SECURE_UPGRADE_MODE == 'dev' || $SECURE_UPGRADE_MODE == "prod" ]]; then
         sudo ./scripts/secure_boot_signature_verification.sh -e $FILESYSTEM_ROOT/boot/vmlinuz-${LINUX_KERNEL_VERSION}-sonic-${CONFIGURED_ARCH} \
                                                              -c $SECURE_UPGRADE_SIGNING_CERT
     fi
+
+    # Embed the UEFI Secure Boot db certificate (DB.auth) into the image so the installer can
+    # enroll it into the DUT firmware. The file is placed under /boot so it ships at
+    # image-<version>/boot/ alongside the signed shim/grub.
+    if [ -n "$SECURE_BOOT_DB_CERT" ]; then
+        echo "Secure Boot support build stage: embedding Secure Boot db certificate from $SECURE_BOOT_DB_CERT"
+        if [ ! -f "$SECURE_BOOT_DB_CERT" ]; then
+            echo "Error: SECURE_BOOT_DB_CERT=$SECURE_BOOT_DB_CERT is set but the file is missing"
+            exit 1
+        fi
+        sudo cp "$SECURE_BOOT_DB_CERT" "$FILESYSTEM_ROOT/boot/DB.auth"
+    fi
     echo "Secure Boot support build stage: END."
 fi
 

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -472,7 +472,148 @@ demo_install_uefi_shim()
         echo "ERROR: efibootmgr failed to create new boot variable on: $blk_dev"
         exit 1
     }
+
     echo "demo_install_uefi_shim(): Secure Boot components installed successfully"
+}
+
+# Clear the immutable (i) attribute on an efivarfs file so the variable can be updated. The
+# kernel marks existing Secure Boot variables (db/dbx/KEK/PK) immutable; a write fails while
+# the i flag is set. Returns 0 only when the file does not exist yet or is no longer immutable.
+clear_efivar_immutable()
+{
+    local efivar_path="$1"
+
+    [ -e "$efivar_path" ] || return 0
+    chattr -i "$efivar_path" || return 1
+
+    # lsattr prints "<attrs> <path>"; inspect only the attribute field so the "i" in the
+    # efivar path (e.g. /sys/firmware/efi/efivars/...) is not mistaken for the immutable flag.
+    local attrs
+    attrs="$(lsattr "$efivar_path")" || return 1
+    attrs="${attrs%% *}"
+    case "$attrs" in
+        *i*) return 1 ;;
+    esac
+    return 0
+}
+
+# Write a signed authenticated variable update ($3 = .auth) to UEFI variable $1. $2 is the
+# matching efivarfs path used to clear the immutable flag. efi-updatevar selects the standard
+# variable namespace from $1; its -g option controls certificate ownership and does not select
+# the namespace for .auth files. $4 selects "append" or "replace".
+write_efi_auth_var()
+{
+    local var_name="$1"
+    local efivar_path="$2"
+    local auth_file="$3"
+    local mode="$4"
+
+    if ! command -v efi-updatevar >/dev/null 2>&1; then
+        echo "write_efi_auth_var(): efi-updatevar not found, cannot enroll $var_name"
+        return 1
+    fi
+
+    # The variable can only be written once the immutable flag is cleared. Bail out if a
+    # previous entry remains immutable, since efi-updatevar cannot update it in that state.
+    if ! clear_efivar_immutable "$efivar_path"; then
+        echo "write_efi_auth_var(): $efivar_path is immutable, cannot enroll $var_name"
+        return 1
+    fi
+
+    if [ "$mode" = "append" ]; then
+        efi-updatevar -a -f "$auth_file" "$var_name" && return 0
+    else
+        efi-updatevar -f "$auth_file" "$var_name" && return 0
+    fi
+    echo "write_efi_auth_var(): efi-updatevar failed for $var_name"
+    return 1
+}
+
+# Return success only when firmware explicitly reports that Secure Boot is disabled.
+secure_boot_is_disabled()
+{
+    local secure_boot_path="/sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c"
+    local secure_boot_value
+
+    [ -r "$secure_boot_path" ] || return 1
+    secure_boot_value="$(od -An -tu1 -j4 -N1 "$secure_boot_path")" || return 1
+    [ "$secure_boot_value" -eq 0 ]
+}
+
+# Enroll the UEFI Secure Boot db certificate bundled in the installed image (image-<ver>/boot/)
+# into firmware NVRAM. This must run BEFORE the SONiC image filesystem is installed, so the
+# signed image is trusted by firmware on first boot. The certificate is appended so it coexists
+# with any pre-existing keys; firmware ignores a duplicate append of an already-enrolled cert.
+# Enrollment failure aborts installation unless Secure Boot is explicitly disabled.
+demo_enroll_secure_boot_keys()
+{
+    local demo_mnt="$1"
+    local keys_dir="$demo_mnt/$image_dir/boot"
+    local db_efivar_path="/sys/firmware/efi/efivars/db-d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+
+    # Only proceed if the image bundled Secure Boot key material.
+    if [ ! -f "$keys_dir/DB.auth" ]; then
+        echo "demo_enroll_secure_boot_keys(): no Secure Boot keys bundled in image, skipping key enrollment"
+        return 0
+    fi
+
+    # Persist the db certificate shipped with the image under /host/db-auth using a unique,
+    # content-based name, so certificates from successive installations accumulate instead of
+    # overwriting each other. If a byte-identical DB.auth is already stored (e.g. re-installing
+    # an image that ships the same certificate), it is not copied again. A hash-name collision
+    # with different content is an error rather than overwriting the existing authentication
+    # file. demo_mnt is the host partition, mounted at /host on the booted system. Best-effort.
+    local db_auth_dir="$demo_mnt/db-auth"
+    local existing_auth found_auth db_hash db_dest
+    if mkdir -p "$db_auth_dir" 2>/dev/null; then
+        found_auth=""
+        for existing_auth in "$db_auth_dir"/*.auth; do
+            [ -e "$existing_auth" ] || continue
+            if cmp -s "$keys_dir/DB.auth" "$existing_auth"; then
+                found_auth="$existing_auth"
+                break
+            fi
+        done
+        if [ -n "$found_auth" ]; then
+            echo "demo_enroll_secure_boot_keys(): DB.auth already present at $found_auth, not copying"
+        else
+            db_hash="$(sha256sum "$keys_dir/DB.auth")" || return 1
+            db_hash="${db_hash%% *}"
+            db_dest="$db_auth_dir/DB-${db_hash}.auth"
+            if [ -e "$db_dest" ]; then
+                if cmp -s "$keys_dir/DB.auth" "$db_dest"; then
+                    echo "demo_enroll_secure_boot_keys(): DB.auth already present at $db_dest, not copying"
+                else
+                    echo "ERROR: demo_enroll_secure_boot_keys(): $db_dest has different content (SHA-256 collision)"
+                    return 1
+                fi
+            elif cp "$keys_dir/DB.auth" "$db_dest" 2>/dev/null; then
+                echo "demo_enroll_secure_boot_keys(): copied DB.auth to $db_dest"
+            else
+                echo "WARNING: demo_enroll_secure_boot_keys(): failed to copy DB.auth to $db_dest"
+            fi
+        fi
+    else
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to create $db_auth_dir"
+    fi
+
+    if [ ! -d /sys/firmware/efi/efivars ]; then
+        echo "demo_enroll_secure_boot_keys(): efivars not available, skipping key enrollment"
+        return 0
+    fi
+    if ! mountpoint -q /sys/firmware/efi/efivars 2>/dev/null; then
+        mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
+    fi
+
+    echo "demo_enroll_secure_boot_keys(): enrolling db from $keys_dir"
+    if write_efi_auth_var "db" "$db_efivar_path" "$keys_dir/DB.auth" "append"; then
+        echo "demo_enroll_secure_boot_keys(): db enrolled"
+    elif secure_boot_is_disabled; then
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to enroll db while Secure Boot is disabled"
+    else
+        echo "ERROR: demo_enroll_secure_boot_keys(): failed to enroll db while Secure Boot is enabled or unknown"
+        return 1
+    fi
 }
 
 bootloader_menu_config()

--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -472,7 +472,132 @@ demo_install_uefi_shim()
         echo "ERROR: efibootmgr failed to create new boot variable on: $blk_dev"
         exit 1
     }
+
     echo "demo_install_uefi_shim(): Secure Boot components installed successfully"
+}
+
+# Clear the immutable (i) attribute on an efivarfs file so the variable can be updated. The
+# kernel marks existing Secure Boot variables (db/dbx/KEK/PK) immutable; a write fails while
+# the i flag is set. Returns 0 only when the file does not exist yet or is no longer immutable.
+clear_efivar_immutable()
+{
+    local efivar_path="$1"
+
+    [ -e "$efivar_path" ] || return 0
+    if command -v chattr >/dev/null 2>&1; then
+        chattr -i "$efivar_path" 2>/dev/null || true
+    fi
+    if command -v lsattr >/dev/null 2>&1; then
+        # lsattr prints "<attrs> <path>"; inspect only the attribute field so the "i" in the
+        # efivar path (e.g. /sys/firmware/efi/efivars/...) is not mistaken for the immutable flag.
+        local attrs
+        attrs="$(lsattr "$efivar_path" 2>/dev/null)"
+        attrs="${attrs%% *}"
+        case "$attrs" in
+            *i*) return 1 ;;
+        esac
+    fi
+    return 0
+}
+
+# Write a signed authenticated variable update ($3 = .auth) to UEFI variable $1 (GUID $2)
+# using efi-updatevar (efitools). $4 selects "append" (coexist with existing entries) or
+# "replace". efitools is installed in the SONiC image; enrollment is skipped if it is absent.
+write_efi_auth_var()
+{
+    local var_name="$1"
+    local var_guid="$2"
+    local auth_file="$3"
+    local mode="$4"
+    local efivar_path="/sys/firmware/efi/efivars/${var_name}-${var_guid}"
+
+    if ! command -v efi-updatevar >/dev/null 2>&1; then
+        echo "write_efi_auth_var(): efi-updatevar not found, cannot enroll $var_name"
+        return 1
+    fi
+
+    # The variable can only be written once the immutable flag is cleared. Bail out if a
+    # previous entry remains immutable, since efi-updatevar cannot update it in that state.
+    if ! clear_efivar_immutable "$efivar_path"; then
+        echo "write_efi_auth_var(): $efivar_path is immutable, cannot enroll $var_name"
+        return 1
+    fi
+
+    if [ "$mode" = "append" ]; then
+        efi-updatevar -a -f "$auth_file" "$var_name" && return 0
+    else
+        efi-updatevar -f "$auth_file" "$var_name" && return 0
+    fi
+    echo "write_efi_auth_var(): efi-updatevar failed for $var_name"
+    return 1
+}
+
+# Enroll the UEFI Secure Boot db certificate bundled in the installed image (image-<ver>/boot/)
+# into firmware NVRAM. This must run BEFORE the SONiC image filesystem is installed, so the
+# signed image is trusted by firmware on first boot. The certificate is appended so it coexists
+# with any pre-existing keys; firmware ignores a duplicate append of an already-enrolled cert.
+# Every step is best-effort: failures are logged but never abort the installation.
+demo_enroll_secure_boot_keys()
+{
+    local demo_mnt="$1"
+    local keys_dir="$demo_mnt/$image_dir/boot"
+    local db_guid="d719b2cb-3d3a-4596-a3bc-dad00e67656f"
+
+    # Only proceed if the image bundled Secure Boot key material.
+    if [ ! -f "$keys_dir/DB.auth" ]; then
+        echo "demo_enroll_secure_boot_keys(): no Secure Boot keys bundled in image, skipping key enrollment"
+        return 0
+    fi
+
+    # Persist the db certificate shipped with the image under /host/db-auth using a unique,
+    # content-based name, so certificates from successive installations accumulate instead of
+    # overwriting each other. If a byte-identical DB.auth is already stored (e.g. re-installing
+    # an image that ships the same certificate), it is not copied again. demo_mnt is the host
+    # partition, mounted at /host on the booted system. Best-effort.
+    local db_auth_dir="$demo_mnt/db-auth"
+    local existing_auth found_auth db_hash db_dest
+    if mkdir -p "$db_auth_dir" 2>/dev/null; then
+        found_auth=""
+        for existing_auth in "$db_auth_dir"/*.auth; do
+            [ -e "$existing_auth" ] || continue
+            if cmp -s "$keys_dir/DB.auth" "$existing_auth"; then
+                found_auth="$existing_auth"
+                break
+            fi
+        done
+        if [ -n "$found_auth" ]; then
+            echo "demo_enroll_secure_boot_keys(): DB.auth already present at $found_auth, not copying"
+        else
+            db_hash=$(sha256sum "$keys_dir/DB.auth" 2>/dev/null | cut -d' ' -f1)
+            if [ -n "$db_hash" ]; then
+                db_dest="$db_auth_dir/DB-${db_hash}.auth"
+            else
+                db_dest="$db_auth_dir/DB-$(date -u +%Y%m%d%H%M%S).auth"
+            fi
+            if cp "$keys_dir/DB.auth" "$db_dest" 2>/dev/null; then
+                echo "demo_enroll_secure_boot_keys(): copied DB.auth to $db_dest"
+            else
+                echo "WARNING: demo_enroll_secure_boot_keys(): failed to copy DB.auth to $db_dest"
+            fi
+        fi
+    else
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to create $db_auth_dir"
+    fi
+
+    if [ ! -d /sys/firmware/efi/efivars ]; then
+        echo "demo_enroll_secure_boot_keys(): efivars not available, skipping key enrollment"
+        return 0
+    fi
+    if ! mountpoint -q /sys/firmware/efi/efivars 2>/dev/null; then
+        mount -t efivarfs efivarfs /sys/firmware/efi/efivars 2>/dev/null || true
+    fi
+
+    echo "demo_enroll_secure_boot_keys(): enrolling db from $keys_dir"
+    if write_efi_auth_var "db" "$db_guid" "$keys_dir/DB.auth" "append"; then
+        echo "demo_enroll_secure_boot_keys(): db enrolled"
+    else
+        echo "WARNING: demo_enroll_secure_boot_keys(): failed to enroll db"
+    fi
 }
 
 bootloader_menu_config()

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -217,6 +217,14 @@ else
     }
 fi
 
+# Enroll the UEFI Secure Boot db certificate BEFORE installing the SONiC image, so the signed
+# image is trusted by firmware on first boot. Extract only boot/DB.auth from the payload up
+# front; the full image extraction below repopulates boot/ with the rest. Best-effort.
+if [ "$install_env" != "build" ]; then
+    unzip -o $INSTALLER_PAYLOAD "boot/DB.auth" -d $demo_mnt/$image_dir > /dev/null 2>&1 || true
+    demo_enroll_secure_boot_keys "$demo_mnt" || true
+fi
+
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -217,6 +217,14 @@ else
     }
 fi
 
+# Enroll the UEFI Secure Boot db certificate BEFORE installing the SONiC image, so the signed
+# image is trusted by firmware on first boot. Extract only boot/DB.auth from the payload up
+# front; the full image extraction below repopulates boot/ with the rest.
+if [ "$install_env" != "build" ]; then
+    unzip -o $INSTALLER_PAYLOAD "boot/DB.auth" -d $demo_mnt/$image_dir > /dev/null 2>&1 || true
+    demo_enroll_secure_boot_keys "$demo_mnt" || exit 1
+fi
+
 # Decompress the file for the file system directly to the partition
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd

--- a/rules/config
+++ b/rules/config
@@ -299,12 +299,18 @@ SONIC_ENABLE_IMAGE_SIGNATURE ?= n
 # SECURE_UPGRADE_MODE - enum value for secure upgrade mode, valid options are "dev", "prod" and "no_sign"
 # SECURE_UPGRADE_PROD_SIGNING_TOOL - path to a vendor signing tool for production flow.
 # SECURE_UPGRADE_PROD_TOOL_ARGS - Extra arguments options for vendor to use to run his specific prod signing script
+# SECURE_BOOT_DB_CERT - path to the UEFI Secure Boot db certificate file (DB.auth). Only takes
+#                       effect when SECURE_UPGRADE_MODE is "dev" or "prod"; it is ignored in the
+#                       default "no_sign" mode. When set (in dev/prod), this file is embedded into
+#                       the image (under image-<version>/boot/) and enrolled into the DUT's UEFI
+#                       firmware during installation. Leave empty to disable key embedding/enrollment.
 SECURE_UPGRADE_DEV_SIGNING_KEY ?=
 SECURE_UPGRADE_SIGNING_CERT ?=
 SECURE_UPGRADE_MODE ?= "no_sign"
 SECURE_UPGRADE_KERNEL_CAFILE ?= $(SECURE_UPGRADE_SIGNING_CERT)
 SECURE_UPGRADE_PROD_SIGNING_TOOL ?=
 SECURE_UPGRADE_PROD_TOOL_ARGS ?=
+SECURE_BOOT_DB_CERT ?=
 
 # BUILD_SNAPSHOT_URL - Default debian snapshot mirror url
 # Mirror of https://snapshot.debian.org/archive


### PR DESCRIPTION
#### Why I did it
Embed the UEFI Secure Boot **db** certificate in the image and enroll it during installation so a signed image is trusted by firmware on first boot.

##### Work item tracking
- Microsoft ADO (number only): 38692567

#### How I did it
- `SECURE_BOOT_DB_CERT` build variable embeds `DB.auth` at `image-<version>/boot/` (Makefile.work, rules/config, build_debian.sh).
- `installer/default_platform.conf` + `installer/install.sh`: enroll the image's db cert into the UEFI db before the filesystem is written. Append-only, blocks the installation only when in secure boot enabled state.
- The enroll script itself ships in **sonic-net/sonic-utilities#4700**. Submodule bump to follow separately (not included here).

#### How to verify it
Build a signed image with `SECURE_BOOT_DB_CERT` set; install on a UEFI switch; confirm the db cert is enrolled and verification passes.

#### Which release branch to backport
None (feature).