### PR TITLE
[Nexthop] nh-4210: add polling for asic enumeration

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/utils/asic_init.sh
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/utils/asic_init.sh
@@ -185,31 +185,42 @@ for attempt in {0..2}; do
   fpga_0_write 0x90 0x1 "9:9"
   logger -t $LOG_TAG -p $LOG_PRIO "Waiting for power-up sequence"
 
-  sleep 8
+  # Wait for ASIC_PGOOD (0x98 bit 23) to assert, then for the ASIC to show
+  # up on PCIe. Poll at 100ms: PGOOD asserts ~2s in, coarser just adds boot time.
+  pcie_ok=0
+  for _ in {1..100}; do
+    pgood=$(fpga read32 "$FPGA_0_BDF" 0x98 --bits "23:23" 2>/dev/null)
+    if [ "$(( pgood ))" -eq 1 ] 2>/dev/null && lspci -n | grep -q "$ASIC_BDF"; then
+      pcie_ok=1
+      break
+    fi
+    sleep 0.1
+  done
 
   clear_sticky_bits
 
-  lspci -n | grep -q "$ASIC_BDF"
-  if [ $? -eq 0 ]; then
-    if [ "$attempt" -eq 0 ]; then
-        logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up"
-    else
-        logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up after power cycle $attempt"
-    fi
-
-    logger -t $LOG_TAG -p $LOG_PRIO "Current lspci error(s) output"
-    output=$(lspci -vvv 2>/dev/null | grep -i -e '^0' -e 'CESta' | grep -B 1 -e 'CESta' | grep -B 1 -e '+ ' -e '+$')
-    logger -t $LOG_TAG -p $LOG_PRIO "lspci Errors: ${output}"
-
-    if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
-      logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules: $(lsmod | grep linux_ngbde)"
-      /etc/init.d/opennsl-modules start
-      logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules done: $(lsmod | grep linux_ngbde)"
-    fi
-
-    release_lock
-    exit 0
+  if [ "$pcie_ok" -ne 1 ]; then
+    continue
   fi
+
+  if [ "$attempt" -eq 0 ]; then
+    logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up"
+  else
+    logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up after power cycle $attempt"
+  fi
+
+  logger -t $LOG_TAG -p $LOG_PRIO "Current lspci error(s) output"
+  output=$(lspci -vvv 2>/dev/null | grep -i -e '^0' -e 'CESta' | grep -B 1 -e 'CESta' | grep -B 1 -e '+ ' -e '+$')
+  logger -t $LOG_TAG -p $LOG_PRIO "lspci Errors: ${output}"
+
+  if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
+    logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules: $(lsmod | grep linux_ngbde)"
+    /etc/init.d/opennsl-modules start
+    logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules done: $(lsmod | grep linux_ngbde)"
+  fi
+
+  release_lock
+  exit 0
 done
 
 logger -t $LOG_TAG -p $LOG_ERR "Switch ASIC not found after power cycle attempts, giving up."

--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/utils/asic_init.sh
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/utils/asic_init.sh
@@ -231,7 +231,17 @@ for attempt in {0..2}; do
   fpga_0_write 0x90 0x1 "9:9"
   logger -t $LOG_TAG -p $LOG_PRIO "Waiting for power-up sequence"
 
-  sleep 8
+  # Wait for ASIC_PGOOD (0x98 bit 23) to assert, then for the ASIC to show
+  # up on PCIe. Poll at 100ms: PGOOD asserts ~2s in, coarser just adds boot time.
+  pcie_ok=0
+  for _ in {1..100}; do
+    pgood=$(fpga read32 "$FPGA_0_BDF" 0x98 --bits "23:23" 2>/dev/null)
+    if [ "$(( pgood ))" -eq 1 ] 2>/dev/null && lspci -n | grep -q "$ASIC_BDF"; then
+      pcie_ok=1
+      break
+    fi
+    sleep 0.1
+  done
 
   clear_sticky_bits
 
@@ -244,32 +254,33 @@ for attempt in {0..2}; do
     logger -t "$LOG_TAG" -p "$LOG_ERR" "ASIC power good bit not set"
   fi
 
-  lspci -n | grep -q "$ASIC_BDF"
-  if [ $? -eq 0 ]; then
-    if [ "$attempt" -eq 0 ]; then
-        logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up"
-    else
-        logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up after power cycle $attempt"
-    fi
-
-    logger -t $LOG_TAG -p $LOG_PRIO "Current lspci error(s) output"
-    output=$(lspci -vvv 2>/dev/null | grep -i -e '^0' -e 'CESta' | grep -B 1 -e 'CESta' | grep -B 1 -e '+ ' -e '+$')
-    logger -t $LOG_TAG -p $LOG_PRIO "lspci Errors: ${output}"
-
-    logger -t $LOG_TAG -p $LOG_PRIO "Clearing lspci errors"
-    setpci -s "$ASIC_BRIDGE" 0x160.l=$(setpci -s "$ASIC_BRIDGE" 0x160.l)
-
-    # CPU enables common clk during pcie link training.
-
-    if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
-      logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules: $(lsmod | grep linux_ngbde)"
-      /etc/init.d/opennsl-modules start
-      logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules done: $(lsmod | grep linux_ngbde)"
-    fi
-
-    release_lock
-    exit 0
+  if [ "$pcie_ok" -ne 1 ]; then
+    continue
   fi
+
+  if [ "$attempt" -eq 0 ]; then
+    logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up"
+  else
+    logger -t "$LOG_TAG" -p "$LOG_PRIO" "Switch ASIC is up after power cycle $attempt"
+  fi
+
+  logger -t $LOG_TAG -p $LOG_PRIO "Current lspci error(s) output"
+  output=$(lspci -vvv 2>/dev/null | grep -i -e '^0' -e 'CESta' | grep -B 1 -e 'CESta' | grep -B 1 -e '+ ' -e '+$')
+  logger -t $LOG_TAG -p $LOG_PRIO "lspci Errors: ${output}"
+
+  logger -t $LOG_TAG -p $LOG_PRIO "Clearing lspci errors"
+  setpci -s "$ASIC_BRIDGE" 0x160.l=$(setpci -s "$ASIC_BRIDGE" 0x160.l)
+
+  # CPU enables common clk during pcie link training.
+
+  if [ "$IS_OPENNSL_INITIALLY_LOADED" -eq 0 ]; then
+    logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules: $(lsmod | grep linux_ngbde)"
+    /etc/init.d/opennsl-modules start
+    logger -t $LOG_TAG -p $LOG_PRIO "Inserting ASIC modules done: $(lsmod | grep linux_ngbde)"
+  fi
+
+  release_lock
+  exit 0
 done
 
 logger -t $LOG_TAG -p $LOG_ERR "Switch ASIC not found after power cycle attempts, giving up, powering it down."


### PR DESCRIPTION
#### Why I did it

Resolves #28607

On the Nexthop NH-4210 (Tomahawk6) platform, `asic_init.sh` waits a fixed `sleep 8` after powering on the dataplane before checking that the ASIC has enumerated on PCIe. Measured on hardware, ASIC_PGOOD asserts ~2.0s after dataplane power-on and PCIe presence follows at ~2.5s, so ~5.5s of every cold boot (and of every syncd-restart power cycle) is spent sleeping unnecessarily.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Replace the fixed `sleep 8` with a readiness poll (up to 100 x 100ms): each tick reads ASIC_PGOOD (FPGA reg 0x98 bit 23) and checks ASIC PCIe presence via `lspci`, exiting as soon as both are up. On timeout (10s, the same order as the previous fixed wait) the script falls through to the existing power-cycle retry loop, so failure behavior is unchanged.

#### How to verify it

Measured on NH-4210 units: `asic_init.sh` drops from ~10.2s to ~3.3-4.8s per cold boot; the poll observes PGOOD at ~2.0s and exits on PCIe presence at ~2.5s. Cold boots are healthy: all ports and containers up, BGP established, no PCIe/AER errors in dmesg.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608

Reason: Nexthop's NH-4210 platform ships on 202512-based images and needs the boot-time improvement there. The change only touches this one platform's ASIC init script in the Nexthop vendor directory — no common code and no other platforms are affected — and it replaces a fixed sleep with a bounded poll of the same duration, keeping failure/retry behavior unchanged. Risk to the branch is confined to the NH-4210 platform, where it has been validated on hardware (see Test result).

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #28607
Failure type: other (boot-time improvement on Nexthop platform)

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: validated on NH-4210 hardware running an internal image built from master (2 baseline + 2 patched cold boots) — asic_init span 10.2s -> ~4.8s, all health checks passing.
- 202512: validated on NH-4210 hardware running an image built from the 202512 branch (2 baseline + 2 patched cold boots) — asic_init span 9.2–11.1s -> ~3.8s, readiness poll exits ~2.9s after DP power-on; BGP 8/8 established, all containers and ports up, zero PCIe/AER errors, zero cores.

#### Description for the changelog

[Nexthop] nh-4210: poll ASIC_PGOOD/PCIe readiness in asic_init.sh instead of a fixed 8s sleep, cutting ~5.5s from cold boot.

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.

#### A picture of a cute animal (not mandatory but encouraged)







