### PR TITLE
[Mellanox] The SN6600 buffer pool sizes needed to be aligned with the latest buffer-sizing calculations.

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t0.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
-{% set ingress_lossless_pool_size =  '81007616' %}
-{% set ingress_lossy_pool_size =  '81007616' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '81007616' %}
+{% set ingress_lossless_pool_size =  '83356672' %}
+{% set ingress_lossy_pool_size =  '83356672' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '83356672' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t1.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '60167168' %}
-{% set ingress_lossy_pool_size =  '60167168' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '60167168' %}
+{% set ingress_lossless_pool_size =  '62516224' %}
+{% set ingress_lossy_pool_size =  '62516224' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '62516224' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t0.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '214429696' %}
+{% set ingress_lossless_pool_size =  '216778752' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '214429696' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '216778752' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t1.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '214429696' %}
+{% set ingress_lossless_pool_size =  '216778752' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '214429696' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '216778752' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t0.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '209776640' %}
+{% set ingress_lossless_pool_size =  '212125696' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '209776640' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '212125696' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t1.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '209776640' %}
+{% set ingress_lossless_pool_size =  '212125696' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '209776640' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '212125696' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_simx-r0/ACS-SN6600/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_simx-r0/ACS-SN6600/buffers_defaults_t0.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
-{% set ingress_lossless_pool_size =  '81007616' %}
-{% set ingress_lossy_pool_size =  '81007616' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '81007616' %}
+{% set ingress_lossless_pool_size =  '83356672' %}
+{% set ingress_lossy_pool_size =  '83356672' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '83356672' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_simx-r0/ACS-SN6600/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_simx-r0/ACS-SN6600/buffers_defaults_t1.j2
@@ -1,6 +1,6 @@
 {#
     SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
     Apache-2.0
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '60167168' %}
-{% set ingress_lossy_pool_size =  '60167168' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '60167168' %}
+{% set ingress_lossless_pool_size =  '62516224' %}
+{% set ingress_lossy_pool_size =  '62516224' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '62516224' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The SN6600 buffer pool sizes needed to be aligned with the latest buffer-sizing calculations.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Updated the ingress lossless, ingress lossy, egress lossless, and egress lossy pool sizes for the affected SN6600 physical and simx SKUs. Applied the calculated values consistently to both T0 and T1
buffer templates.

#### How to verify it

- Recalculate the affected SKUs using the latest buffer-sizing Excel workbook.
- Confirm that the generated pool sizes match the values in the updated Jinja2 templates.
- Verify that corresponding physical and simx SKUs use consistent values.
- Generate the buffer configuration for the affected T0 and T1 SKUs and confirm that it renders successfully.


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
