### PR TITLE
[Mellanox] Update SN6810 buffer pool sizes from latest calculation

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/ACS-SN6810_LD/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/ACS-SN6810_LD/buffers_defaults_t0.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
-{% set ingress_lossless_pool_size =  '81007616' %}
-{% set ingress_lossy_pool_size =  '81007616' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '81007616' %}
+{% set ingress_lossless_pool_size =  '83356672' %}
+{% set ingress_lossy_pool_size =  '83356672' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '83356672' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6810_ld-r0/ACS-SN6810_LD/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld-r0/ACS-SN6810_LD/buffers_defaults_t1.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '60167168' %}
-{% set ingress_lossy_pool_size =  '60167168' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '60167168' %}
+{% set ingress_lossless_pool_size =  '62516224' %}
+{% set ingress_lossy_pool_size =  '62516224' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '62516224' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/ACS-SN6810_LD/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/ACS-SN6810_LD/buffers_defaults_t0.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
-{% set ingress_lossless_pool_size =  '81007616' %}
-{% set ingress_lossy_pool_size =  '81007616' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '81007616' %}
+{% set ingress_lossless_pool_size =  '83356672' %}
+{% set ingress_lossy_pool_size =  '83356672' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '83356672' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/ACS-SN6810_LD/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6810_ld_simx-r0/ACS-SN6810_LD/buffers_defaults_t1.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '60167168' %}
-{% set ingress_lossy_pool_size =  '60167168' %}
-{% set egress_lossless_pool_size =  '224143360' %}
-{% set egress_lossy_pool_size =  '60167168' %}
+{% set ingress_lossless_pool_size =  '62516224' %}
+{% set ingress_lossy_pool_size =  '62516224' %}
+{% set egress_lossless_pool_size =  '226492416' %}
+{% set egress_lossy_pool_size =  '62516224' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 


### PR DESCRIPTION
Apply the revised SN6810 pool allocation to physical and simulation SKUs.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The SN6810 buffer pool sizes needed to be aligned with the latest buffer-sizing Excel calculations.

#### How I did it
Updated the ingress lossless, ingress lossy, egress lossless, and egress lossy pool sizes for the affected Cham6 physical and simx SKUs. Applied the calculated values consistently to both T0 and T1 buffer templates.

#### How to verify it
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
Recalculate the affected Cham6 SKUs using the latest buffer-sizing Excel workbook.
Confirm that the generated pool sizes match the updated Jinja2 templates.
Verify that corresponding physical and simx SKUs use consistent values.
Generate the buffer configuration for the affected T0 and T1 SKUs and confirm that it renders successfully.


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] master_RC

#### Tested branch
<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->
- [x] master_RC

#### Test result
Test pass in Cham6 switch.