### PR TITLE
Fix show macsec crash after deleting macsec ports

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/config_db.json
+++ b/dockers/docker-macsec/cli-plugin-tests/config_db.json
@@ -64,7 +64,6 @@
             "description": "Ethernet6/1",
             "index": "1",
             "lanes": "72,73,74,75,76,77,78,79",
-            "macsec": "macsec_profile",
             "mtu": "9100",
             "num_voq": "8",
             "pfc_asym": "off",

--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -25,6 +25,16 @@ class TestShowMACsec(object):
         result = runner.invoke(show_macsec.macsec,["Ethernet1"])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 
+    def test_show_port_deleted_from_config(self):
+        """A port whose 'macsec' field was removed from CONFIG_DB but whose
+        APPL_DB entry has not been cleaned up yet (mid-teardown of
+        'config macsec port del') is still shown, with an empty profile.
+        Ethernet5 is in this state in the mock DBs."""
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec,[])
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert "MACsec port(Ethernet5)" in result.output
+
     def test_show_profile(self):
         runner = CliRunner()
         result = runner.invoke(show_macsec.macsec,["--profile"])

--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -28,6 +28,16 @@ class TestShowMACsec(object):
         result = runner.invoke(show_macsec.macsec,["Ethernet1"])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
 
+    def test_show_port_deleted_from_config(self):
+        """A port whose 'macsec' field was removed from CONFIG_DB but whose
+        APPL_DB entry has not been cleaned up yet (mid-teardown of
+        'config macsec port del') is still shown, with an empty profile.
+        Ethernet5 is in this state in the mock DBs."""
+        runner = CliRunner()
+        result = runner.invoke(show_macsec.macsec,[])
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert "MACsec port(Ethernet5)" in result.output
+
     def test_show_profile(self):
         runner = CliRunner()
         result = runner.invoke(show_macsec.macsec,["--profile"])

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -156,7 +156,7 @@ class MACsecPort(MACsecAppMeta, MACsecCfgMeta):
         buffer = self.get_header()
 
         # Add the profile information to the meta dict from config meta dict
-        self.meta["profile"] = self.cfgMeta["macsec"]
+        self.meta["profile"] = self.cfgMeta.get("macsec", "")
 
         buffer += tabulate(sorted(self.meta.items(), key=lambda x: x[0]))
         return buffer
@@ -216,7 +216,9 @@ def create_macsec_profile_obj(key: str) -> MACsecCfgMeta:
 
 def create_macsec_objs(interface_name: str) -> typing.List[MACsecAppMeta]:
     objs = []
-    objs.append(create_macsec_obj(MACsecPort.get_appl_table_name() + ":" + interface_name))
+    port = create_macsec_obj(MACsecPort.get_appl_table_name() + ":" + interface_name)
+    if port is not None:
+        objs.append(port)
     egress_scs = DB_CONNECTOR.keys(DB_CONNECTOR.APPL_DB, MACsecEgressSC.get_appl_table_name() + ":" + interface_name + ":*")
     for sc_name in natsorted(egress_scs):
         sc = create_macsec_obj(sc_name)


### PR DESCRIPTION
#### Why I did it

`config macsec port del <port>` removes the `macsec` field from the CONFIG_DB PORT entry immediately, while the APPL_DB MACSEC_PORT_TABLE entry is cleaned up asynchronously by macsecmgrd. If `show macsec` runs in that window (for example, while deleting several ports at once), `MACsecPort.dump_str` finds the APPL_DB entry but no `macsec` field in CONFIG_DB and crashes:

```
File ".../show/plugins/macsec.py", line 158, in dump_str
    self.meta["profile"] = self.cfgMeta["macsec"]
KeyError: 'macsec'
```

The error is transient and re-running `show macsec` after teardown completes succeeds.

fixes #28584

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Switch to `self.cfgMeta.get("macsec", "")` in `MACsecPort.dump_str`

If a port is mid-teardown, it will be shown with an empty profile instead of crashing, e.g.:
```
MACsec port(Ethernet5)
cipher_suite           GCM-AES-256
enable                 true
enable_encrypt         true
enable_protect         true
enable_replay_protect  false
profile
replay_window          0
send_sci               true
```

Reasoning is that the port still exists in APPL_DB, so we should still show the port in `show macsec` while it is still programmed. This output is transient and the port will simply disappear once macsecmgrd has unprogrammed it.

Also adds a guard for the port append in `create_macsec_objs` against None result from `create_macsec_obj`.

#### How to verify it

New regression test `test_show_port_deleted_from_config`: Ethernet5 in the mock DBs has an APPL_DB `MACSEC_PORT_TABLE` entry but no `macsec` field in CONFIG_DB (the mid-teardown state). Without the fix, `test_show_all` and the new test both crash with the KeyError above; with the fix the port shows with an empty profile and all macsec cli-plugin-tests pass.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #28584
Failure type: day-one issue

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
(with fix)
202511:
```
  MACsec port(Ethernet16)
  ------------  -----------
  cipher_suite  GCM-AES-256
  enable        true
  profile
  ------------  -----------
```

#### Description for the changelog
Fix `show macsec` KeyError crash when run while MACsec port deletion is still being processed.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
