### PR TITLE
Add YANG model for PFCWD BIG_RED_SWITCH config

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -53,5 +53,12 @@
     "PFC_WDOG_WITH_INVALID_PFC_STAT_HISTORY": {
         "desc": "PFC_WDOG_WITH_INVALID_PFC_STAT_HISTORY",
         "eStr": ["pfc_stat_history must be either enable or disable"]
+    },
+    "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH": {
+        "desc": "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH no failure."
+    },
+    "PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH": {
+        "desc": "PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH",
+        "eStr": ["BIG_RED_SWITCH must be either enable or disable"]
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/pfc.json
@@ -60,5 +60,12 @@
     "PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH": {
         "desc": "PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH",
         "eStr": ["BIG_RED_SWITCH must be either enable or disable"]
+    },
+    "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH_ENABLE": {
+        "desc": "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH_ENABLE no failure."
+    },
+    "PFC_WDOG_WITH_BIG_RED_SWITCH_ON_NON_GLOBAL": {
+        "desc": "PFC_WDOG_WITH_BIG_RED_SWITCH_ON_NON_GLOBAL must condition failure.",
+        "eStrKey": "Must"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
@@ -375,5 +375,30 @@
                 ]
             }
         }
+    },
+    "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 200,
+                        "BIG_RED_SWITCH": "disable"
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "BIG_RED_SWITCH": "on"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/pfc.json
@@ -400,5 +400,49 @@
                 ]
             }
         }
+    },
+    "PFC_WDOG_WITH_VALID_BIG_RED_SWITCH_ENABLE": {
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "GLOBAL",
+                        "POLL_INTERVAL": 200,
+                        "BIG_RED_SWITCH": "enable"
+                    }
+                ]
+            }
+        }
+    },
+    "PFC_WDOG_WITH_BIG_RED_SWITCH_ON_NON_GLOBAL": {
+        "sonic-port:sonic-port": {
+            "sonic-port:PORT": {
+                "PORT_LIST": [
+                {
+                    "admin_status": "up",
+                    "alias": "eth0",
+                    "description": "Ethernet4",
+                    "lanes": "65",
+                    "mtu": "9000",
+                    "name": "Ethernet4",
+                    "tpid": "0x8100",
+                    "speed": "25000"
+                }
+                ]
+            }
+        },
+        "sonic-pfcwd:sonic-pfcwd": {
+            "sonic-pfcwd:PFC_WD": {
+                "PFC_WD_LIST": [
+                    {
+                        "ifname": "Ethernet4",
+                        "action": "drop",
+                        "detection_time": 400,
+                        "restoration_time": 800,
+                        "BIG_RED_SWITCH": "enable"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
+++ b/src/sonic-yang-models/yang-models/sonic-pfcwd.yang
@@ -97,6 +97,17 @@ module sonic-pfcwd {
                     description
                         "PFC watchdog global polling interval in msec.";
                 }
+                leaf BIG_RED_SWITCH {
+                    must "../ifname = 'GLOBAL'";
+                    type string {
+                        pattern "enable|disable" {
+                            error-message "BIG_RED_SWITCH must be either enable or disable";
+                            error-app-tag big-red-switch-invalid-status;
+                        }
+                    }
+                    description
+                        "Global toggle to force all ports into PFC Watchdog storm state.";
+                }
             }
         }
     }


### PR DESCRIPTION
#### Why I did it

Add a `BIG_RED_SWITCH` config leaf to the PFC watchdog YANG model (`sonic-pfcwd.yang`). BIG_RED_SWITCH is a global PFCWD kill switch that forces all ports into PFC Watchdog storm state. The YANG model had no schema for it, so `PFC_WD|GLOBAL` config carrying this field would fail YANG validation.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added `leaf BIG_RED_SWITCH` under the `PFC_WD` GLOBAL container in `sonic-pfcwd.yang`:
- `must "../ifname = 'GLOBAL'"` — only valid on the GLOBAL entry.
- `type string` constrained to `enable|disable`, with an `error-message` / `error-app-tag` for invalid values.
- description: "Global toggle to force all ports into PFC Watchdog storm state."

Added positive and negative YANG unit tests (and their config):
- `PFC_WDOG_WITH_VALID_BIG_RED_SWITCH` — accepted.
- `PFC_WDOG_WITH_INVALID_BIG_RED_SWITCH` — rejected with "BIG_RED_SWITCH must be either enable or disable".

#### How to verify it

Run the sonic-yang-models tests under `src/sonic-yang-models/tests/` — the valid case passes and the invalid value is rejected with the expected error.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [ ] master
