### PR TITLE
Compile Debian 12 grub 2.06-13+deb12u2 for Trixie (fix Secure Boot SBAT grub,5)

### DIFF
--- a/files/build/versions-public/host-image/versions-deb-trixie
+++ b/files/build/versions-public/host-image/versions-deb-trixie
@@ -73,8 +73,8 @@ gir1.2-girepository-2.0==1.84.0-1
 gir1.2-glib-2.0==2.84.4-3~deb13u3
 gpg==2.4.7-21+deb13u1+b3
 gpgconf==2.4.7-21+deb13u1+b3
-grub-common==2.06-13+deb13u1
-grub2-common==2.06-13+deb13u1
+grub-common==2.06-13+deb12u2
+grub2-common==2.06-13+deb12u2
 haveged==1.9.19-12+deb13u1
 hdparm==9.65+ds-1.1
 hping3==3.a2.ds2-10.1

--- a/rules/grub2.mk
+++ b/rules/grub2.mk
@@ -1,6 +1,6 @@
 # grub2 package
 
-GRUB2_VERSION := 2.06-13+deb13u1
+GRUB2_VERSION := 2.06-13+deb12u2
 
 export GRUB2_VERSION
 

--- a/src/grub2/patch/series
+++ b/src/grub2/patch/series
@@ -1,3 +1,3 @@
-# This series applies on GIT commit f954d68d5e8dc7eb0081ad7bc1ced9ff5ca687a7
+# This series applies on GIT commit eed42793a8c82278474e91e4c1cfe2b0ff340d7b
 adjust-build-rules-for-debian.patch
 large-uid-skip-cpio-ustar.patch


### PR DESCRIPTION
Fixes the Secure Boot / SBAT boot failure reported in sonic-net/sonic-buildimage#28442, using the latest bookworm grub.

## Problem

Debian trixie's `shim-unsigned 16.1-2~deb13u1` bumped its embedded SBAT revocation level to require **`grub,5`**. The grub SONiC compiles for trixie (`2.06-13+deb13u1`, pinned in `rules/grub2.mk`) only declares **`grub,4`**. At boot, shim writes its revocation level into the `SbatLevelRT` UEFI variable (a one-way NVRAM ratchet) and then refuses to load `grubx64.efi` — bricking Secure Boot, and because the level persists in NVRAM, every subsequently installed image that ships the same `grub,4` binary is blocked too.

There is **no `2.06-13+deb13u2`** that advances the SBAT level for trixie.

## Fix

Compile Debian 12 (bookworm) grub **`2.06-13+deb12u2`** for trixie instead. Its changelog bumps the SBAT level to **`grub,5`** (along with the associated CVE fixes), which satisfies the new shim's `grub,5` requirement.

Both the alternative approaches trixie grub 2.12-9+deb13u1 and forky grub 2.14-3 will cause the issue https://github.com/sonic-net/sonic-buildimage/issues/24249

Hence sticking with this approach until that is addressed.

Both existing SONiC grub patches apply **unchanged** — `debian/control`, `debian/rules` and `tests/cpio_test.in` are byte-identical between `debian/2.06-13+deb13u1` and `debian/2.06-13+deb12u2`:
- `adjust-build-rules-for-debian.patch` (Trixie gcc/qemu build fixup)
- `large-uid-skip-cpio-ustar.patch` (#25400 / #25401)

## Changes

- `rules/grub2.mk`: `GRUB2_VERSION` → `2.06-13+deb12u2`
- `files/build/versions-public/host-image/versions-deb-trixie`: pin `grub-common` / `grub2-common` to `2.06-13+deb12u2`
- `src/grub2/patch/series`: update the base-commit comment to the `2.06-13+deb12u2` release commit (`eed42793a`)

## Verification

```
ONIE:~ # grep -a 'grub,' /boot/efi/EFI/SONiC-OS/grubx64.efi
grub,5,Free Software Foundation,grub,2.06,https://www.gnu.org/software/grub/
```
- Built the grub target `target/debs/trixie/grub2-common_2.06-13+deb12u2_amd64.deb` — all 6 grub debs produced; both patches applied cleanly on top of the `deb12u2` tag.
- Confirmed the compiled source declares **`grub,5`** in `debian/sbat.debian.csv.in`, matching the shim's new requirement.
