### PR TITLE
[nvidia-bluefield] Preserve MFT parent dep for kernel-mft-dkms

### DIFF
--- a/platform/nvidia-bluefield/recipes/mft.mk
+++ b/platform/nvidia-bluefield/recipes/mft.mk
@@ -35,7 +35,7 @@ $(eval $(call add_derived_package,$(MFT),$(MFT_OEM)))
 
 KERNEL_MFT_DKMS = kernel-mft-dkms_$(MFT_VERSION)-$(MFT_REVISION)_all.deb
 $(eval $(call add_derived_package,$(MFT),$(KERNEL_MFT_DKMS)))
-$(KERNEL_MFT_DKMS)_DEPENDS = $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
+$(KERNEL_MFT_DKMS)_DEPENDS += $(LINUX_HEADERS) $(LINUX_HEADERS_COMMON)
 # Note: Restrict the DKMS package to compile the driver only against the target kernel headers
 $(KERNEL_MFT_DKMS)_DEB_INSTALL_OPTS = "KVERSION=$(KVERSION)"
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

To fix KERNEL_MFT_DKMS build failure race condition

#### How I did it

Use += when adding LINUX_HEADERS deps so add_derived_package's dependency on mft_*.deb is not overwritten, which left kernel-mft-dkms finishing with no .deb on cache miss.

#### How to verify it
Run build with parallel schedule where KERNEL_MFT chains outruns mft.

Without this fix we see the build failure below

```
10:20:36  target/debs/trixie/kernel-mft-dkms_4.36.0-147_all.deb does not exist
10:20:36  [  FAIL LOG END  ] [ target/debs/trixie/kernel-mft-dkms_4.36.0-147_all.deb-install ]
10:20:36  make: *** [slave.mk:1058: target/debs/trixie/kernel-mft-dkms_4.36.0-147_all.deb-install] Error 1
10:20:39  make[1]: *** [Makefile.work:719: target/sonic-nvidia-bluefield.bfb] Error 2
10:20:39  make[1]: Leaving directory '/builds2/sw-r2d2-bot/workspace/sonic_main/sonic'
10:20:39  make: *** [Makefile:51: target/sonic-nvidia-bluefield.bfb] Error 2
```

With the fix, the build failure does not occur

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
