### PR TITLE
[SmartSwitch] Restore DPU gNMI midplane connectivity

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -2,7 +2,6 @@
 
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
-MIDPLANE_ADDRESS_NOT_FOUND=3
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
@@ -22,6 +21,7 @@ TELEMETRY_VARS=${TELEMETRY_VARS//[\']/\"}
 X509=$(echo $TELEMETRY_VARS | jq -r '.x509')
 GNMI=$(echo $TELEMETRY_VARS | jq -r '.gnmi')
 CERTS=$(echo $TELEMETRY_VARS | jq -r '.certs')
+IS_SMART_SWITCH_DPU=$(echo $TELEMETRY_VARS | jq -r '.is_smart_switch_dpu')
 
 # Enable GRPC GO LOG
 export GRPC_GO_LOG_VERBOSITY_LEVEL=99
@@ -58,19 +58,8 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    DEVICE_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "type")
-    SWITCH_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type")
-    if [[ x"${DEVICE_TYPE}" == x"SmartSwitchDPU" || x"${SWITCH_TYPE}" == x"dpu" ]]; then
-        for _ in {1..30}; do
-            MIDPLANE_ADDRESS=$(ip -4 -o addr show dev eth0-midplane 2>/dev/null | awk '{sub(/\/.*/, "", $4); print $4; exit}')
-            [[ -n "${MIDPLANE_ADDRESS}" ]] && break
-            sleep 1
-        done
-        if [[ -z "${MIDPLANE_ADDRESS}" ]]; then
-            echo "SmartSwitch DPU midplane IPv4 address not found" >&2
-            exit $MIDPLANE_ADDRESS_NOT_FOUND
-        fi
-        TELEMETRY_ARGS+=" --noTLS --bind_address ${MIDPLANE_ADDRESS} --allow_no_tls_link_local"
+    if [[ x"${IS_SMART_SWITCH_DPU}" == x"true" ]]; then
+        TELEMETRY_ARGS+=" --noTLS --no_tls_link_local_interface eth0-midplane"
     else
         TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
     fi

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -2,6 +2,7 @@
 
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
+MIDPLANE_ADDRESS_NOT_FOUND=3
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
@@ -57,7 +58,22 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
+    DEVICE_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "type")
+    SWITCH_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type")
+    if [[ x"${DEVICE_TYPE}" == x"SmartSwitchDPU" || x"${SWITCH_TYPE}" == x"dpu" ]]; then
+        for _ in {1..30}; do
+            MIDPLANE_ADDRESS=$(ip -4 -o addr show dev eth0-midplane 2>/dev/null | awk '{sub(/\/.*/, "", $4); print $4; exit}')
+            [[ -n "${MIDPLANE_ADDRESS}" ]] && break
+            sleep 1
+        done
+        if [[ -z "${MIDPLANE_ADDRESS}" ]]; then
+            echo "SmartSwitch DPU midplane IPv4 address not found" >&2
+            exit $MIDPLANE_ADDRESS_NOT_FOUND
+        fi
+        TELEMETRY_ARGS+=" --noTLS --bind_address ${MIDPLANE_ADDRESS} --allow_no_tls_link_local"
+    else
+        TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
+    fi
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port

--- a/dockers/docker-sonic-gnmi/telemetry_vars.j2
+++ b/dockers/docker-sonic-gnmi/telemetry_vars.j2
@@ -1,5 +1,6 @@
 {
-    "certs": {% if "certs" in GNMI.keys() %}{{ GNMI["certs"] }}{% else %}""{% endif %},
-    "gnmi" : {% if "gnmi" in GNMI.keys() %}{{ GNMI["gnmi"] }}{% else %}""{% endif %},
-    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
+    "certs": {% if GNMI is defined and "certs" in GNMI %}{{ GNMI["certs"] }}{% else %}""{% endif %},
+    "gnmi" : {% if GNMI is defined and "gnmi" in GNMI %}{{ GNMI["gnmi"] }}{% else %}""{% endif %},
+    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %},
+    "is_smart_switch_dpu": {{ (DEVICE_METADATA["localhost"].get("type") == "SmartSwitchDPU" or DEVICE_METADATA["localhost"].get("switch_type") == "dpu") | lower }}
 }

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -23,7 +23,6 @@ fi
 
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
-MIDPLANE_ADDRESS_NOT_FOUND=3
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
@@ -43,6 +42,7 @@ TELEMETRY_VARS=${TELEMETRY_VARS//[\']/\"}
 X509=$(echo $TELEMETRY_VARS | jq -r '.x509')
 GNMI=$(echo $TELEMETRY_VARS | jq -r '.gnmi')
 CERTS=$(echo $TELEMETRY_VARS | jq -r '.certs')
+IS_SMART_SWITCH_DPU=$(echo $TELEMETRY_VARS | jq -r '.is_smart_switch_dpu')
 
 export GRPC_GO_LOG_VERBOSITY_LEVEL=99
 export GRPC_GO_LOG_SEVERITY_LEVEL=info
@@ -78,19 +78,8 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    DEVICE_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "type")
-    SWITCH_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type")
-    if [[ x"${DEVICE_TYPE}" == x"SmartSwitchDPU" || x"${SWITCH_TYPE}" == x"dpu" ]]; then
-        for _ in {1..30}; do
-            MIDPLANE_ADDRESS=$(ip -4 -o addr show dev eth0-midplane 2>/dev/null | awk '{sub(/\/.*/, "", $4); print $4; exit}')
-            [[ -n "${MIDPLANE_ADDRESS}" ]] && break
-            sleep 1
-        done
-        if [[ -z "${MIDPLANE_ADDRESS}" ]]; then
-            echo "SmartSwitch DPU midplane IPv4 address not found" >&2
-            exit $MIDPLANE_ADDRESS_NOT_FOUND
-        fi
-        TELEMETRY_ARGS+=" --noTLS --bind_address ${MIDPLANE_ADDRESS} --allow_no_tls_link_local"
+    if [[ x"${IS_SMART_SWITCH_DPU}" == x"true" ]]; then
+        TELEMETRY_ARGS+=" --noTLS --no_tls_link_local_interface eth0-midplane"
     else
         TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
     fi

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -23,6 +23,7 @@ fi
 
 EXIT_TELEMETRY_VARS_FILE_NOT_FOUND=1
 INCORRECT_TELEMETRY_VALUE=2
+MIDPLANE_ADDRESS_NOT_FOUND=3
 TELEMETRY_VARS_FILE=/usr/share/sonic/templates/telemetry_vars.j2
 ESCAPE_QUOTE="'\''"
 
@@ -77,7 +78,22 @@ elif [ -n "$X509" ]; then
         TELEMETRY_ARGS+=" --ca_crt $CA_CRT"
     fi
 else
-    TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
+    DEVICE_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "type")
+    SWITCH_TYPE=$(sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type")
+    if [[ x"${DEVICE_TYPE}" == x"SmartSwitchDPU" || x"${SWITCH_TYPE}" == x"dpu" ]]; then
+        for _ in {1..30}; do
+            MIDPLANE_ADDRESS=$(ip -4 -o addr show dev eth0-midplane 2>/dev/null | awk '{sub(/\/.*/, "", $4); print $4; exit}')
+            [[ -n "${MIDPLANE_ADDRESS}" ]] && break
+            sleep 1
+        done
+        if [[ -z "${MIDPLANE_ADDRESS}" ]]; then
+            echo "SmartSwitch DPU midplane IPv4 address not found" >&2
+            exit $MIDPLANE_ADDRESS_NOT_FOUND
+        fi
+        TELEMETRY_ARGS+=" --noTLS --bind_address ${MIDPLANE_ADDRESS} --allow_no_tls_link_local"
+    else
+        TELEMETRY_ARGS+=" --noTLS --bind_address 127.0.0.1"
+    fi
 fi
 
 # If no configuration entry exists for TELEMETRY, create one default port

--- a/dockers/docker-sonic-telemetry/telemetry_vars.j2
+++ b/dockers/docker-sonic-telemetry/telemetry_vars.j2
@@ -1,5 +1,6 @@
 {
-    "certs": {% if "certs" in TELEMETRY.keys() %}{{ TELEMETRY["certs"] }}{% else %}""{% endif %},
-    "gnmi" : {% if "gnmi" in TELEMETRY.keys() %}{{ TELEMETRY["gnmi"] }}{% else %}""{% endif %},
-    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %}
+    "certs": {% if TELEMETRY is defined and "certs" in TELEMETRY %}{{ TELEMETRY["certs"] }}{% else %}""{% endif %},
+    "gnmi" : {% if TELEMETRY is defined and "gnmi" in TELEMETRY %}{{ TELEMETRY["gnmi"] }}{% else %}""{% endif %},
+    "x509" : {% if "x509" in DEVICE_METADATA.keys() %}{{ DEVICE_METADATA["x509"] }}{% else %}""{% endif %},
+    "is_smart_switch_dpu": {{ (DEVICE_METADATA["localhost"].get("type") == "SmartSwitchDPU" or DEVICE_METADATA["localhost"].get("switch_type") == "dpu") | lower }}
 }


### PR DESCRIPTION
#### Why I did it

SmartSwitch DPUs normally run gNMI/gNOI without certificate configuration so
the NPU can proxy plaintext RPCs over the chassis-internal midplane. After
sonic-gnmi#712 and sonic-buildimage#28110, both DPU services bind only to
`127.0.0.1`, so the NPU gets connection refused at the DPU's IPv4 link-local
address.

Fixes #28540.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Detect SmartSwitch DPUs using either `DEVICE_METADATA.type=SmartSwitchDPU`
  or `switch_type=dpu` in the existing single `sonic-cfggen` template render.
- For a DPU without certificates, pass only
  `--noTLS --no_tls_link_local_interface eth0-midplane`.
- Let the telemetry binary resolve, validate, and bind the concrete IPv4
  link-local address, including bounded address-readiness handling.
- Keep all other no-certificate devices bound to loopback.
- Avoid direct `sonic-db-cli` calls, `ip`/`awk` parsing, and polling in both
  launch scripts.
- Pin sonic-gnmi PR https://github.com/sonic-net/sonic-gnmi/pull/721.

#### How to verify it

Native arm64 SONiC build succeeded for the gNMI package and both affected
containers.

Physical SmartSwitch validation:

- Baseline post-regression images listened only on loopback; NPU connections to
  both DPU ports were refused and direct gNOI `System.Time` failed.
- Fixed images listened only on the concrete DPU IPv4 link-local address at
  ports `50052` and `8080`.
- NPU TCP probes passed for both ports.
- Direct plaintext gNOI `System.Time` passed on `50052`.
- The real NPU UDS call with `x-sonic-ss-target-type=dpu` and index metadata
  passed through DPUProxy.
- Negative probes confirmed neither service listened on the DPU management
  address or loopback.
- The DPU was restored to its original images after testing; all DPUs remained
  reachable and the baseline direct RPC passed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #28540
Failure type: regression

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: native arm64 build passed; physical SmartSwitch direct and proxied
  gNOI validation passed.

#### Description for the changelog

Restore SmartSwitch NPU-to-DPU gNMI/gNOI connectivity over the link-local midplane.

#### Link to config_db schema for YANG module changes

N/A
