### PR TITLE
fix(docker-ptf): update grpc-go to 1.82.1

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -128,7 +128,7 @@ ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 RUN GRPCURL_VERSION=v1.9.3 \
     && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
     && cd /tmp/grpcurl \
-    && go get google.golang.org/grpc@v1.79.3 \
+    && go get google.golang.org/grpc@v1.82.1 \
     && go get github.com/go-jose/go-jose/v4@latest \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
     && go mod tidy \

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -428,16 +428,17 @@ RUN cd gnxi \
 # ENV PATH="$BACKUP_OF_PATH"
 
 # Build gnmic from source at a pinned upstream main commit. Picks up the
-# dependency fixes merged after v0.45.0 (grpc 1.79.3, otel-sdk 1.43.0,
+# dependency fixes merged after v0.45.0 (otel-sdk 1.43.0,
 # go-git 5.19.0, prometheus 0.311.3, etc.) that address the CVEs which
-# forced removal in #27059. The golang.org/x/* modules are additionally
-# upgraded to latest to clear current/future golang.org/x/* CVEs (the
-# pinned commit still locks older x/crypto, x/net, etc.). Temporary until
-# the next tagged gnmic release ships.
+# forced removal in #27059. grpc and the golang.org/x/* modules are
+# additionally upgraded to patched versions to clear current CVEs (the
+# pinned commit still locks older grpc, x/crypto, x/net, etc.). Temporary
+# until the next tagged gnmic release ships.
 RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
     && git clone https://github.com/openconfig/gnmic.git /tmp/gnmic \
     && cd /tmp/gnmic \
     && git checkout "${GNMIC_REV}" \
+    && go get google.golang.org/grpc@v1.82.1 \
     && go get golang.org/x/crypto@latest golang.org/x/net@latest golang.org/x/text@latest golang.org/x/sys@latest golang.org/x/oauth2@latest \
     && go mod tidy \
     && go build -o /usr/local/bin/gnmic . \


### PR DESCRIPTION
#### Why I did it

The grpcurl and gnmic binaries in docker-ptf include google.golang.org/grpc v1.79.3, which is affected by [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf). The first fixed release is v1.82.1.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Updated the grpc-go version used when building grpcurl and gnmic from source from v1.79.3 to v1.82.1.

#### How to verify it

Build `target/docker-ptf.gz`, load the generated image, and scan its language packages with Trivy:

```text
Target                  Type       Vulnerabilities
usr/local/bin/gnmic     gobinary   0
usr/local/bin/grpcurl   gobinary   0
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

No backport is requested.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: `target/docker-ptf.gz` built successfully. A Trivy image scan with HIGH and CRITICAL library findings enabled reported zero vulnerabilities for both `usr/local/bin/gnmic` and `usr/local/bin/grpcurl`.

#### Description for the changelog

Update grpcurl and gnmic to use grpc-go v1.82.1 and resolve GHSA-hrxh-6v49-42gf.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
