### PR TITLE
[Mellanox] Abort SFP readiness waits on daemon shutdown

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -148,6 +148,7 @@ class Chassis(ChassisBase):
         Chassis.chassis_instance = self
 
         self.module_host_mgmt_initializer = module_host_mgmt_initializer.ModuleHostMgmtInitializer()
+        utils.watch_shutdown_signals()
         self.poll_obj = None
         self.registered_fds = None
 
@@ -468,11 +469,17 @@ class Chassis(ChassisBase):
             return True
 
         if not DeviceDataManager.wait_sysfs_ready(self.get_num_sfps()):
-            logger.log_error('SFPs are not ready for usage')
+            if utils.get_shutdown_event().is_set():
+                logger.log_notice('SFP readiness wait aborted: daemon is shutting down')
+            else:
+                logger.log_error('SFPs are not ready for usage')
             return False
 
         if not self.wait_sfp_eeprom_ready():
-            logger.log_error('SFPs are not ready for usage due to eeprom not ready')
+            if utils.get_shutdown_event().is_set():
+                logger.log_notice('SFP EEPROM readiness wait aborted: daemon is shutting down')
+            else:
+                logger.log_error('SFPs are not ready for usage due to eeprom not ready')
             return False
 
         Path(sfp_ready_file).touch(exist_ok=True)

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -82,6 +82,9 @@ class ModuleHostMgmtInitializer:
                         logger.log_notice('Waiting for modules to be ready...')
                         sfp_count = chassis.get_num_sfps()
                         if not DeviceDataManager.wait_sysfs_ready(sfp_count):
+                            if utils.get_shutdown_event().is_set():
+                                logger.log_notice('Module sysfs readiness wait aborted: daemon is shutting down')
+                                return
                             logger.log_error('Modules are not ready')
                         else:
                             logger.log_notice('Modules are ready')

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/utils.py
@@ -17,6 +17,7 @@
 #
 import ctypes
 import functools
+import signal
 import subprocess
 import json
 import queue
@@ -388,8 +389,53 @@ def get_path_list_to_asic_hwsku_dir(num_of_asics):
         return [os.path.join(get_path_to_hwsku_directory(asic_id), HWSKU_JSON) for asic_id in range(num_of_asics)]
 
 
+_shutdown_event = threading.Event()
+_shutdown_watch_installed = False
+
+SHUTDOWN_SIGNALS = (signal.SIGTERM, signal.SIGINT)
+
+
+def get_shutdown_event():
+    return _shutdown_event
+
+
+def _handle_shutdown_signal(previous_handler, signum, frame):
+    """Set the shutdown event, then preserve the signal's original behavior by
+    chaining onto whatever handler was installed before us.
+    """
+    _shutdown_event.set()
+    if callable(previous_handler):
+        previous_handler(signum, frame)
+    elif previous_handler == signal.SIG_DFL:
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+
+def watch_shutdown_signals():
+    """Set the shutdown event when a termination signal arrives, so readiness
+    waits can abort.
+    """
+    global _shutdown_watch_installed
+
+    if _shutdown_watch_installed:
+        return
+
+    if threading.current_thread() is not threading.main_thread():
+        logger.log_notice('watch_shutdown_signals skipped: not in main thread, '
+                          'readiness waits will not abort on shutdown until armed from the main thread')
+        return
+
+    for sig in SHUTDOWN_SIGNALS:
+        signal.signal(sig, functools.partial(_handle_shutdown_signal, signal.getsignal(sig)))
+
+    _shutdown_watch_installed = True
+
+
 def wait_until(predict, timeout, interval=1, *args, **kwargs):
     """Wait until a condition become true
+
+    The wait aborts early if a shutdown signal has been received (see
+    watch_shutdown_signals).
 
     Args:
         predict (object): a callable such as function, lambda
@@ -402,7 +448,8 @@ def wait_until(predict, timeout, interval=1, *args, **kwargs):
     if predict(*args, **kwargs):
         return True
     while timeout > 0:
-        time.sleep(interval)
+        if _shutdown_event.wait(interval):
+            return False
         timeout -= interval
         if predict(*args, **kwargs):
             return True
@@ -412,6 +459,10 @@ def wait_until(predict, timeout, interval=1, *args, **kwargs):
 def wait_until_conditions(conditions, timeout, interval=1):
     """
     Wait until all the conditions become true
+
+    The wait aborts early if a shutdown signal has been received (see
+    watch_shutdown_signals).
+
     Args:
         conditions (list): a list of callable which generate True|False
         timeout (int): wait time in seconds
@@ -428,7 +479,8 @@ def wait_until_conditions(conditions, timeout, interval=1):
         if not pending_conditions:
             return True
         conditions = pending_conditions
-        time.sleep(interval)
+        if _shutdown_event.wait(interval):
+            return False
         timeout -= interval
     return False
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_utils.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_utils.py
@@ -18,6 +18,7 @@
 
 import os
 import pytest
+import signal
 import sys
 import threading
 import time
@@ -320,12 +321,35 @@ class TestUtils:
         with mock.patch('sonic_platform.utils.open', mock_os_open):
             assert utils.read_key_value_file('some_file', delimeter='=') == {'a':'b'}
             
-    @mock.patch('sonic_platform.utils.time.sleep', mock.MagicMock())
+    @mock.patch('sonic_platform.utils._shutdown_event.wait', mock.MagicMock(return_value=False))
     def test_wait_until_conditions(self):
         conditions = [lambda: True]
         assert utils.wait_until_conditions(conditions, 1)
         conditions = [lambda: False]
         assert not utils.wait_until_conditions(conditions, 1)
+
+    def test_wait_until_aborts_on_shutdown(self):
+        utils.get_shutdown_event().set()
+        try:
+            assert not utils.wait_until(lambda: False, timeout=10, interval=1)
+        finally:
+            utils.get_shutdown_event().clear()
+
+    def test_wait_until_conditions_aborts_on_shutdown(self):
+        utils.get_shutdown_event().set()
+        try:
+            assert not utils.wait_until_conditions([lambda: False], timeout=10, interval=1)
+        finally:
+            utils.get_shutdown_event().clear()
+
+    def test_handle_shutdown_signal_sets_event_and_chains(self):
+        previous_handler = mock.MagicMock()
+        try:
+            utils._handle_shutdown_signal(previous_handler, signal.SIGTERM, None)
+            assert utils.get_shutdown_event().is_set()
+            previous_handler.assert_called_once_with(signal.SIGTERM, None)
+        finally:
+            utils.get_shutdown_event().clear()
 
     @mock.patch('sonic_platform.utils.inotify.adapters.Inotify')
     @mock.patch('os.access')


### PR DESCRIPTION
#### Why I did it
`wait_until`/`wait_until_conditions` poll with an uninterruptible sleep and never check a stop flag, so a thread inside a readiness wait can't observe SIGTERM. xcvrd then exceeds the docker stop timeout and is SIGKILLed before cleanup runs, leaving stale STATE_DB entries.

#### How I did it
Arm a SIGTERM/SIGINT watcher that sets a shutdown event, and make `wait_until`/`wait_until_conditions` return early once it is set.

#### How to verify it
Unit tests in `test_utils.py`. On hardware: stall a readiness wait, send SIGTERM, and confirm xcvrd stops gracefully instead of being SIGKILLed.

#### How to reproduce
1. Make the readiness wait get stuck - force the polled condition to never become true (so wait_sysfs_ready / wait_until_conditions keeps looping), then restart xcvrd so it enters the wait during init.

2. Confirm it's stuck - the log shows the daemon entered the readiness wait but never reports it ready.

3. Trigger shutdown while it's stuck - stop xcvrd (send it SIGTERM).

4. Observe the outcome:
    - Without the fix: the daemon can't react to SIGTERM (uninterruptible sleep loop), blows the stop timeout (~10s), and is SIGKILLed - so cleanup is skipped and stale STATE_DB entries remain.
    - With the fix: the wait aborts on the shutdown signal, the daemon stops gracefully in well under a second, and cleanup runs.
