### PR TITLE
Add qos config support for NH-4010 - T0 platforms

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/BALANCED/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/BALANCED/buffers_defaults_t0.j2
@@ -1,0 +1,35 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "165558216",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "19994880"
+        },
+        "egress_lossless_pool": {
+            "size": "165558216",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "1778",
+            "dynamic_th": "0"
+        },
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        }
+    },
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t1.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-128x400G-2x25G/buffers_defaults_t1.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/BALANCED/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/BALANCED/buffers_defaults_t0.j2
@@ -1,0 +1,35 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+    "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "165558216",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "21652992"
+        },
+        "egress_lossless_pool": {
+            "size": "165558216",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "1778",
+            "dynamic_th": "0"
+        },
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        }
+    },
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t1.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010-256x200G-2x25G/buffers_defaults_t1.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/BALANCED/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/BALANCED/buffers_defaults_t0.j2
@@ -1,0 +1,35 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_lossless_pool": {
+            "size": "165558216",
+            "type": "ingress",
+            "mode": "dynamic",
+            "xoff": "19312128"
+        },
+        "egress_lossless_pool": {
+            "size": "165558216",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "1778",
+            "dynamic_th": "0"
+        },
+        "egress_lossless_profile": {
+            "pool": "egress_lossless_pool",
+            "size": "0",
+            "static_th": "82434938"
+        }
+    },
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t1.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r0/NH-4010/buffers_defaults_t1.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/buffers_defaults_t0.j2
@@ -1,0 +1,49 @@
+{%- set default_cable = '5m' %}
+
+{%- include 'buffer_ports.j2' %}
+{%- macro generate_buffer_pool_and_profiles() %}
+ "BUFFER_POOL": {
+        "ingress_pool": {
+            "size": "166115492",
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_pool": {
+            "size": "166115492",
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        "ingress_lossy_profile": {
+            "pool": "ingress_pool",
+            "dynamic_th": "3",
+            "size": "0"
+        },
+        "egress_lossy_profile": {
+            "pool": "egress_pool",
+            "size": "1778",
+            "dynamic_th": "3"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_pg_profils(port_names_active) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    },
+{%- endmacro %}
+
+{% macro generate_queue_buffers(port_names_active) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0-7": {
+            "profile" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+    }
+{% endmacro %}

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/buffers_defaults_t0.j2
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/buffers_defaults_t0.j2
@@ -47,3 +47,7 @@
 {% endfor %}
     }
 {% endmacro %}
+
+{%- macro generate_cable_length_config(port_names_all) %}
+{# CABLE_LENGTH is disabled #}
+{%- endmacro %}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Support T0 QoS configuration on NH-4010 platforms by adding the missing buffers_defaults_t0.j2 files required for T0 topology devices. 
I see that the lossless BUFFER_PG are generated on master, however on 202605 they are not getting generated will fix that as a seperate issue. 

update:
There seems to be a race condition, which I am unable to repro, I see that all the required profiles are generated consistently on 202605 now, will revisit once I have a repro.

admin@DUT:-$ redis-cli -n 4 hgetall "BUFFER_PG|Ethernet96|3-4"
"profile"
"pg_lossless_800000_40m_profile"
admin@DUT:-$
admin@DUT:-$ redis-cli -n 4 keys "*BUFFER_PG*"
 1) "BUFFER_PG|Ethernet72|0"
 2) "BUFFER_PG|Ethernet96|3-4"
 3) "BUFFER_PG|Ethernet112|0"
 4) "BUFFER_PG|Ethernet112|3-4"
 5) "BUFFER_PG|Ethernet104|3-4"
 6) "BUFFER_PG|Ethernet72|3-4"
 7) "BUFFER_PG|Ethernet88|3-4"
 8) "BUFFER_PG|Ethernet64|0"
 9) "BUFFER_PG|Ethernet80|3-4"
10) "BUFFER_PG|Ethernet88|0"
11) "BUFFER_PG|Ethernet120|3-4"
12) "BUFFER_PG|Ethernet64|3-4"
13) "BUFFER_PG|Ethernet120|0"
14) "BUFFER_PG|Ethernet80|0"
15) "BUFFER_PG|Ethernet104|0"
16) "BUFFER_PG|Ethernet96|0"
admin@DUT:-$ redis-cli -n 0 hgetall "BUFFER_PROFILE_TABLE:pg_lossless_800000_300m_profile"
 1) "pool"
 2) "ingress_lossless_pool"
 3) "xon"
 4) "0"
 5) "xon_offset"
 6) "3556"
 7) "xoff"
 8) "612140"
 9) "size"
10) "18796"
11) "dynamic_th"
12) "0"
admin@DUT:-$
admin@DUT:-$ redis-cli -n 0 hgetall "BUFFER_PROFILE_TABLE:pg_lossless_800000_40m_profile"
 1) "pool"
 2) "ingress_lossless_pool"
 3) "xon"
 4) "0"
 5) "xon_offset"
 6) "3556"
 7) "xoff"
 8) "612140"
 9) "size"
10) "18796"
11) "dynamic_th"
12) "0"
admin@DUT:-$


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added buffers_defaults_t0.j2 for the affected NH-4010 HWSKUs. Kept the change scoped to initial T0 QoS config enablement for NH-4010 platforms.

#### How to verify it
Build and install an image containing this change on an affected NH-4010 platform. Run QoS configuration generation / reload for a T0 topology device.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
202605:
show ver --brief

SONiC Software Version: SONiC.202605.0-3b88b9ea8
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 3b88b9ea8
Build date: Wed Aug 19 18:14:44 UTC 2026
Built by: vijaya@dev-vm

Platform: x86_64-nexthop_4010-r0
HwSKU: NH-4010
ASIC: broadcom
ASIC Count: 1
Serial Number: NH-FSJ25160005
Model Number: NH-4010-F
Hardware Revision: N/A
Uptime: 04:17:58 up 29 min,  1 user,  load average: 0.08, 0.36, 0.57
Date: Thu 20 Aug 2026 04:17:58

admin@dut:~$ redis-cli -n 4 keys  "*BUFFER_PG*"
 1) "BUFFER_PG|Ethernet104|3-4"
 2) "BUFFER_PG|Ethernet112|0"
 3) "BUFFER_PG|Ethernet80|0"
 4) "BUFFER_PG|Ethernet88|3-4"
 5) "BUFFER_PG|Ethernet64|0"
 6) "BUFFER_PG|Ethernet80|3-4"
 7) "BUFFER_PG|Ethernet72|3-4"
 8) "BUFFER_PG|Ethernet96|0"
 9) "BUFFER_PG|Ethernet88|0"
10) "BUFFER_PG|Ethernet72|0"
11) "BUFFER_PG|Ethernet120|3-4"
12) "BUFFER_PG|Ethernet96|3-4"
13) "BUFFER_PG|Ethernet112|3-4"
14) "BUFFER_PG|Ethernet104|0"
15) "BUFFER_PG|Ethernet120|0"
16) "BUFFER_PG|Ethernet64|3-4"
admin@dut:~$ redis-cli -n 4 hgetall "BUFFER_PG|Ethernet104|3-4"
1) "profile"
2) "pg_lossless_800000_40m_profile"
admin@gold107:~$ redis-cli -n 4 keys "*PROFILE*"
1) "WRED_PROFILE|AZURE_LOSSLESS"
2) "BUFFER_PROFILE|pg_lossless_800000_300m_profile"
3) "BUFFER_PROFILE|egress_lossy_profile"
4) "LOGGER|SAI_API_ARS_PROFILE"
5) "BUFFER_PROFILE|egress_lossless_profile"
6) "BUFFER_PROFILE|ingress_lossy_profile"
7) "BUFFER_PROFILE|pg_lossless_800000_40m_profile"
admin@dut:~$ redis-cli -n 4 hgetall "BUFFER_PROFILE|pg_lossless_800000_40m_profile"
 1) "pool"
 2) "ingress_lossless_pool"
 3) "xon"
 4) "0"
 5) "xon_offset"
 6) "3556"
 7) "xoff"
 8) "612140"
 9) "size"
10) "18796"
11) "dynamic_th"
12) "0"
admin@gold107:~$

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
