### PR TITLE
[frrcfgd] BGP feature parity with bgpcfgd (frr_mgmt_framework)

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -15,7 +15,6 @@ import logging
 import netaddr
 import io
 import struct
-import yaml
 
 class CachedDataWithOp:
     OP_NONE = 0
@@ -89,7 +88,6 @@ class BgpdClientMgr(threading.Thread):
             'BGP_PEER_GROUP': ['bgpd'],
             'BGP_NEIGHBOR': ['bgpd'],
             'LOOPBACK_INTERFACE': ['zebra'],
-            'BGP_SENTINELS': ['bgpd'],
             'BGP_PEER_GROUP_AF': ['bgpd'],
             'BGP_NEIGHBOR_AF': ['bgpd'],
             'BGP_GLOBALS_LISTEN_PREFIX': ['bgpd'],
@@ -2280,9 +2278,6 @@ class BGPConfigDaemon:
         # address-family (socket.AF_INET/AF_INET6) -> Loopback0 IP programmed into the zebra
         # "set src" route-maps (RM_SET_SRC/RM_SET_SRC6). See loopback_setsrc_handler.
         self.set_src_lo = {}
-        # set of BGP_SENTINELS keys currently configured; the fixed sentinel base policy is
-        # rendered while this is non-empty. See bgp_sentinels_handler.
-        self.bgp_sentinels = set()
         vrf_table = self.config_db.get_table('VRF')
         for key, entry in vrf_table.items():
             if 'vni' in entry:
@@ -2318,7 +2313,6 @@ class BGPConfigDaemon:
             ('BGP_PEER_GROUP', self.bgp_neighbor_handler),
             ('BGP_NEIGHBOR', self.bgp_neighbor_handler),
             ('LOOPBACK_INTERFACE', self.loopback_setsrc_handler),
-            ('BGP_SENTINELS', self.bgp_sentinels_handler),
             ('BGP_PEER_GROUP_AF', self.bgp_table_handler_common),
             ('BGP_NEIGHBOR_AF', self.bgp_table_handler_common),
             ('BGP_GLOBALS_LISTEN_PREFIX', self.bgp_table_handler_common),
@@ -2515,61 +2509,6 @@ class BGPConfigDaemon:
                    '-c', '{} protocol bgp route-map {}'.format(proto, rm_name)]
         if self.__run_command(table, command, ['zebra']):
             self.set_src_lo[af] = ip_addr
-
-    @staticmethod
-    def __get_sentinel_community():
-        """Return constants.bgp.sentinel_community from /etc/sonic/constants.yml (the same
-        source the traditional bgpcfgd sentinel template uses), or None if unavailable."""
-        try:
-            with open('/etc/sonic/constants.yml') as fp:
-                content = yaml.safe_load(fp)
-            return content.get('constants', {}).get('bgp', {}).get('sentinel_community')
-        except Exception as e:
-            syslog.syslog(syslog.LOG_WARNING,
-                          'sentinel: could not read sentinel_community from constants.yml: {}'.format(e))
-            return None
-
-    def __apply_sentinel_base_policy(self, table, add):
-        """Render (add) or remove the fixed BGP-sentinel base-policy objects, mirroring the
-        traditional bgpcfgd template dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/
-        policies.conf.j2: the community-list 'sentinel_community' (only when
-        constants.bgp.sentinel_community is defined) and the route-maps FROM_BGP_SENTINEL
-        (permit 100 matching that community + deny 200) and TO_BGP_SENTINEL (permit 100)."""
-        community = self.__get_sentinel_community()
-        commands = []
-        if add:
-            if community is not None:
-                commands.append('bgp community-list standard sentinel_community permit {} no-export'.format(community))
-            commands.append('route-map FROM_BGP_SENTINEL permit 100')
-            if community is not None:
-                commands.append('match community sentinel_community')
-            commands.append('exit')
-            commands += ['route-map FROM_BGP_SENTINEL deny 200', 'exit',
-                         'route-map TO_BGP_SENTINEL permit 100', 'exit']
-        else:
-            commands += ['no route-map FROM_BGP_SENTINEL', 'no route-map TO_BGP_SENTINEL']
-            if community is not None:
-                commands.append('no bgp community-list standard sentinel_community')
-        command = ['vtysh', '-c', 'configure terminal']
-        for cmd in commands:
-            command += ['-c', cmd]
-        return self.__run_command(table, command, ['bgpd'])
-
-    def bgp_sentinels_handler(self, table, key, data):
-        """Render the fixed BGP-sentinel base policy when the first BGP_SENTINELS entry appears
-        and remove it when the last one is deleted. The per-neighbor sentinel session
-        (peer-group / listen-range / address-family, which reference FROM_/TO_BGP_SENTINEL) is
-        programmed through the standard BGP_PEER_GROUP / BGP_GLOBALS_LISTEN_PREFIX /
-        BGP_PEER_GROUP_AF tables. See sonic-buildimage#28482."""
-        if data:
-            was_empty = len(self.bgp_sentinels) == 0
-            self.bgp_sentinels.add(key)
-            if was_empty:
-                self.__apply_sentinel_base_policy(table, True)
-        else:
-            self.bgp_sentinels.discard(key)
-            if len(self.bgp_sentinels) == 0:
-                self.__apply_sentinel_base_policy(table, False)
 
     def __get_vrf_asn(self, vrf):
         if vrf in self.bgp_asn:

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -15,6 +15,7 @@ import logging
 import netaddr
 import io
 import struct
+import yaml
 
 class CachedDataWithOp:
     OP_NONE = 0
@@ -87,6 +88,8 @@ class BgpdClientMgr(threading.Thread):
             'PREFIX': ['zebra', 'bgpd', 'ospfd', 'pimd'],
             'BGP_PEER_GROUP': ['bgpd'],
             'BGP_NEIGHBOR': ['bgpd'],
+            'LOOPBACK_INTERFACE': ['zebra'],
+            'BGP_SENTINELS': ['bgpd'],
             'BGP_PEER_GROUP_AF': ['bgpd'],
             'BGP_NEIGHBOR_AF': ['bgpd'],
             'BGP_GLOBALS_LISTEN_PREFIX': ['bgpd'],
@@ -1940,9 +1943,11 @@ class BGPConfigDaemon:
                          ('match_as_path',                  '[bgpd]{no:no-prefix}match as-path {}'),
                          ('match_src_vrf',                  '[bgpd]{no:no-prefix}match source-vrf {}'),
                          ('call_route_map',                 '{no:no-prefix}call {:enable-only}'),
+                         ('set_on_match_next',              '{no:no-prefix}on-match next', ['true', 'false']),
                          ('set_origin',                     '[bgpd]{no:no-prefix}set origin {:tolower}'),
                          ('set_local_pref',                 '[bgpd]{no:no-prefix}set local-preference {}'),
                          ('set_next_hop',                   '{no:no-prefix}set ip next-hop {}'),
+                         ('set_src',                        '[zebra]{no:no-prefix}set src {}'),
                          ('set_ipv6_next_hop_global',       '[bgpd]{no:no-prefix}set ipv6 next-hop global {}'),
                          ('set_ipv6_next_hop_prefer_global', '[bgpd]{no:no-prefix}set ipv6 next-hop prefer-global', ['true', 'false']),
                          (['set_metric_action', '+set_metric', '+set_med'], '{}set metric {} ', handle_rmap_set_metric),
@@ -2272,6 +2277,12 @@ class BGPConfigDaemon:
                 self.af_aggr_list.setdefault(vrf, {})[norm_ip_pfx] = aggr_obj
 
         self.vrf_vni_map = {}
+        # address-family (socket.AF_INET/AF_INET6) -> Loopback0 IP programmed into the zebra
+        # "set src" route-maps (RM_SET_SRC/RM_SET_SRC6). See loopback_setsrc_handler.
+        self.set_src_lo = {}
+        # set of BGP_SENTINELS keys currently configured; the fixed sentinel base policy is
+        # rendered while this is non-empty. See bgp_sentinels_handler.
+        self.bgp_sentinels = set()
         vrf_table = self.config_db.get_table('VRF')
         for key, entry in vrf_table.items():
             if 'vni' in entry:
@@ -2306,6 +2317,8 @@ class BGPConfigDaemon:
             ('ROUTE_MAP', self.bgp_table_handler_common),
             ('BGP_PEER_GROUP', self.bgp_neighbor_handler),
             ('BGP_NEIGHBOR', self.bgp_neighbor_handler),
+            ('LOOPBACK_INTERFACE', self.loopback_setsrc_handler),
+            ('BGP_SENTINELS', self.bgp_sentinels_handler),
             ('BGP_PEER_GROUP_AF', self.bgp_table_handler_common),
             ('BGP_NEIGHBOR_AF', self.bgp_table_handler_common),
             ('BGP_GLOBALS_LISTEN_PREFIX', self.bgp_table_handler_common),
@@ -2443,6 +2456,121 @@ class BGPConfigDaemon:
             if positive_execute == True:
                 self.__run_command(table, command)
 
+    # Route-map names for the zebra "set src" feature, mirroring the traditional bgpcfgd
+    # ZebraSetSrc manager (src/sonic-bgpcfgd/bgpcfgd/managers_setsrc.py +
+    # dockers/docker-fpm-frr/frr/zebra/zebra.set_src.conf.j2).
+    SET_SRC_RM_V4 = 'RM_SET_SRC'
+    SET_SRC_RM_V6 = 'RM_SET_SRC6'
+
+    @staticmethod
+    def __ip_addr_family(ip_addr):
+        for af in (socket.AF_INET, socket.AF_INET6):
+            try:
+                socket.inet_pton(af, ip_addr)
+                return af
+            except socket.error:
+                continue
+        return None
+
+    def loopback_setsrc_handler(self, table, key, data):
+        """Program the zebra "set src" route-maps from the Loopback0 address.
+
+        Mirrors the traditional bgpcfgd ZebraSetSrc manager, which renders
+        RM_SET_SRC / RM_SET_SRC6 (a 'set src <Loopback0 ip>' route-map) and binds them via
+        'ip[v6] protocol bgp route-map ...' so BGP-installed routes source from Loopback0. In
+        frr_mgmt_framework mode bgpcfgd does not run, so frrcfgd installs the same objects from
+        the Loopback0 IP in CONFIG_DB. Like bgpcfgd, Loopback0 is hardcoded and update/delete of
+        the address is not supported (programmed once per address family). See
+        sonic-buildimage#28482.
+        """
+        key_params = key.split('|')
+        if len(key_params) < 2 or key_params[0] != 'Loopback0':
+            # Interface-level row (no IP) or a non-Loopback0 interface -- nothing to program.
+            return
+        ip_addr = key_params[1].rsplit('/', 1)[0]
+        af = self.__ip_addr_family(ip_addr)
+        if af is None:
+            syslog.syslog(syslog.LOG_ERR, 'set src: ambiguous Loopback0 address {}'.format(ip_addr))
+            return
+        if data is None:
+            # A LOOPBACK_INTERFACE IP-member row carries the address in the key, so its value
+            # may legitimately be empty ({} / {'NULL': 'NULL'}) -- only a None payload is a
+            # delete. bgpcfgd does not support deleting the set src route-maps; keep parity.
+            syslog.syslog(syslog.LOG_WARNING,
+                          'set src: delete of Loopback0 {} not supported'.format(ip_addr))
+            return
+        rm_name, proto = ((self.SET_SRC_RM_V4, 'ip') if af == socket.AF_INET
+                          else (self.SET_SRC_RM_V6, 'ipv6'))
+        if self.set_src_lo.get(af) == ip_addr:
+            return
+        if af in self.set_src_lo:
+            syslog.syslog(syslog.LOG_WARNING,
+                          'set src: Loopback0 address change {} -> {} not supported'.format(
+                              self.set_src_lo[af], ip_addr))
+            return
+        command = ['vtysh', '-c', 'configure terminal',
+                   '-c', 'route-map {} permit 10'.format(rm_name),
+                   '-c', 'set src {}'.format(ip_addr),
+                   '-c', 'exit',
+                   '-c', '{} protocol bgp route-map {}'.format(proto, rm_name)]
+        if self.__run_command(table, command, ['zebra']):
+            self.set_src_lo[af] = ip_addr
+
+    @staticmethod
+    def __get_sentinel_community():
+        """Return constants.bgp.sentinel_community from /etc/sonic/constants.yml (the same
+        source the traditional bgpcfgd sentinel template uses), or None if unavailable."""
+        try:
+            with open('/etc/sonic/constants.yml') as fp:
+                content = yaml.safe_load(fp)
+            return content.get('constants', {}).get('bgp', {}).get('sentinel_community')
+        except Exception as e:
+            syslog.syslog(syslog.LOG_WARNING,
+                          'sentinel: could not read sentinel_community from constants.yml: {}'.format(e))
+            return None
+
+    def __apply_sentinel_base_policy(self, table, add):
+        """Render (add) or remove the fixed BGP-sentinel base-policy objects, mirroring the
+        traditional bgpcfgd template dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/
+        policies.conf.j2: the community-list 'sentinel_community' (only when
+        constants.bgp.sentinel_community is defined) and the route-maps FROM_BGP_SENTINEL
+        (permit 100 matching that community + deny 200) and TO_BGP_SENTINEL (permit 100)."""
+        community = self.__get_sentinel_community()
+        commands = []
+        if add:
+            if community is not None:
+                commands.append('bgp community-list standard sentinel_community permit {} no-export'.format(community))
+            commands.append('route-map FROM_BGP_SENTINEL permit 100')
+            if community is not None:
+                commands.append('match community sentinel_community')
+            commands.append('exit')
+            commands += ['route-map FROM_BGP_SENTINEL deny 200', 'exit',
+                         'route-map TO_BGP_SENTINEL permit 100', 'exit']
+        else:
+            commands += ['no route-map FROM_BGP_SENTINEL', 'no route-map TO_BGP_SENTINEL']
+            if community is not None:
+                commands.append('no bgp community-list standard sentinel_community')
+        command = ['vtysh', '-c', 'configure terminal']
+        for cmd in commands:
+            command += ['-c', cmd]
+        return self.__run_command(table, command, ['bgpd'])
+
+    def bgp_sentinels_handler(self, table, key, data):
+        """Render the fixed BGP-sentinel base policy when the first BGP_SENTINELS entry appears
+        and remove it when the last one is deleted. The per-neighbor sentinel session
+        (peer-group / listen-range / address-family, which reference FROM_/TO_BGP_SENTINEL) is
+        programmed through the standard BGP_PEER_GROUP / BGP_GLOBALS_LISTEN_PREFIX /
+        BGP_PEER_GROUP_AF tables. See sonic-buildimage#28482."""
+        if data:
+            was_empty = len(self.bgp_sentinels) == 0
+            self.bgp_sentinels.add(key)
+            if was_empty:
+                self.__apply_sentinel_base_policy(table, True)
+        else:
+            self.bgp_sentinels.discard(key)
+            if len(self.bgp_sentinels) == 0:
+                self.__apply_sentinel_base_policy(table, False)
+
     def __get_vrf_asn(self, vrf):
         if vrf in self.bgp_asn:
             return self.bgp_asn[vrf]
@@ -2473,13 +2601,27 @@ class BGPConfigDaemon:
             dval.op = CachedDataWithOp.OP_DELETE
         return True
 
-    def __cleanup_nbr_cache(self, vrf, nbr):
-        nbr_key = ExtConfigDBConnector.get_table_key('BGP_NEIGHBOR',
+    def __cleanup_nbr_cache(self, vrf, nbr, is_peer_grp=False):
+        # A peer-group's cached rows live under BGP_PEER_GROUP / BGP_PEER_GROUP_AF, a
+        # neighbor's under BGP_NEIGHBOR / BGP_NEIGHBOR_AF. When a peer-group is deleted we must
+        # evict the BGP_PEER_GROUP rows -- previously this always popped the BGP_NEIGHBOR keys,
+        # so the peer-group cache row was orphaned. On a later re-create (e.g. a listen-range /
+        # SLB reconfiguration deletes then re-adds the peer-group) the incremental diff compared
+        # the incoming row against that stale cache row, resolved every field to OP_NONE, and
+        # silently dropped the peer-group's attributes (update-source, remote-as, ...) from the
+        # FRR render even though CONFIG_DB still carried them. See sonic-buildimage#28482.
+        if is_peer_grp:
+            base_tbl, af_tbl = 'BGP_PEER_GROUP', 'BGP_PEER_GROUP_AF'
+            af_list = ['ipv4_unicast', 'ipv6_unicast', 'l2vpn_evpn']
+        else:
+            base_tbl, af_tbl = 'BGP_NEIGHBOR', 'BGP_NEIGHBOR_AF'
+            af_list = ['ipv4_unicast', 'ipv6_unicast']
+        nbr_key = ExtConfigDBConnector.get_table_key(base_tbl,
                                             self.config_db.serialize_key((vrf, nbr)))
         self.table_data_cache.pop(nbr_key, None)
-        for af in ['ipv4', 'ipv6']:
-            nbr_af_key = ExtConfigDBConnector.get_table_key('BGP_NEIGHBOR_AF',
-                                                self.config_db.serialize_key((vrf, nbr, af + '_unicast')))
+        for af in af_list:
+            nbr_af_key = ExtConfigDBConnector.get_table_key(af_tbl,
+                                                self.config_db.serialize_key((vrf, nbr, af)))
             self.table_data_cache.pop(nbr_af_key, None)
 
     def __delete_vrf_neighbor(self, vrf, peer, data, is_peer_grp):
@@ -2493,7 +2635,7 @@ class BGPConfigDaemon:
                         peer_grp.ref_nbrs.remove(peer)
             if not self.__peer_is_ip(peer) and vrf in self.bgp_intf_nbr and peer in self.bgp_intf_nbr[vrf]:
                 self.bgp_intf_nbr[vrf].remove(peer)
-        self.__cleanup_nbr_cache(vrf, peer)
+        self.__cleanup_nbr_cache(vrf, peer, is_peer_grp)
         for dkey, dval in data.items():
             # bypass cache update because cache entry was removed
             dval.status = CachedDataWithOp.STAT_SUCC
@@ -2701,7 +2843,14 @@ class BGPConfigDaemon:
                         if dval.op == CachedDataWithOp.OP_NONE:
                             prog_asn = False
                         if prog_asn:
-                            command = ['vtysh', '-c', 'configure terminal', '-c', 'router bgp {} vrf {}'.format(dval.data, vrf), '-c', 'no bgp default ipv4-unicast']
+                            # Emit 'no bgp ebgp-requires-policy' unconditionally for every BGP
+                            # instance, mirroring the traditional bgpcfgd template
+                            # (dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2), which renders
+                            # it with no CONFIG_DB field. Without it, FRR's default (policy
+                            # required) discards eBGP routes on address-families that have no
+                            # inbound route-map. Companion to the 'no bgp default ipv4-unicast'
+                            # default below. See sonic-buildimage#28482.
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'router bgp {} vrf {}'.format(dval.data, vrf), '-c', 'no bgp default ipv4-unicast', '-c', 'no bgp ebgp-requires-policy']
                             if self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_DEBUG, 'set local_asn %s to VRF %s, re-apply all VRF related tables' % (dval.data, vrf))
                                 self.bgp_asn[vrf] = dval.data

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -1818,6 +1818,7 @@ class BGPConfigDaemon:
                       ('disable_ebgp_connected_rt_check',               '{no:no-prefix}bgp disable-ebgp-connected-route-check', ['true', 'false']),
                       ('fast_external_failover',                        '{no:no-prefix}bgp fast-external-failover', ['true', 'false', True]),
                       ('network_import_check',                          '{no:no-prefix}bgp network import-check', ['true', 'false']),
+                      ('ebgp_requires_policy',                          '{no:no-prefix}bgp ebgp-requires-policy', ['true', 'false']),
                       ('graceful_shutdown',                             '{no:no-prefix}bgp graceful-shutdown', ['true', 'false']),
                       ('rr_clnt_to_clnt_reflection',                    '{no:no-prefix}bgp client-to-client reflection', ['true', 'false', True]),
                       ('max_dynamic_neighbors',                         '{no:no-prefix}bgp listen limit {}'),
@@ -2802,14 +2803,7 @@ class BGPConfigDaemon:
                         if dval.op == CachedDataWithOp.OP_NONE:
                             prog_asn = False
                         if prog_asn:
-                            # Emit 'no bgp ebgp-requires-policy' unconditionally for every BGP
-                            # instance, mirroring the traditional bgpcfgd template
-                            # (dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2), which renders
-                            # it with no CONFIG_DB field. Without it, FRR's default (policy
-                            # required) discards eBGP routes on address-families that have no
-                            # inbound route-map. Companion to the 'no bgp default ipv4-unicast'
-                            # default below. See sonic-buildimage#28482.
-                            command = ['vtysh', '-c', 'configure terminal', '-c', 'router bgp {} vrf {}'.format(dval.data, vrf), '-c', 'no bgp default ipv4-unicast', '-c', 'no bgp ebgp-requires-policy']
+                            command = ['vtysh', '-c', 'configure terminal', '-c', 'router bgp {} vrf {}'.format(dval.data, vrf), '-c', 'no bgp default ipv4-unicast']
                             if self.__run_command(table, command):
                                 syslog.syslog(syslog.LOG_DEBUG, 'set local_asn %s to VRF %s, re-apply all VRF related tables' % (dval.data, vrf))
                                 self.bgp_asn[vrf] = dval.data

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -508,6 +508,26 @@ def handle_rmap_set_metric(daemon, cmd_str, op, st_idx, args, data):
                                    CommandArgument(daemon, True, metric_param)))
     return cmd_list
 
+def handle_rmap_on_match(daemon, cmd_str, op, st_idx, args, data):
+    # Render the route-map 'on-match' continue-flow clause from the set_on_match_action enum
+    # (ON_MATCH_NEXT -> 'on-match next', ON_MATCH_GOTO -> 'on-match goto <seq>' using the
+    # companion set_on_match_goto value). Mirrors handle_rmap_set_metric's action+value shape.
+    no_op = 'no ' if op == CachedDataWithOp.OP_DELETE else ''
+    action = args[0] if len(args) >= 1 else ''
+    goto = args[1] if len(args) >= 2 else ''
+    if action == 'ON_MATCH_NEXT':
+        on_match_param = 'next'
+    elif action == 'ON_MATCH_GOTO':
+        if goto == '':
+            syslog.syslog(syslog.LOG_ERR, 'set_on_match_action ON_MATCH_GOTO requires set_on_match_goto: {}'.format(args))
+            return None
+        on_match_param = 'goto {}'.format(goto)
+    else:
+        syslog.syslog(syslog.LOG_ERR, 'invalid set_on_match_action {}'.format(action))
+        return None
+    return [cmd_str.format(CommandArgument(daemon, True, no_op),
+                           CommandArgument(daemon, True, on_match_param))]
+
 class BGPKeyMapInfo:
     def __init__(self, cmd_str, hdlr, data):
         self.daemons, self.run_cmd = extract_cmd_daemons(cmd_str)
@@ -1941,7 +1961,7 @@ class BGPConfigDaemon:
                          ('match_as_path',                  '[bgpd]{no:no-prefix}match as-path {}'),
                          ('match_src_vrf',                  '[bgpd]{no:no-prefix}match source-vrf {}'),
                          ('call_route_map',                 '{no:no-prefix}call {:enable-only}'),
-                         ('set_on_match_next',              '{no:no-prefix}on-match next', ['true', 'false']),
+                         (['set_on_match_action', '+set_on_match_goto'], '{}on-match {} ', handle_rmap_on_match),
                          ('set_origin',                     '[bgpd]{no:no-prefix}set origin {:tolower}'),
                          ('set_local_pref',                 '[bgpd]{no:no-prefix}set local-preference {}'),
                          ('set_next_hop',                   '{no:no-prefix}set ip next-hop {}'),

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -87,7 +87,7 @@ class BgpdClientMgr(threading.Thread):
             'PREFIX': ['zebra', 'bgpd', 'ospfd', 'pimd'],
             'BGP_PEER_GROUP': ['bgpd'],
             'BGP_NEIGHBOR': ['bgpd'],
-            'LOOPBACK_INTERFACE': ['zebra'],
+            'PROTOCOL_ROUTE_MAP': ['zebra'],
             'BGP_PEER_GROUP_AF': ['bgpd'],
             'BGP_NEIGHBOR_AF': ['bgpd'],
             'BGP_GLOBALS_LISTEN_PREFIX': ['bgpd'],
@@ -2296,9 +2296,6 @@ class BGPConfigDaemon:
                 self.af_aggr_list.setdefault(vrf, {})[norm_ip_pfx] = aggr_obj
 
         self.vrf_vni_map = {}
-        # address-family (socket.AF_INET/AF_INET6) -> Loopback0 IP programmed into the zebra
-        # "set src" route-maps (RM_SET_SRC/RM_SET_SRC6). See loopback_setsrc_handler.
-        self.set_src_lo = {}
         vrf_table = self.config_db.get_table('VRF')
         for key, entry in vrf_table.items():
             if 'vni' in entry:
@@ -2333,7 +2330,7 @@ class BGPConfigDaemon:
             ('ROUTE_MAP', self.bgp_table_handler_common),
             ('BGP_PEER_GROUP', self.bgp_neighbor_handler),
             ('BGP_NEIGHBOR', self.bgp_neighbor_handler),
-            ('LOOPBACK_INTERFACE', self.loopback_setsrc_handler),
+            ('PROTOCOL_ROUTE_MAP', self.protocol_route_map_handler),
             ('BGP_PEER_GROUP_AF', self.bgp_table_handler_common),
             ('BGP_NEIGHBOR_AF', self.bgp_table_handler_common),
             ('BGP_GLOBALS_LISTEN_PREFIX', self.bgp_table_handler_common),
@@ -2471,65 +2468,32 @@ class BGPConfigDaemon:
             if positive_execute == True:
                 self.__run_command(table, command)
 
-    # Route-map names for the zebra "set src" feature, mirroring the traditional bgpcfgd
-    # ZebraSetSrc manager (src/sonic-bgpcfgd/bgpcfgd/managers_setsrc.py +
-    # dockers/docker-fpm-frr/frr/zebra/zebra.set_src.conf.j2).
-    SET_SRC_RM_V4 = 'RM_SET_SRC'
-    SET_SRC_RM_V6 = 'RM_SET_SRC6'
-
-    @staticmethod
-    def __ip_addr_family(ip_addr):
-        for af in (socket.AF_INET, socket.AF_INET6):
-            try:
-                socket.inet_pton(af, ip_addr)
-                return af
-            except socket.error:
-                continue
-        return None
-
-    def loopback_setsrc_handler(self, table, key, data):
-        """Program the zebra "set src" route-maps from the Loopback0 address.
-
-        Mirrors the traditional bgpcfgd ZebraSetSrc manager, which renders
-        RM_SET_SRC / RM_SET_SRC6 (a 'set src <Loopback0 ip>' route-map) and binds them via
-        'ip[v6] protocol bgp route-map ...' so BGP-installed routes source from Loopback0. In
-        frr_mgmt_framework mode bgpcfgd does not run, so frrcfgd installs the same objects from
-        the Loopback0 IP in CONFIG_DB. Like bgpcfgd, Loopback0 is hardcoded and update/delete of
-        the address is not supported (programmed once per address family). See
-        sonic-buildimage#28482.
-        """
+    def protocol_route_map_handler(self, table, key, data):
+        """Bind a route-map to a routing protocol's FIB installation in zebra:
+        'ip protocol <proto> route-map <name>' (IPv4) / 'ipv6 protocol <proto> route-map <name>'
+        (IPv6). Key is '<address_family>|<protocol>' (address_family ipv4|ipv6). A generic zebra
+        primitive -- e.g. sourcing BGP-installed routes from a loopback via a 'set src' route-map
+        (the RM_SET_SRC use case) is expressed as a normal ROUTE_MAP (with set_src) plus a
+        PROTOCOL_ROUTE_MAP row. See sonic-buildimage#28482."""
         key_params = key.split('|')
-        if len(key_params) < 2 or key_params[0] != 'Loopback0':
-            # Interface-level row (no IP) or a non-Loopback0 interface -- nothing to program.
+        if len(key_params) != 2:
+            syslog.syslog(syslog.LOG_ERR, 'protocol route-map: invalid key {}'.format(key))
             return
-        ip_addr = key_params[1].rsplit('/', 1)[0]
-        af = self.__ip_addr_family(ip_addr)
-        if af is None:
-            syslog.syslog(syslog.LOG_ERR, 'set src: ambiguous Loopback0 address {}'.format(ip_addr))
-            return
-        if data is None:
-            # A LOOPBACK_INTERFACE IP-member row carries the address in the key, so its value
-            # may legitimately be empty ({} / {'NULL': 'NULL'}) -- only a None payload is a
-            # delete. bgpcfgd does not support deleting the set src route-maps; keep parity.
-            syslog.syslog(syslog.LOG_WARNING,
-                          'set src: delete of Loopback0 {} not supported'.format(ip_addr))
-            return
-        rm_name, proto = ((self.SET_SRC_RM_V4, 'ip') if af == socket.AF_INET
-                          else (self.SET_SRC_RM_V6, 'ipv6'))
-        if self.set_src_lo.get(af) == ip_addr:
-            return
-        if af in self.set_src_lo:
-            syslog.syslog(syslog.LOG_WARNING,
-                          'set src: Loopback0 address change {} -> {} not supported'.format(
-                              self.set_src_lo[af], ip_addr))
-            return
-        command = ['vtysh', '-c', 'configure terminal',
-                   '-c', 'route-map {} permit 10'.format(rm_name),
-                   '-c', 'set src {}'.format(ip_addr),
-                   '-c', 'exit',
-                   '-c', '{} protocol bgp route-map {}'.format(proto, rm_name)]
-        if self.__run_command(table, command, ['zebra']):
-            self.set_src_lo[af] = ip_addr
+        af, protocol = key_params
+        ip_kw = 'ipv6' if af == 'ipv6' else 'ip'
+        if not data:
+            # 'no ip[v6] protocol <proto> route-map' removes the binding (name optional to FRR).
+            command = ['vtysh', '-c', 'configure terminal',
+                       '-c', 'no {} protocol {} route-map'.format(ip_kw, protocol)]
+        else:
+            route_map = data.get('route_map')
+            if not route_map:
+                syslog.syslog(syslog.LOG_ERR,
+                              'protocol route-map: missing route_map for {}'.format(key))
+                return
+            command = ['vtysh', '-c', 'configure terminal',
+                       '-c', '{} protocol {} route-map {}'.format(ip_kw, protocol, route_map)]
+        self.__run_command(table, command, ['zebra'])
 
     def __get_vrf_asn(self, vrf):
         if vrf in self.bgp_asn:

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -3924,6 +3924,15 @@ class BGPConfigDaemon:
                         syslog.syslog(syslog.LOG_ERR, 'failed running PIM config command')
                         continue
 
+            elif table == 'DEVICE_METADATA':
+                # Device-wide zebra knobs (device_metadata_key_map). These are top-level FRR
+                # commands, so the prefix is just 'configure terminal' -- no VRF or router-bgp
+                # framing. suppress-fib-pending is NOT handled here; it is a router-bgp
+                # sub-command and metadata_handler() emits it separately.
+                if not key_map.run_command(self, table, data, ['configure terminal']):
+                    syslog.syslog(syslog.LOG_ERR, 'failed running DEVICE_METADATA config command')
+                    continue
+
             elif table == 'PIM_GLOBALS':
 
                 vrf = prefix

--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2126,8 +2126,27 @@ class BGPConfigDaemon:
                              ('icmp_tos', 'tos {}', handle_ip_sla_common),
                            ]
 
+    # Device-wide routing knobs living in DEVICE_METADATA|localhost. bgpcfgd renders these
+    # from its zebra template; frrcfgd did not, so a frrcfgd DUT silently ran with different
+    # behaviour -- e.g. losing 'zebra nexthop-group keep 1' reverts nexthop-group retention
+    # to FRR's 180s default, which shows up much later as unstable nexthop-group counts.
+    #
+    # Every entry is opt-in: an absent field emits nothing and leaves FRR's own default in
+    # place, so upgrading changes no existing installation. Only an explicit value -- set by
+    # an operator or by the sonic-mgmt config migrator -- alters behaviour.
+    #
+    # 'bgp suppress-fib-pending' is deliberately NOT here: it is a 'router bgp <asn>'
+    # sub-command rather than a top-level one, and this map has no ASN context to frame it
+    # with, so metadata_handler() emits it with an explicit router-bgp prefix instead.
+    device_metadata_key_map = [
+            ('nexthop_group_keep_time', '[zebra]{no:no-prefix}zebra nexthop-group keep {}'),
+            ('zebra_nexthop',           '[zebra]{no:no-prefix}zebra nexthop kernel enable',
+             ['enabled', 'disabled']),
+    ]
 
-    tbl_to_key_map = {'BGP_GLOBALS':                    global_key_map,
+
+    tbl_to_key_map = {'DEVICE_METADATA':                device_metadata_key_map,
+                      'BGP_GLOBALS':                    global_key_map,
                       'BGP_GLOBALS_AF':                 global_af_key_map,
                       'BGP_GLOBALS_LISTEN_PREFIX':      listen_prefix_key_map,
                       'BGP_NEIGHBOR':                   cmn_key_map[0:2] + nbr_key_map + cmn_key_map[2:],
@@ -2401,6 +2420,39 @@ class BGPConfigDaemon:
             self.metadata_asn = None
         else:
             self.metadata_asn = data['bgp_asn']
+        self.__update_suppress_fib_pending(data)
+        # Device-wide zebra knobs (see device_metadata_key_map). Routed through the common
+        # table path so a CONFIG_DB change is pushed to FRR live, not only at the next
+        # config reload / template render.
+        self.bgp_table_handler_common(table, key, data)
+
+    def __update_suppress_fib_pending(self, data):
+        """Apply DEVICE_METADATA|localhost:suppress-fib-pending to FRR.
+
+        Kept out of device_metadata_key_map because 'bgp suppress-fib-pending' is a
+        'router bgp <asn>' sub-command: the generic key_map path emits at top level, where
+        FRR rejects it. DEVICE_METADATA stays the single source of truth -- it is what
+        `config suppress-fib-pending` writes and what route_check.py reads -- so this reads
+        it from there rather than duplicating the setting into BGP_GLOBALS.
+
+        Opt-in like the rest: an absent field emits nothing and leaves FRR's default alone.
+        """
+        state = (data or {}).get('suppress-fib-pending')
+        if state is None:
+            return
+        if state not in ('enabled', 'disabled'):
+            syslog.syslog(syslog.LOG_ERR,
+                          '[bgp cfgd] invalid suppress-fib-pending value {}'.format(state))
+            return
+        if self.metadata_asn is None:
+            syslog.syslog(syslog.LOG_DEBUG,
+                          '[bgp cfgd] no bgp_asn yet; deferring suppress-fib-pending')
+            return
+        no_prefix = '' if state == 'enabled' else 'no '
+        command = ['vtysh', '-c', 'configure terminal',
+                   '-c', 'router bgp {}'.format(self.metadata_asn),
+                   '-c', '{}bgp suppress-fib-pending'.format(no_prefix)]
+        self.__run_command('DEVICE_METADATA', command, ['bgpd'])
 
     def bfd_handler(self, table, key, data):
         syslog.syslog(syslog.LOG_INFO, '[bgp cfgd](bfd) value for {} changed to {}'.format(key, data))

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
@@ -30,10 +30,13 @@ router bgp {{ bgp_sess['local_asn']}}
 {% else %}
 router bgp {{ bgp_sess['local_asn']}} vrf {{ vrf }}
 {% endif %}
-{# Emit 'no bgp ebgp-requires-policy' unconditionally for every BGP instance, mirroring the #}
-{# traditional bgpcfgd template (bgpd.main.conf.j2). Without it FRR's default (policy required) #}
-{# discards eBGP routes on address-families that have no inbound route-map. See sonic-buildimage#28482. #}
+{% if 'ebgp_requires_policy' in bgp_sess %}
+{% if bgp_sess['ebgp_requires_policy'] == 'true' %}
+ bgp ebgp-requires-policy
+{% else %}
  no bgp ebgp-requires-policy
+{% endif %}
+{% endif %}
 {% if 'fast_external_failover' in bgp_sess and bgp_sess['fast_external_failover'] == 'false' %}
  no bgp fast-external-failover
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
@@ -30,6 +30,10 @@ router bgp {{ bgp_sess['local_asn']}}
 {% else %}
 router bgp {{ bgp_sess['local_asn']}} vrf {{ vrf }}
 {% endif %}
+{# Emit 'no bgp ebgp-requires-policy' unconditionally for every BGP instance, mirroring the #}
+{# traditional bgpcfgd template (bgpd.main.conf.j2). Without it FRR's default (policy required) #}
+{# discards eBGP routes on address-families that have no inbound route-map. See sonic-buildimage#28482. #}
+ no bgp ebgp-requires-policy
 {% if 'fast_external_failover' in bgp_sess and bgp_sess['fast_external_failover'] == 'false' %}
  no bgp fast-external-failover
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.j2
@@ -37,6 +37,17 @@ router bgp {{ bgp_sess['local_asn']}} vrf {{ vrf }}
  no bgp ebgp-requires-policy
 {% endif %}
 {% endif %}
+{# suppress-fib-pending is device-wide (DEVICE_METADATA), not per-VRF, but the FRR command
+   is a router-bgp sub-command, so it is rendered here for every BGP instance. Absent =>
+   nothing emitted, leaving FRR's default. #}
+{% if vrf == 'default' and DEVICE_METADATA is defined and 'localhost' in DEVICE_METADATA and
+      'suppress-fib-pending' in DEVICE_METADATA['localhost'] %}
+{% if DEVICE_METADATA['localhost']['suppress-fib-pending'] == 'enabled' %}
+ bgp suppress-fib-pending
+{% else %}
+ no bgp suppress-fib-pending
+{% endif %}
+{% endif %}
 {% if 'fast_external_failover' in bgp_sess and bgp_sess['fast_external_failover'] == 'false' %}
  no bgp fast-external-failover
 {% endif %}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
@@ -9,8 +9,12 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
 {% if 'call_route_map' in rm_val %}
  call {{rm_val['call_route_map']}}
 {% endif %}
-{% if 'set_on_match_next' in rm_val and rm_val['set_on_match_next'] == 'true' %}
+{% if 'set_on_match_action' in rm_val %}
+{% if rm_val['set_on_match_action'] == 'ON_MATCH_NEXT' %}
  on-match next
+{% elif rm_val['set_on_match_action'] == 'ON_MATCH_GOTO' and 'set_on_match_goto' in rm_val %}
+ on-match goto {{ rm_val['set_on_match_goto'] }}
+{% endif %}
 {% endif %}
 {% if 'match_community' in rm_val %}
  match community {{rm_val['match_community']}}

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
@@ -9,6 +9,9 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
 {% if 'call_route_map' in rm_val %}
  call {{rm_val['call_route_map']}}
 {% endif %}
+{# ON_MATCH_GOTO without a set_on_match_goto target is rejected by the YANG 'must' on          #}
+{# set_on_match_action, so it cannot reach here from a validated config; render nothing rather #}
+{# than an incomplete 'on-match goto' clause that FRR would reject.                            #}
 {% if 'set_on_match_action' in rm_val %}
 {% if rm_val['set_on_match_action'] == 'ON_MATCH_NEXT' %}
  on-match next

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.route_map.j2
@@ -9,6 +9,9 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
 {% if 'call_route_map' in rm_val %}
  call {{rm_val['call_route_map']}}
 {% endif %}
+{% if 'set_on_match_next' in rm_val and rm_val['set_on_match_next'] == 'true' %}
+ on-match next
+{% endif %}
 {% if 'match_community' in rm_val %}
  match community {{rm_val['match_community']}}
 {% endif %}
@@ -108,6 +111,9 @@ route-map {{rm_key[0]}} {{rm_val['route_operation']}} {{rm_key[1]}}
 {% endif %}
 {% if 'set_next_hop' in rm_val %}
  set ip next-hop {{rm_val['set_next_hop']}}
+{% endif %}
+{% if 'set_src' in rm_val %}
+ set src {{rm_val['set_src']}}
 {% endif %}
 {% if 'set_ipv6_next_hop_global' in rm_val %}
  set ipv6 next-hop global {{rm_val['set_ipv6_next_hop_global']}}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -69,24 +69,6 @@ ipv6 protocol bgp route-map RM_SET_SRC6
 {% endif %}
 {% endif %}
 !
-{# BGP-sentinel base policy (fixed route-maps + community-list), mirroring the traditional bgpcfgd #}
-{# template dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/policies.conf.j2. Rendered whenever #}
-{# any BGP_SENTINELS entry exists; the frrcfgd runtime bgp_sentinels_handler renders the same at    #}
-{# runtime. See sonic-buildimage#28482.                                                             #}
-{% if BGP_SENTINELS is defined and BGP_SENTINELS|length > 0 %}
-{% if constants is defined and constants.bgp is defined and constants.bgp.sentinel_community is defined %}
-bgp community-list standard sentinel_community permit {{ constants.bgp.sentinel_community }} no-export
-!
-route-map FROM_BGP_SENTINEL permit 100
- match community sentinel_community
-!
-{% endif %}
-route-map FROM_BGP_SENTINEL deny 200
-!
-route-map TO_BGP_SENTINEL permit 100
-!
-{% endif %}
-!
 {% include "ospfd.conf.j2" %}
 !
 {% include "bfdd.conf.j2" %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -36,37 +36,20 @@ fpm address 127.0.0.1
 !
 {% include "bgpd.conf.db.j2" %}
 !
-{# BGP-learned routes source from Loopback0: render the RM_SET_SRC / RM_SET_SRC6 route-maps and #}
-{# the 'ip[v6] protocol bgp route-map' binds, mirroring the traditional bgpcfgd ZebraSetSrc      #}
-{# manager (dockers/docker-fpm-frr/frr/zebra/zebra.set_src.conf.j2). The frrcfgd runtime          #}
-{# loopback_setsrc_handler renders the same at runtime; this covers boot / config reload.         #}
-{# See sonic-buildimage#28482.                                                                     #}
-{% if LOOPBACK_INTERFACE is defined %}
-{% set setsrc = namespace(v4=None, v6=None) %}
-{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
-{% if name == 'Loopback0' %}
-{% set addr = prefix.split('/')[0] %}
-{% if ':' in addr %}
-{% if setsrc.v6 is none %}{% set setsrc.v6 = addr %}{% endif %}
+{# Zebra protocol route-map bindings: 'ip[v6] protocol <proto> route-map <name>'. A generic     #}
+{# primitive -- e.g. the RM_SET_SRC loopback-source setup is a normal ROUTE_MAP (rendered above  #}
+{# with 'set src') plus a PROTOCOL_ROUTE_MAP row bound here. See sonic-buildimage#28482.          #}
+{% if PROTOCOL_ROUTE_MAP is defined %}
+{% for key, val in PROTOCOL_ROUTE_MAP.items() %}
+{% if 'route_map' in val %}
+{% if key[0] == 'ipv6' %}
+ipv6 protocol {{ key[1] }} route-map {{ val['route_map'] }}
 {% else %}
-{% if setsrc.v4 is none %}{% set setsrc.v4 = addr %}{% endif %}
+ip protocol {{ key[1] }} route-map {{ val['route_map'] }}
 {% endif %}
+!
 {% endif %}
 {% endfor %}
-{% if setsrc.v4 is not none %}
-route-map RM_SET_SRC permit 10
- set src {{ setsrc.v4 }}
-!
-ip protocol bgp route-map RM_SET_SRC
-!
-{% endif %}
-{% if setsrc.v6 is not none %}
-route-map RM_SET_SRC6 permit 10
- set src {{ setsrc.v6 }}
-!
-ipv6 protocol bgp route-map RM_SET_SRC6
-!
-{% endif %}
 {% endif %}
 !
 {% include "ospfd.conf.j2" %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -36,6 +36,57 @@ fpm address 127.0.0.1
 !
 {% include "bgpd.conf.db.j2" %}
 !
+{# BGP-learned routes source from Loopback0: render the RM_SET_SRC / RM_SET_SRC6 route-maps and #}
+{# the 'ip[v6] protocol bgp route-map' binds, mirroring the traditional bgpcfgd ZebraSetSrc      #}
+{# manager (dockers/docker-fpm-frr/frr/zebra/zebra.set_src.conf.j2). The frrcfgd runtime          #}
+{# loopback_setsrc_handler renders the same at runtime; this covers boot / config reload.         #}
+{# See sonic-buildimage#28482.                                                                     #}
+{% if LOOPBACK_INTERFACE is defined %}
+{% set setsrc = namespace(v4=None, v6=None) %}
+{% for (name, prefix) in LOOPBACK_INTERFACE|pfx_filter %}
+{% if name == 'Loopback0' %}
+{% set addr = prefix.split('/')[0] %}
+{% if ':' in addr %}
+{% if setsrc.v6 is none %}{% set setsrc.v6 = addr %}{% endif %}
+{% else %}
+{% if setsrc.v4 is none %}{% set setsrc.v4 = addr %}{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% if setsrc.v4 is not none %}
+route-map RM_SET_SRC permit 10
+ set src {{ setsrc.v4 }}
+!
+ip protocol bgp route-map RM_SET_SRC
+!
+{% endif %}
+{% if setsrc.v6 is not none %}
+route-map RM_SET_SRC6 permit 10
+ set src {{ setsrc.v6 }}
+!
+ipv6 protocol bgp route-map RM_SET_SRC6
+!
+{% endif %}
+{% endif %}
+!
+{# BGP-sentinel base policy (fixed route-maps + community-list), mirroring the traditional bgpcfgd #}
+{# template dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/policies.conf.j2. Rendered whenever #}
+{# any BGP_SENTINELS entry exists; the frrcfgd runtime bgp_sentinels_handler renders the same at    #}
+{# runtime. See sonic-buildimage#28482.                                                             #}
+{% if BGP_SENTINELS is defined and BGP_SENTINELS|length > 0 %}
+{% if constants is defined and constants.bgp is defined and constants.bgp.sentinel_community is defined %}
+bgp community-list standard sentinel_community permit {{ constants.bgp.sentinel_community }} no-export
+!
+route-map FROM_BGP_SENTINEL permit 100
+ match community sentinel_community
+!
+{% endif %}
+route-map FROM_BGP_SENTINEL deny 200
+!
+route-map TO_BGP_SENTINEL permit 100
+!
+{% endif %}
+!
 {% include "ospfd.conf.j2" %}
 !
 {% include "bfdd.conf.j2" %}

--- a/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
+++ b/src/sonic-frr-mgmt-framework/templates/frr/frr.conf.j2
@@ -22,6 +22,16 @@ no fpm use-next-hop-groups
 ! Add fpm address for zebra
 fpm address 127.0.0.1
 !
+{% if ( ('localhost' in DEVICE_METADATA) and ('zebra_nexthop' in DEVICE_METADATA['localhost']) and
+        (DEVICE_METADATA['localhost']['zebra_nexthop'] == 'enabled') ) %}
+! enable kernel nexthop group programming
+zebra nexthop kernel enable
+{% endif %}
+{% if ( ('localhost' in DEVICE_METADATA) and ('nexthop_group_keep_time' in DEVICE_METADATA['localhost']) ) %}
+! seconds to retain an unused nexthop group (unset => FRR default of 180)
+zebra nexthop-group keep {{ DEVICE_METADATA['localhost']['nexthop_group_keep_time'] }}
+{% endif %}
+!
 {% include "zebra/zebra.interfaces.conf.j2" %}
 !
 {% if MGMT_VRF_CONFIG %}

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -312,7 +312,7 @@ def test_bgp_neighbor_description_injection(run_cmd):
 # ---------------------------------------------------------------------------
 # Feature / regression tests for the frrcfgd BGP parity gaps (sonic-buildimage#28482):
 #   * 'no bgp ebgp-requires-policy' emitted per BGP instance
-#   * route-map 'on-match next' (continue-flow) clause
+#   * route-map 'on-match next' / 'on-match goto' (continue-flow) clause
 #   * zebra route-map 'set src' clause
 #   * zebra RM_SET_SRC / RM_SET_SRC6 route-maps from Loopback0 (ZebraSetSrc parity)
 #   * listen-range peer-group attribute drop on delete + re-create
@@ -362,13 +362,22 @@ def test_bgp_ebgp_requires_policy(run_cmd):
 
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
-def test_route_map_on_match_next(run_cmd):
+def test_route_map_on_match(run_cmd):
     daemon = _make_daemon()
-    _handler(daemon, 'ROUTE_MAP')('ROUTE_MAP', 'RM_OMN|10',
-                                  {'route_operation': 'permit', 'set_on_match_next': 'true'})
+    rm_hdlr = _handler(daemon, 'ROUTE_MAP')
+    # ON_MATCH_NEXT -> 'on-match next'
+    rm_hdlr('ROUTE_MAP', 'RM_OMN|10',
+            {'route_operation': 'permit', 'set_on_match_action': 'ON_MATCH_NEXT'})
     lines = _collect_vtysh_lines(run_cmd)
     assert 'route-map RM_OMN permit 10' in lines, lines
-    assert 'on-match next' in lines, lines
+    assert any(line.strip() == 'on-match next' for line in lines), lines
+    # ON_MATCH_GOTO with a target sequence -> 'on-match goto 20'
+    run_cmd.reset_mock()
+    rm_hdlr('ROUTE_MAP', 'RM_OMG|10',
+            {'route_operation': 'permit', 'set_on_match_action': 'ON_MATCH_GOTO',
+             'set_on_match_goto': '20'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert any(line.strip() == 'on-match goto 20' for line in lines), lines
 
 
 @patch.dict('sys.modules', **mockmapping)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -410,24 +410,26 @@ def test_route_map_set_src_clause(run_cmd):
 
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
-def test_zebra_set_src_from_loopback(run_cmd):
-    """RM_SET_SRC / RM_SET_SRC6 + 'ip[v6] protocol bgp route-map' from Loopback0 (ZebraSetSrc parity)."""
+def test_protocol_route_map(run_cmd):
+    """PROTOCOL_ROUTE_MAP renders the zebra 'ip[v6] protocol <proto> route-map <name>' bind
+    (the RM_SET_SRC loopback-source setup is a ROUTE_MAP with set_src + this bind)."""
     daemon = _make_daemon()
-    lo_hdlr = _handler(daemon, 'LOOPBACK_INTERFACE')
-    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0|10.1.0.1/32', {})
-    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0|fc00:1::1/128', {})
-    lines = _collect_vtysh_lines(run_cmd)
-    assert 'route-map RM_SET_SRC permit 10' in lines, lines
-    assert 'set src 10.1.0.1' in lines, lines
-    assert 'ip protocol bgp route-map RM_SET_SRC' in lines, lines
-    assert 'route-map RM_SET_SRC6 permit 10' in lines, lines
-    assert 'set src fc00:1::1' in lines, lines
-    assert 'ipv6 protocol bgp route-map RM_SET_SRC6' in lines, lines
-    # non-Loopback0 interfaces and interface-level rows (no address) must be ignored
+    prm_hdlr = _handler(daemon, 'PROTOCOL_ROUTE_MAP')
+    # IPv4 bind
+    prm_hdlr('PROTOCOL_ROUTE_MAP', 'ipv4|bgp', {'route_map': 'RM_SET_SRC'})
+    assert 'ip protocol bgp route-map RM_SET_SRC' in _collect_vtysh_lines(run_cmd), \
+        _collect_vtysh_lines(run_cmd)
+    # IPv6 bind targets zebra
     run_cmd.reset_mock()
-    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback1|20.1.0.1/32', {})
-    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0', {})
-    assert not run_cmd.called, run_cmd.call_args_list
+    prm_hdlr('PROTOCOL_ROUTE_MAP', 'ipv6|bgp', {'route_map': 'RM_SET_SRC6'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'ipv6 protocol bgp route-map RM_SET_SRC6' in lines, lines
+    for call in run_cmd.call_args_list:
+        assert call[0][3] == ['zebra'], call
+    # delete -> 'no ip protocol <proto> route-map'
+    run_cmd.reset_mock()
+    prm_hdlr('PROTOCOL_ROUTE_MAP', 'ipv4|bgp', None)
+    assert 'no ip protocol bgp route-map' in _collect_vtysh_lines(run_cmd), _collect_vtysh_lines(run_cmd)
 
 
 @patch.dict('sys.modules', **mockmapping)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -100,7 +100,7 @@ def hdl_confed_peers_cmd(is_del, cmd_list, chk_data):
 conf_cmd = 'configure terminal'
 conf_bgp_cmd = lambda vrf, asn: [conf_cmd, 'router bgp %d vrf %s' % (asn, vrf)]
 conf_no_bgp_cmd = lambda vrf, asn: [conf_cmd, 'no router bgp %d%s' % (asn, '' if vrf == 'default' else ' vrf %s' % vrf)]
-conf_bgp_dft_cmd = lambda vrf, asn: conf_bgp_cmd(vrf, asn) + ['no bgp default ipv4-unicast']
+conf_bgp_dft_cmd = lambda vrf, asn: conf_bgp_cmd(vrf, asn) + ['no bgp default ipv4-unicast', 'no bgp ebgp-requires-policy']
 conf_bgp_af_cmd = lambda vrf, asn, af: conf_bgp_cmd(vrf, asn) + ['address-family %s %s' % (af, 'evpn' if af == 'l2vpn' else 'unicast')]
 
 bgp_globals_data = [
@@ -307,3 +307,172 @@ def test_bgp_neighbor_description_injection(run_cmd):
         if any('description' in arg for arg in cmd):
             assert any(injection_payload in arg for arg in cmd), \
                 "injection payload not found as literal arg: {}".format(cmd)
+
+
+# ---------------------------------------------------------------------------
+# Feature / regression tests for the frrcfgd BGP parity gaps (sonic-buildimage#28482):
+#   * 'no bgp ebgp-requires-policy' emitted per BGP instance
+#   * route-map 'on-match next' (continue-flow) clause
+#   * zebra route-map 'set src' clause
+#   * zebra RM_SET_SRC / RM_SET_SRC6 route-maps from Loopback0 (ZebraSetSrc parity)
+#   * BGP-sentinel base-policy route-maps / community-list
+#   * listen-range peer-group attribute drop on delete + re-create
+# ---------------------------------------------------------------------------
+
+def _collect_vtysh_lines(run_cmd):
+    """Return every vtysh '-c' payload across all g_run_command calls, in order."""
+    lines = []
+    for call in run_cmd.call_args_list:
+        argv = call[0][1]
+        if not isinstance(argv, list):
+            continue
+        i = 0
+        while i < len(argv):
+            if argv[i] == '-c' and i + 1 < len(argv):
+                lines.append(argv[i + 1])
+                i += 2
+            else:
+                i += 1
+    return lines
+
+
+def _make_daemon():
+    from frrcfgd.frrcfgd import BGPConfigDaemon
+    return BGPConfigDaemon()
+
+
+def _handler(daemon, table):
+    hdlrs = [h for t, h in daemon.table_handler_list if t == table]
+    assert len(hdlrs) == 1, "expected exactly one handler for {}".format(table)
+    return hdlrs[0]
+
+
+def _seed_bgp_asn(daemon, asn='100', vrf='default'):
+    _handler(daemon, 'BGP_GLOBALS')('BGP_GLOBALS', vrf, {'local_asn': asn})
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_ebgp_requires_policy(run_cmd):
+    """Every BGP instance must render 'no bgp ebgp-requires-policy' (bgpcfgd parity)."""
+    daemon = _make_daemon()
+    _seed_bgp_asn(daemon, '100')
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'no bgp ebgp-requires-policy' in lines, lines
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_route_map_on_match_next(run_cmd):
+    daemon = _make_daemon()
+    _handler(daemon, 'ROUTE_MAP')('ROUTE_MAP', 'RM_OMN|10',
+                                  {'route_operation': 'permit', 'set_on_match_next': 'true'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'route-map RM_OMN permit 10' in lines, lines
+    assert 'on-match next' in lines, lines
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_route_map_set_src_clause(run_cmd):
+    daemon = _make_daemon()
+    _handler(daemon, 'ROUTE_MAP')('ROUTE_MAP', 'RM_SRC|10',
+                                  {'route_operation': 'permit', 'set_src': '10.1.0.1'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'set src 10.1.0.1' in lines, lines
+    # the 'set src' clause must be dispatched to zebra
+    for call in run_cmd.call_args_list:
+        argv = call[0][1]
+        if isinstance(argv, list) and 'set src 10.1.0.1' in argv:
+            assert call[0][3] == ['zebra'], call
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_zebra_set_src_from_loopback(run_cmd):
+    """RM_SET_SRC / RM_SET_SRC6 + 'ip[v6] protocol bgp route-map' from Loopback0 (ZebraSetSrc parity)."""
+    daemon = _make_daemon()
+    lo_hdlr = _handler(daemon, 'LOOPBACK_INTERFACE')
+    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0|10.1.0.1/32', {})
+    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0|fc00:1::1/128', {})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'route-map RM_SET_SRC permit 10' in lines, lines
+    assert 'set src 10.1.0.1' in lines, lines
+    assert 'ip protocol bgp route-map RM_SET_SRC' in lines, lines
+    assert 'route-map RM_SET_SRC6 permit 10' in lines, lines
+    assert 'set src fc00:1::1' in lines, lines
+    assert 'ipv6 protocol bgp route-map RM_SET_SRC6' in lines, lines
+    # non-Loopback0 interfaces and interface-level rows (no address) must be ignored
+    run_cmd.reset_mock()
+    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback1|20.1.0.1/32', {})
+    lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0', {})
+    assert not run_cmd.called, run_cmd.call_args_list
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_sentinel_base_policy_no_community(run_cmd):
+    """With no constants.yml community available, only the fixed base route-maps render."""
+    daemon = _make_daemon()
+    with patch.object(type(daemon), '_BGPConfigDaemon__get_sentinel_community', return_value=None):
+        _handler(daemon, 'BGP_SENTINELS')('BGP_SENTINELS', 'sentinel1',
+                                          {'name': 'BGPSentinel', 'src_address': '10.1.0.32'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'route-map FROM_BGP_SENTINEL deny 200' in lines, lines
+    assert 'route-map TO_BGP_SENTINEL permit 100' in lines, lines
+    assert not any('community-list' in line for line in lines), lines
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_sentinel_base_policy_with_community(run_cmd):
+    daemon = _make_daemon()
+    with patch.object(type(daemon), '_BGPConfigDaemon__get_sentinel_community',
+                      return_value='12345:12346'):
+        sent_hdlr = _handler(daemon, 'BGP_SENTINELS')
+        sent_hdlr('BGP_SENTINELS', 'sentinel1', {'name': 'BGPSentinel', 'src_address': '10.1.0.32'})
+        first = _collect_vtysh_lines(run_cmd)
+        assert 'bgp community-list standard sentinel_community permit 12345:12346 no-export' in first, first
+        assert 'route-map FROM_BGP_SENTINEL permit 100' in first, first
+        assert 'match community sentinel_community' in first, first
+        # a second sentinel must NOT re-render the (idempotent) base policy
+        run_cmd.reset_mock()
+        sent_hdlr('BGP_SENTINELS', 'sentinel2', {'name': 'BGPSentinel', 'src_address': '10.1.0.33'})
+        assert not run_cmd.called, run_cmd.call_args_list
+        # removing the last sentinel tears the base policy down
+        sent_hdlr('BGP_SENTINELS', 'sentinel1', None)
+        run_cmd.reset_mock()
+        sent_hdlr('BGP_SENTINELS', 'sentinel2', None)
+        del_lines = _collect_vtysh_lines(run_cmd)
+        assert 'no route-map FROM_BGP_SENTINEL' in del_lines, del_lines
+        assert 'no route-map TO_BGP_SENTINEL' in del_lines, del_lines
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_peer_group_rerender_after_delete(run_cmd):
+    """Regression (sonic-buildimage#28482): a listen-range peer-group re-created after a delete
+    must re-render its attributes (e.g. update-source), not silently drop them because a stale
+    cache row made the incremental diff resolve every field to 'no change'."""
+    daemon = _make_daemon()
+    # The real swsscommon ConfigDBConnector.serialize_key joins a key tuple with '|'; the test
+    # mock does not, so make it realistic -- the peer-group cache-eviction path reconstructs the
+    # cache key via serialize_key((vrf, pg)), and it must match the stored 'vrf|pg' key.
+    daemon.config_db.serialize_key = lambda key_tuple: '|'.join(key_tuple)
+    _seed_bgp_asn(daemon, '100')
+    pg_hdlr = _handler(daemon, 'BGP_PEER_GROUP')
+    pg_data = {'asn': '100', 'local_addr': '1.1.1.1'}
+
+    run_cmd.reset_mock()
+    pg_hdlr('BGP_PEER_GROUP', 'default|PG1', dict(pg_data))
+    assert 'neighbor PG1 update-source 1.1.1.1' in _collect_vtysh_lines(run_cmd), \
+        'update-source missing on initial peer-group create'
+
+    # delete the peer-group
+    pg_hdlr('BGP_PEER_GROUP', 'default|PG1', None)
+
+    # re-create: attributes must be programmed again (pre-fix they were dropped)
+    run_cmd.reset_mock()
+    pg_hdlr('BGP_PEER_GROUP', 'default|PG1', dict(pg_data))
+    assert 'neighbor PG1 update-source 1.1.1.1' in _collect_vtysh_lines(run_cmd), \
+        'update-source dropped on peer-group re-create (cache not evicted on delete)'

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -100,7 +100,7 @@ def hdl_confed_peers_cmd(is_del, cmd_list, chk_data):
 conf_cmd = 'configure terminal'
 conf_bgp_cmd = lambda vrf, asn: [conf_cmd, 'router bgp %d vrf %s' % (asn, vrf)]
 conf_no_bgp_cmd = lambda vrf, asn: [conf_cmd, 'no router bgp %d%s' % (asn, '' if vrf == 'default' else ' vrf %s' % vrf)]
-conf_bgp_dft_cmd = lambda vrf, asn: conf_bgp_cmd(vrf, asn) + ['no bgp default ipv4-unicast', 'no bgp ebgp-requires-policy']
+conf_bgp_dft_cmd = lambda vrf, asn: conf_bgp_cmd(vrf, asn) + ['no bgp default ipv4-unicast']
 conf_bgp_af_cmd = lambda vrf, asn, af: conf_bgp_cmd(vrf, asn) + ['address-family %s %s' % (af, 'evpn' if af == 'l2vpn' else 'unicast')]
 
 bgp_globals_data = [
@@ -353,11 +353,24 @@ def _seed_bgp_asn(daemon, asn='100', vrf='default'):
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
 def test_bgp_ebgp_requires_policy(run_cmd):
-    """Every BGP instance must render 'no bgp ebgp-requires-policy' (bgpcfgd parity)."""
+    """ebgp_requires_policy is field-driven (NOT an unconditional default): false ->
+    'no bgp ebgp-requires-policy', true -> 'bgp ebgp-requires-policy'. The migrator sets it
+    to replicate bgpcfgd's traditional behavior. See sonic-buildimage#28482."""
     daemon = _make_daemon()
     _seed_bgp_asn(daemon, '100')
-    lines = _collect_vtysh_lines(run_cmd)
-    assert 'no bgp ebgp-requires-policy' in lines, lines
+    # Not set by default -> frrcfgd must not touch ebgp-requires-policy.
+    assert not any('ebgp-requires-policy' in line for line in _collect_vtysh_lines(run_cmd)), \
+        'ebgp-requires-policy must not be emitted unless the field is set'
+    # Field false -> 'no bgp ebgp-requires-policy'
+    run_cmd.reset_mock()
+    _handler(daemon, 'BGP_GLOBALS')('BGP_GLOBALS', 'default',
+                                    {'local_asn': '100', 'ebgp_requires_policy': 'false'})
+    assert 'no bgp ebgp-requires-policy' in _collect_vtysh_lines(run_cmd), _collect_vtysh_lines(run_cmd)
+    # Field true -> 'bgp ebgp-requires-policy'
+    run_cmd.reset_mock()
+    _handler(daemon, 'BGP_GLOBALS')('BGP_GLOBALS', 'default',
+                                    {'local_asn': '100', 'ebgp_requires_policy': 'true'})
+    assert 'bgp ebgp-requires-policy' in _collect_vtysh_lines(run_cmd), _collect_vtysh_lines(run_cmd)
 
 
 @patch.dict('sys.modules', **mockmapping)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -315,7 +315,6 @@ def test_bgp_neighbor_description_injection(run_cmd):
 #   * route-map 'on-match next' (continue-flow) clause
 #   * zebra route-map 'set src' clause
 #   * zebra RM_SET_SRC / RM_SET_SRC6 route-maps from Loopback0 (ZebraSetSrc parity)
-#   * BGP-sentinel base-policy route-maps / community-list
 #   * listen-range peer-group attribute drop on delete + re-create
 # ---------------------------------------------------------------------------
 
@@ -407,45 +406,6 @@ def test_zebra_set_src_from_loopback(run_cmd):
     lo_hdlr('LOOPBACK_INTERFACE', 'Loopback1|20.1.0.1/32', {})
     lo_hdlr('LOOPBACK_INTERFACE', 'Loopback0', {})
     assert not run_cmd.called, run_cmd.call_args_list
-
-
-@patch.dict('sys.modules', **mockmapping)
-@patch('frrcfgd.frrcfgd.g_run_command')
-def test_bgp_sentinel_base_policy_no_community(run_cmd):
-    """With no constants.yml community available, only the fixed base route-maps render."""
-    daemon = _make_daemon()
-    with patch.object(type(daemon), '_BGPConfigDaemon__get_sentinel_community', return_value=None):
-        _handler(daemon, 'BGP_SENTINELS')('BGP_SENTINELS', 'sentinel1',
-                                          {'name': 'BGPSentinel', 'src_address': '10.1.0.32'})
-    lines = _collect_vtysh_lines(run_cmd)
-    assert 'route-map FROM_BGP_SENTINEL deny 200' in lines, lines
-    assert 'route-map TO_BGP_SENTINEL permit 100' in lines, lines
-    assert not any('community-list' in line for line in lines), lines
-
-
-@patch.dict('sys.modules', **mockmapping)
-@patch('frrcfgd.frrcfgd.g_run_command')
-def test_bgp_sentinel_base_policy_with_community(run_cmd):
-    daemon = _make_daemon()
-    with patch.object(type(daemon), '_BGPConfigDaemon__get_sentinel_community',
-                      return_value='12345:12346'):
-        sent_hdlr = _handler(daemon, 'BGP_SENTINELS')
-        sent_hdlr('BGP_SENTINELS', 'sentinel1', {'name': 'BGPSentinel', 'src_address': '10.1.0.32'})
-        first = _collect_vtysh_lines(run_cmd)
-        assert 'bgp community-list standard sentinel_community permit 12345:12346 no-export' in first, first
-        assert 'route-map FROM_BGP_SENTINEL permit 100' in first, first
-        assert 'match community sentinel_community' in first, first
-        # a second sentinel must NOT re-render the (idempotent) base policy
-        run_cmd.reset_mock()
-        sent_hdlr('BGP_SENTINELS', 'sentinel2', {'name': 'BGPSentinel', 'src_address': '10.1.0.33'})
-        assert not run_cmd.called, run_cmd.call_args_list
-        # removing the last sentinel tears the base policy down
-        sent_hdlr('BGP_SENTINELS', 'sentinel1', None)
-        run_cmd.reset_mock()
-        sent_hdlr('BGP_SENTINELS', 'sentinel2', None)
-        del_lines = _collect_vtysh_lines(run_cmd)
-        assert 'no route-map FROM_BGP_SENTINEL' in del_lines, del_lines
-        assert 'no route-map TO_BGP_SENTINEL' in del_lines, del_lines
 
 
 @patch.dict('sys.modules', **mockmapping)

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -460,3 +460,81 @@ def test_peer_group_rerender_after_delete(run_cmd):
     pg_hdlr('BGP_PEER_GROUP', 'default|PG1', dict(pg_data))
     assert 'neighbor PG1 update-source 1.1.1.1' in _collect_vtysh_lines(run_cmd), \
         'update-source dropped on peer-group re-create (cache not evicted on delete)'
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_device_metadata_zebra_knobs(run_cmd):
+    """The device-wide zebra knobs bgpcfgd renders must apply at runtime, not only via the
+    boot-time template render -- a CONFIG_DB write should reach FRR without a config reload.
+
+    Each is opt-in: absent emits nothing and leaves FRR's own default (180s retention for
+    nexthop groups), so upgrading changes no existing installation. See
+    sonic-buildimage#28482."""
+    daemon = _make_daemon()
+    md_hdlr = _handler(daemon, 'DEVICE_METADATA')
+
+    # Nothing set -> frrcfgd must not touch either knob.
+    md_hdlr('DEVICE_METADATA', 'localhost', {'bgp_asn': '100'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert not any('nexthop-group keep' in line for line in lines), lines
+    assert not any('nexthop kernel' in line for line in lines), lines
+
+    # nexthop_group_keep_time -> 'zebra nexthop-group keep <N>'
+    run_cmd.reset_mock()
+    md_hdlr('DEVICE_METADATA', 'localhost',
+            {'bgp_asn': '100', 'nexthop_group_keep_time': '1'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert any(line.strip() == 'zebra nexthop-group keep 1' for line in lines), lines
+
+    # zebra_nexthop enabled/disabled -> the enable line and its 'no' form
+    run_cmd.reset_mock()
+    md_hdlr('DEVICE_METADATA', 'localhost',
+            {'bgp_asn': '100', 'zebra_nexthop': 'enabled'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert any(line.strip() == 'zebra nexthop kernel enable' for line in lines), lines
+
+    run_cmd.reset_mock()
+    md_hdlr('DEVICE_METADATA', 'localhost',
+            {'bgp_asn': '100', 'zebra_nexthop': 'disabled'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert any(line.strip() == 'no zebra nexthop kernel enable' for line in lines), lines
+
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_device_metadata_suppress_fib_pending(run_cmd):
+    """suppress-fib-pending is a 'router bgp <asn>' sub-command, so it is emitted with an
+    explicit router-bgp prefix rather than through device_metadata_key_map (which has no ASN
+    context and would emit at top level, where FRR rejects it).
+
+    DEVICE_METADATA stays the single source of truth: it is what `config
+    suppress-fib-pending` writes and what route_check.py reads."""
+    daemon = _make_daemon()
+    md_hdlr = _handler(daemon, 'DEVICE_METADATA')
+
+    # Absent -> nothing emitted.
+    md_hdlr('DEVICE_METADATA', 'localhost', {'bgp_asn': '100'})
+    assert not any('suppress-fib-pending' in line for line in _collect_vtysh_lines(run_cmd))
+
+    # enabled -> the line, framed inside 'router bgp <asn>'
+    run_cmd.reset_mock()
+    md_hdlr('DEVICE_METADATA', 'localhost',
+            {'bgp_asn': '100', 'suppress-fib-pending': 'enabled'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert 'router bgp 100' in lines, lines
+    assert any(line.strip() == 'bgp suppress-fib-pending' for line in lines), lines
+
+    # disabled -> the 'no' form
+    run_cmd.reset_mock()
+    md_hdlr('DEVICE_METADATA', 'localhost',
+            {'bgp_asn': '100', 'suppress-fib-pending': 'disabled'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert any(line.strip() == 'no bgp suppress-fib-pending' for line in lines), lines
+
+    # No ASN known yet -> defer rather than emit a malformed 'router bgp None'.
+    run_cmd.reset_mock()
+    daemon.metadata_asn = None
+    md_hdlr('DEVICE_METADATA', 'localhost', {'suppress-fib-pending': 'enabled'})
+    lines = _collect_vtysh_lines(run_cmd)
+    assert not any('suppress-fib-pending' in line for line in lines), lines

--- a/src/sonic-frr-mgmt-framework/tests/test_templates.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_templates.py
@@ -1,0 +1,155 @@
+"""Render tests for the startup/reload jinja2 templates.
+
+frrcfgd has two independent render paths for the same CONFIG_DB fields: the runtime
+vtysh path (tested in test_config.py) and these templates, which build /etc/frr/frr.conf
+at boot and on `config reload`. These tests pin the template side so the two cannot
+silently diverge.
+
+Includes that live outside this package (docker-fpm-frr's common/ and zebra/ templates)
+are stubbed out, as are the non-BGP daemon includes, so a render exercises only the
+templates shipped here.
+"""
+import os
+
+from jinja2 import ChoiceLoader, DictLoader, Environment, FileSystemLoader
+
+TEMPLATE_ROOT = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'templates')
+
+# Includes pulled in by frr.conf.j2 that are either shipped by docker-fpm-frr or belong to
+# another daemon; neither is under test here.
+STUBBED_INCLUDES = {
+    'common/daemons.common.conf.j2': '',
+    'zebra/zebra.interfaces.conf.j2': '',
+    'staticd.db.default_route.conf.j2': '',
+    'staticd.db.conf.j2': '',
+    'ospfd.conf.j2': '',
+    'bfdd.conf.j2': '',
+}
+
+
+def render(template, **params):
+    loader = ChoiceLoader([
+        DictLoader(STUBBED_INCLUDES),
+        FileSystemLoader([os.path.join(TEMPLATE_ROOT, sub)
+                          for sub in ('bgpd', 'frr', 'staticd', 'ospfd', 'bfdd')]),
+    ])
+    env = Environment(loader=loader, trim_blocks=True)
+    return env.get_template(template).render(**params)
+
+
+def lines(rendered):
+    return [line.strip() for line in rendered.splitlines() if line.strip() not in ('', '!')]
+
+
+# ---------------------------------------------------------------- ebgp-requires-policy
+
+def bgp_globals(**attrs):
+    attrs.setdefault('local_asn', '65100')
+    return {'BGP_GLOBALS': {'default': attrs}}
+
+
+def test_ebgp_requires_policy_false():
+    out = lines(render('bgpd.conf.db.j2', **bgp_globals(ebgp_requires_policy='false')))
+    assert 'no bgp ebgp-requires-policy' in out
+    assert 'bgp ebgp-requires-policy' not in out
+
+
+def test_ebgp_requires_policy_true():
+    out = lines(render('bgpd.conf.db.j2', **bgp_globals(ebgp_requires_policy='true')))
+    assert 'bgp ebgp-requires-policy' in out
+    assert 'no bgp ebgp-requires-policy' not in out
+
+
+def test_ebgp_requires_policy_absent():
+    # No field: leave FRR's built-in default alone, emit nothing either way.
+    out = lines(render('bgpd.conf.db.j2', **bgp_globals()))
+    assert not any('ebgp-requires-policy' in line for line in out)
+
+
+# --------------------------------------------------------------------- route-map on-match
+
+def route_map(stmt, **attrs):
+    attrs.setdefault('route_operation', 'permit')
+    return {'ROUTE_MAP': {('TEST_RM', stmt): attrs}}
+
+
+def test_route_map_on_match_next():
+    out = lines(render('bgpd.conf.db.route_map.j2',
+                       **route_map('10', set_on_match_action='ON_MATCH_NEXT')))
+    assert 'route-map TEST_RM permit 10' in out
+    assert 'on-match next' in out
+
+
+def test_route_map_on_match_goto():
+    out = lines(render('bgpd.conf.db.route_map.j2',
+                       **route_map('10', set_on_match_action='ON_MATCH_GOTO',
+                                   set_on_match_goto='20')))
+    assert 'on-match goto 20' in out
+
+
+def test_route_map_on_match_goto_without_target():
+    # Rejected by the YANG 'must', so it cannot reach the renderer from a validated config;
+    # if it ever does, fail safe rather than emit an incomplete clause. The runtime handler
+    # (handle_rmap_on_match) drops the same input.
+    out = lines(render('bgpd.conf.db.route_map.j2',
+                       **route_map('10', set_on_match_action='ON_MATCH_GOTO')))
+    assert 'route-map TEST_RM permit 10' in out
+    assert not any(line.startswith('on-match') for line in out)
+
+
+def test_route_map_on_match_absent():
+    out = lines(render('bgpd.conf.db.route_map.j2', **route_map('10')))
+    assert not any(line.startswith('on-match') for line in out)
+
+
+# --------------------------------------------------------------------------- set src
+
+def test_route_map_set_src():
+    out = lines(render('bgpd.conf.db.route_map.j2',
+                       **route_map('10', set_src='10.1.0.32')))
+    assert 'set src 10.1.0.32' in out
+
+
+def test_route_map_set_src_v6():
+    out = lines(render('bgpd.conf.db.route_map.j2',
+                       **route_map('10', set_src='fc00:1::32')))
+    assert 'set src fc00:1::32' in out
+
+
+# ----------------------------------------------------------------- PROTOCOL_ROUTE_MAP bind
+
+def frr_conf(**params):
+    params.setdefault('DEVICE_METADATA', {})
+    return lines(render('frr.conf.j2', **params))
+
+
+def test_protocol_route_map_binds():
+    out = frr_conf(PROTOCOL_ROUTE_MAP={
+        ('ipv4', 'bgp'): {'route_map': 'RM_SET_SRC'},
+        ('ipv6', 'bgp'): {'route_map': 'RM_SET_SRC6'},
+        ('ipv4', 'static'): {'route_map': 'RM_SET_SRC'},
+    })
+    assert 'ip protocol bgp route-map RM_SET_SRC' in out
+    assert 'ipv6 protocol bgp route-map RM_SET_SRC6' in out
+    assert 'ip protocol static route-map RM_SET_SRC' in out
+
+
+def test_protocol_route_map_absent():
+    out = frr_conf()
+    assert not any('protocol' in line and 'route-map' in line for line in out)
+
+
+def test_protocol_route_map_row_without_route_map():
+    out = frr_conf(PROTOCOL_ROUTE_MAP={('ipv4', 'bgp'): {}})
+    assert not any('protocol' in line and 'route-map' in line for line in out)
+
+
+def test_set_src_route_map_renders_with_its_bind():
+    # The RM_SET_SRC loopback-source setup end to end: a ROUTE_MAP carrying 'set src' plus
+    # the PROTOCOL_ROUTE_MAP row that binds it, both out of a single frr.conf render.
+    out = frr_conf(ROUTE_MAP={('RM_SET_SRC', '10'): {'route_operation': 'permit',
+                                                     'set_src': '10.1.0.32'}},
+                   PROTOCOL_ROUTE_MAP={('ipv4', 'bgp'): {'route_map': 'RM_SET_SRC'}})
+    assert 'route-map RM_SET_SRC permit 10' in out
+    assert 'set src 10.1.0.32' in out
+    assert 'ip protocol bgp route-map RM_SET_SRC' in out

--- a/src/sonic-frr-mgmt-framework/tests/test_templates.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_templates.py
@@ -153,3 +153,57 @@ def test_set_src_route_map_renders_with_its_bind():
     assert 'route-map RM_SET_SRC permit 10' in out
     assert 'set src 10.1.0.32' in out
     assert 'ip protocol bgp route-map RM_SET_SRC' in out
+
+
+# --------------------------------------------------------- device-wide routing knobs
+#
+# bgpcfgd renders these from its own zebra/bgpd templates. frrcfgd rendered none of them,
+# so a frrcfgd DUT silently diverged -- most sharply on nexthop-group retention, where
+# losing the line reverts zebra to FRR's 180s default. Each knob is opt-in: absent means
+# nothing is emitted and FRR's own default stands, so upgrading changes no installation.
+
+def device_metadata(**attrs):
+    return {'DEVICE_METADATA': {'localhost': attrs}}
+
+
+def test_nexthop_group_keep_time_rendered():
+    out = frr_conf(**device_metadata(nexthop_group_keep_time='1'))
+    assert 'zebra nexthop-group keep 1' in out
+
+
+def test_nexthop_group_keep_time_absent_emits_nothing():
+    # Absent => FRR's default (180s) applies; emitting anything here would change behaviour
+    # for every existing installation on upgrade.
+    out = frr_conf(**device_metadata())
+    assert not any('nexthop-group keep' in line for line in out)
+
+
+def test_zebra_nexthop_kernel_enable_rendered():
+    out = frr_conf(**device_metadata(zebra_nexthop='enabled'))
+    assert 'zebra nexthop kernel enable' in out
+
+
+def test_zebra_nexthop_kernel_disabled_emits_nothing():
+    out = frr_conf(**device_metadata(zebra_nexthop='disabled'))
+    assert not any('nexthop kernel' in line for line in out)
+
+
+def test_suppress_fib_pending_enabled():
+    out = lines(render('bgpd.conf.db.j2',
+                       BGP_GLOBALS={'default': {'local_asn': '65100'}},
+                       **device_metadata(**{'suppress-fib-pending': 'enabled'})))
+    assert 'bgp suppress-fib-pending' in out
+    assert 'no bgp suppress-fib-pending' not in out
+
+
+def test_suppress_fib_pending_disabled():
+    out = lines(render('bgpd.conf.db.j2',
+                       BGP_GLOBALS={'default': {'local_asn': '65100'}},
+                       **device_metadata(**{'suppress-fib-pending': 'disabled'})))
+    assert 'no bgp suppress-fib-pending' in out
+
+
+def test_suppress_fib_pending_absent_emits_nothing():
+    out = lines(render('bgpd.conf.db.j2', BGP_GLOBALS={'default': {'local_asn': '65100'}},
+                       **device_metadata()))
+    assert not any('suppress-fib-pending' in line for line in out)

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -9,6 +9,9 @@
   * [Incremental Configuration](#incremental-configuration)
 * [<strong>Redis and Json Schema</strong>](#redis-and-json-schema)
   * [ACL and Mirroring](#acl-and-mirroring)
+  * [BGP Globals (frr_mgmt_framework)](#bgp-globals-frr_mgmt_framework)
+  * [Route Map (frr_mgmt_framework)](#route-map-frr_mgmt_framework)
+  * [Protocol Route Map (frr_mgmt_framework)](#protocol-route-map-frr_mgmt_framework)
   * [BGP BBR](#bgp-bbr)
   * [ASIC SDK health event](#asic-sdk-health-event)
   * [BGP Device Global](#bgp-device-global)
@@ -422,6 +425,74 @@ and migration plan
             "PRIORITY": "999",
             "SRC_IP": "1.1.1.1/32",
             "PACKET_ACTION": "DISABLE_TRIM"
+        }
+    }
+}
+```
+
+### BGP Globals (frr_mgmt_framework)
+
+The **BGP_GLOBALS** table holds per-VRF BGP instance configuration in `frr_mgmt_framework`
+(FRR "unified") mode. The **ebgp_requires_policy** field controls whether an eBGP session
+requires an inbound/outbound policy before routes are accepted or advertised. It defaults to
+true (FRR's built-in default); set it to false to allow eBGP routes without a configured policy.
+
+```
+{
+    "BGP_GLOBALS": {
+        "default": {
+            "local_asn": "65100",
+            "ebgp_requires_policy": "false"
+        }
+    }
+}
+```
+
+### Route Map (frr_mgmt_framework)
+
+The **ROUTE_MAP** table defines route-map entries (keyed by `name|stmt_name`) in
+`frr_mgmt_framework` mode. In addition to the match/set clauses, the following fields are
+supported:
+
+- **set_src** — source IP address (IPv4 or IPv6) to set on matched routes when they are
+  installed into the forwarding table (route-map `set src`).
+- **set_on_match_action** — route-map continue-flow action after a match: `ON_MATCH_NEXT`
+  (fall through to the next entry) or `ON_MATCH_GOTO` (jump to **set_on_match_goto**).
+- **set_on_match_goto** — target entry sequence number for `ON_MATCH_GOTO` (uint16, 1..65535).
+
+```
+{
+    "ROUTE_MAP": {
+        "RM_SET_SRC|10": {
+            "route_operation": "permit",
+            "set_src": "10.1.0.32"
+        },
+        "FROM_BGP_PEER_V4|10": {
+            "route_operation": "permit",
+            "call_route_map": "ALLOW_LIST_DEPLOYMENT_ID_0_V4",
+            "set_on_match_action": "ON_MATCH_NEXT"
+        }
+    }
+}
+```
+
+### Protocol Route Map (frr_mgmt_framework)
+
+The **PROTOCOL_ROUTE_MAP** table applies a route-map to the routes a routing protocol installs
+into the forwarding table, per address family (zebra `ip[v6] protocol <proto> route-map <name>`).
+The key is `address_family|protocol` (address_family: `ipv4`/`ipv6`; protocol: `bgp`, `ospf`,
+`static`, `connected`, `kernel`), and **route_map** names the route-map to apply. For example,
+binding a route-map that has a `set src` clause to protocol `bgp` sources BGP-installed routes
+from a chosen local address.
+
+```
+{
+    "PROTOCOL_ROUTE_MAP": {
+        "ipv4|bgp": {
+            "route_map": "RM_SET_SRC"
+        },
+        "ipv6|bgp": {
+            "route_map": "RM_SET_SRC6"
         }
     }
 }

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -448,6 +448,41 @@ true (FRR's built-in default); set it to false to allow eBGP routes without a co
 }
 ```
 
+### Device-wide routing knobs (frr_mgmt_framework)
+
+Three `DEVICE_METADATA|localhost` fields are consumed by `frr_mgmt_framework` to reproduce
+settings the bgpcfgd path renders from its own templates. All three are optional and
+opt-in: when a field is absent nothing is emitted and the routing stack's own default
+applies, so an upgrade changes no existing installation.
+
+| Field | Effect | When unset |
+|---|---|---|
+| **nexthop_group_keep_time** | Seconds (1-3600) to retain an unused nexthop group before deleting it. | Routing stack default (180 seconds) |
+| **zebra_nexthop** | `enabled` programs nexthop groups into the kernel. | Routing stack default |
+| **suppress-fib-pending** | `enabled` makes BGP wait for FIB installation before announcing routes. | Routing stack default |
+
+**nexthop_group_keep_time** is only supported when `frr_mgmt_framework_config` is true; on
+the bgpcfgd path the value is fixed by that module's own template. The other two fields are
+shared with the bgpcfgd path — **suppress-fib-pending** is also what `config
+suppress-fib-pending` writes and what `route_check.py` reads, so it stays the single source
+of truth regardless of which daemon renders the routing config.
+
+Each field applies both at boot (template render) and at runtime, so a CONFIG_DB write takes
+effect without a `config reload`.
+
+```
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "frr_mgmt_framework_config": "true",
+            "nexthop_group_keep_time": "1",
+            "zebra_nexthop": "enabled",
+            "suppress-fib-pending": "enabled"
+        }
+    }
+}
+```
+
 ### Route Map (frr_mgmt_framework)
 
 The **ROUTE_MAP** table defines route-map entries (keyed by `name|stmt_name`) in

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -73,7 +73,7 @@
     },
     "ROUTE_MAP_ON_MATCH_GOTO_MISSING_TARGET": {
         "desc": "Configure route map table with set_on_match_action ON_MATCH_GOTO but no set_on_match_goto target.",
-        "eStrKey": "Must"
+        "eStr": ["set_on_match_goto must be set"]
     },
     "PROTOCOL_ROUTE_MAP_VALID": {
         "desc": "Bind a route-map to a protocol's installed routes per address family."

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -75,6 +75,10 @@
         "desc": "Configure route map table with set_on_match_action ON_MATCH_GOTO but no set_on_match_goto target.",
         "eStr": ["set_on_match_goto must be set"]
     },
+    "ROUTE_MAP_ON_MATCH_GOTO_BACKWARD_TARGET": {
+        "desc": "Configure route map table with a set_on_match_goto target not greater than stmt_name.",
+        "eStr": ["set_on_match_goto must be greater than"]
+    },
     "PROTOCOL_ROUTE_MAP_VALID": {
         "desc": "Bind a route-map to a protocol's installed routes per address family."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -75,6 +75,14 @@
         "desc": "Configure route map table with set_on_match_action ON_MATCH_GOTO but no set_on_match_goto target.",
         "eStrKey": "Must"
     },
+    "PROTOCOL_ROUTE_MAP_VALID": {
+        "desc": "Bind a route-map to a protocol's installed routes per address family."
+    },
+    "PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL": {
+        "desc": "Protocol route-map with an unsupported protocol enum.",
+        "eStrKey": "InvalidValue",
+        "eStr": ["protocol"]
+    },
     "ROUTE_PREFIX_VALID": {
         "desc": "Configure prefix table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -71,6 +71,10 @@
         "desc": "Configure route map table with non-existent set extended community set name.",
         "eStrKey": "LeafRef"
     },
+    "ROUTE_MAP_ON_MATCH_GOTO_MISSING_TARGET": {
+        "desc": "Configure route map table with set_on_match_action ON_MATCH_GOTO but no set_on_match_goto target.",
+        "eStrKey": "Must"
+    },
     "ROUTE_PREFIX_VALID": {
         "desc": "Configure prefix table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -181,7 +181,8 @@
                     "set_metric": 50,
                     "set_next_hop": "10.10.10.10",
                     "set_src": "10.10.10.10",
-                    "set_on_match_next": true,
+                    "set_on_match_action": "ON_MATCH_GOTO",
+                    "set_on_match_goto": 20,
                     "set_ipv6_next_hop_global": "1000::1",
                     "set_ipv6_next_hop_prefer_global": true,
                     "set_repeat_asn": 5,
@@ -383,6 +384,20 @@
                     "name": "map14",
                     "stmt_name": 14,
                     "set_ext_community_ref": "null"
+                }
+                ]
+            }
+        }
+    },
+    "ROUTE_MAP_ON_MATCH_GOTO_MISSING_TARGET": {
+        "sonic-route-map:sonic-route-map":{
+            "sonic-route-map:ROUTE_MAP": {
+                "ROUTE_MAP_LIST": [
+                {
+                    "name": "map15",
+                    "stmt_name": 15,
+                    "route_operation": "permit",
+                    "set_on_match_action": "ON_MATCH_GOTO"
                 }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -403,6 +403,21 @@
             }
         }
     },
+    "ROUTE_MAP_ON_MATCH_GOTO_BACKWARD_TARGET": {
+        "sonic-route-map:sonic-route-map":{
+            "sonic-route-map:ROUTE_MAP": {
+                "ROUTE_MAP_LIST": [
+                {
+                    "name": "map16",
+                    "stmt_name": 20,
+                    "route_operation": "permit",
+                    "set_on_match_action": "ON_MATCH_GOTO",
+                    "set_on_match_goto": 10
+                }
+                ]
+            }
+        }
+    },
     "PROTOCOL_ROUTE_MAP_VALID": {
         "sonic-route-map:sonic-route-map":{
             "sonic-route-map:PROTOCOL_ROUTE_MAP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -403,6 +403,32 @@
             }
         }
     },
+    "PROTOCOL_ROUTE_MAP_VALID": {
+        "sonic-route-map:sonic-route-map":{
+            "sonic-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                {
+                    "address_family": "ipv4",
+                    "protocol": "bgp",
+                    "route_map": "RM_SET_SRC"
+                }
+                ]
+            }
+        }
+    },
+    "PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL": {
+        "sonic-route-map:sonic-route-map":{
+            "sonic-route-map:PROTOCOL_ROUTE_MAP": {
+                "PROTOCOL_ROUTE_MAP_LIST": [
+                {
+                    "address_family": "ipv4",
+                    "protocol": "bogus",
+                    "route_map": "RM_SET_SRC"
+                }
+                ]
+            }
+        }
+    },
     "ROUTE_PREFIX_VALID": {
         "sonic-routing-policy-sets:sonic-routing-policy-sets":{
             "sonic-routing-policy-sets:PREFIX_SET": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -180,6 +180,8 @@
                     "set_metric_action": "METRIC_SET_VALUE",
                     "set_metric": 50,
                     "set_next_hop": "10.10.10.10",
+                    "set_src": "10.10.10.10",
+                    "set_on_match_next": true,
                     "set_ipv6_next_hop_global": "1000::1",
                     "set_ipv6_next_hop_prefer_global": true,
                     "set_repeat_asn": 5,

--- a/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-global.yang
@@ -137,6 +137,16 @@ module sonic-bgp-global {
                     description "Check BGP network route exists in IGP";
                 }
 
+                leaf ebgp_requires_policy {
+                    type boolean;
+                    default "true";
+                    description
+                        "Whether an eBGP session requires an inbound/outbound policy
+                         (route-map, prefix-list, or filter-list) before routes are
+                         accepted or advertised. Defaults to true; set false to allow
+                         eBGP routes without a configured policy.";
+                }
+
                 leaf graceful_shutdown {
                     type boolean;
                     description "Enable graceful shutdown";

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -331,6 +331,25 @@ module sonic-device_metadata {
                     default disabled;
                 }
 
+                leaf nexthop_group_keep_time {
+                    description
+                        "Seconds to retain an unused nexthop group before deleting it. When
+                         unset, the routing stack default (180 seconds) applies, so leaving
+                         this out preserves existing behaviour.
+
+                         Only takes effect when frr_mgmt_framework_config is true: it is
+                         consumed by sonic-frr-mgmt-framework. With the bgpcfgd path the
+                         value is fixed by that module's own zebra template and this leaf is
+                         ignored.";
+                    type uint16 {
+                        range "1..3600";
+                    }
+
+                    must "../frr_mgmt_framework_config = 'true'" {
+                        error-message "nexthop_group_keep_time is only supported when frr_mgmt_framework_config is true";
+                    }
+                }
+
                 leaf ring_thread_enabled {
                     type boolean;
                     description "Enable gRingMode of OrchDaemon, which would set up its ring thread to accelerate task execution.";

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -308,6 +308,14 @@ module sonic-route-map {
                     description "Set IP nexthop";
                 }
 
+                leaf set_src {
+                    type inet:ip-address;
+                    description
+                        "Set the source IP address (IPv4 or IPv6) used by zebra when
+                         installing matched routes into the kernel (route-map 'set src').
+                         The address must be locally configured on the device.";
+                }
+
                 leaf set_ipv6_next_hop_global {
                     type string;
                     description "Set IPv6 global next hop";
@@ -316,6 +324,15 @@ module sonic-route-map {
                 leaf set_ipv6_next_hop_prefer_global {
                     type boolean;
                     description "Set to prefer IPv6 nexthop global address";
+                }
+
+                leaf set_on_match_next {
+                    type boolean;
+                    description
+                        "When true, continue route-map processing at the next entry after a
+                         match in this entry ('on-match next' / continue-flow), instead of
+                         terminating the route-map. Used by the allow-list framework's
+                         re-advertise chain.";
                 }
 
                 leaf set_repeat_asn{

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -329,9 +329,9 @@ module sonic-route-map {
                 leaf set_src {
                     type inet:ip-address;
                     description
-                        "Set the source IP address (IPv4 or IPv6) used by zebra when
-                         installing matched routes into the kernel (route-map 'set src').
-                         The address must be locally configured on the device.";
+                        "Set the source IP address (IPv4 or IPv6) for matched routes when
+                         they are installed into the forwarding table. The address must be
+                         locally configured on the device.";
                 }
 
                 leaf set_ipv6_next_hop_global {
@@ -413,6 +413,47 @@ module sonic-route-map {
                     type uint32;
                     description
                         "Value of the tag set member";
+                }
+            }
+        }
+
+        container PROTOCOL_ROUTE_MAP {
+            description
+                "Applies a route-map to the routes a routing protocol installs into the
+                 forwarding table, per address family (zebra 'ip[v6] protocol <proto>
+                 route-map <name>'). For example, a route-map with a 'set src' clause bound
+                 to protocol 'bgp' sources BGP-installed routes from a specific local address.";
+
+            list PROTOCOL_ROUTE_MAP_LIST {
+                key "address_family protocol";
+
+                leaf address_family {
+                    type enumeration {
+                        enum ipv4 {
+                            description "IPv4 routes.";
+                        }
+                        enum ipv6 {
+                            description "IPv6 routes.";
+                        }
+                    }
+                    description "Address family whose installed routes the route-map applies to.";
+                }
+
+                leaf protocol {
+                    type enumeration {
+                        enum bgp { description "BGP-learned routes."; }
+                        enum ospf { description "OSPF routes."; }
+                        enum static { description "Static routes."; }
+                        enum connected { description "Connected (directly attached) routes."; }
+                        enum kernel { description "Kernel routes."; }
+                    }
+                    description "Routing protocol whose installed routes the route-map applies to.";
+                }
+
+                leaf route_map {
+                    type string;
+                    mandatory true;
+                    description "Name of the route-map to apply to this protocol's installed routes.";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -121,6 +121,24 @@ module sonic-route-map {
             to be set in a policy chain.";
     }
 
+    typedef on-match-action-type {
+        type enumeration {
+            enum ON_MATCH_NEXT {
+                description
+                    "On a match in this route-map entry, continue processing at
+                    the next entry ('on-match next').";
+            }
+            enum ON_MATCH_GOTO {
+                description
+                    "On a match in this route-map entry, continue processing at
+                    the entry whose sequence number is given by set_on_match_goto
+                    ('on-match goto <seq>').";
+            }
+        }
+        description
+            "Type used to specify the route-map 'on-match' continue-flow action.";
+    }
+
     container sonic-route-map {
         container ROUTE_MAP_SET {
             list ROUTE_MAP_SET_LIST {
@@ -326,13 +344,28 @@ module sonic-route-map {
                     description "Set to prefer IPv6 nexthop global address";
                 }
 
-                leaf set_on_match_next {
-                    type boolean;
+                leaf set_on_match_action {
+                    type on-match-action-type;
+                    must "current() != 'ON_MATCH_GOTO' or ../set_on_match_goto" {
+                        error-message
+                            "set_on_match_goto must be set when set_on_match_action is ON_MATCH_GOTO";
+                    }
                     description
-                        "When true, continue route-map processing at the next entry after a
-                         match in this entry ('on-match next' / continue-flow), instead of
-                         terminating the route-map. Used by the allow-list framework's
-                         re-advertise chain.";
+                        "Route-map 'on-match' continue-flow action taken after a match in this
+                         entry: ON_MATCH_NEXT falls through to the next entry, ON_MATCH_GOTO
+                         jumps to the entry given by set_on_match_goto. Used by the allow-list
+                         framework's re-advertise chain.";
+                }
+
+                leaf set_on_match_goto {
+                    when "../set_on_match_action = 'ON_MATCH_GOTO'";
+                    type uint16 {
+                        range "1..65535";
+                    }
+                    description
+                        "Target entry sequence number for 'on-match goto'. Applicable only when
+                         set_on_match_action is ON_MATCH_GOTO, and must be greater than this
+                         entry's stmt_name.";
                 }
 
                 leaf set_repeat_asn{

--- a/src/sonic-yang-models/yang-models/sonic-route-map.yang
+++ b/src/sonic-yang-models/yang-models/sonic-route-map.yang
@@ -362,10 +362,14 @@ module sonic-route-map {
                     type uint16 {
                         range "1..65535";
                     }
+                    must "current() > ../stmt_name" {
+                        error-message
+                            "set_on_match_goto must be greater than the entry's stmt_name";
+                    }
                     description
                         "Target entry sequence number for 'on-match goto'. Applicable only when
                          set_on_match_action is ON_MATCH_GOTO, and must be greater than this
-                         entry's stmt_name.";
+                         entry's stmt_name (FRR only allows a forward jump).";
                 }
 
                 leaf set_repeat_asn{


### PR DESCRIPTION
#### Why I did it

Closes #28482 — frrcfgd (the `frr_mgmt_framework` / FRR "unified" config daemon) does not render several BGP behaviors that the traditional bgpcfgd path renders, so a DUT running frrcfgd diverges from a bgpcfgd DUT. This PR closes the tracked parity gaps:

1. **`ebgp-requires-policy`** — frrcfgd had no way to express it, so FRR's default (policy required) discarded eBGP routes on address-families with no inbound route-map. Now a field (`BGP_GLOBALS.ebgp_requires_policy`); the migrator sets it to reproduce the traditional `no bgp ebgp-requires-policy` behavior (not a frrcfgd default).
2. **route-map `on-match next`** (continue-flow) — no equivalent existed, breaking the allow-list re-advertise chain.
3. **zebra `set src`** — no route-map `set src` clause, and no way to bind a route-map to a protocol's FIB installation (`ip[v6] protocol <proto> route-map`), so the loopback-source setup (`RM_SET_SRC`/`RM_SET_SRC6`) couldn't be expressed.
4. **Listen-range peer-group under-render** — after a runtime peer-group delete + re-create (e.g. an SLB/Vac listen-range reconfiguration), previously-set attributes such as `update-source` were silently dropped from the FRR render even though CONFIG_DB still carried them.

5. **Device-wide routing knobs** — three settings the bgpcfgd path renders from its own zebra/bgpd templates that frrcfgd rendered nowhere, so a frrcfgd DUT silently diverged. Found while validating this PR's sonic-mgmt counterpart on hardware (t0, NH-4010, FRR 10.5.4):
   * `zebra nexthop-group keep <N>` — bgpcfgd renders this unconditionally. Without it zebra falls back to FRR's 180s nexthop-group retention (`ZEBRA_DEFAULT_NHG_KEEP_TIMER`), which surfaces later as unstable nexthop-group/CRM counts rather than as an obvious config difference. New field `DEVICE_METADATA.nexthop_group_keep_time` (uint16, 1..3600, matching FRR's own range in `zebra_vty.c`).
   * `zebra nexthop kernel enable` — `DEVICE_METADATA.zebra_nexthop` already existed and drove this for bgpcfgd; frrcfgd ignored it. No new field.
   * `bgp suppress-fib-pending` — `DEVICE_METADATA.suppress-fib-pending` is already modelled, is what `config suppress-fib-pending` writes and what `route_check.py` reads; frrcfgd neither read it nor emitted the line. No new field.

   All three are **opt-in**: an absent field emits nothing and leaves FRR's default in place, so upgrading changes no existing installation — the same contract as `ebgp_requires_policy` above. Each applies both at boot (template render) and at runtime via `device_metadata_key_map`, so a CONFIG_DB write takes effect without a `config reload`. `nexthop_group_keep_time` carries a YANG `must` limiting it to `frr_mgmt_framework_config = true`, since bgpcfgd fixes the value in its own template.

**Explicitly out of scope — BGP sentinels (`BGP_SENTINELS`) is bgpcfgd-only by design** and is *not* implemented here. It is an opinionated bgpcfgd macro (it expands to a listen-range peer-group + fixed `FROM_/TO_BGP_SENTINEL` route-maps + a `sentinel_community` community-list from `constants.yml`), not a routing primitive — everything it produces is already expressible via the generic CONFIG_DB tables frrcfgd renders (`BGP_PEER_GROUP`, `BGP_GLOBALS_LISTEN_PREFIX`, `BGP_PEER_GROUP_AF`, `ROUTE_MAP`, `COMMUNITY_SET`). Teaching frrcfgd a bespoke sentinel expander conflicts with its "render only generic primitives" design, so sentinels stay bgpcfgd-only (same treatment as bgpmon), and the corresponding sonic-mgmt test is skipped for frrcfgd.

> Note: this is the daemon-side implementation of the four gaps. Behavioral validation on hardware/KVM is done by the sonic-mgmt dual-mode BGP suite — **sonic-net/sonic-mgmt#26461** — whose frr-variant skips are gated on this issue and auto-lift when it closes.

> **Note on `set_extcommunity_bandwidth_type` (W-ECMP):** this PR does **not** add it, and it exists in neither `sonic-route-map.yang` nor frrcfgd's `route_map_key_map` today. `BGP_DEVICE_GLOBAL` W-ECMP therefore has no frrcfgd representation at all. sonic-mgmt#26461's description previously listed it among this PR's additions; that was wrong and is corrected there. Tracked as a remaining gap on #28482.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

**frrcfgd (`src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py`):**
- **ebgp-requires-policy** — added a field-driven `global_key_map` entry: `ebgp_requires_policy` → `bgp ebgp-requires-policy` / `no bgp ebgp-requires-policy`. **Not** an unconditional frrcfgd default (that would be a surprising behavior change); the sonic-mgmt migrator sets the field (to `false`) from the running config to reproduce the traditional behavior.
- **on-match** — a `set_on_match_action` enum (`ON_MATCH_NEXT`/`ON_MATCH_GOTO`) + `set_on_match_goto` target, rendered via a `handle_rmap_on_match` handler → `on-match next` / `on-match goto <seq>`.
- **set src** — two generic primitives, no bgpcfgd-manager port: (1) a `set_src` route-map clause in `route_map_key_map`, dispatched to zebra → `set src <addr>`; (2) a new `PROTOCOL_ROUTE_MAP` table + handler for the zebra `ip[v6] protocol <proto> route-map <name>` bind. The `RM_SET_SRC` loopback-source setup is then just a normal `ROUTE_MAP` (with `set_src`) plus a `PROTOCOL_ROUTE_MAP` row, assembled by the migrator — frrcfgd does **not** watch interfaces or hardcode route-map names.
- **peer-group re-render fix** — `__cleanup_nbr_cache` now evicts the `BGP_PEER_GROUP`/`BGP_PEER_GROUP_AF` cache rows (not the `BGP_NEIGHBOR` ones) when a peer-group is deleted, so a subsequent re-create diffs against an empty cache and re-emits every attribute.

**Startup templates (the jinja2 chain that builds `/etc/frr/frr.conf` in unified mode at boot / `config reload`).** Every runtime change is mirrored here so it survives a reload:
- `templates/bgpd/bgpd.conf.db.j2` — `ebgp_requires_policy` (field-driven).
- `templates/bgpd/bgpd.conf.db.route_map.j2` — `on-match next` / `on-match goto`, and `set src`.
- `templates/frr/frr.conf.j2` — the `PROTOCOL_ROUTE_MAP` binds (`ip[v6] protocol <proto> route-map <name>`). The route-map body (incl. `set src`) renders via `bgpd.conf.db.route_map.j2`.

The peer-group re-render fix is runtime-only — the startup template always renders peer-group attributes fresh from CONFIG_DB, so it has no stale-cache failure mode.

**YANG:**
- `sonic-bgp-global.yang` — new leaf `ebgp_requires_policy` (`boolean`, `default true` matching FRR's built-in default).
- `sonic-route-map.yang` — new leaf `set_src` (`inet:ip-address`); new `on-match-action-type` enum + leaves `set_on_match_action` and `set_on_match_goto` (`uint16`, `when` action is `ON_MATCH_GOTO`; a `must` on the action requires the goto target when GOTO); new `PROTOCOL_ROUTE_MAP` table (key `address_family|protocol`, leaf `route_map`) for the zebra protocol→route-map bind.
- Each new leaf has a description. Positive coverage in `ROUTE_MAP_VALID` / `PROTOCOL_ROUTE_MAP_VALID`; negative tests `ROUTE_MAP_ON_MATCH_GOTO_MISSING_TARGET` (exercises the `must`) and `PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL`.

#### How to verify it

- **Offline unit tests** (run here, all pass): `cd src/sonic-frr-mgmt-framework && python3 -m pytest tests/` — 22 passed, including new tests for each gap. The peer-group regression test was confirmed to fail against the unpatched daemon and pass with the fix.
- **YANG**: `sonic-yang-models` model tests validate the new schema via `ROUTE_MAP_VALID` / `PROTOCOL_ROUTE_MAP_VALID` (+ negative `ROUTE_MAP_ON_MATCH_GOTO_MISSING_TARGET`, `PROTOCOL_ROUTE_MAP_INVALID_PROTOCOL`).
- **On hardware/KVM**: the sonic-mgmt dual-mode BGP suite (sonic-net/sonic-mgmt#26461, `--frr-config-mode=both`) exercises these on a live DUT; the frr-variant skips gated on #28482 auto-lift once the issue closes.

> Cannot be validated on real hardware from this change alone; behavioral correctness of the set-src rendering (ROUTE_MAP `set_src` + `PROTOCOL_ROUTE_MAP` bind) is expected to be confirmed via CI/the sonic-mgmt suite.

#### Which release branch to backport (provide reason below if selected)

None — this is a feature/parity change, not a fix to backport.

#### Tested branch

- [x] master

#### Test result

- master: offline `pytest` for `sonic-frr-mgmt-framework` — 22 passed.

#### Description for the changelog

frrcfgd: BGP parity with bgpcfgd — `ebgp-requires-policy` field, route-map `on-match next`/`goto` and zebra `set src`, and a listen-range peer-group re-render fix.

#### Link to config_db schema for YANG module changes

Documented in `src/sonic-yang-models/doc/Configuration.md` (this PR):
- [BGP Globals (frr_mgmt_framework)](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#bgp-globals-frr_mgmt_framework) — `ebgp_requires_policy`
- [Route Map (frr_mgmt_framework)](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#route-map-frr_mgmt_framework) — `set_src`, `set_on_match_action`, `set_on_match_goto`
- [Protocol Route Map (frr_mgmt_framework)](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#protocol-route-map-frr_mgmt_framework) — new table


