### PR TITLE
Add aspeed platform service to disable boot watchdog timer A (WDTA)

### DIFF
--- a/platform/aspeed/aspeed-platform-services/debian/control
+++ b/platform/aspeed/aspeed-platform-services/debian/control
@@ -15,6 +15,7 @@ Description: Aspeed platform services for SONiC
   - Switch CPU console initialization
   - U-Boot environment initialization
   - Hardware watchdog manager daemon
+  - ABR boot watchdog disarm
  .
  The hardware watchdog manager daemon owns /dev/watchdog0, pets it while armed,
  and serves arm/disarm/status requests over an IPC socket for the SONiC

--- a/platform/aspeed/aspeed-platform-services/debian/rules
+++ b/platform/aspeed/aspeed-platform-services/debian/rules
@@ -30,4 +30,5 @@ override_dh_installsystemd:
 	dh_installsystemd --name=sonic-switchcpu-console-init sonic-switchcpu-console-init.service
 	dh_installsystemd --name=sonic-uboot-env-init sonic-uboot-env-init.service
 	dh_installsystemd --name=hw-watchdog-mgrd hw-watchdog-mgrd.service
+	dh_installsystemd --name=aspeed-disable-boot-watchdog aspeed-disable-boot-watchdog.service
 

--- a/platform/aspeed/aspeed-platform-services/scripts/aspeed-disable-boot-watchdog.sh
+++ b/platform/aspeed/aspeed-platform-services/scripts/aspeed-disable-boot-watchdog.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Disarm AST2720 WDTA boot watchdog for ABR support
+# Clears bit 0 of WDTA_CTRL_REG (0x14c3740c) when ABR is enabled via OTP
+
+set -e
+
+WDTA_CTRL_REG=0x14c3740c
+
+cur_val=$(busybox devmem "$WDTA_CTRL_REG" 2>/dev/null)
+
+new_val=$(printf "0x%08X" $(( cur_val & 0xFFFFFFFE )))
+busybox devmem "$WDTA_CTRL_REG" 32 "$new_val" 2>/dev/null
+
+echo "aspeed-disable-boot-watchdog: WDTA ctrl: $cur_val -> $new_val"

--- a/platform/aspeed/aspeed-platform-services/systemd/aspeed-disable-boot-watchdog.service
+++ b/platform/aspeed/aspeed-platform-services/systemd/aspeed-disable-boot-watchdog.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=AST2720 ABR Boot Watchdog Disarm
+DefaultDependencies=no
+After=local-fs-pre.target
+Before=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/aspeed-disable-boot-watchdog.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=local-fs.target
+


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
When ABR (Alternate Bootblock Recovery) is enabled, SONiC is expected to bootup and stop the WDTA.
This is required by the ABR mechanism to stop booting from resetting and booting from secondary boot source

HLD PR : https://github.com/sonic-net/SONiC/pull/2470

##### Work item tracking
- Microsoft ADO **(number only)**: NA

#### How I did it
Added a service that starts early in the sequence, before local-fs.target, and disarms WDTA by clearing the enable bit in the WDTA control register.

NOTE - On device where ABR is not enabled the service shall not do anything.
              Here we simply switch the enable bit to 0 on the WDTA control register, which shall not do anything on device with ABR enabled

#### How to verify it
On ABR enabled BMC aspeed 2700 devie, run the service and expect following logs:
```
admin@sonic:~$ sudo journalctl -u aspeed-disable-boot-watchdog.service -n 2 --no-pager
Apr 13 20:12:22 sonic aspeed-disable-boot-watchdog.sh[368]: aspeed-disable-boot-watchdog: WDTA ctrl: 0x00000003 -> 0x00000002
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [X] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608
- [ ] N/A

#### Test result
The introduced service is successfully able to disable the WDTA on bootup in time, on ABR enabled dut -
```
admin@sonic:~$ sudo systemctl status aspeed-disable-boot-watchdog.service
● aspeed-disable-boot-watchdog.service - AST2720 ABR Boot Watchdog Disarm
     Loaded: loaded (/usr/lib/systemd/system/aspeed-disable-boot-watchdog.service; enabled; preset: enabled)
     Active: active (exited) since Mon 2026-04-13 20:12:21 UTC; 1min 0s ago
 Invocation: 6532cc9d0e36485784978b121973a16c
   Main PID: 368 (code=exited, status=0/SUCCESS)
   Mem peak: 4.3M
        CPU: 134ms

Apr 13 20:12:22 sonic aspeed-disable-boot-watchdog.sh[368]: aspeed-disable-boot-watchdog: WDTA ctrl: 0x00000003 -> 0x00000002
Notice: journal has been rotated since unit was started, output may be incomplete.
admin@sonic:~$
admin@sonic:~$ sudo journalctl -u aspeed-disable-boot-watchdog.service -n 2 --no-pager
Apr 13 20:12:22 sonic aspeed-disable-boot-watchdog.sh[368]: aspeed-disable-boot-watchdog: WDTA ctrl: 0x00000003 -> 0x00000002
admin@sonic:~$
```

On DUT where ABR is not enabled, the service simply tries to flip the WDTA ctrl bit , which doesn't do anything and doesn't create any problems. the system runs fine.
```
admin@sonic:~$ sudo systemctl status aspeed-disable-boot-watchdog.service
● aspeed-disable-boot-watchdog.service - AST2720 ABR Boot Watchdog Disarm
     Loaded: loaded (/usr/lib/systemd/system/aspeed-disable-boot-watchdog.servi>
     Active: active (exited) since Mon 2026-04-13 19:55:51 UTC; 4min 59s ago
 Invocation: dea86fcbfe74443eae53454a44fb55e2
   Main PID: 366 (code=exited, status=0/SUCCESS)
   Mem peak: 4.2M
        CPU: 139ms

Apr 13 19:55:53 sonic aspeed-disable-boot-watchdog.sh[366]: aspeed-disable-boot>
Notice: journal has been rotated since unit was started, output may be incomple>
admin@sonic:~$
admin@sonic:~$ sudo journalctl -u aspeed-disable-boot-watchdog.service -n 2 --no-pager
Apr 13 19:55:53 sonic aspeed-disable-boot-watchdog.sh[366]: aspeed-disable-boot-watchdog: WDTA ctrl: 0x00000010 -> 0x00000010
```


<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)