### PR TITLE
[Mellanox] Update PSU fan speed tolerance and validation logic

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/fan.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -211,6 +211,56 @@ class PsuFan(MlnxFan):
         """
         return self.psu.get_presence() and self.psu.get_powergood_status() and os.path.exists(self.fan_presence_path)
 
+    def get_speed_tolerance(self):
+        """
+        Retrieves the speed tolerance of the fan
+
+        Returns:
+            An integer, the percentage of variance from min/max speed which is
+                 considered tolerable
+        """
+        # The tolerance value is fixed as 30% for PSU fans
+        return 30
+
+    def is_under_speed(self):
+        """
+        Checks if PSU fan speed is below the hardware minimum RPM threshold.
+
+        Returns:
+            bool: True if fan speed is under the minimum threshold, False if not
+        """
+        if not self.get_presence():
+            return False
+
+        try:
+            speed_in_rpm = utils.read_int_from_file(self.fan_speed_get_path, raise_exception=True)
+            min_speed_in_rpm = utils.read_int_from_file(self.fan_min_speed_path, raise_exception=True)
+        except (ValueError, IOError):
+            return False
+
+        return speed_in_rpm < min_speed_in_rpm * (1 - self.get_speed_tolerance() / 100.0)
+
+    def is_over_speed(self):
+        """
+        Checks if PSU fan speed is above the hardware maximum RPM threshold.
+
+        Returns:
+            bool: True if fan speed is over the maximum threshold, False if not
+        """
+        if not self.get_presence():
+            return False
+
+        try:
+            speed_in_rpm = utils.read_int_from_file(self.fan_speed_get_path, raise_exception=True)
+            max_speed_in_rpm = utils.read_int_from_file(self.fan_max_speed_path, raise_exception=True)
+        except (ValueError, IOError):
+            return False
+
+        if max_speed_in_rpm == 0:
+            return False
+
+        return speed_in_rpm > max_speed_in_rpm * (1 + self.get_speed_tolerance() / 100.0)
+
     def get_target_speed(self):
         """
         Retrieves the expected speed of fan
@@ -218,15 +268,31 @@ class PsuFan(MlnxFan):
         Returns:
             int: percentage of the max fan speed
         """
+        if not self.get_presence():
+            return 0
+
         try:
-            # Get PSU fan target speed according to current system cooling level
-            pwm = utils.read_int_from_file('/run/hw-management/thermal/pwm1', log_func=None)
-            if pwm >= PWM_MAX:
-                pwm = PWM_MAX - 1
-            cooling_level = int(pwm / PWM_MAX * 10)
-            return int(self.PSU_FAN_SPEED[cooling_level], 16)
-        except Exception:
+            speed_in_rpm = utils.read_int_from_file(self.fan_speed_get_path, raise_exception=True)
+            max_speed_in_rpm = utils.read_int_from_file(self.fan_max_speed_path, raise_exception=True)
+            min_speed_in_rpm = utils.read_int_from_file(self.fan_min_speed_path, raise_exception=True)
+        except (ValueError, IOError):
             return self.get_speed()
+
+        if max_speed_in_rpm == 0:
+            return self.get_speed()
+
+        if speed_in_rpm < min_speed_in_rpm:
+            target_rpm = min_speed_in_rpm
+        elif speed_in_rpm > max_speed_in_rpm:
+            target_rpm = max_speed_in_rpm
+        else:
+            target_rpm = speed_in_rpm
+
+        speed = 100 * target_rpm // max_speed_in_rpm
+        if speed > 100:
+            speed = 100
+
+        return speed
 
     def set_speed(self, speed):
         """

--- a/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_fan_api.py
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -126,14 +126,128 @@ class TestFan:
         assert fan.get_presence() is False
         mock_path_exists.return_value = True
         assert fan.get_presence() is True
-        mock_read_int.return_value = int(255 / 10 * 7)
-        assert fan.get_target_speed() == 60
         mock_read_int.return_value = FAN_DIR_VALUE_INTAKE
         assert fan.get_direction() == Fan.FAN_DIRECTION_INTAKE
         mock_read_int.return_value = FAN_DIR_VALUE_EXHAUST
         assert fan.get_direction() == Fan.FAN_DIRECTION_EXHAUST
         mock_read_int.return_value = -1 # invalid value
         assert fan.get_direction() == Fan.FAN_DIRECTION_NOT_APPLICABLE
+
+    def test_psu_fan_get_speed_tolerance(self):
+        psu = Psu(0)
+        fan = PsuFan(0, 1, psu)
+        assert fan.get_speed_tolerance() == 30
+
+    def test_psu_fan_is_under_speed(self):
+        psu = Psu(0)
+        fan = PsuFan(0, 1, psu)
+        fan.get_presence = MagicMock(return_value=False)
+        assert fan.is_under_speed() is False
+
+        fan.get_presence = MagicMock(return_value=True)
+        mock_sysfs_content = {
+            fan.fan_speed_get_path: 3000,
+            fan.fan_min_speed_path: 5000,
+        }
+
+        def mock_read_int_from_file(file_path, default=0, raise_exception=False, log_func=None):
+            return mock_sysfs_content[file_path]
+
+        utils.read_int_from_file = mock_read_int_from_file
+        # threshold = 5000 * (1 - 0.3) = 3500, speed 3000 < 3500 -> under speed
+        assert fan.is_under_speed() is True
+
+        mock_sysfs_content[fan.fan_speed_get_path] = 3500
+        assert fan.is_under_speed() is False
+
+        # genuine 0 RPM stall should still trigger under-speed
+        mock_sysfs_content[fan.fan_speed_get_path] = 0
+        assert fan.is_under_speed() is True
+
+        # read failure should not trigger under-speed
+        def mock_read_int_raise(file_path, default=0, raise_exception=False, log_func=None):
+            if raise_exception and file_path == fan.fan_speed_get_path:
+                raise IOError('read failed')
+            return mock_sysfs_content[file_path]
+
+        utils.read_int_from_file = mock_read_int_raise
+        assert fan.is_under_speed() is False
+
+    def test_psu_fan_is_over_speed(self):
+        psu = Psu(0)
+        fan = PsuFan(0, 1, psu)
+        fan.get_presence = MagicMock(return_value=False)
+        assert fan.is_over_speed() is False
+
+        fan.get_presence = MagicMock(return_value=True)
+        mock_sysfs_content = {
+            fan.fan_speed_get_path: 27000,
+            fan.fan_max_speed_path: 20000,
+        }
+
+        def mock_read_int_from_file(file_path, default=0, raise_exception=False, log_func=None):
+            return mock_sysfs_content[file_path]
+
+        utils.read_int_from_file = mock_read_int_from_file
+        # threshold = 20000 * (1 + 0.3) = 26000, speed 27000 > 26000 -> over speed
+        assert fan.is_over_speed() is True
+
+        mock_sysfs_content[fan.fan_speed_get_path] = 26000
+        assert fan.is_over_speed() is False
+
+        # max_rpm == 0 is an unavailable threshold -> not over-speed
+        mock_sysfs_content[fan.fan_max_speed_path] = 0
+        assert fan.is_over_speed() is False
+
+        # read failure of max speed should not trigger over-speed
+        mock_sysfs_content[fan.fan_max_speed_path] = 20000
+        def mock_read_int_raise(file_path, default=0, raise_exception=False, log_func=None):
+            if raise_exception and file_path == fan.fan_max_speed_path:
+                raise IOError('read failed')
+            return mock_sysfs_content[file_path]
+
+        utils.read_int_from_file = mock_read_int_raise
+        assert fan.is_over_speed() is False
+
+    def test_psu_fan_get_target_speed(self):
+        psu = Psu(0)
+        fan = PsuFan(0, 1, psu)
+        fan.get_presence = MagicMock(return_value=True)
+
+        mock_sysfs_content = {
+            fan.fan_speed_get_path: 15000,
+            fan.fan_min_speed_path: 10000,
+            fan.fan_max_speed_path: 20000,
+        }
+
+        def mock_read_int_from_file(file_path, default=0, raise_exception=False, log_func=None):
+            return mock_sysfs_content[file_path]
+
+        utils.read_int_from_file = mock_read_int_from_file
+        # speed in [min, max] -> return current speed as percentage
+        assert fan.get_target_speed() == 75
+
+        mock_sysfs_content[fan.fan_speed_get_path] = 5000
+        # below min -> clamp to min as percentage: 100 * 10000 // 20000 = 50
+        assert fan.get_target_speed() == 50
+
+        mock_sysfs_content[fan.fan_speed_get_path] = 30000
+        # above max -> clamp to max as percentage: 100
+        assert fan.get_target_speed() == 100
+
+        mock_sysfs_content[fan.fan_max_speed_path] = 0
+        mock_sysfs_content[fan.fan_speed_get_path] = 8000
+        fan.get_speed = MagicMock(return_value=30)
+        # max_rpm == 0 -> fall back to get_speed()
+        assert fan.get_target_speed() == 30
+
+        fan.get_speed = MagicMock(return_value=42)
+        utils.read_int_from_file = MagicMock(side_effect=IOError('read failed'))
+        # read failure -> fall back to get_speed()
+        assert fan.get_target_speed() == 42
+
+        fan.get_presence = MagicMock(return_value=False)
+        assert fan.get_target_speed() == 0
 
     def test_psu_fan_set_speed(self):
         psu = Psu(0)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
update the PSU fan speed tolerance, and change the over_speed and under_speed condition accordingly.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
For PsuFan, target speed is now computed from current/min/max RPM in hw-mgmt sysfs (clamped into that range), and is_under_speed / is_over_speed compare actual RPM against those thresholds with a 30% tolerance; unit tests cover presence, clamp, and sysfs-read failure cases.

#### How to verify it
Check that /var/run/hw-management/thermal/psu{N}_fan_min and psu{N}_fan_max contain valid values, then restart pmon and monitor thermalctld logs. The repeated Fan low speed warning around 29% current speed and 60% target speed should no longer appear as a false warning.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 20260531.42

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
