### PR TITLE
[dhcp_server] Wait for caclmgrd-owned docker0 syslog rule on start/stop

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -131,6 +131,21 @@ function preStartAction()
         echo "Cannot fetch system eeprom information. Setting chassis serial number to N/A."
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
     fi
+{%- elif docker_container_name == "dhcp_server" %}
+    # dhcp_server runs in bridge mode; its rsyslog is sent over docker0 to
+    # host rsyslog via RELP (tcp/2514). caclmgrd owns the matching INPUT ACCEPT rule
+    # (gated on FEATURE|dhcp_server) and re-installs it on every control-plane ACL rebuild.
+    # When the feature is enabled, wait (bounded) for caclmgrd to install the rule before
+    # the container starts, so the RELP client's first connection is not dropped by the
+    # control-plane catch-all DROP.
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "enabled" ]; then
+        for i in $(seq 1 10); do
+            iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null && break
+            sleep 1
+        done
+        iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null || \
+            echo "Warning: caclmgrd-owned dhcp_server docker0 syslog ACCEPT rule still absent after the bounded wait; syslog to host may be dropped until caclmgrd installs it."
+    fi
 {%- else %}
     : # nothing
 {%- endif %}
@@ -900,6 +915,20 @@ stop() {
         /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}
     fi
+{%- if docker_container_name == "dhcp_server" %}
+    # caclmgrd removes the docker0 syslog ACCEPT rule when FEATURE|dhcp_server is disabled.
+    # On an explicit feature disable, wait (bounded) for the rule to be removed so the
+    # control-plane ACL state is consistent before we return. Plain container restarts and
+    # shutdown (state not "disabled", or CONFIG_DB unreachable) skip the wait.
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "disabled" ]; then
+        for i in $(seq 1 10); do
+            iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null || break
+            sleep 1
+        done
+        iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null && \
+            echo "Warning: caclmgrd-owned dhcp_server docker0 syslog ACCEPT rule still present after the bounded wait despite dhcp_server feature disabled."
+    fi
+{%- endif %}
     {%- endif %}
 }
 

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -140,11 +140,8 @@ function preStartAction()
     if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "enabled" ]; then
         local attempt status
         for attempt in {0..10}; do
-            if "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null; then
-                status=0
-            else
-                status=$?
-            fi
+            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+            status=$?
 
             case "$status" in
                 0) break ;;
@@ -936,11 +933,8 @@ stop() {
     if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "disabled" ]; then
         local attempt status
         for attempt in {0..10}; do
-            if "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null; then
-                status=0
-            else
-                status=$?
-            fi
+            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+            status=$?
 
             case "$status" in
                 1) break ;;

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -143,20 +143,13 @@ function preStartAction()
             "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
             status=$?
 
-            case "$status" in
-                0) break ;;
-                1|4)
-                    if [ "$attempt" -eq 10 ]; then
-                        echo "Warning: dhcp_server syslog rule not present after 10 seconds (iptables status $status)."
-                    else
-                        sleep 1
-                    fi
-                    ;;
-                *)
-                    echo "Warning: failed to check dhcp_server syslog rule (iptables status $status)."
-                    break
-                    ;;
-            esac
+            if [ "$status" -eq 0 ]; then
+                break
+            elif [ "$attempt" -eq 10 ]; then
+                echo "Warning: dhcp_server syslog rule not present after 10 seconds (iptables status $status)."
+            else
+                sleep 1
+            fi
         done
     fi
 {%- else %}
@@ -936,20 +929,13 @@ stop() {
             "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
             status=$?
 
-            case "$status" in
-                1) break ;;
-                0|4)
-                    if [ "$attempt" -eq 10 ]; then
-                        echo "Warning: dhcp_server syslog rule not absent after 10 seconds (iptables status $status)."
-                    else
-                        sleep 1
-                    fi
-                    ;;
-                *)
-                    echo "Warning: failed to check dhcp_server syslog rule (iptables status $status)."
-                    break
-                    ;;
-            esac
+            if [ "$status" -eq 1 ]; then
+                break
+            elif [ "$attempt" -eq 10 ]; then
+                echo "Warning: dhcp_server syslog rule not absent after 10 seconds (iptables status $status)."
+            else
+                sleep 1
+            fi
         done
     fi
 {%- endif %}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -41,6 +41,10 @@ get_pmon_device_mounts() {
 }
 {%- endif %}
 
+{%- if docker_container_name == "dhcp_server" %}
+DHCP_SERVER_SYSLOG_CHECK=(iptables -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment dhcp_server_syslog -j ACCEPT)
+{%- endif %}
+
 function updateSyslogConf()
 {
     # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
@@ -132,19 +136,31 @@ function preStartAction()
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
     fi
 {%- elif docker_container_name == "dhcp_server" %}
-    # dhcp_server runs in bridge mode; its rsyslog is sent over docker0 to
-    # host rsyslog via RELP (tcp/2514). caclmgrd owns the matching INPUT ACCEPT rule
-    # (gated on FEATURE|dhcp_server) and re-installs it on every control-plane ACL rebuild.
-    # When the feature is enabled, wait (bounded) for caclmgrd to install the rule before
-    # the container starts, so the RELP client's first connection is not dropped by the
-    # control-plane catch-all DROP.
+    # Wait for caclmgrd to allow dhcp_server syslog before startup.
     if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "enabled" ]; then
-        for i in $(seq 1 10); do
-            iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null && break
-            sleep 1
+        local attempt status
+        for attempt in {0..10}; do
+            if "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null; then
+                status=0
+            else
+                status=$?
+            fi
+
+            case "$status" in
+                0) break ;;
+                1|4)
+                    if [ "$attempt" -eq 10 ]; then
+                        echo "Warning: dhcp_server syslog rule not present after 10 seconds (iptables status $status)."
+                    else
+                        sleep 1
+                    fi
+                    ;;
+                *)
+                    echo "Warning: failed to check dhcp_server syslog rule (iptables status $status)."
+                    break
+                    ;;
+            esac
         done
-        iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null || \
-            echo "Warning: caclmgrd-owned dhcp_server docker0 syslog ACCEPT rule still absent after the bounded wait; syslog to host may be dropped until caclmgrd installs it."
     fi
 {%- else %}
     : # nothing
@@ -916,17 +932,31 @@ stop() {
     {%- endif %}
     fi
 {%- if docker_container_name == "dhcp_server" %}
-    # caclmgrd removes the docker0 syslog ACCEPT rule when FEATURE|dhcp_server is disabled.
-    # On an explicit feature disable, wait (bounded) for the rule to be removed so the
-    # control-plane ACL state is consistent before we return. Plain container restarts and
-    # shutdown (state not "disabled", or CONFIG_DB unreachable) skip the wait.
+    # Wait for caclmgrd to remove the rule after feature disable.
     if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "disabled" ]; then
-        for i in $(seq 1 10); do
-            iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null || break
-            sleep 1
+        local attempt status
+        for attempt in {0..10}; do
+            if "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null; then
+                status=0
+            else
+                status=$?
+            fi
+
+            case "$status" in
+                1) break ;;
+                0|4)
+                    if [ "$attempt" -eq 10 ]; then
+                        echo "Warning: dhcp_server syslog rule not absent after 10 seconds (iptables status $status)."
+                    else
+                        sleep 1
+                    fi
+                    ;;
+                *)
+                    echo "Warning: failed to check dhcp_server syslog rule (iptables status $status)."
+                    break
+                    ;;
+            esac
         done
-        iptables -w 1 -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment "dhcp_server_syslog" -j ACCEPT 2>/dev/null && \
-            echo "Warning: caclmgrd-owned dhcp_server docker0 syslog ACCEPT rule still present after the bounded wait despite dhcp_server feature disabled."
     fi
 {%- endif %}
     {%- endif %}


### PR DESCRIPTION
#### Why I did it

`dhcp_server` is the only container that forwards its rsyslog to the host over `docker0` (other containers, including bridge-mode `redfish`, log to `127.0.0.1`); that forwarded traffic uses RELP (**tcp/2514**). `caclmgrd` flushes and rebuilds the `INPUT` chain on every control-plane ACL change and appends a catch-all `DROP`. Ownership of the `docker0`/2514 `ACCEPT` exception has moved from the container start/stop script to `caclmgrd`, which re-installs it on every rebuild keyed on `FEATURE|dhcp_server` (fixes sonic-net/sonic-buildimage#27584).

This is **step 3 of 3**:
1. sonic-net/sonic-buildimage#28328 (merged) removed the old container-side add/del of the rule.
2. sonic-net/sonic-host-services#412 (merged) made `caclmgrd` own the rule.
3. **This PR** replaces the removed container-side add/del with feature-gated bounded waits that synchronize with `caclmgrd`.

##### Work item tracking
- Microsoft ADO (number only): 38745012

#### How I did it

Re-add the `dhcp_server` branches in `files/build_templates/docker_image_ctl.j2` at the same spots #28328 reverted, but as bounded waits instead of add/del:

- `preStartAction`: when `FEATURE|dhcp_server` is `enabled`, wait up to 10s for the `docker0` tcp/2514 `ACCEPT` rule to be **present** before the container starts, so the RELP client's first (state `NEW`) connection is not dropped by the control-plane catch-all `DROP`.
- `stop()`: when `FEATURE|dhcp_server` is `disabled`, wait up to 10s for the rule to be **removed**. Plain container restarts, shutdown, and `CONFIG_DB`-unreachable all skip the wait (positive-state gate, so a restart with the feature still enabled does not block).

The canonical `iptables -C` command is defined once and reused by both waits. Each wait checks at seconds 0 through 10 without a duplicate final command and exits only when the desired rule state is observed; any other status is retried until the bounded timeout. The rule specification matches the stored form `caclmgrd` installs and the live `iptables -S INPUT` output.

#### How to verify it

The exact final wait logic from head `60fbc8eeaa` was hardware-validated by temporarily patching the rendered `dhcp_server` ctl script onto a running DUT (no image rebuild).

- **DUT / topology:** `bjw-can-720dt-2` (720dt, `mx`), `dhcp_server` enabled; RELP tcp/2514 to host `rsyslogd` on `240.127.1.1:2514` (the `docker0` IP); a control-plane ACL rule present so `caclmgrd` programs its catch-all `-A INPUT -j DROP`.
- **Plain restart:** `systemctl restart dhcp_server` completed in 4 seconds with the feature enabled, so the stop wait was skipped; the start-side check observed the rule and no warning was logged.
- **Feature disable:** the rule was absent by the 1-second poll and the container was exited by the 4-second poll, with no timeout warning.
- **Feature enable:** the rule was present by the 1-second poll and the container was running by the 2-second poll, with no timeout warning.
- **RELP delivery:** end-to-end syslog reached host `/var/log/syslog` after both restart and re-enable.
- **Final polling implementation:** rendered the `dhcp_server` specialization and passed `bash -n`; a controlled shell harness passed present, absent, transient-error, and timeout cases. After validation the pre-run script was restored, leaving the feature enabled, container running, and rule present.

> Note: this hardware validation was performed on a 202605 image (identical container ctl / caclmgrd path); the change under test is the same logic.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Coordinated with the caclmgrd change (step 2); the buildimage backport is handled together with #28328 as a set so the branch is never left with neither party owning the rule.
Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 38745012
Failure type: day-one issue (the container-owned docker0 syslog rule never survived a caclmgrd control-plane ACL rebuild)

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Test result

- 202605: 20260510.07 — hand-patched HW validation on `bjw-can-720dt-2` (720dt, `mx`); see "How to verify it" above. The docker0 tcp/2514 `ACCEPT` rule is programmed above the catch-all `DROP`, end-to-end RELP syslog is delivered, the feature toggle adds/removes the rule cleanly, and the rule survives an unrelated control-plane ACL re-walk (bug #27584 fix).
- master: validation pending — the rendered `dhcp_server` ctl script and `caclmgrd` code path are identical to 202605; a master-image run is the only remaining validation step.

#### Description for the changelog

[dhcp_server] Replace the container-side docker0 syslog iptables add/del with feature-gated bounded waits on the caclmgrd-owned tcp/2514 rule.

