### PR TITLE
[sonic-yang-models]: Add VNet name support to BGP_NEIGHBOR YANG model

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -557,7 +557,8 @@ form, `vrf_name` accepts a VRF name (e.g. `default`, `Vrf1`) or a VNet name
                 "name": "overlay-peer",
                 "admin_status": "up"
         }
-
+    }
+}
 "BGP_PEER_RANGE": {
     "BGPSLBPassive": {
         "name": "BGPSLBPassive",

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -523,11 +523,10 @@ attributes include remote AS number, neighbor router name, and local
 peering address. Dynamic neighbor is also supported by defining peer
 group name and IP ranges in **BGP_PEER_RANGE** table.
 
-The table key format is `vrf_name|neighbor` where `vrf_name` can be:
-- A VRF name (e.g. `default`, `Vrf1`) referencing an entry in **BGP_GLOBALS**
-- A VNet name (e.g. `Vnet1`) referencing an entry in **VNET**, for overlay BGP neighbors
-
-Example: `BGP_NEIGHBOR|Vnet1|10.0.0.0` creates a BGP neighbor under VNet `Vnet1`.
+The table key can be a plain neighbor IP (e.g. `BGP_NEIGHBOR|10.0.0.61`) or a
+`vrf_name|neighbor` pair (e.g. `BGP_NEIGHBOR|default|10.0.0.61`). In the second
+form, `vrf_name` accepts a VRF name (e.g. `default`, `Vrf1`) or a VNet name
+(e.g. `Vnet1`) for overlay BGP neighbors.
 
 ```
 {
@@ -543,7 +542,7 @@ Example: `BGP_NEIGHBOR|Vnet1|10.0.0.0` creates a BGP neighbor under VNet `Vnet1`
                 "name": "ARISTA09T0"
         },
 
-        "10.0.0.63": {
+        "default|10.0.0.63": {
                 "rrclient": "0",
 				"name": "ARISTA04T1",
 				"local_addr": "10.0.0.62",

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -523,6 +523,12 @@ attributes include remote AS number, neighbor router name, and local
 peering address. Dynamic neighbor is also supported by defining peer
 group name and IP ranges in **BGP_PEER_RANGE** table.
 
+The table key format is `vrf_name|neighbor` where `vrf_name` can be:
+- A VRF name (e.g. `default`, `Vrf1`) referencing an entry in **BGP_GLOBALS**
+- A VNet name (e.g. `Vnet1`) referencing an entry in **VNET**, for overlay BGP neighbors
+
+Example: `BGP_NEIGHBOR|Vnet1|10.0.0.0` creates a BGP neighbor under VNet `Vnet1`.
+
 ```
 {
 "BGP_NEIGHBOR": {
@@ -545,6 +551,12 @@ group name and IP ranges in **BGP_PEER_RANGE** table.
 				"holdtime": "10",
 				"asn": "64600",
 				"keepalive": "3"
+        },
+
+        "Vnet1|10.0.0.0": {
+                "asn": 65100,
+                "name": "overlay-peer",
+                "admin_status": "up"
         }
 
 "BGP_PEER_RANGE": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1971,12 +1971,21 @@
                 "asn": "65100",
                 "name": "bgp peer 65100",
                 "ebgp_multihop_ttl": "3"
+            },
+            "Vnet55|10.0.0.0": {
+                "asn": "65300",
+                "name": "overlay-peer",
+                "admin_status": "up"
             }
         },
         "BGP_NEIGHBOR_AF": {
             "default|192.168.1.1|ipv4_unicast": {
                 "route_map_in": [ "map1" ],
                 "route_map_out": [ "map1" ]
+            },
+            "Vnet55|10.0.0.0|ipv4_unicast": {
+                "admin_status": "up",
+                "send_default_route": false
             }
         },
         "BGP_PEER_GROUP": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1985,7 +1985,7 @@
             },
             "Vnet55|10.0.0.0|ipv4_unicast": {
                 "admin_status": "up",
-                "send_default_route": false
+                "send_default_route": "false"
             }
         },
         "BGP_PEER_GROUP": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -32,6 +32,13 @@
     "BGP_NEIGHBOR_ALL_VALID": {
         "desc": "Configure BGP neighbor table."
     },
+    "BGP_NEIGHBOR_VNET_VALID": {
+        "desc": "Configure BGP neighbor with a VNet name as vrf_name."
+    },
+    "BGP_NEIGHBOR_NEG_VNET_NOT_EXIST": {
+        "desc": "BGP neighbor vrf_name references a non-existing VNet.",
+        "eStrKey": "LeafRef"
+    },
     "BGP_PEERGROUP_ALL_VALID": {
         "desc": "Configure BGP peer group table."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/bgp.json
@@ -37,7 +37,7 @@
     },
     "BGP_NEIGHBOR_NEG_VNET_NOT_EXIST": {
         "desc": "BGP neighbor vrf_name references a non-existing VNet.",
-        "eStrKey": "LeafRef"
+        "eStrKey": "InvalidValue"
     },
     "BGP_PEERGROUP_ALL_VALID": {
         "desc": "Configure BGP peer group table."
@@ -52,7 +52,7 @@
     },
     "BGP_NEIGHBOR_NEG_GLOBAL_NOT_EXIST": {
         "desc": "Referring non-existing BGP global table.",
-        "eStrKey" : "LeafRef"
+        "eStrKey" : "InvalidValue"
     },
     "BGP_NEIGHBOR_AF_NEG_NEIGHBOR_NOT_EXIST": {
         "desc": "Referring non-existing BGP neighbor table.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -619,6 +619,8 @@
             }
         }
     },
+
+    "BGP_GLOBAL_AF_NEG_GLOBAL_NOT_EXIST": {
         "sonic-bgp-global:sonic-bgp-global": {
             "sonic-bgp-global:BGP_GLOBALS_AF": {
                 "BGP_GLOBALS_AF_LIST": [

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/bgp.json
@@ -549,6 +549,64 @@
             }
         }
     },
+
+    "BGP_NEIGHBOR_VNET_VALID": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                {
+                    "name": "vtep1",
+                    "src_ip": "1.2.3.4"
+                }]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                {
+                    "name": "Vnet1",
+                    "vxlan_tunnel": "vtep1",
+                    "vni": "10000"
+                }]
+            }
+        },
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                {
+                    "vrf_name": "Vnet1",
+                    "neighbor": "10.0.0.0",
+                    "asn": 65100,
+                    "name": "overlay-peer",
+                    "admin_status": "up"
+                }]
+            },
+            "sonic-bgp-neighbor:BGP_NEIGHBOR_AF": {
+                "BGP_NEIGHBOR_AF_LIST": [
+                {
+                    "vrf_name": "Vnet1",
+                    "neighbor": "10.0.0.0",
+                    "afi_safi": "ipv4_unicast",
+                    "admin_status": "up"
+                }]
+            }
+        }
+    },
+
+    "BGP_NEIGHBOR_NEG_VNET_NOT_EXIST": {
+        "sonic-bgp-neighbor:sonic-bgp-neighbor": {
+            "sonic-bgp-neighbor:BGP_NEIGHBOR": {
+                "BGP_NEIGHBOR_LIST": [
+                {
+                    "vrf_name": "Vnet1",
+                    "neighbor": "10.0.0.0",
+                    "asn": 65100,
+                    "name": "overlay-peer"
+                }]
+            }
+        }
+    },
+
     "BGP_GLOBAL_NEG_VRF_NOT_EXIST": {
         "sonic-bgp-global:sonic-bgp-global": {
             "sonic-bgp-global:BGP_GLOBALS": {
@@ -561,8 +619,6 @@
             }
         }
     },
-
-    "BGP_GLOBAL_AF_NEG_GLOBAL_NOT_EXIST": {
         "sonic-bgp-global:sonic-bgp-global": {
             "sonic-bgp-global:BGP_GLOBALS_AF": {
                 "BGP_GLOBALS_AF_LIST": [

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -32,6 +32,10 @@ module sonic-bgp-neighbor {
         prefix bgppg;
     }
 
+    import sonic-vnet {
+        prefix svnet;
+    }
+
     organization
         "SONiC";
 
@@ -40,6 +44,11 @@ module sonic-bgp-neighbor {
 
     description
         "SONIC BGP Neighbor";
+
+    revision 2026-07-22 {
+        description
+            "Add VNet name support to BGP_NEIGHBOR_LIST and BGP_NEIGHBOR_AF_LIST vrf_name leaf.";
+    }
 
     revision 2021-02-26 {
         description
@@ -72,10 +81,15 @@ module sonic-bgp-neighbor {
                 key "vrf_name neighbor";
 
                 leaf vrf_name {
-                    type leafref {
-                        path "/bgpg:sonic-bgp-global/bgpg:BGP_GLOBALS/bgpg:BGP_GLOBALS_LIST/bgpg:vrf_name";
+                    type union {
+                        type leafref {
+                            path "/bgpg:sonic-bgp-global/bgpg:BGP_GLOBALS/bgpg:BGP_GLOBALS_LIST/bgpg:vrf_name";
+                        }
+                        type leafref {
+                            path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                        }
                     }
-                    description "Network-instance/VRF name";
+                    description "Network-instance/VRF name or VNet name (e.g. Vnet1) for overlay BGP neighbors";
                 }
 
                 leaf neighbor {
@@ -114,10 +128,15 @@ module sonic-bgp-neighbor {
                 key "vrf_name neighbor afi_safi";
 
                 leaf vrf_name {
-                    type leafref {
-                        path "/bgpg:sonic-bgp-global/bgpg:BGP_GLOBALS/bgpg:BGP_GLOBALS_LIST/bgpg:vrf_name";
+                    type union {
+                        type leafref {
+                            path "/bgpg:sonic-bgp-global/bgpg:BGP_GLOBALS/bgpg:BGP_GLOBALS_LIST/bgpg:vrf_name";
+                        }
+                        type leafref {
+                            path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                        }
                     }
-                    description "Network-instance/VRF name";
+                    description "Network-instance/VRF name or VNet name (e.g. Vnet1) for overlay BGP neighbors";
                 }
 
                 leaf neighbor {

--- a/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
+++ b/src/sonic-yang-models/yang-models/sonic-bgp-neighbor.yang
@@ -89,7 +89,7 @@ module sonic-bgp-neighbor {
                             path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
                         }
                     }
-                    description "Network-instance/VRF name or VNet name (e.g. Vnet1) for overlay BGP neighbors";
+                    description "Network-instance/VRF name or VNet name";
                 }
 
                 leaf neighbor {
@@ -136,7 +136,7 @@ module sonic-bgp-neighbor {
                             path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
                         }
                     }
-                    description "Network-instance/VRF name or VNet name (e.g. Vnet1) for overlay BGP neighbors";
+                    description "Network-instance/VRF name or VNet name";
                 }
 
                 leaf neighbor {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `BGP_NEIGHBOR` YANG model only accepted a VRF name (referencing `BGP_GLOBALS`) as the first key component. This prevented creating BGP neighbor configurations scoped to a VNet, such as `BGP_NEIGHBOR|Vnet1|10.0.0.0`, which is needed for overlay BGP sessions over VxLAN tunnels.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Changed the `vrf_name` leaf type in `BGP_NEIGHBOR_LIST` and `BGP_NEIGHBOR_AF_LIST` from a plain `leafref` to a `union` of two `leafref` types — one pointing to `BGP_GLOBALS_LIST` (existing VRF path) and one pointing to `VNET_LIST` (new VNet path). This follows the identical pattern already used in `sonic-bgp-peerrange` for the same requirement.

Files changed:
- `yang-models/sonic-bgp-neighbor.yang` — import `sonic-vnet`, change `vrf_name` to union
  leafref in both `BGP_NEIGHBOR_LIST` and `BGP_NEIGHBOR_AF_LIST`
- `doc/Configuration.md` — document VNet key format and add example
- `tests/files/sample_config_db.json` — add `Vnet55|10.0.0.0` BGP_NEIGHBOR and
  BGP_NEIGHBOR_AF entries
- `tests/yang_model_tests/tests/bgp.json` — add `BGP_NEIGHBOR_VNET_VALID` and
  `BGP_NEIGHBOR_NEG_VNET_NOT_EXIST` test descriptors
- `tests/yang_model_tests/tests_config/bgp.json` — add full test data for both new cases
#### How to verify it


Run the existing YANG model tests:
```bash
cd src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/test_yang_model.py -v -k "BGP_NEIGHBOR"
```


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [x] 202506

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
