### PR TITLE
Fix Redis crash on BMC systems by deferring bmc0 bind to supervisord program

### DIFF
--- a/dockers/docker-database/supervisord.conf.j2
+++ b/dockers/docker-database/supervisord.conf.j2
@@ -46,7 +46,7 @@ dependent_startup=true
 {%- else %}
 {%- set ADDITIONAL_OPTS = '' %}
 {%- endif -%}
-command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && {% if redis_items.get('bmc_link_ip') and redis_items.get('bmc_link_if') %}for ((i=0; i<300; i++)); do ip -o -4 addr show dev {{ redis_items['bmc_link_if'] }} up 2>/dev/null | grep -q 'inet {{ redis_items['bmc_link_ip'] }}/' && break; sleep 1; done; ip -o -4 addr show dev {{ redis_items['bmc_link_if'] }} up 2>/dev/null | grep -q 'inet {{ redis_items['bmc_link_ip'] }}/' || { echo 'Timed out waiting for {{ redis_items['bmc_link_if'] }} to be configured with {{ redis_items['bmc_link_ip'] }}' >&2; exit 1; } && {% endif %}exec /usr/bin/redis-server /etc/redis/redis.conf --bind {{ LOOPBACK_IP }} {{ redis_items['hostname'] }}{% if redis_items.get('bmc_link_ip') and redis_items.get('bmc_link_if') %} {{ redis_items['bmc_link_ip'] }}{% endif %} --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }} {{ ADDITIONAL_OPTS }}"
+command=/bin/bash -c "{ [[ -s /var/lib/{{ redis_inst }}/dump.rdb ]] || rm -f /var/lib/{{ redis_inst }}/dump.rdb; } && mkdir -p /var/lib/{{ redis_inst }} && exec /usr/bin/redis-server /etc/redis/redis.conf --bind {{ LOOPBACK_IP }} {{ redis_items['hostname'] }} --port {{ redis_items['port'] }} --unixsocket {{ redis_items['unix_socket_path'] }} --pidfile /var/run/redis/{{ redis_inst }}.pid --dir /var/lib/{{ redis_inst }} {{ ADDITIONAL_OPTS }}"
 priority=2
 user=redis
 autostart=true
@@ -55,6 +55,20 @@ stdout_logfile=NONE
 stdout_syslog=true
 stderr_logfile=NONE
 stderr_syslog=true
+
+{% if redis_items.get('bmc_link_ip') and redis_items.get('bmc_link_if') %}
+[program:{{ redis_inst }}_bmc_bind]
+command=/bin/bash -c "echo 'Waiting for {{ redis_items['bmc_link_if'] }} to get {{ redis_items['bmc_link_ip'] }}'; for ((i=0; i<300; i++)); do ip -o -4 addr show dev {{ redis_items['bmc_link_if'] }} 2>/dev/null | grep -q 'inet {{ redis_items['bmc_link_ip'] }}/' && break; sleep 1; done; if ip -o -4 addr show dev {{ redis_items['bmc_link_if'] }} 2>/dev/null | grep -q 'inet {{ redis_items['bmc_link_ip'] }}/'; then echo '{{ redis_items['bmc_link_if'] }} ready after '$i's'; bound_ips=$(redis-cli --raw -h 127.0.0.1 -p {{ redis_items['port'] }} config get bind | sed -n '2p'); redis-cli -h 127.0.0.1 -p {{ redis_items['port'] }} config set bind \"$bound_ips {{ redis_items['bmc_link_ip'] }}\"; redis-cli -h 127.0.0.1 -p {{ redis_items['port'] }} config rewrite; echo 'Bound {{ redis_items['bmc_link_ip'] }} to {{ redis_inst }} port {{ redis_items['port'] }}'; else echo 'Timed out waiting for {{ redis_items['bmc_link_if'] }} to get {{ redis_items['bmc_link_ip'] }} after 300s' >&2; exit 1; fi"
+priority=3
+autostart=false
+autorestart=false
+stdout_logfile=NONE
+stdout_syslog=true
+stderr_logfile=NONE
+stderr_syslog=true
+dependent_startup=true
+dependent_startup_wait_for={{ redis_inst }}:running
+{% endif %}
 
 {% endif %}
 {%     endfor %}


### PR DESCRIPTION
#### Why I did it
On BMC devices, Redis (port 6379) crashes on reboot because of a race condition between preStartAction and the Redis bmc0 wait loop.

The redis startup command in supervisord.conf waits up to 300s for bmc0 to get its IP before starting redis-server. During this wait window, systemd's 90s ExecStartPre timeout fires, triggering a service restart. The restart calls preStartAction again, which injects a 0-byte dump.rdb into the running container via docker cp — after the startup guard already deleted the previous one. When bmc0 finally arrives and Redis starts, it loads the corrupt dump.rdb and aborts with "Short read or OOM loading DB".

The issue has been seen due to the following commit: https://github.com/sonic-net/sonic-buildimage/pull/27907

##### Work item tracking
- Microsoft ADO **(number only)**: NA

#### How I did it

Fix:
Remove the bmc0 wait loop and bmc0 bind from the [program:redis] command in supervisord.conf.j2. Instead, add a new [program:redis_bmc_bind] supervised program that starts after redis is running, waits for the bmc0 interface to be configured, then hot-adds the bmc0 IP to redis via "redis-cli config set bind". This program is conditionally generated only on BMC platforms (when bmc_link_ip and bmc_link_if are set in the template data).

#### How to verify it
bootup image , "show version" should not fail with cannot connect with reddit error.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
Manually tested this by running the image with and without fix

```
WITHOUT FIX (baseline) — Redis crashes, show version broken:

  $ docker exec database supervisorctl status redis
  redis                            EXITED    Jul 06 08:51 AM

  $ docker exec database redis-cli -p 6379 ping
  Could not connect to Redis at 127.0.0.1:6379: Connection refused

  $ show version
  Traceback (most recent call last):
    File "/usr/local/bin/show", line 8, in <module>
      sys.exit(cli())
  RuntimeError: Unable to connect to redis

  $ sudo grep "database.service" /var/log/syslog | grep -i "timed out\|Failed\|Starting\|restart"
  08:48:27 INFO systemd[1]: Starting database.service - Database container...
  08:49:57 WARNING systemd[1]: database.service: start-pre operation timed out. Terminating.
  08:49:57 WARNING systemd[1]: database.service: Failed with result 'timeout'.
  08:49:58 INFO systemd[1]: database.service: Scheduled restart job immediately, restart counter is at 1.
  08:49:58 INFO systemd[1]: Starting database.service - Database container...
  08:51:28 WARNING systemd[1]: database.service: start-pre operation timed out. Terminating.
  08:51:28 WARNING systemd[1]: database.service: Failed with result 'timeout'.

  $ sudo grep "configured bmc0" /var/log/syslog
  08:51:33 INFO arista: BmcUsbDeviceNic(): configured bmc0 with 169.254.100.1/30
  # bmc0 arrived 5 seconds after systemd gave up (186s > 180s budget)

  $ sudo grep "Short read\|RDB ERROR\|Unexpected EOF" /var/log/syslog
  08:51:33 redis: Short read or OOM loading DB. Unrecoverable error, aborting now.
  08:51:33 redis: Internal error in RDB reading offset 0 -> Unexpected EOF reading RDB file
  08:51:33 redis --- RDB ERROR DETECTED ---

  $ systemctl --failed
  database.service  loaded failed failed Database container
```

WITH FIX — Redis starts immediately, bmc0 bound asynchronously:
```
  $ docker exec database supervisorctl status
  redis                            RUNNING   pid 64, uptime 0:04:05
  redis_bmc_bind                   EXITED    Jul 06 08:41 AM
  redis_bmp                        RUNNING   pid 65, uptime 0:04:05

  $ docker exec database redis-cli -p 6379 ping
  PONG

  $ docker exec database redis-cli -p 6379 config get bind
  bind
  127.0.0.1 169.254.100.1

  $ sudo grep "database.service" /var/log/syslog | grep -i "Starting\|Started\|timed out"
  08:41:04 INFO systemd[1]: Starting database.service - Database container...
  08:41:17 INFO systemd[1]: Started database.service - Database container.
  # No timeouts — database.service completed in 13 seconds

  $ sudo grep "bmc_bind\|Waiting for bmc\|Bound\|ready after" /var/log/syslog
  08:41:15 redis_bmc_bind: Waiting for bmc0 to get 169.254.100.1
  08:41:23 redis_bmc_bind: bmc0 ready after 7s
  08:41:23 redis_bmc_bind: Bound 169.254.100.1 to redis port 6379
  08:41:23 exited: redis_bmc_bind (exit status 0; expected)

  $ sudo grep "Short read\|RDB ERROR" /var/log/syslog
  # (no output — no Redis crash)

  $ systemctl --failed
  0 loaded units listed.

```
Tested with 3 consecutive reboots — all passed cleanly.


<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
