### PR TITLE
libteam: Fix teamsyncd fd corruption during teamd -r

### DIFF
--- a/src/libteam/patch/0019-fix-event-fd-init-and-free.patch
+++ b/src/libteam/patch/0019-fix-event-fd-init-and-free.patch
@@ -1,0 +1,51 @@
+From 1a95ef78742428a278c5087ca323cab6b359e7a1 Mon Sep 17 00:00:00 2001
+From: markxiao <markxiao@arista.com>
+Date: Fri, 24 Jul 2026 01:59:20 -0700
+Subject: [PATCH] libteam: fix fd corruption when team_init fails before team_init_event_fd
+
+team_handle is allocated with myzalloc which zeroes all fields, setting
+event_fd to 0. If team_init fails before reaching team_init_event_fd
+(e.g. port_list_init returns EADDRNOTAVAIL during teamd -r restart),
+event_fd remains 0. team_free then calls close(0), closing stdin.
+
+nl_cli.sock is the only socket connected during team_alloc. After stdin
+is closed, each subsequent team_alloc gets nl_cli.sock on fd 0 (lowest
+available). Each subsequent failed team_free repeats close(event_fd=0),
+which closes whatever currently holds fd 0 — including a previously
+successful TeamPortSync's nl_cli.sock. This cascading corruption causes
+NLE_BAD_SOCK (-3) and NLE_SEQ_MISMATCH (-16) on affected handles,
+preventing team_ifindex2ifname from resolving member ports.
+
+Fix by initializing event_fd to -1 in team_alloc and guarding the close
+in team_free.
+
+Signed-off-by: markxiao <markxiao@arista.com>
+---
+ libteam/libteam.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index 1b9895f..a02bb31 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -382,6 +382,7 @@ struct team_handle *team_alloc(void)
+ 	if (!th)
+ 		return NULL;
+ 
++	th->event_fd = -1;
+ 	th->log_fn = log_stderr;
+ 	th->log_priority = LOG_ERR;
+ 	/* environment overwrites config */
+@@ -705,7 +706,8 @@ int team_init(struct team_handle *th, uint32_t ifindex)
+ TEAM_EXPORT
+ void team_free(struct team_handle *th)
+ {
+-	close(th->event_fd);
++	if (th->event_fd >= 0)
++		close(th->event_fd);
+ 	ifinfo_list_free(th);
+ 	port_list_free(th);
+ 	option_list_free(th);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -16,3 +16,4 @@
 0016-block-retry-count-changes.patch
 0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch
 0018-Replace-FD_SET-select-with-poll-to-avoid-FD_SETSIZE-abort.patch
+0019-fix-event-fd-init-and-free.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
process_monitoring/test_critical_process_monitoring.py has been flaky on t1 topos with portchannels and Arista-7060X6-64PE-B-P32O64 had 100% failure rate on t1-f2-d10u8 since https://github.com/sonic-net/sonic-swss/pull/3984 merged.

After SIGKILL + config reload, some PortChannels have members "not synced" (S* in show int portchannel). APP_LAG_MEMBER_TABLE is empty for affected LAGs, so orchagent never programs members in the ASIC. BGP sessions on these LAGs stay permanently down.

https://github.com/sonic-net/sonic-swss/pull/3984 is not the root cause, but it changed timing and exposed the issue.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
team_handle is allocated with myzalloc which zeroes all fields, setting event_fd to 0. If team_init fails before reaching team_init_event_fd (e.g. port_list_init returns EADDRNOTAVAIL during teamd -r restart), event_fd remains 0. team_free then calls close(0), closing stdin.

nl_cli.sock is the only socket connected during team_alloc. After stdin is closed, each subsequent team_alloc gets nl_cli.sock on fd 0 (lowest available). Each subsequent failed team_free repeats close(event_fd=0), which closes whatever currently holds fd 0 — including a previously successful TeamPortSync's nl_cli.sock. This cascading corruption causes NLE_BAD_SOCK (-3) and NLE_SEQ_MISMATCH (-16) on affected handles, preventing team_ifindex2ifname from resolving member ports.

Fix by initializing event_fd to -1 in team_alloc and guarding the close in team_free.

#### How to verify it
Run process_monitoring/test_critical_process_monitoring.py on t1 topos with portchannels

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

On 202511/202605, process_monitoring/test_critical_process_monitoring.py passed with Arista-7060X6-64PE-B-P32O64 on t1-f2-d10u topo
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Initialize event_fd to -1 in team_alloc and guarding the close in team_free

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
