### PR TITLE
[nexthop] watchdog implementation: temporary workaround to arm 2 watchdogs

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
@@ -15,7 +15,7 @@ _logger = syslogger.SysLogger(_SYSLOG_IDENTIFIER)
 # Watchdog punching is paused if file is present
 _WATCHDOG_PAUSE_FILE_PATH = Path("/var/lock/pddf-locks/watchdog.pause")
 # How long the watchdog is armed for by the watchdog.timer
-_WATCHDOG_PUNCH_DAEMON_ARM_SECONDS = 360
+_WATCHDOG_PUNCH_DAEMON_ARM_SECONDS = 300
 
 
 def _pause_watchdog_punching(duration: datetime.timedelta) -> None:

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
@@ -126,6 +126,12 @@ class Watchdog(WatchdogBase):
             self._toggle_watchdog_counter_enable(True)
             self._toggle_watchdog_reboot(True)
             self._update_watchdog_countdown_value(milliseconds=seconds*1_000)
+            # TODO: workaround: arm watchdog 2 to trigger watchdog 1
+            fpga_lib.write_32(
+                pci_address=self.fpga_pci_addr,
+                offset=0x1d8,
+                val=0x80000001,
+            )
         except Exception as e:
             _logger.log_error(f"cannot arm watchdog: {e}")
             return -1

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_watchdog.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/sonic_platform/test_watchdog.py
@@ -195,6 +195,7 @@ class TestWatchdogAPI:
 
     def test_arm_should_update_counter(
         self,
+        watchdog_module,
         mock_update_watchdog_countdown_value,
         mock_toggle_watchdog_reboot,
         mock_toggle_watchdog_counter_enable,
@@ -211,7 +212,9 @@ class TestWatchdogAPI:
         )
 
         # Act
-        actual_return_value = self.watchdog.arm(timeout_seconds)
+        # TODO: workaround: arm watchdog 2 to trigger watchdog 1
+        with patch.object(watchdog_module.fpga_lib, "write_32", autospec=True):
+            actual_return_value = self.watchdog.arm(timeout_seconds)
 
         # Assert
         assert (


### PR DESCRIPTION
#### Why I did it

This is a temporary workaround to arm hardware watchdog that triggers power cycle. The workaround is needed until full SW support of both watchdog 1 and 2.

Also updates the arm value to 300 seconds as this is what [platform_tests
/test_hw_watchdog.py](https://github.com/sonic-net/sonic-mgmt/blob/7a73917c813d20b62e72e47a15d9c4825fe8c2f8/tests/platform_tests/test_hw_watchdog.py#L90) expects

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Arm watchdog 2 by writing to `0x1d8` register before arming watchdog 1.

#### How to verify it

Arm watchdog using `watchdogutil`. sonic-mgmt test `tests/platform_tests/api/test_watchdog.py`

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [x] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result


```
sudo watchdogutil status
sudo watchdogutil arm -s 10
sudo watchdogutil status
sudo watchdogutil disarm
```

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
