### PR TITLE
[Mellanox] Fix speed in Mellanox-SN5600-C256-S1 SKU port config

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini
@@ -272,4 +272,4 @@ Ethernet500    500                                    etp63e    63       100000 
 Ethernet501    501                                    etp63f    63       100000   off
 Ethernet502    502                                    etp63g    63       100000   off
 Ethernet503    503                                    etp63h    63       100000   off
-Ethernet512    512                                    etp65     65        10
+Ethernet512    512                                    etp65     65        10000


### PR DESCRIPTION
Fix a typo introduced in #25958.
Speed of Ethernet512 must be 10000 instead of 10.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`sonic-cfggen -H -k Mellanox-SN5600-C256S1 --preset t1 > /etc/sonic/config_db.json` on SN5600 generates an invalid config that causes ports to have "n/a" operational status.

#### How I did it
Changed speed of Ethernet512 in `device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/port_config.ini` from `10` to `10000`

#### How to verify it
Under root user on SN5600 switch:
1. `sonic-cfggen -H -k Mellanox-SN5600-C256S1 --preset t1 > /etc/sonic/config_db.json`
2. `config reload`
3. `show int status` should show operational status down or up, depending on devices connected to ports.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
4. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
202605: tested manually according to steps written above

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img height="250" alt="image" src="https://github.com/user-attachments/assets/ce5e863a-38ea-4302-bd4a-d36865c8112a" />

Uni