### PR TITLE
[Mellanox] Added read eeprom check for FW control

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -486,10 +486,15 @@ class SFP(NvidiaSFPCommon):
                     if not os.path.exists(get_asic_ready_file_path(asic_id)):
                         return False
 
-                presence_file = 'hw_present' if self.is_sw_control() else 'present'
-                presence_sysfs = f'/sys/module/sx_core/asic0/module{self.sdk_index}/{presence_file}'
-                if utils.read_int_from_file(presence_sysfs, log_func=None) == 1:
-                    return True
+                presence_path = f'/sys/module/sx_core/asic0/module{self.sdk_index}'
+                if self.is_sw_control():
+                    presence_sysfs = presence_path + '/hw_present'
+                    if utils.read_int_from_file(presence_sysfs, log_func=None) == 1:
+                        return True
+                else:
+                    presence_sysfs = presence_path + '/present'
+                    if utils.read_int_from_file(presence_sysfs, log_func=None) == 1:
+                        return self._read_eeprom(0, 1, log_on_error=False) is not None
             return False
         except Exception as e:
             logger.log_warning(f'Failed to check presence of SFP {self.sdk_index}: {e}')

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -244,10 +244,11 @@ class TestSfp:
         assert page == '/tmp/1/data'
         assert page_offset is 0
 
+    @mock.patch('sonic_platform.sfp.SFP._read_eeprom')
     @mock.patch('sonic_platform.sfp.SFP.is_sw_control')
     @mock.patch('sonic_platform.sfp.os.path.exists')
     @mock.patch('sonic_platform.utils.read_int_from_file')
-    def test_sfp_get_presence(self, mock_read_int, mock_exists, mock_is_sw_control):
+    def test_sfp_get_presence(self, mock_read_int, mock_exists, mock_is_sw_control, mock_read_eeprom):
         # Test case 1: asic_ready config file not ready (returns 0)
         sfp = SFP(0, asic_id='asic0')
         mock_read_int.return_value = 0
@@ -274,12 +275,18 @@ class TestSfp:
         # Verify the presence file path was checked with hw_present
         assert mock_read_int.call_args_list[-1] == mock.call('/sys/module/sx_core/asic0/module0/hw_present', log_func=None)
 
-        # Test case 4: asic_ready config file ready, asic's ready file exists, sw_control=False, presence=1
+        # Test case 4: asic_ready config file ready, asic's ready file exists, sw_control=False, presence=1.
+        # A firmware-controlled module is only present if its EEPROM is also readable.
         sfp = SFP(0, asic_id='asic0')
         mock_read_int.reset_mock()
         mock_is_sw_control.return_value = False
         mock_read_int.side_effect = [1, 1]  # config file ready=1, present=1
+        mock_read_eeprom.return_value = 0  # EEPROM readable -> present
         assert sfp.get_presence()
+        mock_read_int.reset_mock()
+        mock_read_int.side_effect = [1, 1]  # config file ready=1, present=1
+        mock_read_eeprom.return_value = None  # EEPROM not readable -> not present
+        assert not sfp.get_presence()
         # Verify the presence file path was checked with present (not hw_present)
         assert mock_read_int.call_args_list[-1] == mock.call('/sys/module/sx_core/asic0/module0/present', log_func=None)
 


### PR DESCRIPTION
This PR must be merged (to master & 202605) after https://github.com/sonic-net/sonic-buildimage/pull/26678

#### Why I did it
Reinstated previous flow for FW control ASICs because on flaps file presence returned true while eeprom was still unreadable.

On firmware-controlled ASICs, `SFP.get_presence()` relied only on the `present` sysfs flag. During module flaps (or a plug-out simulated with `mlxreg`), that flag can read `1` while the module EEPROM is still unreadable, causing `DomInfoUpdateTask` in xcvrd to attempt EEPROM reads on modules that are not actually ready and log errors.

#### How I did it
For firmware-controlled modules, presence now requires both the `present` sysfs flag to be set and a minimal EEPROM read to succeed. Software-controlled modules keep relying on the `hw_present` flag, since their EEPROM readiness is already handled by the host-management flow.

#### How to verify it
Run the mlnx-platform-api unit tests.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605

#### Description for the changelog
[Mellanox] SFP get_presence verifies EEPROM readability for FW-controlled modules