### PR TITLE
[docker-dash-engine]: Make supervisord-dependent-startup install base-agnostic

### DIFF
--- a/platform/vs/docker-dash-engine/Dockerfile.j2
+++ b/platform/vs/docker-dash-engine/Dockerfile.j2
@@ -13,7 +13,7 @@ RUN sed -i 's|http://.*.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/s
 RUN apt-get update
 
 RUN apt-get install -f -y net-tools supervisor rsyslog  python3-pip
-RUN pip3 install supervisord-dependent-startup
+RUN pip3 install --break-system-packages supervisord-dependent-startup || pip3 install supervisord-dependent-startup
 
 COPY ["start.sh", "/usr/bin/"]
 

--- a/scripts/docker_version_control.sh
+++ b/scripts/docker_version_control.sh
@@ -27,7 +27,7 @@ tag=`echo $image_tag | cut -f2 -d:`
 
 if [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,all,* ]] || [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," == *,docker,* ]]; then
     # if docker image not in white list, exit
-    if [[ "$image_tag" != */debian:* ]] && [[ "$image_tag" != debian:* ]] && [[ "$image_tag" != multiarch/debian-debootstrap:* ]];then
+    if [[ "$image_tag" != */debian:* ]] && [[ "$image_tag" != debian:* ]] && [[ "$image_tag" != multiarch/debian-debootstrap:* ]] && [[ "$image_tag" != *p4lang/behavioral-model:* ]];then
         exit 0
     fi
     if [ -f $version_file ];then


### PR DESCRIPTION
#### Why I did it

`docker-dash-engine` builds `FROM p4lang/behavioral-model:latest`, whose `:latest` tag resolves to different Ubuntu bases across mirrors:
- a newer PEP 668 base, where a plain system `pip3 install` is refused (`error: externally-managed-environment`), and
- an older base whose `pip3` does not support `--break-system-packages` (`no such option: --break-system-packages`).

So a plain install breaks on the first base and a `--break-system-packages` install breaks on the second; the step fails on one base or the other depending on which image `:latest` currently points to.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `platform/vs/docker-dash-engine/Dockerfile.j2`: install with `--break-system-packages` and fall back to a plain `pip3 install`, so the package installs regardless of whether the base `pip3` supports the flag:
  `RUN pip3 install --break-system-packages supervisord-dependent-startup || pip3 install supervisord-dependent-startup`
- `scripts/docker_version_control.sh`: add `p4lang/behavioral-model` to the reproducible-build version-control whitelist so its digest recorded in `versions-docker` is actually pinned at build time (reduces `:latest` drift).

#### How to verify it

Build the `docker-dash-engine` image / `target/sonic-vs.img.gz`; the `supervisord-dependent-startup` install succeeds on both a PEP 668 base and an older base.

#### Which release branch to backport (provide reason below if selected)

This is a build fix; it can be backported to active release branches that build `docker-dash-engine` and hit the same base-image drift.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master

#### Test result

Verified on both base variants. The PR CI (`Azure.sonic-buildimage`) build passed on this commit — all `BuildVS` (vs / alpinevs / vpp) and platform `Build` jobs are green; the public CI base exercises the older-pip path (the fallback to a plain `pip3 install`). The PEP 668 (Ubuntu 24.04) base path was verified on a separate internal build.

#### Description for the changelog

docker-dash-engine: install supervisord-dependent-startup so it works on both PEP 668 and older pip bases, and pin the p4lang base in version control.

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

