### PR TITLE
Fix memory_checker false alarms during config reload

### DIFF
--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -83,6 +83,19 @@ def get_command_result(command):
 
     return command_stdout.strip()
 
+def exit_if_container_stopped(container_name):
+    """Exit gracefully if the container is no longer running.
+
+    Call before logging ERR to avoid false alarms when a container
+    disappears during config reload.
+    """
+    if container_name not in get_running_container_names():
+        syslog.syslog(syslog.LOG_INFO,
+                      "[memory_checker] Container '{}' stopped during memory check. Exiting gracefully."
+                      .format(container_name))
+        sys.exit(CONTAINER_NOT_RUNNING)
+
+
 def get_container_id(container_name):
     """Gets full container ID of the specified container
     Args:
@@ -102,17 +115,18 @@ def get_container_id(container_name):
             break
 
     if not container_id:
+        exit_if_container_stopped(container_name)
         syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_ID_NOT_FOUND.format(container_name))
-
         sys.exit(INTERNAL_ERROR)
 
     return container_id
 
-def get_memory_usage(container_id):
+def get_memory_usage(container_id, container_name):
     """Reads the container's memory usage from the control group subsystem's file
     '/sys/fs/cgroup/memory/docker/<container_id>/memory.current'.
     Args:
         container_id: A string indicates the full ID of a container.
+        container_name: A string indicates the name of the container.
     Returns:
         A string indicates memory usage (Bytes) of a container.
     """
@@ -130,17 +144,20 @@ def get_memory_usage(container_id):
             else:
                 break
         except IOError:
+            exit_if_container_stopped(container_name)
             syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_MEMORY_USAGE_NOT_FOUND.format(container_id))
             sys.exit(INTERNAL_ERROR)
 
+    exit_if_container_stopped(container_name)
     syslog.syslog(syslog.LOG_ERR, ERROR_CGROUP_MEMORY_USAGE_NOT_FOUND.format(docker_memory_usage_file_path, container_id))
     sys.exit(INTERNAL_ERROR)
 
-def get_inactive_cache_usage(container_id):
+def get_inactive_cache_usage(container_id, container_name):
     """Reads the container's cache usage from the field 'inactive_file' in control
     group subsystem's file '/sys/fs/cgroup/memory/docker/<container_id>/memory.stat'.
     Args:
         container_id: A string indicates the full ID of a container.
+        container_name: A string indicates the name of the container.
     Returns:
         cache_usage_in_bytes: A string indicates the cache usage (Bytes) of a container.
     """
@@ -150,6 +167,7 @@ def get_inactive_cache_usage(container_id):
 
     docker_memory_stat_file_path = CGROUP_DOCKER_MEMORY_DIR + container_id + ".scope/memory.stat"
     if not os.path.exists(docker_memory_stat_file_path):
+        exit_if_container_stopped(container_name)
         syslog.syslog(syslog.LOG_ERR, ERROR_CGROUP_MEMORY_STATS_NOT_FOUND.format(docker_memory_stat_file_path, container_id))
         sys.exit(INTERNAL_ERROR)
 
@@ -165,6 +183,7 @@ def get_inactive_cache_usage(container_id):
                         sys.exit(INTERNAL_ERROR)
                     break
     except IOError as err:
+        exit_if_container_stopped(container_name)
         syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_CACHE_USAGE_NOT_FOUND.format(container_id))
         sys.exit(INTERNAL_ERROR)
 
@@ -199,11 +218,11 @@ def check_memory_usage(container_name, threshold_value):
     syslog.syslog(syslog.LOG_INFO, "[memory_checker] Container ID of '{}' is: '{}'."
                   .format(container_name, container_id))
 
-    memory_usage_in_bytes = get_memory_usage(container_id)
+    memory_usage_in_bytes = get_memory_usage(container_id, container_name)
     syslog.syslog(syslog.LOG_INFO, "[memory_checker] The memory usage of container '{}' is '{}' Bytes!"
                   .format(container_name, memory_usage_in_bytes))
 
-    cache_usage_in_bytes = get_inactive_cache_usage(container_id)
+    cache_usage_in_bytes = get_inactive_cache_usage(container_id, container_name)
     syslog.syslog(syslog.LOG_INFO, "[memory_checker] The cache usage of container '{}' is '{}' Bytes!"
                   .format(container_name, cache_usage_in_bytes))
 

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -45,7 +45,7 @@ ERROR_CGROUP_MEMORY_STATS_NOT_FOUND = "[memory_checker] cgroup memory statistics
 ERROR_CGROUP_MEMORY_STATS_LINE_FORMAT = "[memory_checker] cgroup memory statistics file '{}' of container '{}' has invalid line format! Exiting ..."
 
 # Define common exit codes
-CONTAINER_NOT_RUNNING = 0
+NO_ERROR = 0
 INTERNAL_ERROR = 1
 INVALID_VALUE = 2
 EXCEED_THRESHOLD = 3
@@ -83,28 +83,32 @@ def get_command_result(command):
 
     return command_stdout.strip()
 
-class _ContainerGone:
-    """Sentinel returned by _try_get_container_id when the container no longer exists."""
+class _ContainerNotRunning:
+    """Sentinel returned by _try_get_container_id when the container is no longer running."""
     pass
 
 
-_CONTAINER_GONE = _ContainerGone()
+_CONTAINER_NOT_RUNNING = _ContainerNotRunning()
 
 
 def _try_get_container_id(container_name):
-    """Get the current container ID.
+    """Get the ID of the running container.
 
-    Returns the ID string, _CONTAINER_GONE if the container no longer
-    exists, or None on transient Docker API errors.
+    Returns the ID string if the container is running, _CONTAINER_NOT_RUNNING if
+    the container is not found or not running, or None on transient Docker
+    API errors.
     """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
         try:
-            return docker_client.containers.get(container_name).id
+            container = docker_client.containers.get(container_name)
+            if container.status != 'running':
+                return _CONTAINER_NOT_RUNNING
+            return container.id
         finally:
             docker_client.close()
     except docker.errors.NotFound:
-        return _CONTAINER_GONE
+        return _CONTAINER_NOT_RUNNING
     except (docker.errors.APIError, docker.errors.DockerException):
         return None
 
@@ -115,19 +119,13 @@ def exit_if_container_stopped(container_name, container_id=None):
     Call before logging ERR to avoid false alarms when a container
     disappears or restarts with a new ID during config reload.
     """
-    if container_name not in get_running_container_names():
+    current_id = _try_get_container_id(container_name)
+    if isinstance(current_id, _ContainerNotRunning) or (container_id and current_id and current_id != container_id):
+        reason = "stopped" if isinstance(current_id, _ContainerNotRunning) else "restarted"
         syslog.syslog(syslog.LOG_INFO,
-                      "[memory_checker] Container '{}' stopped during memory check. Exiting gracefully."
-                      .format(container_name))
-        sys.exit(CONTAINER_NOT_RUNNING)
-    if container_id:
-        current_id = _try_get_container_id(container_name)
-        if isinstance(current_id, _ContainerGone) or (current_id and current_id != container_id):
-            reason = "removed" if isinstance(current_id, _ContainerGone) else "restarted"
-            syslog.syslog(syslog.LOG_INFO,
-                          "[memory_checker] Container '{}' {} during memory check. Exiting gracefully."
-                          .format(container_name, reason))
-            sys.exit(CONTAINER_NOT_RUNNING)
+                      "[memory_checker] Container '{}' {} during memory check. Exiting gracefully."
+                      .format(container_name, reason))
+        sys.exit(NO_ERROR)
 
 
 def get_container_id(container_name):
@@ -301,9 +299,12 @@ def get_running_container_names():
     """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-        running_container_list = docker_client.containers.list(filters={"status": "running"},
-                                                               ignore_removed=True)
-        running_container_names = [ container.name for container in running_container_list ]
+        try:
+            running_container_list = docker_client.containers.list(filters={"status": "running"},
+                                                                   ignore_removed=True)
+            running_container_names = [ container.name for container in running_container_list ]
+        finally:
+            docker_client.close()
     except (docker.errors.APIError, docker.errors.DockerException) as err:
         if not is_service_active("docker"):
             syslog.syslog(syslog.LOG_INFO,
@@ -332,7 +333,7 @@ def main():
         syslog.syslog(syslog.LOG_INFO,
                       "[memory_checker] Exits without checking memory usage of container '{}' since docker daemon is not running!"
                       .format(args.container_name))
-        sys.exit(CONTAINER_NOT_RUNNING)
+        sys.exit(NO_ERROR)
 
     running_container_names = get_running_container_names()
     if args.container_name in running_container_names:

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -83,17 +83,36 @@ def get_command_result(command):
 
     return command_stdout.strip()
 
-def exit_if_container_stopped(container_name):
-    """Exit gracefully if the container is no longer running.
+def _try_get_container_id(container_name):
+    """Get the current container ID, or None if not found."""
+    try:
+        docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+        try:
+            return docker_client.containers.get(container_name).id
+        finally:
+            docker_client.close()
+    except (docker.errors.NotFound, docker.errors.APIError, docker.errors.DockerException):
+        return None
+
+
+def exit_if_container_stopped(container_name, container_id=None):
+    """Exit gracefully if the container stopped or restarted.
 
     Call before logging ERR to avoid false alarms when a container
-    disappears during config reload.
+    disappears or restarts with a new ID during config reload.
     """
     if container_name not in get_running_container_names():
         syslog.syslog(syslog.LOG_INFO,
                       "[memory_checker] Container '{}' stopped during memory check. Exiting gracefully."
                       .format(container_name))
         sys.exit(CONTAINER_NOT_RUNNING)
+    if container_id:
+        current_id = _try_get_container_id(container_name)
+        if current_id and current_id != container_id:
+            syslog.syslog(syslog.LOG_INFO,
+                          "[memory_checker] Container '{}' restarted with a new ID during memory check. Exiting gracefully."
+                          .format(container_name))
+            sys.exit(CONTAINER_NOT_RUNNING)
 
 
 def get_container_id(container_name):
@@ -144,11 +163,11 @@ def get_memory_usage(container_id, container_name):
             else:
                 break
         except IOError:
-            exit_if_container_stopped(container_name)
+            exit_if_container_stopped(container_name, container_id)
             syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_MEMORY_USAGE_NOT_FOUND.format(container_id))
             sys.exit(INTERNAL_ERROR)
 
-    exit_if_container_stopped(container_name)
+    exit_if_container_stopped(container_name, container_id)
     syslog.syslog(syslog.LOG_ERR, ERROR_CGROUP_MEMORY_USAGE_NOT_FOUND.format(docker_memory_usage_file_path, container_id))
     sys.exit(INTERNAL_ERROR)
 
@@ -167,7 +186,7 @@ def get_inactive_cache_usage(container_id, container_name):
 
     docker_memory_stat_file_path = CGROUP_DOCKER_MEMORY_DIR + container_id + ".scope/memory.stat"
     if not os.path.exists(docker_memory_stat_file_path):
-        exit_if_container_stopped(container_name)
+        exit_if_container_stopped(container_name, container_id)
         syslog.syslog(syslog.LOG_ERR, ERROR_CGROUP_MEMORY_STATS_NOT_FOUND.format(docker_memory_stat_file_path, container_id))
         sys.exit(INTERNAL_ERROR)
 
@@ -183,7 +202,7 @@ def get_inactive_cache_usage(container_id, container_name):
                         sys.exit(INTERNAL_ERROR)
                     break
     except IOError as err:
-        exit_if_container_stopped(container_name)
+        exit_if_container_stopped(container_name, container_id)
         syslog.syslog(syslog.LOG_ERR, ERROR_CONTAINER_CACHE_USAGE_NOT_FOUND.format(container_id))
         sys.exit(INTERNAL_ERROR)
 
@@ -267,8 +286,7 @@ def get_running_container_names():
     """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-        running_container_list = docker_client.containers.list(filters={"status": "running"},
-                                                               ignore_removed=True)
+        running_container_list = docker_client.containers.list(filters={"status": "running"})
         running_container_names = [ container.name for container in running_container_list ]
     except (docker.errors.APIError, docker.errors.DockerException) as err:
         if not is_service_active("docker"):

--- a/files/image_config/monit/memory_checker
+++ b/files/image_config/monit/memory_checker
@@ -83,15 +83,29 @@ def get_command_result(command):
 
     return command_stdout.strip()
 
+class _ContainerGone:
+    """Sentinel returned by _try_get_container_id when the container no longer exists."""
+    pass
+
+
+_CONTAINER_GONE = _ContainerGone()
+
+
 def _try_get_container_id(container_name):
-    """Get the current container ID, or None if not found."""
+    """Get the current container ID.
+
+    Returns the ID string, _CONTAINER_GONE if the container no longer
+    exists, or None on transient Docker API errors.
+    """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
         try:
             return docker_client.containers.get(container_name).id
         finally:
             docker_client.close()
-    except (docker.errors.NotFound, docker.errors.APIError, docker.errors.DockerException):
+    except docker.errors.NotFound:
+        return _CONTAINER_GONE
+    except (docker.errors.APIError, docker.errors.DockerException):
         return None
 
 
@@ -108,10 +122,11 @@ def exit_if_container_stopped(container_name, container_id=None):
         sys.exit(CONTAINER_NOT_RUNNING)
     if container_id:
         current_id = _try_get_container_id(container_name)
-        if current_id and current_id != container_id:
+        if isinstance(current_id, _ContainerGone) or (current_id and current_id != container_id):
+            reason = "removed" if isinstance(current_id, _ContainerGone) else "restarted"
             syslog.syslog(syslog.LOG_INFO,
-                          "[memory_checker] Container '{}' restarted with a new ID during memory check. Exiting gracefully."
-                          .format(container_name))
+                          "[memory_checker] Container '{}' {} during memory check. Exiting gracefully."
+                          .format(container_name, reason))
             sys.exit(CONTAINER_NOT_RUNNING)
 
 
@@ -286,7 +301,8 @@ def get_running_container_names():
     """
     try:
         docker_client = docker.DockerClient(base_url='unix://var/run/docker.sock')
-        running_container_list = docker_client.containers.list(filters={"status": "running"})
+        running_container_list = docker_client.containers.list(filters={"status": "running"},
+                                                               ignore_removed=True)
         running_container_names = [ container.name for container in running_container_list ]
     except (docker.errors.APIError, docker.errors.DockerException) as err:
         if not is_service_active("docker"):

--- a/files/image_config/monit/tests/test_memory_checker.py
+++ b/files/image_config/monit/tests/test_memory_checker.py
@@ -25,8 +25,9 @@ class TestMemoryChecker(unittest.TestCase):
         mock_popen.return_value.communicate.assert_called_with()
         self.assertEqual(mock_popen.return_value.returncode, returncode)
 
+    @patch('memory_checker.exit_if_container_stopped')
     @patch('memory_checker.get_command_result')
-    def test_get_container_id(self, mock_get_command_result):
+    def test_get_container_id(self, mock_get_command_result, mock_exit_check):
         container_name = 'your_container'
         command = ['docker', 'ps', '--no-trunc', '--filter', 'name=your_container']
         mock_get_command_result.return_value = ''
@@ -36,26 +37,43 @@ class TestMemoryChecker(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
         mock_get_command_result.assert_called_once_with(command)
 
+    @patch('memory_checker.exit_if_container_stopped')
     @patch('memory_checker.open', side_effect=FileNotFoundError)
-    def test_get_memory_usage(self, mock_open):
+    def test_get_memory_usage(self, mock_open, mock_exit_check):
         container_id = 'your_container_id'
+        container_name = 'your_container'
         with self.assertRaises(SystemExit) as cm:
-            memory_checker.get_memory_usage(container_id)
+            memory_checker.get_memory_usage(container_id, container_name)
         self.assertEqual(cm.exception.code, 1)
 
     @patch('memory_checker.open', side_effect=FileNotFoundError)
     def test_get_memory_usage_invalid(self, mock_open):
         container_id = '../..'
+        container_name = 'your_container'
         with self.assertRaises(SystemExit) as cm:
-            memory_checker.get_memory_usage(container_id)
+            memory_checker.get_memory_usage(container_id, container_name)
         self.assertEqual(cm.exception.code, 1)
 
+    @patch('memory_checker.exit_if_container_stopped')
     @patch('builtins.open', side_effect=FileNotFoundError)
-    def test_get_inactive_cache_usage(self, mock_open):
+    def test_get_inactive_cache_usage(self, mock_open, mock_exit_check):
         container_id = 'your_container_id'
+        container_name = 'your_container'
         with self.assertRaises(SystemExit) as cm:
-            memory_checker.get_inactive_cache_usage(container_id)
+            memory_checker.get_inactive_cache_usage(container_id, container_name)
         self.assertEqual(cm.exception.code, 1)
+
+    @patch('memory_checker.get_running_container_names', return_value=[])
+    def test_exit_if_container_stopped(self, mock_running):
+        """Container not running - should exit gracefully."""
+        with self.assertRaises(SystemExit) as cm:
+            memory_checker.exit_if_container_stopped('gnmi')
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
+    def test_exit_if_container_stopped_still_running(self, mock_running):
+        """Container still running - should not exit."""
+        memory_checker.exit_if_container_stopped('gnmi')
 
     @patch('syslog.syslog')
     @patch('memory_checker.get_container_id')
@@ -75,7 +93,7 @@ class TestMemoryChecker(unittest.TestCase):
             memory_checker.check_memory_usage(container_name, threshold_value)
 
         self.assertEqual(cm.exception.code, 3)
-        mock_get_memory_usage.assert_called_once_with(container_name)
+        mock_get_memory_usage.assert_called_once_with(container_id, container_name)
 
 if __name__ == '__main__':
     unittest.main()

--- a/files/image_config/monit/tests/test_memory_checker.py
+++ b/files/image_config/monit/tests/test_memory_checker.py
@@ -89,6 +89,20 @@ class TestMemoryChecker(unittest.TestCase):
         """Container running with same ID - should not exit."""
         memory_checker.exit_if_container_stopped('gnmi', container_id='same_id_123')
 
+    @patch('memory_checker._try_get_container_id', return_value=memory_checker._CONTAINER_GONE)
+    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
+    def test_exit_if_container_removed_between_checks(self, mock_running, mock_get_id):
+        """Container in running list but gone by ID lookup - should exit gracefully."""
+        with self.assertRaises(SystemExit) as cm:
+            memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch('memory_checker._try_get_container_id', return_value=None)
+    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
+    def test_exit_if_docker_api_error_does_not_exit(self, mock_running, mock_get_id):
+        """Docker API error (None) should not cause graceful exit - let original error path handle it."""
+        memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
+
     @patch('syslog.syslog')
     @patch('memory_checker.get_container_id')
     @patch('memory_checker.get_memory_usage')

--- a/files/image_config/monit/tests/test_memory_checker.py
+++ b/files/image_config/monit/tests/test_memory_checker.py
@@ -72,8 +72,22 @@ class TestMemoryChecker(unittest.TestCase):
 
     @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
     def test_exit_if_container_stopped_still_running(self, mock_running):
-        """Container still running - should not exit."""
+        """Container still running, no container_id check - should not exit."""
         memory_checker.exit_if_container_stopped('gnmi')
+
+    @patch('memory_checker._try_get_container_id', return_value='new_id_456')
+    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
+    def test_exit_if_container_restarted(self, mock_running, mock_get_id):
+        """Container running with different ID - should exit gracefully."""
+        with self.assertRaises(SystemExit) as cm:
+            memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
+        self.assertEqual(cm.exception.code, 0)
+
+    @patch('memory_checker._try_get_container_id', return_value='same_id_123')
+    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
+    def test_exit_if_container_same_id(self, mock_running, mock_get_id):
+        """Container running with same ID - should not exit."""
+        memory_checker.exit_if_container_stopped('gnmi', container_id='same_id_123')
 
     @patch('syslog.syslog')
     @patch('memory_checker.get_container_id')

--- a/files/image_config/monit/tests/test_memory_checker.py
+++ b/files/image_config/monit/tests/test_memory_checker.py
@@ -63,45 +63,81 @@ class TestMemoryChecker(unittest.TestCase):
             memory_checker.get_inactive_cache_usage(container_id, container_name)
         self.assertEqual(cm.exception.code, 1)
 
-    @patch('memory_checker.get_running_container_names', return_value=[])
-    def test_exit_if_container_stopped(self, mock_running):
+    @patch('memory_checker._try_get_container_id', return_value=memory_checker._CONTAINER_NOT_RUNNING)
+    def test_exit_if_container_stopped(self, mock_get_id):
         """Container not running - should exit gracefully."""
         with self.assertRaises(SystemExit) as cm:
             memory_checker.exit_if_container_stopped('gnmi')
         self.assertEqual(cm.exception.code, 0)
 
-    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
-    def test_exit_if_container_stopped_still_running(self, mock_running):
-        """Container still running, no container_id check - should not exit."""
+    @patch('memory_checker._try_get_container_id', return_value='current_id_123')
+    def test_exit_if_container_still_running(self, mock_get_id):
+        """Container running, no container_id check - should not exit."""
         memory_checker.exit_if_container_stopped('gnmi')
 
     @patch('memory_checker._try_get_container_id', return_value='new_id_456')
-    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
-    def test_exit_if_container_restarted(self, mock_running, mock_get_id):
+    def test_exit_if_container_restarted(self, mock_get_id):
         """Container running with different ID - should exit gracefully."""
         with self.assertRaises(SystemExit) as cm:
             memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
         self.assertEqual(cm.exception.code, 0)
 
     @patch('memory_checker._try_get_container_id', return_value='same_id_123')
-    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
-    def test_exit_if_container_same_id(self, mock_running, mock_get_id):
+    def test_exit_if_container_same_id(self, mock_get_id):
         """Container running with same ID - should not exit."""
         memory_checker.exit_if_container_stopped('gnmi', container_id='same_id_123')
 
-    @patch('memory_checker._try_get_container_id', return_value=memory_checker._CONTAINER_GONE)
-    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
-    def test_exit_if_container_removed_between_checks(self, mock_running, mock_get_id):
-        """Container in running list but gone by ID lookup - should exit gracefully."""
+    @patch('memory_checker._try_get_container_id', return_value=memory_checker._CONTAINER_NOT_RUNNING)
+    def test_exit_if_container_removed(self, mock_get_id):
+        """Container gone by ID lookup - should exit gracefully."""
         with self.assertRaises(SystemExit) as cm:
             memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
         self.assertEqual(cm.exception.code, 0)
 
     @patch('memory_checker._try_get_container_id', return_value=None)
-    @patch('memory_checker.get_running_container_names', return_value=['gnmi'])
-    def test_exit_if_docker_api_error_does_not_exit(self, mock_running, mock_get_id):
+    def test_exit_if_docker_api_error_does_not_exit(self, mock_get_id):
         """Docker API error (None) should not cause graceful exit - let original error path handle it."""
         memory_checker.exit_if_container_stopped('gnmi', container_id='old_id_123')
+
+    @patch('memory_checker.docker')
+    def test_try_get_container_id_running(self, mock_docker):
+        """Container running - should return its ID."""
+        mock_container = MagicMock()
+        mock_container.id = 'abc123'
+        mock_container.status = 'running'
+        mock_docker.DockerClient.return_value.containers.get.return_value = mock_container
+        result = memory_checker._try_get_container_id('gnmi')
+        self.assertEqual(result, 'abc123')
+
+    @patch('memory_checker.docker')
+    def test_try_get_container_id_stopped(self, mock_docker):
+        """Container exists but stopped - should return _CONTAINER_NOT_RUNNING."""
+        mock_container = MagicMock()
+        mock_container.id = 'abc123'
+        mock_container.status = 'exited'
+        mock_docker.DockerClient.return_value.containers.get.return_value = mock_container
+        result = memory_checker._try_get_container_id('gnmi')
+        self.assertIsInstance(result, memory_checker._ContainerNotRunning)
+
+    @patch('memory_checker.docker')
+    def test_try_get_container_id_not_found(self, mock_docker):
+        """Container not found - should return _CONTAINER_NOT_RUNNING."""
+        import docker as real_docker
+        mock_docker.errors.NotFound = real_docker.errors.NotFound
+        mock_docker.DockerClient.return_value.containers.get.side_effect = real_docker.errors.NotFound('not found')
+        result = memory_checker._try_get_container_id('gnmi')
+        self.assertIsInstance(result, memory_checker._ContainerNotRunning)
+
+    @patch('memory_checker.docker')
+    def test_try_get_container_id_api_error(self, mock_docker):
+        """Docker API error - should return None."""
+        import docker as real_docker
+        mock_docker.errors.NotFound = real_docker.errors.NotFound
+        mock_docker.errors.APIError = real_docker.errors.APIError
+        mock_docker.errors.DockerException = real_docker.errors.DockerException
+        mock_docker.DockerClient.return_value.containers.get.side_effect = real_docker.errors.APIError('error')
+        result = memory_checker._try_get_container_id('gnmi')
+        self.assertIsNone(result)
 
     @patch('syslog.syslog')
     @patch('memory_checker.get_container_id')


### PR DESCRIPTION
Fix memory_checker false alarms during config reload

Fixes: https://github.com/sonic-net/sonic-mgmt/issues/26428

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
During config reload, Monit continues to invoke `memory_checker` for individual containers (`container_memory_gnmi`, `container_memory_snmp`, etc.) while those containers are being stopped and restarted. This causes `memory_checker` to log syslog errors like "`Failed to get container ID of 'gnmi'`" which LogAnalyzer catches.

##### Work item tracking
- Microsoft ADO **(number only)**: 38614044

#### How I did it
 Two fixes:

1. [sonic-utilities]\[ https://github.com/sonic-net/sonic-utilities/pull/4710 \]: Unmonitor container_memory_* checks during service restart. Add `_get_monit_services_by_prefix()` to discover `container_memory_*` services from monit summary, and unmonitor/monitor them in `_stop_services()`/`_restart_services()`.

2. [memory_checker][this]: Re-check container state before logging errors. If memory_checker was already running when config reload starts, the unmonitor only prevents future invocations. Add `exit_if_container_stopped()` to re-check whether the container is still running before logging error. If it stopped, exit gracefully.

#### How to verify it
check test result section


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/26428/ ADO: 38614044
Failure type: <!-- day-one issue / regression / other --> day-one issue

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
202605: SONiC.branch.202605-ars.6e4b5dc6-buildimage.89ae323bca4e5777f36534b4a4e1f3470aeae4e4-nightly-2026.08.02.14.40 -
[memory_checker_test.log](https://github.com/user-attachments/files/30703637/memory_checker_test.log)


<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
Fix memory_checker false alarms during config reload
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
