### PR TITLE
[yang] portchannel: add learn_mode leaf to PORTCHANNEL_LIST

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -137,7 +137,8 @@
                 "fast_rate": "false",
                 "fallback" : "true",
                 "mode":"routed",
-                "system_mac": "aa:bb:cc:dd:ee:ff"
+                "system_mac": "aa:bb:cc:dd:ee:ff",
+                "learn_mode": "disable"
             }
         },
         "PORTCHANNEL_INTERFACE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/portchannel.json
@@ -34,6 +34,14 @@
         "eStrKey" : "Pattern",
         "eStr": ["false|true|False|True"]
     },
+    "PORTCHANNEL_LEARN_MODE_VALID": {
+        "desc": "Configure a valid learn_mode in PORTCHANNEL table."
+    },
+    "PORTCHANNEL_LEARN_MODE_INVALID": {
+        "desc": "INCORRECT LEARN_MODE IN PORTCHANNEL TABLE.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["learn_mode"]
+    },
     "PORTCHANNEL_INTERFACE_IP_ADDR_TEST": {
         "desc": "Configure IP address on PORTCHANNEL_INTERFACE table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/portchannel.json
@@ -171,6 +171,34 @@
             }
         }
     },
+    "PORTCHANNEL_LEARN_MODE_VALID": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "learn_mode": "disable"
+                    }
+                ]
+            }
+        }
+    },
+    "PORTCHANNEL_LEARN_MODE_INVALID": {
+        "sonic-portchannel:sonic-portchannel": {
+            "sonic-portchannel:PORTCHANNEL": {
+                "PORTCHANNEL_LIST": [
+                    {
+                        "admin_status": "up",
+                        "mtu": "9100",
+                        "name": "PortChannel0001",
+                        "learn_mode": "invalid"
+                    }
+                ]
+            }
+        }
+    },
     "PORTCHANNEL_INTERFACE_IP_ADDR_TEST": {
         "sonic-portchannel:sonic-portchannel": {
             "sonic-portchannel:PORTCHANNEL": {

--- a/src/sonic-yang-models/yang-models/sonic-portchannel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-portchannel.yang
@@ -24,6 +24,10 @@ module sonic-portchannel {
 
     description "Link Aggregation Group (LAG/PortChannel) configuration using LACP";
 
+    revision 2026-07-17 {
+        description "Add learn_mode leaf to PORTCHANNEL_LIST";
+    }
+
     revision 2025-06-24 {
         description "Add LACP System MAC address";
     }
@@ -135,6 +139,34 @@ module sonic-portchannel {
                          deployments that require peer devices to advertise a shared LACP system ID.
                          When unset, the device's default system MAC is used.";
                     type yang:mac-address;
+                }
+
+                leaf learn_mode {
+                    description
+                        "MAC address learning mode for the PortChannel bridge port. teammgr reads
+                         this value from CONFIG_DB and portsorch applies it as the SAI bridge-port
+                         FDB learning mode. When unset, hardware learning is used.";
+                    type enumeration {
+                        enum drop {
+                            description "Drop packets with an unknown source MAC and do not learn.";
+                        }
+                        enum disable {
+                            description "Do not learn new source MACs. Forwarding is unaffected.";
+                        }
+                        enum hardware {
+                            description "Learn source MACs in hardware. This is the default.";
+                        }
+                        enum cpu_trap {
+                            description "Trap packets with an unknown source MAC to the CPU and do not learn in hardware.";
+                        }
+                        enum cpu_log {
+                            description "Copy packets with an unknown source MAC to the CPU for logging and do not learn in hardware.";
+                        }
+                        enum notification {
+                            description "Raise an FDB event for an unknown source MAC and do not learn in hardware.";
+                        }
+                    }
+                    default hardware;
                 }
 
             } /* end of list PORTCHANNEL_LIST */


### PR DESCRIPTION
#### Why I did it

`learn_mode` is a valid CONFIG_DB `PORTCHANNEL` field, but the `sonic-portchannel` YANG model does not define it. Any configuration that sets `learn_mode` on a PortChannel fails YANG validation, so `config apply-patch` and other GenericConfigUpdater flows reject the whole configuration.

`learn_mode` is already handled end to end by swss, only the YANG model was missing it:

- `teammgr` reads `learn_mode` from the CONFIG_DB `PORTCHANNEL` table (`cfgmgr/teammgr.cpp`) and writes it to the APPL_DB LAG table.
- `orchagent`/`portsorch` maps the value to the SAI bridge-port FDB learning mode via `learn_mode_map` (`orchagent/portsorch.cpp`), accepting `drop`, `disable`, `hardware`, `cpu_trap`, `cpu_log` and `notification`, with `hardware` as the default.

Fixes #28471

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added the `learn_mode` leaf to `PORTCHANNEL_LIST` in `sonic-portchannel.yang` as an enumeration of the six values accepted by orchagent, with `default hardware`, and bumped the model revision. This follows the same pattern as [yang] interface: add missing mac_addr leaf (#20968).

Also exercised the leaf in `tests/files/sample_config_db.json` and added positive and negative cases to the sonic-yang-models tests (`tests/yang_model_tests/tests/portchannel.json` and `tests/yang_model_tests/tests_config/portchannel.json`).

#### How to verify it

1. Run the sonic-yang-models model tests:

   ```
   cd src/sonic-yang-models && pytest tests/yang_model_tests/test_yang_model.py
   ```

   The new `PORT_CHANNEL_VALID_LEARN_MODE` and `PORT_CHANNEL_INVALID_LEARN_MODE` cases exercise the leaf.

2. Load a PORTCHANNEL config that sets `learn_mode` through the `sonic_yang` library (the same validation path `config apply-patch` uses):

   ```json
   "PORTCHANNEL": {
       "PortChannel0001": { "admin_status": "up", "learn_mode": "disable" }
   }
   ```

   Before this change validation fails with `All Keys are not parsed in PORTCHANNEL ... 'learn_mode'`. After it, each of the six valid values and the default are accepted, and an invalid value is rejected with `Invalid value "invalid" in "learn_mode" element.`

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master

#### Test result

master: verified with the `sonic_yang` library used by `config apply-patch`. All six enum values (`drop`, `disable`, `hardware`, `cpu_trap`, `cpu_log`, `notification`) and an absent leaf (default `hardware`) validate cleanly, and an invalid value is rejected with `Invalid value "invalid" in "learn_mode" element.` The added positive and negative yang model tests follow the existing `portchannel.json` pattern.
