### PR TITLE
Add SYSTEM_DEFAULTS['decap_qos_map'] to control IPInIP decap_dscp_to_tc_map

### DIFF
--- a/dockers/docker-orchagent/ipinip.json.j2
+++ b/dockers/docker-orchagent/ipinip.json.j2
@@ -103,9 +103,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and SYSTEM_DEFAULTS is defined and 'decap_qos_map' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['decap_qos_map']['status'] == 'enabled' %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -133,9 +133,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and SYSTEM_DEFAULTS is defined and 'decap_qos_map' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['decap_qos_map']['status'] == 'enabled' %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -170,9 +170,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and SYSTEM_DEFAULTS is defined and 'decap_qos_map' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['decap_qos_map']['status'] == 'enabled' %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"
@@ -200,9 +200,9 @@
 {% endif %}
 {% else %}
             "dscp_mode":"pipe",
-{% if azure_qos_exists %}
-            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
+{% if azure_qos_exists and SYSTEM_DEFAULTS is defined and 'decap_qos_map' in SYSTEM_DEFAULTS and SYSTEM_DEFAULTS['decap_qos_map']['status'] == 'enabled' %}
+            "decap_dscp_to_tc_map":"AZURE",
 {% endif %}
             "ecn_mode":"copy_from_outer",
             "ttl_mode":"pipe"

--- a/files/build_templates/init_cfg.json.j2
+++ b/files/build_templates/init_cfg.json.j2
@@ -208,8 +208,15 @@
 {% else %}
             "status": "disabled"
 {% endif %}
-        }
+        },
 {% endif %}
+        "decap_qos_map": {
+{%- if sonic_asic_platform == "broadcom" %}
+            "status": "disabled"
+{% else %}
+            "status": "enabled"
+{% endif %}
+        }
     },
     "KDUMP": {
         "config": {

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -2944,6 +2944,9 @@
             "tunnel_qos_remap": {
                 "status": "enabled"
             },
+            "decap_qos_map": {
+                "status": "enabled"
+            },
             "mux_tunnel_egress_acl":
             {
                 "status": "enabled"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/system_defaults.json
@@ -8,6 +8,10 @@
                         "status": "enabled"
                     },
                     {
+                        "name": "decap_qos_map",
+                        "status": "enabled"
+                    },
+                    {
                         "name": "mux_tunnel_egress_acl",
                         "status": "enabled"
                     },
@@ -29,6 +33,10 @@
                 "SYSTEM_DEFAULTS_LIST": [
                     {
                         "name": "tunnel_qos_remap",
+                        "status": "invalid_status"
+                    },
+                    {
+                        "name": "decap_qos_map",
                         "status": "invalid_status"
                     },
                     {


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Currently ipinip.json.j2 is having platform checks for enabling/disabling decap entries. We want to prevent having platform checks for simple enable/disable scenarios.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Use SYSTEM_DEFAULTS['decap_qos_map']['status'] to control decap_dscp_to_tc_map instead of hardcoded ASIC vendor and hwsku checks. The decap_qos_map default is set in init_cfg.json.j2 (disabled for broadcom, enabled for others) and can be overridden per-SKU via golden config.

#### How to verify it
decap_qos_remap is set to disabled for Broadcom platforms, and enabled for others.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
With decap_qos_map disabled, decap_dscp_to_tc_map is not set:
```shell
admin@qspf201:~$ sonic-cfggen -d -v "SYSTEM_DEFAULTS"
{'decap_qos_map': {'status': 'disabled'}, 'mux_tunnel_egress_acl': {'status': 'disabled'}}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
{'dscp_mode': 'pipe', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL"
{'dscp_mode': 'pipe', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}
```
With golden config enabling decap_qos_map:
```shell
admin@qspf201:~$ sonic-cfggen -d -v "SYSTEM_DEFAULTS"
{'decap_qos_map': {'status': 'enabled'}, 'mux_tunnel_egress_acl': {'status': 'disabled'}}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_TUNNEL"
{'decap_dscp_to_tc_map': 'AZURE', 'dscp_mode': 'uniform', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}

admin@qspf201:~$ sonic-db-cli APPL_DB HGETALL "TUNNEL_DECAP_TABLE:IPINIP_V6_TUNNEL"
{'decap_dscp_to_tc_map': 'AZURE', 'dscp_mode': 'uniform', 'ecn_mode': 'copy_from_outer', 'ttl_mode': 'pipe', 'tunnel_type': 'IPINIP'}

```

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Use SYSTEM_DEFAULTS['decap_qos_map']['status'] to control decap_dscp_to_tc_map
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
