### PR TITLE
[Mellanox] Create ASIC ready dir before writing ready file

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/module_host_mgmt_initializer.py
@@ -129,6 +129,7 @@ class ModuleHostMgmtInitializer:
         Args:
             asic_ids (list): list of asic ids to add (numbers)
         """
+        os.makedirs(ASIC_READY_DIR, exist_ok=True)
         for asic_id in asic_ids:
             path = get_asic_ready_file_path(asic_id)
             with open(path, 'w') as file:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Ensure asic_ready exists in add_asics_to_ready_file() before open().
During deploy, xcvrd can fail with FileNotFoundError when writing
module_host_mgmt_asic_ready_asic0 even though init already calls
makedirs(), due to pmon bind-mount timing after nv-syncd-shared reset.
This causes init retry loops (Start is not defined in Software Control)
and xcvrd crash via DomThermalInfoUpdateTask.


#### How I did it
add a call to mkdir to the relevant folder.


#### How to verify it
make sure there are no errors of missing file in log during deploy


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
