### PR TITLE
[Mellanox] Add file lock for psu_sensors_conf_updater to resolve race condition

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors_conf_updater
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/psu_sensors_conf_updater
@@ -1,81 +1,155 @@
 #!/bin/bash
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-function update_psu_sensors_configuration() {
-    local SENSORS_CONFIG_FILE="/tmp/sensors.conf"
+# Update PSU section in sensors.conf.
+#
+# Usage:
+#   update_psu_sensors_configuration <src_sensors_conf> [dest_sensors_conf]
+#
+# dest defaults to /etc/sensors.d/sensors.conf.
+# Uses a private workdir + flock so concurrent callers cannot corrupt a shared
+# /tmp/sensors.conf (which previously could leave a PSU-only config).
+
+function _update_psu_sensors_configuration_locked() {
+    local SRC_FILE="$1"
+    local DEST_FILE="$2"
+    local workfile="$3"
     local PSU_SENSORS_CONFIG="/usr/share/sonic/platform/psu_sensors.json"
+    local platform rev start_marker_number end_marker_number bus
+    local platform_info rev_info
+    local chips chip number side psu vendor opers oper section dest_tmp
 
-    if [ -f $SENSORS_CONFIG_FILE ]; then
-        rm $SENSORS_CONFIG_FILE
-    fi
-
-    if [ -z "$1" ]; then
-        echo "psu_sensors_conf_updater ERROR: no sensors configuration file had been selected"
-        return
-    else
-        cp $1 $SENSORS_CONFIG_FILE
-    fi
+    /bin/cp -f "$SRC_FILE" "$workfile" || return 1
 
     platform=$(jq -r '.chassis.name' /usr/share/sonic/platform/platform.json)
-    # built-in psu, no need for dynamic configruation
-    if [[ "$platform" == "MSN2100" || "$platform" == "MSN2010" ]]; then return; fi
-    # incase we don't have this platform's info
-    if [[ $(jq -r --arg platform "$platform" '.platform[$platform]' $PSU_SENSORS_CONFIG) == "null" ]]; then return; fi
+    platform_info=$(jq -r --arg platform "$platform" '.platform[$platform]' $PSU_SENSORS_CONFIG 2>/dev/null)
 
-    local rev=$(cat "$1" | grep "Hardware revision" | awk '{print $NF}')
-    # incase we don't find the revision number
-    if [ ! $rev ]; then return; fi
-    # incase we don't have that revision's data
-    if [[ $(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev]' $PSU_SENSORS_CONFIG) == "null" ]]; then return; fi
+    if [[ -n "$platform_info" && "$platform_info" != "null" ]]; then
 
-    start_marker_number=$(grep -n "Power supplies" $SENSORS_CONFIG_FILE |  cut -f1 -d:)
-    end_marker_number=$(($(tail -n +$(($start_marker_number + 1)) $SENSORS_CONFIG_FILE | grep -n '^$' | head -n 1 | cut -d: -f1) + $start_marker_number))
-    # In some cases, the PSU sensor section may be at the end of the file,
-    # so using grep alone may not match it. Let's set the end marker
-    # to the total number of lines in the file directly.
-    if [ "$end_marker_number" == "$start_marker_number" ]; then
-        end_marker_number=$(wc -l $SENSORS_CONFIG_FILE | cut -f1 -d' ')
-    fi
-    
-    sed -i "${start_marker_number},${end_marker_number}d" $SENSORS_CONFIG_FILE
+        rev=$(grep "Hardware revision" "$SRC_FILE" | awk '{print $NF}')
+        rev_info=
+        if [ -n "$rev" ]; then
+            rev_info=$(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev]' $PSU_SENSORS_CONFIG 2>/dev/null)
+        fi
+        # incase we don't find the revision number / don't have that revision's data
+        if [ -n "$rev" ] && [[ -n "$rev_info" && "$rev_info" != "null" ]]; then
 
-    echo "" >> $SENSORS_CONFIG_FILE
-    echo "# Power supplies" >> $SENSORS_CONFIG_FILE
+            start_marker_number=$(grep -n "Power supplies" "$workfile" | cut -f1 -d:)
+            if [ -n "$start_marker_number" ]; then
+                end_marker_number=$(($(tail -n +$(($start_marker_number + 1)) "$workfile" | grep -n '^$' | head -n 1 | cut -d: -f1) + $start_marker_number))
+                # In some cases, the PSU sensor section may be at the end of the file,
+                # so using grep alone may not match it. Let's set the end marker
+                # to the total number of lines in the file directly.
+                if [ "$end_marker_number" == "$start_marker_number" ]; then
+                    end_marker_number=$(wc -l "$workfile" | cut -f1 -d' ')
+                fi
 
-    bus=$(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev].bus | map("\"" + . + "\"") | join(" ")' $PSU_SENSORS_CONFIG)
-    if [ "$bus" ]; then echo "bus $bus" >> $SENSORS_CONFIG_FILE; fi
-
-    mapfile -t chips < <(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev].chip | to_entries[] | .key' $PSU_SENSORS_CONFIG )
-
-    for chip in "${chips[@]}"; do
-        number=$(jq -r --arg platform "$platform" --arg rev "$rev" --arg chip "$chip" '.platform[$platform][$rev].chip[$chip] | to_entries | .[0].value' $PSU_SENSORS_CONFIG)
-        side=$(jq -r --arg platform "$platform" --arg rev "$rev" --arg chip "$chip" '.platform[$platform][$rev].chip[$chip] | to_entries | .[1].value' $PSU_SENSORS_CONFIG)
-        psu=$(cat /var/run/hw-management/eeprom/psu${number}_vpd | grep "PN_VPD_FIELD" | cut -d ' ' -f 2 2>&1)
-        if [ ! "$psu" ]; then
-            echo "psu_sensors_conf_updater ERROR: Failed to read from /var/run/hw-management/eeprom/psu${number}_vpd"
-            # keep looking for the rest psus
-            continue
-        else
-            psu=$(echo "$psu" | sed -r 's/-PSR|-PSF//g')
-            if [ "$psu" == "MTEF-AC-G" ]; then
-                vendor=$(cat /var/run/hw-management/eeprom/psu${number}_vpd | grep "MFR_NAME:" | cut -d ' ' -f 2 2>&1)
-                psu="${psu}-${vendor}"
+                sed -i "${start_marker_number},${end_marker_number}d" "$workfile"
             fi
 
-            echo "    chip \""$chip"\"" >> $SENSORS_CONFIG_FILE
-            mapfile -t opers < <(jq -r --arg psu "$psu" '.psu[$psu] | keys[]' $PSU_SENSORS_CONFIG)
-            for oper in "${opers[@]}"; do
-                if [ "$oper" == "label" ]; then
-                    section=$(jq -r --arg psu "$psu" --arg oper "$oper" '.psu[$psu][$oper] | map("        " + $oper + " " + . + "\"") | join("\n")' $PSU_SENSORS_CONFIG)                
-                    if [[ ! "$side" || "$side" == "null" ]]; then
-                        echo "$section" | sed "s/PSU/\"PSU-$number/g"   >> $SENSORS_CONFIG_FILE
-                    else
-                        echo "$section" | sed "s/PSU/\"PSU-$number($side)/g" >> $SENSORS_CONFIG_FILE
-                    fi
+            echo "" >> "$workfile"
+            echo "# Power supplies" >> "$workfile"
+
+            bus=$(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev].bus | map("\"" + . + "\"") | join(" ")' $PSU_SENSORS_CONFIG)
+            if [ "$bus" ]; then echo "bus $bus" >> "$workfile"; fi
+
+            mapfile -t chips < <(jq -r --arg platform "$platform" --arg rev "$rev" '.platform[$platform][$rev].chip | to_entries[] | .key' $PSU_SENSORS_CONFIG)
+
+            for chip in "${chips[@]}"; do
+                number=$(jq -r --arg platform "$platform" --arg rev "$rev" --arg chip "$chip" '.platform[$platform][$rev].chip[$chip] | to_entries | .[0].value' $PSU_SENSORS_CONFIG)
+                side=$(jq -r --arg platform "$platform" --arg rev "$rev" --arg chip "$chip" '.platform[$platform][$rev].chip[$chip] | to_entries | .[1].value' $PSU_SENSORS_CONFIG)
+                psu=$(cat /var/run/hw-management/eeprom/psu${number}_vpd | grep "PN_VPD_FIELD" | cut -d ' ' -f 2 2>&1)
+                if [ ! "$psu" ]; then
+                    echo "psu_sensors_conf_updater ERROR: Failed to read from /var/run/hw-management/eeprom/psu${number}_vpd"
+                    # keep looking for the rest psus
+                    continue
                 else
-                    jq -r --arg psu "$psu" --arg oper "$oper" '.psu[$psu][$oper] | map("        " + $oper + " "  + .) | join("\n")' $PSU_SENSORS_CONFIG >> $SENSORS_CONFIG_FILE   
+                    psu=$(echo "$psu" | sed -r 's/-PSR|-PSF//g')
+                    if [ "$psu" == "MTEF-AC-G" ]; then
+                        vendor=$(cat /var/run/hw-management/eeprom/psu${number}_vpd | grep "MFR_NAME:" | cut -d ' ' -f 2 2>&1)
+                        psu="${psu}-${vendor}"
+                    fi
+
+                    echo "    chip \""$chip"\"" >> "$workfile"
+                    mapfile -t opers < <(jq -r --arg psu "$psu" '.psu[$psu] | keys[]' $PSU_SENSORS_CONFIG)
+                    for oper in "${opers[@]}"; do
+                        if [ "$oper" == "label" ]; then
+                            section=$(jq -r --arg psu "$psu" --arg oper "$oper" '.psu[$psu][$oper] | map("        " + $oper + " " + . + "\"") | join("\n")' $PSU_SENSORS_CONFIG)
+                            if [[ ! "$side" || "$side" == "null" ]]; then
+                                echo "$section" | sed "s/PSU/\"PSU-$number/g"   >> "$workfile"
+                            else
+                                echo "$section" | sed "s/PSU/\"PSU-$number($side)/g" >> "$workfile"
+                            fi
+                        else
+                            jq -r --arg psu "$psu" --arg oper "$oper" '.psu[$psu][$oper] | map("        " + $oper + " "  + .) | join("\n")' $PSU_SENSORS_CONFIG >> "$workfile"
+                        fi
+                    done
                 fi
             done
         fi
-    done
+    fi
 
+    # Atomic install: write beside dest then rename into place.
+    dest_tmp=$(mktemp "$(dirname "$DEST_FILE")/sensors.conf.XXXXXX")
+    if [ -z "$dest_tmp" ]; then
+        echo "psu_sensors_conf_updater ERROR: failed to create temp file for ${DEST_FILE}"
+        return 1
+    fi
+    if ! /bin/cp -f "$workfile" "$dest_tmp"; then
+        echo "psu_sensors_conf_updater ERROR: failed to copy workfile to ${dest_tmp}"
+        rm -f "$dest_tmp"
+        return 1
+    fi
+    if ! /bin/mv -f "$dest_tmp" "$DEST_FILE"; then
+        echo "psu_sensors_conf_updater ERROR: failed to install ${DEST_FILE}"
+        rm -f "$dest_tmp"
+        return 1
+    fi
+    return 0
+}
+
+function update_psu_sensors_configuration() {
+    local SRC_FILE="$1"
+    local DEST_FILE="${2:-/etc/sensors.d/sensors.conf}"
+    local LOCK_FILE="/var/lock/psu_sensors_conf.lock"
+    local workdir workfile rc
+
+    if [ -z "$SRC_FILE" ] || [ ! -f "$SRC_FILE" ]; then
+        echo "psu_sensors_conf_updater ERROR: no valid sensors configuration file had been selected: ${SRC_FILE}"
+        return 1
+    fi
+
+    mkdir -p "$(dirname "$LOCK_FILE")" "$(dirname "$DEST_FILE")"
+
+    workdir=$(mktemp -d /tmp/psu_sensors_conf.XXXXXX) || return 1
+    workfile="$workdir/sensors.conf"
+
+    (
+        flock -w 60 9 || {
+            echo "psu_sensors_conf_updater ERROR: failed to acquire lock"
+            exit 1
+        }
+        _update_psu_sensors_configuration_locked "$SRC_FILE" "$DEST_FILE" "$workfile"
+        exit $?
+    ) 9>"$LOCK_FILE"
+    rc=$?
+
+    rm -rf "$workdir"
+    return $rc
 }

--- a/dockers/docker-platform-monitor/docker_init.j2
+++ b/dockers/docker-platform-monitor/docker_init.j2
@@ -125,13 +125,14 @@ if [ -e $SENSORS_CONF_FILE ]; then
     mkdir -p /etc/sensors.d
     PSU_SENSORS_CONF_UPDATER="/usr/share/sonic/platform/psu_sensors_conf_updater"
     if [ -e $PSU_SENSORS_CONF_UPDATER ]; then
-        source $PSU_SENSORS_CONF_UPDATER 
-        update_psu_sensors_configuration $SENSORS_CONF_FILE
-        if [ -f /tmp/sensors.conf ]; then
-            SENSORS_CONF_FILE="/tmp/sensors.conf"
+        source $PSU_SENSORS_CONF_UPDATER
+        # Atomically install updated conf; falls back to plain copy on failure
+        if ! update_psu_sensors_configuration "$SENSORS_CONF_FILE" /etc/sensors.d/sensors.conf; then
+            /bin/cp -f "$SENSORS_CONF_FILE" /etc/sensors.d/sensors.conf
         fi
+    else
+        /bin/cp -f "$SENSORS_CONF_FILE" /etc/sensors.d/sensors.conf
     fi
-    /bin/cp -f $SENSORS_CONF_FILE /etc/sensors.d/sensors.conf
 fi
 
 if [ -e $FANCONTROL_CONF_FILE ]; then

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/psu.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2019-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +25,7 @@
 
 try:
     import os
+    import subprocess
     import time
     from sonic_platform_base.psu_base import PsuBase
     from sonic_py_common.logger import Logger
@@ -39,6 +41,9 @@ except ImportError as e:
 logger = Logger()
 
 PSU_PATH = '/var/run/hw-management/'
+PLATFORM_SENSORS_CONF = '/usr/share/sonic/platform/sensors.conf'
+ETC_SENSORS_CONF = '/etc/sensors.d/sensors.conf'
+PSU_SENSORS_CONF_UPDATER = '/usr/share/sonic/platform/psu_sensors_conf_updater'
 
 
 class FixedPsu(PsuBase):
@@ -309,11 +314,32 @@ class Psu(FixedPsu):
             string: Model/part number of device
         """
         current_model = self.vpd_parser.get_model()
-        if current_model != self.model and os.path.exists('/usr/share/sonic/platform/psu_sensors_conf_updater'):
-            utils.run_command(['cp', '-f', '/etc/sensors.d/sensors.conf', '/tmp/sensors.conf.orig'])
-            utils.run_command(['bash', '-c','source /usr/share/sonic/platform/psu_sensors_conf_updater && update_psu_sensors_configuration /tmp/sensors.conf.orig'])
-            utils.run_command(['cp', '-f', '/tmp/sensors.conf', '/etc/sensors.d/'])
-            utils.run_command(['service', 'sensord', 'restart'])
+        if current_model != self.model and os.path.exists(PSU_SENSORS_CONF_UPDATER):
+            # Rebuild from platform sensors.conf (source of truth), not from
+            # /etc/sensors.d/sensors.conf which may already be incomplete.
+            # Updater uses flock to serialize concurrent updates.
+            # On failure leave self.model unchanged so the next call can retry.
+            src = PLATFORM_SENSORS_CONF if os.path.isfile(PLATFORM_SENSORS_CONF) else ETC_SENSORS_CONF
+            if not os.path.isfile(src):
+                self.model = current_model
+                return current_model
+
+            try:
+                subprocess.check_call([
+                    'bash', '-c',
+                    f'source "{PSU_SENSORS_CONF_UPDATER}" && '
+                    f'update_psu_sensors_configuration "{src}" "{ETC_SENSORS_CONF}"'
+                ])
+                subprocess.check_call(['service', 'sensord', 'restart'])
+            except subprocess.CalledProcessError as ce:
+                logger.log_error(
+                    'Failed to update PSU sensors configuration, return code={}, cmd={}'.format(
+                        ce.returncode, ce.cmd))
+                return current_model
+            except Exception as e:
+                logger.log_error('Failed to update PSU sensors configuration - {}'.format(e))
+                return current_model
+
         self.model = current_model
         return current_model
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Prevent concurrent PSU sensor configuration updates from corrupting sensors.conf and leaving only PSU labels.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

1. Replaced the shared /tmp/sensors.conf with a private workdir, flock, and atomic mktemp/mv install so concurrent docker_init and psud callers cannot corrupt the config. 
2. Kept the same PSU rewrite logic from psu_sensors.json/VPD, and made the updater take an explicit source and destination so it installs directly to /etc/sensors.d/sensors.conf
3. Updated docker_init to use that API with a plain-copy fallback, and updated Psu.get_model() to rebuild from platform sensors.conf, check command status, and retry on failure.
#### How to verify it
Run concurrent updates and confirm sensors.conf remains complete and all platform sensor labels are present.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
1. Confirm sensors still shows Chassis/Ambient/PMB and PSU labels after pmon restart. 
2. Mock a PSU model change by editing psu*_vpd, then check show platform psu and sensors pick up the new labels without dropping non-PSU sections. 
3. Run two updaters concurrently and confirm /etc/sensors.d/sensors.conf stays complete.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
1. Manually tested on each platforms to confirm in normal status sensors.conf had been rightly updated after init.
2. Mock tested a new PSU hotplug-in event, the model of it and relevant labels had been updated.
4. Unit  test. 

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
