### PR TITLE
[sonic-py-common]: Derive system MAC from base MAC for Micas platforms

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -966,6 +966,14 @@ def get_system_mac(namespace=None, hostname=None):
         mac_tmp = "{:012x}".format(int(mac_tmp, 16) + 1)
         mac_tmp = re.sub("(.{2})", "\\1:", mac_tmp, 0, re.DOTALL)
         mac = mac_tmp[:-1]
+
+    # Micas platforms use base MAC + 1 as the system MAC
+    elif platform and 'micas' in platform.lower():
+        mac_tmp = mac.replace(':', '')
+        mac_tmp = "{:012x}".format(int(mac_tmp, 16) + 1)
+        mac_tmp = re.sub("(.{2})", "\\1:", mac_tmp, 0, re.DOTALL)
+        mac = mac_tmp[:-1]
+
     return mac.strip() if mac else None
 
 

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -474,6 +474,32 @@ liquid_cooled=true
         mock_bmc_data.return_value = BMC_DATA
         assert device_info.get_switch_host_address() == "169.254.100.2"
 
+    @mock.patch("sonic_py_common.device_info.run_command")
+    @mock.patch("sonic_py_common.device_info.get_platform")
+    @mock.patch("sonic_py_common.device_info.get_sonic_version_info")
+    def test_get_system_mac_for_micas(
+            self, mock_get_sonic_version_info, mock_get_platform,
+            mock_run_command):
+        mock_get_sonic_version_info.return_value = {'asic_type': 'broadcom'}
+        mock_get_platform.return_value = 'x86_64-micas_m2-w6951-64hc-cp-r0'
+        mock_run_command.return_value = ('00:11:22:33:44:ff\n', '')
+
+        assert device_info.get_system_mac() == '00:11:22:33:45:00'
+
+    @mock.patch("sonic_py_common.device_info.run_command")
+    @mock.patch("sonic_py_common.device_info.get_platform")
+    @mock.patch("sonic_py_common.device_info.get_sonic_version_info")
+    def test_get_system_mac_for_micas_centec_arm64(
+            self, mock_get_sonic_version_info, mock_get_platform,
+            mock_run_command):
+        mock_get_sonic_version_info.return_value = {'asic_type': 'centec-arm64'}
+        mock_get_platform.return_value = (
+            'arm64-micas_m2-w6010-48gt4x-fa-r0'
+        )
+        mock_run_command.return_value = ('00:11:22:33:44:55\n', '')
+
+        assert device_info.get_system_mac() == '00:11:22:33:44:56'
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")


### PR DESCRIPTION
#### Why I did it

Micas platforms require the system MAC to be derived from the platform
base MAC plus one. This follows the platform MAC allocation requirement
and avoids using the unmodified base MAC as the system MAC.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Added a Micas platform check after the existing Centec adjustment.
- Used an `elif` so the MAC can be incremented at most once.
- Added unit coverage for Micas Broadcom and Micas Centec ARM64 platforms.

#### How to verify it

Run the targeted unit tests:

`python3 -m pytest tests/device_info_test.py -v -k get_system_mac_for_micas`

On a Micas device, compare the platform base MAC with the configured
system MAC and verify that the system MAC is base MAC plus one. Actual
device MAC addresses are intentionally redacted.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A

Failure type: N/A

#### Tested branch
- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- `python3 -m py_compile`: PASS
- `git diff --check`: PASS
- Added Micas Broadcom and Micas Centec ARM64 unit tests.
- Full pytest execution was not available in the local environment;
  PR CI validation is pending.
- Expected hardware result: the observed system MAC equals the platform
  base MAC plus one. Actual MAC addresses are redacted.

#### Description for the changelog

Derive the system MAC from the base MAC plus one on Micas platforms.

#### Link to config_db schema for YANG module changes

N/A


