### PR TITLE
Skip handling of `CONFED` config in `DeviceGlobalCfgMgr`

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_device_global.py
@@ -62,6 +62,10 @@ class DeviceGlobalCfgMgr(Manager):
             log_err("DeviceGlobalCfgMgr:: data is None")
             return False
 
+        if key == 'CONFED':
+            log_notice("DeviceGlobalCfgMgr:: ignoring CONFED config")
+            return True
+
         # TSA configuration
         self.configure_tsa(data)
         # W-ECMP configuration
@@ -73,6 +77,10 @@ class DeviceGlobalCfgMgr(Manager):
 
     def del_handler(self, key):
         log_debug("DeviceGlobalCfgMgr:: del handler")
+
+        if key == 'CONFED':
+            log_notice("DeviceGlobalCfgMgr:: ignoring CONFED config")
+            return True
 
         # TSA configuration
         self.configure_tsa()


### PR DESCRIPTION
Details in: https://github.com/sonic-net/sonic-buildimage/issues/28515
TL;DR
With the following config:
```
"BGP_DEVICE_GLOBAL": {
    "CONFED": {
        "asn": "65100",
        "peers": "65300"
    },
    "STATE": {
        "idf_isolation_state": "unisolated",
        "tsa_enabled": "false",
        "wcmp_enabled": "false"
    }
},
```
On startup of `DeviceGlobalCfgMgr` if the `STATE` data is handled before the `CONFED` data we could see `TSA` disabled before the appropriate timeout:
```
2026 Jul 20 22:41:04.186752 ctn104 DEBUG bgp#bgpcfgd: Received message : '('STATE', 'SET', (('idf_isolation_state', 'unisolated'), ('tsa_enabled', 'true'), ('wcmp_enabled', 'false')))'
2026 Jul 20 22:41:04.186787 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr:: set handler
2026 Jul 20 22:41:04.186921 ctn104 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'show running-config']'.
2026 Jul 20 22:41:04.203562 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: Device isolated. Executing TSA
2026 Jul 20 22:41:04.203790 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr::Done
2026 Jul 20 22:41:04.203810 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: W-ECMP configuration is up-to-date
2026 Jul 20 22:41:04.203821 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: IDF configuration is up-to-date
2026 Jul 20 22:41:04.203846 ctn104 DEBUG bgp#bgpcfgd: Received message : '('CONFED', 'SET', (('asn', '65100'), ('peers', '65300')))'
2026 Jul 20 22:41:04.203870 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr:: set handler
2026 Jul 20 22:41:04.203962 ctn104 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'show running-config']'.
2026 Jul 20 22:41:04.220648 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: Device un-isolated. Executing TSB
2026 Jul 20 22:41:04.220686 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr::Done
2026 Jul 20 22:41:04.220703 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: W-ECMP configuration is up-to-date
2026 Jul 20 22:41:04.220719 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: IDF configuration is up-to-date
```

```
# TSC no-stats
System Mode: Normal
TSB  : Pending (Time Remaining:578 seconds,  service:startup_tsa_tsb.service)
```

#### Why I did it
DeviceGlobalCfgMgr was written assuming it would only receive updates from 'STATE' key. With the introduction of 'CONFED' if we handle it we could end up disabling 'TSA', 'WCMP', or 'IDF' unintentionally.

#### How I did it
Since CONFED config isn't being handled by this Class currently, just skip handling it's updates.

#### How to verify it
Rebooted system and saw we stayed in TSA mode even though the `CONFED` config handling came 2nd
```
2026 Jul 20 23:48:39.282597 ctn104 DEBUG bgp#bgpcfgd: Received message : '('STATE', 'SET', (('idf_isolation_state', 'unisolated'), ('tsa_enabled', 'true'), ('wcmp_enabled', 'false')))'
2026 Jul 20 23:48:39.282637 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr:: set handler
2026 Jul 20 23:48:39.282796 ctn104 DEBUG bgp#bgpcfgd: execute command '['vtysh', '-c', 'show running-config']'.
2026 Jul 20 23:48:39.300431 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: Device isolated. Executing TSA
2026 Jul 20 23:48:39.300696 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr::Done
2026 Jul 20 23:48:39.300725 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: W-ECMP configuration is up-to-date
2026 Jul 20 23:48:39.300744 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: IDF configuration is up-to-date
2026 Jul 20 23:48:39.300783 ctn104 DEBUG bgp#bgpcfgd: Received message : '('CONFED', 'SET', (('asn', '65100'), ('peers', '65300')))'
2026 Jul 20 23:48:39.300828 ctn104 DEBUG bgp#bgpcfgd: DeviceGlobalCfgMgr:: set handler
2026 Jul 20 23:48:39.300839 ctn104 NOTICE bgp#bgpcfgd: DeviceGlobalCfgMgr:: ignoring CONFED config
```

```
# TSC no-stats
System Mode: Maintenance
TSB  : Pending (Time Remaining:739 seconds,  service:startup_tsa_tsb.service)
```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

202605 - bgp/test_startup_tsa_tsb_service.py no longer fails with:
`Failed: DUT is not in maintenance state when startup_tsa_tsb service is running`

#### Description for the changelog
Skip handling of `CONFED` config in `DeviceGlobalCfgMgr`

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
