### PR TITLE
[dhcp_relay]: Use device base MAC for ISC Remote-ID

### DIFF
--- a/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
+++ b/dockers/docker-dhcp-relay/dhcpv4-relay.agents.j2
@@ -9,7 +9,7 @@
 {% set _dummy = relay_for_ipv4.update({'flag': False}) %}
 [program:isc-dhcpv4-relay-{{ vlan_name }}]
 {# We treat this VLAN as a downstream interface (-id), as we only want to listen for requests #}
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p {{ DEVICE_METADATA['localhost']['mac'] | lower }} --name-alias-map-file /tmp/port-name-alias-map.txt -id {{ vlan_name }}
 {#- Dual ToR Option #}
 {% if 'subtype' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['subtype'] == 'DualToR' %} -U Loopback0 -dt{% endif -%}
 {#- si option to use intf addr in relay #}

--- a/src/sonic-config-engine/tests/dhcp-relay-sample.json
+++ b/src/sonic-config-engine/tests/dhcp-relay-sample.json
@@ -6,5 +6,10 @@
         "dhcp_server": {
             "state": "disabled"
         }
+    },
+    "DEVICE_METADATA": {
+        "localhost": {
+            "mac": "A4:BF:01:02:03:04"
+        }
     }
 }

--- a/src/sonic-config-engine/tests/dhcp-sonic-relay-disabled-sample.json
+++ b/src/sonic-config-engine/tests/dhcp-sonic-relay-disabled-sample.json
@@ -21,6 +21,7 @@
     },
     "DEVICE_METADATA": {
         "localhost": {
+            "mac": "A4:BF:01:02:03:04",
             "has_sonic_dhcpv4_relay": "False"
         }
     }

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -pg 192.168.0.1 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 -pg 192.168.0.1 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -59,7 +59,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan1000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py2/docker-dhcp-relay.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -59,7 +59,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -iu PortChannel01 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-no-ip-helper.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay-secondary-subnets.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -pg 192.168.0.1 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 -pg 192.168.0.1 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -59,7 +59,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan1000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
+++ b/src/sonic-config-engine/tests/sample_output/py3/docker-dhcp-relay.supervisord.conf
@@ -47,7 +47,7 @@ dependent_startup_wait_for=rsyslogd:running
 programs=dhcprelayd,dhcp6relay
 
 [program:isc-dhcpv4-relay-Vlan1000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan1000 -iu Vlan2000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.1 192.0.0.2
 priority=3
 autostart=false
 autorestart=false
@@ -59,7 +59,7 @@ dependent_startup=true
 dependent_startup_wait_for=start:exited
 
 [program:isc-dhcpv4-relay-Vlan2000]
-command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p %%P --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.3 192.0.0.4
+command=/usr/sbin/dhcrelay -d -m discard -a %%h:%%p a4:bf:01:02:03:04 --name-alias-map-file /tmp/port-name-alias-map.txt -id Vlan2000 -iu Vlan1000 -iu Vlan3000 -iu PortChannel01 -iu PortChannel02 -iu PortChannel03 -iu PortChannel04 192.0.0.3 192.0.0.4
 priority=3
 autostart=false
 autorestart=false

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -187,14 +187,14 @@ class TestJ2Files(TestCase):
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'wait_for_intf.sh'), self.output_file))
 
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay', 'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.t0_minigraph_common_dhcp_relay, '-p', self.t0_port_config, '-t', template_path]
+        argument = ['-m', self.t0_minigraph_common_dhcp_relay, '-j', dhc_sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR, 'docker-dhcp-relay.supervisord.conf'), self.output_file))
 
         # Test generation of docker-dhcp-relay.supervisord.conf when a vlan is missing ip/ipv6 helpers
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.no_ip_helper_minigraph, '-p', self.t0_port_config, '-t', template_path]
+        argument = ['-m', self.no_ip_helper_minigraph, '-j', dhc_sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-no-ip-helper.supervisord.conf'), self.output_file))
@@ -202,7 +202,7 @@ class TestJ2Files(TestCase):
         # Test generation of docker-dhcp-relay.supervisord.conf when a vlan has secondary subnets specified
         template_path = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-dhcp-relay',
                                      'docker-dhcp-relay.supervisord.conf.j2')
-        argument = ['-m', self.t0_minigraph_secondary_subnets, '-p', self.t0_port_config, '-t', template_path]
+        argument = ['-m', self.t0_minigraph_secondary_subnets, '-j', dhc_sample_data, '-p', self.t0_port_config, '-t', template_path]
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR,
                                                'docker-dhcp-relay-secondary-subnets.supervisord.conf'), self.output_file))


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft - not hardware tested yet.** Keep this PR in draft until master and local 202605 validation evidence is added.

#### Why I did it

ISC `dhcrelay` currently builds Option 82 Remote-ID from `%P`, the hardware
address of the interface that received the request. On dual-ToR, that interface
is the client VLAN and carries the shared virtual VLAN MAC, so the value is not
a globally unique relay identity.

SONiC `dhcp4relay` already uses the device base MAC. A local 202605 run of
https://github.com/sonic-net/sonic-mgmt/pull/26296 exposed the mismatch before
the test could reach its Option 82 reply-lifecycle assertions:
`test_dhcp_relay_default[isc-relay-agent]` matched 0 of 48 relayed DISCOVER
packets because the test expected the base MAC while ISC emitted the virtual
VLAN MAC.

This change makes both relay implementations use the stable device base MAC for
Remote-ID, matching RFC 3046's globally unique identity requirement.

##### Work item tracking
- Microsoft ADO **(number only)**: 38538173

#### How I did it

- Render the ISC `dhcrelay` Remote-ID argument from
  `DEVICE_METADATA|localhost.mac` instead of `%P`.
- Normalize the rendered MAC to lowercase.
- Update sonic-config-engine DHCP relay fixtures and Python 2/Python 3 golden
  supervisor outputs to verify the exact command.

#### How to verify it

Static checks completed:

- JSON parsing for the updated cfggen fixtures.
- Python compilation for `test_j2files.py`.
- Jinja syntax parsing for `dhcpv4-relay.agents.j2`.
- `git diff --check`.

Hardware validation has not been completed. This PR remains draft, and master
plus local 202605 test evidence will be added before it is marked ready.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://msazure.visualstudio.com/One/_workitems/edit/38538173
Failure type: day-one issue

The fix is required on 202605 to make ISC Remote-ID globally unique on dual-ToR
and unblock the stacked Option 82 lifecycle validation.

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Not tested yet. The PR is intentionally draft; tested image versions and exact
results will be added later.

#### Description for the changelog

Use the device base MAC as ISC DHCP relay Option 82 Remote-ID.

#### Link to config_db schema for YANG module changes

N/A
