### PR TITLE
Remove iptables-persistent package

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -340,7 +340,6 @@ sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y in
     efibootmgr              \
     usbutils                \
     pciutils                \
-    iptables-persistent     \
     ebtables                \
     linux-sysctl-defaults   \
     logrotate               \

--- a/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
+++ b/platform/broadcom/sonic-platform-modules-accton/as4630-54pe/utils/restart_ixgbe.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
-/etc/init.d/netfilter-persistent stop
 modprobe -r ixgbe
 udevadm control --reload-rules
 udevadm trigger
 modprobe ixgbe
-/etc/init.d/netfilter-persistent start
 


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Iptables rules are not meant to be persistent across reboots. However, the iptables-persistent package appears to be saving some build-time iptables rules to the image.

Fixes sonic-net/sonic-mgmt#26179

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove the iptables-persistent package from the image build.

#### How to verify it

The `dualtor/test_mux_port_iptables_entries.py` test for dualtor platforms should XFAIL now, since it'll not see any configured IPv6 iptables rules.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
