### PR TITLE
[Nexthop] Add margin init service to NH-5010

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/voltage_margin_config.json
+++ b/device/nexthop/x86_64-nexthop_5010-r0/voltage_margin_config.json
@@ -1,0 +1,24 @@
+{
+  "rails": {
+    "POS0V78_VDDC_D0": {
+      "device_type": "xdpe1a2g5b",
+      "i2c_bus": 89, "i2c_addr": "0x68", "page": 0,
+      "avs_profile": "nh5010_q3d_vddc",
+      "avs_fpga_register": "0x98",
+      "avs_fpga_bits": "0:7",
+      "margin_low_val_mv": 715.0,
+      "margin_min_val_mv": 610.0,
+      "margin_max_val_mv": 890.0
+    },
+    "POS0V78_VDDC_D1": {
+      "device_type": "xdpe1a2g5b",
+      "i2c_bus": 89, "i2c_addr": "0x70", "page": 0,
+      "avs_profile": "nh5010_q3d_vddc",
+      "avs_fpga_register": "0x98",
+      "avs_fpga_bits": "8:15",
+      "margin_low_val_mv": 715.0,
+      "margin_min_val_mv": 610.0,
+      "margin_max_val_mv": 890.0
+    }
+  }
+}

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/voltage_cli.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/voltage_cli.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``nh_voltage_margin`` -- margin a configured voltage rail high/low.
+
+    nh_voltage_margin POS0V78_VDDC_D0 high
+    nh_voltage_margin POS0V78_VDDC_D0 low
+    nh_voltage_margin POS0V78_VDDC_D0 nominal      # restore
+    nh_voltage_margin POS0V78_VDDC_D0 read         # read-only report
+    nh_voltage_margin all read
+
+Only rails declared in the platform's voltage_margin_config.json can be
+margined; the per-rail absolute target and the [min, max] clamp come from that
+file.
+"""
+
+import os
+import sys
+
+import click
+
+from nexthop import voltage_margin as vm
+
+LEVEL_READ = "read"
+CHOICES = [vm.LEVEL_HIGH, vm.LEVEL_LOW, vm.LEVEL_NOMINAL, LEVEL_READ]
+
+
+def _check_root():
+    if os.getuid() != 0:
+        click.secho("Root privileges required for this operation", fg="red")
+        sys.exit(1)
+
+
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+@click.argument("rail")
+@click.argument("level", type=click.Choice(CHOICES))
+@click.option("--target-mv", type=float, default=None, hidden=True)
+@click.option("--offset-mv", type=float, default=None, hidden=True)
+@click.option("--dry-run", is_flag=True,
+              help="Print every transaction; execute nothing.")
+@click.option("-v", "--verbose", is_flag=True,
+              help="Echo every register access.")
+def cli(rail, level, target_mv, offset_mv, dry_run, verbose):
+    """Margin the RAIL to LEVEL (high, low, nominal, read).
+
+    RAIL is a rail declared in voltage_margin_config.json, or 'all'.
+    """
+    if (target_mv is not None or offset_mv is not None) \
+            and level in (vm.LEVEL_NOMINAL, LEVEL_READ):
+        raise click.BadParameter(
+            "--target-mv/--offset-mv only apply to 'high' or 'low'",
+            param_hint="--target-mv/--offset-mv")
+    if target_mv is not None and offset_mv is not None:
+        raise click.BadParameter("--target-mv and --offset-mv are mutually exclusive",
+                                 param_hint="--target-mv/--offset-mv")
+    if not dry_run:
+        _check_root()
+
+    try:
+        rails = vm.load_config()
+    except vm.VoltageMarginError as e:
+        click.secho("error: %s" % e, fg="red")
+        sys.exit(1)
+
+    if rail == "all":
+        names = sorted(rails)
+    else:
+        # Validate against the allowlist up front for a clean error.
+        try:
+            vm.get_rail(rails, rail)
+        except vm.VoltageMarginError as e:
+            click.secho("error: %s" % e, fg="red")
+            sys.exit(1)
+        names = [rail]
+
+    failures = 0
+    for name in names:
+        try:
+            cfg = vm.get_rail(rails, name)
+            if level == LEVEL_READ:
+                vm.read_rail(name, cfg, dry_run=dry_run, verbose=verbose)
+            else:
+                vm.set_rail(name, cfg, level, target_mv=target_mv,
+                            offset_mv=offset_mv, dry_run=dry_run, verbose=verbose)
+        except vm.VoltageMarginError as e:
+            click.secho("  ! %s: %s" % (name, e), fg="red")
+            failures += 1
+
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    cli()

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/voltage_margin.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/voltage_margin.py
@@ -1,0 +1,476 @@
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Voltage margining for Nexthop platforms.
+
+Only rails defined in `voltage_margin_config.json` in the platform device directory
+can be margined.
+
+Safety guards: An absolute [min, max] clamp is defined per rail. There is also a
+VOUT_MODE sanity check and a read-back settle check that auto-reverts to nominal.
+"""
+
+import json
+import os
+import time
+
+from nexthop import fpga_lib
+
+try:
+    from smbus2 import SMBus
+except ImportError:
+    SMBus = None
+
+CONFIG_FILENAME = "voltage_margin_config.json"
+DEFAULT_PLATFORM_DIR = "/usr/share/sonic/platform"
+
+# AVS profiles: AVS code -> commanded VDDC level (volts) for a board/design.
+# A rail selects its profile via the "avs_profile" config key; only codes present
+# in the selected profile are valid.
+AVS_PROFILES = {
+    # nh-5010 core-VDDC AVS map
+    "nh5010_q3d_vddc": {
+        0x7A: 0.8500, 0x7C: 0.8375, 0x7E: 0.8250, 0x80: 0.8125,
+        0x82: 0.8000, 0x84: 0.7875, 0x86: 0.7750, 0x88: 0.7625,
+        0x8A: 0.7500, 0x8C: 0.7375, 0x8E: 0.7250, 0x90: 0.7125,
+        0x92: 0.7000, 0x94: 0.6875, 0x96: 0.6750, 0x98: 0.6625,
+        0x9A: 0.6500,
+    },
+}
+
+# Default FPGA whose register holds the live AVS-commanded levels.
+# Overridable per-rail via the optional "avs_fpga_name" config key.
+DEFAULT_AVS_FPGA = "SWITCHCARD_FPGA"
+
+# Device types this tool knows how to drive; selected per-rail via "device_type".
+SUPPORTED_DEVICE_TYPES = ("xdpe1a2g5b",)
+
+# PMBus registers.
+PMBUS_PAGE = 0x00
+PMBUS_OPERATION = 0x01
+PMBUS_VOUT_MODE = 0x20
+PMBUS_VOUT_MARGIN_HIGH = 0x25
+PMBUS_VOUT_MARGIN_LOW = 0x26
+PMBUS_READ_VOUT = 0x8B
+# OPERATION: bit7 enable=1; bits[5:4] margin-select 00=nominal, 01=low, 10=high;
+# bits[3:2] fault-response (ignore fault while margined).
+OPERATION_NOMINAL = 0x80
+OPERATION_MARGIN_LOW = 0x98
+OPERATION_MARGIN_HIGH = 0xA8
+
+# Physically-plausible Linear16 volts-per-LSB band (exponent -11..-9, nominal
+# -10 => ~0.9766 mV/LSB).  Outside this => corrupt VOUT_MODE read.
+_VPL_MIN = 0.0004
+_VPL_MAX = 0.0021
+
+# READ_VOUT settle tolerance / poll budget.
+_SETTLE_TOLERANCE_V = 0.025
+_SETTLE_POLLS = 10
+
+# Margin levels.
+LEVEL_HIGH = "high"
+LEVEL_LOW = "low"
+LEVEL_NOMINAL = "nominal"
+LEVELS = (LEVEL_HIGH, LEVEL_LOW, LEVEL_NOMINAL)
+
+# Dry-run simulated reads.  VOUT_MODE 0x16 => Linear16 exponent -10.  FPGA AVS
+# 0x8686 => 0.775 V baseline for both nibbles.
+_DRYRUN_READS = {PMBUS_PAGE: 0x00, PMBUS_VOUT_MODE: 0x16, PMBUS_OPERATION: 0x80}
+_DRYRUN_FPGA_REG = 0x00008686
+
+
+class VoltageMarginError(Exception):
+    """Raised for any condition that should abort margining a rail."""
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                     #
+# --------------------------------------------------------------------------- #
+def _log(msg):
+    print(msg, flush=True)
+
+
+def _vlog(verbose, msg):
+    if verbose:
+        print(msg, flush=True)
+
+
+def _platform_dir():
+    try:
+        from sonic_py_common import device_info
+
+        path = device_info.get_path_to_platform_dir()
+        if path:
+            return path
+    except Exception:
+        pass
+    return DEFAULT_PLATFORM_DIR
+
+
+def load_config(platform_dir=None):
+    """Load and minimally validate `voltage_margin_config.json`. Returns the
+    `rails` dict. Raises VoltageMarginError if the file is missing or
+    malformed."""
+    platform_dir = platform_dir or _platform_dir()
+    path = os.path.join(platform_dir, CONFIG_FILENAME)
+    if not os.path.isfile(path):
+        raise VoltageMarginError("no voltage-margin config at %s" % path)
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError) as e:
+        raise VoltageMarginError("cannot read %s: %s" % (path, e))
+    rails = data.get("rails")
+    if not isinstance(rails, dict) or not rails:
+        raise VoltageMarginError("%s has no 'rails' object" % path)
+    return rails
+
+
+def get_rail(rails, name):
+    """Return the config entry for `name`, enforcing the allowlist: a rail not
+    declared in the config is refused (never margined)."""
+    rail = rails.get(name)
+    if rail is None:
+        raise VoltageMarginError(
+            "rail %r is not declared in %s (declared rails: %s)"
+            % (name, CONFIG_FILENAME, ", ".join(sorted(rails))))
+    dtype = rail.get("device_type")
+    if dtype not in SUPPORTED_DEVICE_TYPES:
+        raise VoltageMarginError(
+            "rail %r has unsupported device_type %r (supported: %s)"
+            % (name, dtype, ", ".join(SUPPORTED_DEVICE_TYPES)))
+    return rail
+
+
+def _parse_bits(spec):
+    """Parse an `avs_fpga_bits` 'lo:hi' field into a (lo, hi) tuple."""
+    try:
+        lo_s, hi_s = str(spec).split(":")
+        lo, hi = int(lo_s), int(hi_s)
+    except (ValueError, AttributeError):
+        raise VoltageMarginError("bad avs_fpga_bits %r (expected 'lo:hi')" % spec)
+    if lo > hi:
+        raise VoltageMarginError("avs_fpga_bits %r must be 'lo:hi' (lo <= hi)" % spec)
+    return (lo, hi)
+
+
+def _avs_table(rail):
+    """Resolve a rail's AVS code->VDDC table from its 'avs_profile' key."""
+    profile = rail.get("avs_profile")
+    if profile is None:
+        raise VoltageMarginError(
+            "rail has no 'avs_profile' -- cannot decode its AVS baseline")
+    table = AVS_PROFILES.get(profile)
+    if table is None:
+        raise VoltageMarginError(
+            "unknown avs_profile %r (known: %s)"
+            % (profile, ", ".join(sorted(AVS_PROFILES))))
+    return table
+
+
+# --------------------------------------------------------------------------- #
+# AVS baseline (FPGA)                                                         #
+# --------------------------------------------------------------------------- #
+def read_avs_baseline_mv(rail, dry_run=False, verbose=False):
+    """Live per-rail baseline (mV): read the AVS-commanded VDDC level from the
+    FPGA register and map it through the rail's AVS profile."""
+    table = _avs_table(rail)
+    reg = int(str(rail["avs_fpga_register"]), 16)
+    bits = _parse_bits(rail["avs_fpga_bits"])
+    fpga_name = rail.get("avs_fpga_name", DEFAULT_AVS_FPGA)
+
+    if dry_run:
+        reg_val = _DRYRUN_FPGA_REG
+        _vlog(verbose, "  [dry-run] %s 0x%02x -> 0x%08x (simulated)"
+                       % (fpga_name, reg, reg_val))
+    else:
+        bdf = fpga_lib.name_to_bdf(fpga_name)
+        if not bdf:
+            raise VoltageMarginError("FPGA %r not found (cannot read AVS)" % fpga_name)
+        reg_val = fpga_lib.read_32(bdf, reg)
+
+    avs = fpga_lib.get_field(reg_val, bits)
+    if avs not in table:
+        raise VoltageMarginError(
+            "%s 0x%02x=0x%08x -> AVS byte 0x%02x is not a known VDDC level for "
+            "profile %r -- refusing (corrupt read)"
+            % (fpga_name, reg, reg_val, avs, rail["avs_profile"]))
+    mv = table[avs] * 1000.0
+    _vlog(verbose, "  AVS byte 0x%02x -> %.1f mV baseline" % (avs, mv))
+    return mv
+
+
+# --------------------------------------------------------------------------- #
+# SMBus access                                                                #
+# --------------------------------------------------------------------------- #
+class _Bus:
+    """Thin SMBus wrapper. In dry-run it simulates reads and drops writes so
+    the full flow can be exercised with no hardware access."""
+
+    def __init__(self, busnum, dry_run, verbose):
+        self._dry = dry_run
+        self._v = verbose
+        if dry_run:
+            self._bus = None
+        elif SMBus is None:
+            raise VoltageMarginError("smbus2 is not available")
+        else:
+            self._bus = SMBus(busnum)
+
+    def close(self):
+        if self._bus is not None:
+            self._bus.close()
+
+    def read_byte(self, addr, reg):
+        if self._dry:
+            val = _DRYRUN_READS.get(reg, 0x00)
+            _vlog(self._v, "  [dry-run] read byte 0x%02x -> 0x%02x" % (reg, val))
+            return val
+        val = self._bus.read_byte_data(addr, reg)
+        _vlog(self._v, "  read byte 0x%02x -> 0x%02x" % (reg, val))
+        return val
+
+    def read_word(self, addr, reg):
+        if self._dry:
+            _vlog(self._v, "  [dry-run] read word 0x%02x -> 0x0000" % reg)
+            return 0x0000
+        val = self._bus.read_word_data(addr, reg)
+        _vlog(self._v, "  read word 0x%02x -> 0x%04x" % (reg, val))
+        return val
+
+    def write_byte(self, addr, reg, val):
+        if self._dry:
+            _vlog(self._v, "  [dry-run] write byte 0x%02x <- 0x%02x" % (reg, val))
+            return
+        _vlog(self._v, "  write byte 0x%02x <- 0x%02x" % (reg, val))
+        self._bus.write_byte_data(addr, reg, val)
+
+    def write_word(self, addr, reg, val):
+        if self._dry:
+            _vlog(self._v, "  [dry-run] write word 0x%02x <- 0x%04x" % (reg, val))
+            return
+        _vlog(self._v, "  write word 0x%02x <- 0x%04x" % (reg, val))
+        self._bus.write_word_data(addr, reg, val)
+
+
+def _dev_id(bus, addr):
+    return "%d-%04x" % (bus, addr)
+
+
+def _unbind_device(bus, addr, dry_run, verbose):
+    """Unbind one device from its kernel driver so the tool can drive it without
+    racing the driver.  Returns the driver dir for _rebind, or None if it was not
+    bound. Raises VoltageMarginError if it is bound but the unbind fails -- the
+    caller must not drive a device whose driver is still attached. Note, unbinding
+    does NOT power down the rail."""
+    dev_id = _dev_id(bus, addr)
+    link = "/sys/bus/i2c/devices/%s/driver" % dev_id
+    if not os.path.islink(link):
+        _vlog(verbose, "  %s not bound to a driver; nothing to unbind" % dev_id)
+        return None
+    drv = os.path.realpath(link)
+    if dry_run:
+        _vlog(verbose, "  [dry-run] would unbind %s from %s"
+                       % (dev_id, os.path.basename(drv)))
+        return drv
+    try:
+        with open(os.path.join(drv, "unbind"), "w") as f:
+            f.write(dev_id)
+    except OSError as e:
+        raise VoltageMarginError(
+            "failed to unbind %s from %s: %s -- refusing to drive it with the "
+            "driver still attached" % (dev_id, os.path.basename(drv), e))
+    _vlog(verbose, "  unbound %s from %s" % (dev_id, os.path.basename(drv)))
+    return drv
+
+
+def _rebind_device(bus, addr, drv, dry_run, verbose):
+    """Rebind a previously-unbound device.  No-op if it was not bound."""
+    if drv is None:
+        return
+    dev_id = _dev_id(bus, addr)
+    bind = os.path.join(drv, "bind")
+    if dry_run:
+        _vlog(verbose, "  [dry-run] would rebind %s to %s"
+                       % (dev_id, os.path.basename(drv)))
+        return
+    try:
+        with open(bind, "w") as f:
+            f.write(dev_id)
+    except OSError as e:
+        _log("  ! failed to rebind %s to %s: %s -- MANUAL RECOVERY: echo %s > %s"
+             % (dev_id, os.path.basename(drv), e, dev_id, bind))
+        return
+    _vlog(verbose, "  rebound %s to %s" % (dev_id, os.path.basename(drv)))
+
+
+def _volts_per_lsb(dev, addr):
+    """Volts-per-LSB for the VOUT-family registers (Linear16). Raises if the decoded
+    value is outside the physically-expected band (corrupt read)."""
+    vout_mode = dev.read_byte(addr, PMBUS_VOUT_MODE)
+    exponent = vout_mode & 0x1F
+    if exponent & 0x10: # sign-extend the 5-bit exponent
+        exponent -= 0x20
+    vpl = 2.0 ** exponent
+    if not (_VPL_MIN <= vpl <= _VPL_MAX):
+        raise VoltageMarginError(
+            "VOUT_MODE=0x%02x -> %.6f V/LSB outside expected band "
+            "[%.4f, %.4f] mV/LSB -- corrupt read, refusing to compute a margin "
+            "code" % (vout_mode, vpl, _VPL_MIN * 1000, _VPL_MAX * 1000))
+    return vpl
+
+
+# --------------------------------------------------------------------------- #
+# Target computation                                                          #
+# --------------------------------------------------------------------------- #
+def compute_target_mv(name, rail, level, target_mv=None, offset_mv=None,
+                      baseline_mv=None):
+    """Absolute target (mV), clamped to the per-rail [min, max] window. Priority:
+    `target_mv` (absolute) > `offset_mv` (baseline + offset, sign from level)
+    > the per-rail configured absolute target for `level`."""
+    if target_mv is not None:
+        target = float(target_mv)
+    elif offset_mv is not None:
+        if baseline_mv is None:
+            raise VoltageMarginError("offset margining needs an AVS baseline")
+        mag = abs(offset_mv)
+        target = baseline_mv + (-mag if level == LEVEL_LOW else mag)
+    else:
+        key = "margin_low_val_mv" if level == LEVEL_LOW else "margin_high_val_mv"
+        cfg = rail.get(key)
+        if cfg is None:
+            raise VoltageMarginError(
+                "rail %r has no %s configured -- refusing %r" % (name, key, level))
+        target = float(cfg)
+    lo = float(rail["margin_min_val_mv"])
+    hi = float(rail["margin_max_val_mv"])
+    if not (lo <= target <= hi):
+        raise VoltageMarginError(
+            "rail %r target %.1f mV is outside the allowed [%.1f, %.1f] mV "
+            "window -- refusing" % (name, target, lo, hi))
+    return target
+
+
+# --------------------------------------------------------------------------- #
+# Rail operations                                                             #
+# --------------------------------------------------------------------------- #
+def set_rail(name, rail, level, target_mv=None, offset_mv=None,
+             dry_run=False, verbose=False):
+    """Drive a rail to `level` (LEVEL_HIGH/LOW = margin, LEVEL_NOMINAL =
+    restore). Unbinds the device, programs the PMBus margin/operation registers,
+    polls READ_VOUT, auto-reverts a margin that doesn't settle, and rebinds."""
+    if level not in LEVELS:
+        raise VoltageMarginError("unknown level %r" % level)
+    busnum = rail["i2c_bus"]
+    addr = int(str(rail["i2c_addr"]), 16)
+    page = rail.get("page", 0)
+
+    if level == LEVEL_NOMINAL:
+        # Restore clears margin-select only -- no target read, no margin code.
+        target = None
+        operation_value = OPERATION_NOMINAL
+        margin_reg = None
+        verb = "nominal"
+    else:
+        baseline_mv = None
+        if offset_mv is not None:
+            baseline_mv = read_avs_baseline_mv(rail, dry_run, verbose)
+        target = compute_target_mv(name, rail, level, target_mv, offset_mv,
+                                   baseline_mv)
+        if level == LEVEL_HIGH:
+            operation_value, margin_reg = OPERATION_MARGIN_HIGH, PMBUS_VOUT_MARGIN_HIGH
+        else:
+            operation_value, margin_reg = OPERATION_MARGIN_LOW, PMBUS_VOUT_MARGIN_LOW
+        if baseline_mv is not None:
+            verb = ("margin-%s %.1fmV (AVS %.1f %+0.1f)"
+                    % (level, target, baseline_mv, target - baseline_mv))
+        else:
+            verb = "margin-%s %.1fmV" % (level, target)
+
+    drv = _unbind_device(busnum, addr, dry_run, verbose)
+    dev = _Bus(busnum, dry_run, verbose)
+    try:
+        if dev.read_byte(addr, PMBUS_PAGE) != page:
+            dev.write_byte(addr, PMBUS_PAGE, page)
+
+        vpl = _volts_per_lsb(dev, addr)
+        margin_code = None
+        if margin_reg is not None:
+            margin_code = int(round((target / 1000.0) / vpl))
+            dev.write_word(addr, margin_reg, margin_code)
+        dev.write_byte(addr, PMBUS_OPERATION, operation_value)
+
+        if dry_run:
+            if margin_reg is None:
+                _log("  [dry-run] %s (bus %d 0x%02x) -> %s: clear margin-select "
+                     "(OPERATION=0x%02x)" % (name, busnum, addr, verb, operation_value))
+            else:
+                _log("  [dry-run] %s (bus %d 0x%02x) -> %s: code %d @ %.4f mV/LSB"
+                     % (name, busnum, addr, verb, margin_code, vpl * 1000))
+            return
+
+        if target is None:
+            raw = dev.read_word(addr, PMBUS_READ_VOUT)
+            _log("  %s (bus %d 0x%02x) -> %s: %.1fmV"
+                 % (name, busnum, addr, verb, raw * vpl * 1000))
+            return
+
+        actual_v = None
+        target_v = target / 1000.0
+        for _ in range(_SETTLE_POLLS):
+            raw = dev.read_word(addr, PMBUS_READ_VOUT)
+            actual_v = raw * vpl
+            if abs(actual_v - target_v) <= _SETTLE_TOLERANCE_V:
+                break
+            time.sleep(0.1)
+
+        settled = actual_v is not None and abs(actual_v - target_v) <= _SETTLE_TOLERANCE_V
+        if settled:
+            _log("  %s (bus %d 0x%02x) -> %s: %.1fmV (target %.1fmV)"
+                 % (name, busnum, addr, verb, actual_v * 1000, target))
+        else:
+            last = ("%.1fmV" % (actual_v * 1000)) if actual_v is not None else "n/a"
+            _log("  ! %s (bus %d 0x%02x) -> %s did NOT settle: last=%s target=%.1fmV"
+                 % (name, busnum, addr, verb, last, target))
+            _log("  ! reverting %s to NOMINAL for safety" % name)
+            dev.write_byte(addr, PMBUS_OPERATION, OPERATION_NOMINAL)
+            raise VoltageMarginError("%s did not settle; reverted to nominal" % name)
+    finally:
+        dev.close()
+        _rebind_device(busnum, addr, drv, dry_run, verbose)
+
+
+def read_rail(name, rail, dry_run=False, verbose=False):
+    """Read-only: report a rail's OPERATION margin state and READ_VOUT voltage."""
+    busnum = rail["i2c_bus"]
+    addr = int(str(rail["i2c_addr"]), 16)
+    page = rail.get("page", 0)
+    state = {0: "NOMINAL", 1: "LOW", 2: "HIGH", 3: "RESERVED"}
+    drv = _unbind_device(busnum, addr, dry_run, verbose)
+    dev = _Bus(busnum, dry_run, verbose)
+    try:
+        avs_mv = (read_avs_baseline_mv(rail, dry_run, verbose)
+                  if rail.get("avs_profile") is not None else None)
+        if dev.read_byte(addr, PMBUS_PAGE) != page:
+            dev.write_byte(addr, PMBUS_PAGE, page)
+        operation = dev.read_byte(addr, PMBUS_OPERATION)
+        vpl = _volts_per_lsb(dev, addr)
+        if dry_run:
+            avs_str = " (AVS %.1fmV)" % avs_mv if avs_mv is not None else ""
+            _log("  [dry-run] %s: would read OPERATION + READ_VOUT%s"
+                 % (name, avs_str))
+            return
+        raw = dev.read_word(addr, PMBUS_READ_VOUT)
+        actual_mv = raw * vpl * 1000
+        margin_bits = (operation >> 4) & 0x03
+        if avs_mv is not None:
+            dev_pct = (actual_mv - avs_mv) / avs_mv * 100.0
+            _log("  %s (bus %d 0x%02x): %.1fmV (AVS %.1fmV, %+.2f%%), "
+                 "OPERATION=0x%02x margin=%s"
+                 % (name, busnum, addr, actual_mv, avs_mv, dev_pct, operation,
+                    state[margin_bits]))
+        else:
+            _log("  %s (bus %d 0x%02x): %.1fmV, OPERATION=0x%02x margin=%s"
+                 % (name, busnum, addr, actual_mv, operation, state[margin_bits]))
+    finally:
+        dev.close()
+        _rebind_device(busnum, addr, drv, dry_run, verbose)

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/utils/nh_voltage_margin
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/utils/nh_voltage_margin
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import os.path
+
+from nexthop import voltage_cli
+
+
+if __name__ == "__main__":
+    voltage_cli.cli()

--- a/platform/broadcom/sonic-platform-modules-nexthop/debian/sonic-platform-nexthop-5010-r0.postinst
+++ b/platform/broadcom/sonic-platform-modules-nexthop/debian/sonic-platform-nexthop-5010-r0.postinst
@@ -10,6 +10,8 @@ systemctl start --no-block system-ledd.service
 systemctl enable transceiver-init.service
 systemctl start transceiver-init.service
 systemctl enable bcm-intf-init.service
+systemctl enable voltage-margin-init.service
+systemctl start voltage-margin-init.service
 systemctl enable adm1266-rtc-sync.timer
 systemctl start adm1266-rtc-sync.timer
 systemctl enable watchdog.timer

--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/service/voltage-margin-init.service
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/service/voltage-margin-init.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Margin NH-5010-F core-VDDC rails low on boards with device version 0
+After=pddf-platform-init.service
+Requires=pddf-platform-init.service
+Before=pmon.service
+Before=syncd.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/hb_voltage_margin_init.py
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/utils/hb_voltage_margin_init.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-5010/utils/hb_voltage_margin_init.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""nh-5010 boot-time core-VDDC margining.
+
+On boards with IDPROM Device Version (ONIE TLV 0x26) == 0 the core-VDDC rails
+are margined low at boot, before syncd brings up the datapath.  The rail set and
+their absolute targets come from the platform's voltage_margin_config.json.
+
+Strictly gated: if the device version cannot be read, or is not 0, no rail is
+touched (fail-safe).  Best-effort: any margining failure is logged to syslog but
+the script always exits 0 so a margining miss can never block boot.
+"""
+
+import sys
+import syslog
+
+from nexthop import voltage_margin as vm
+
+TAG = "nh_5010_voltage_margin_init"
+
+
+def _log(msg):
+    print(msg, flush=True)
+    syslog.syslog(syslog.LOG_INFO, msg)
+
+
+def _read_device_version():
+    """IDPROM Device Version (TLV 0x26) as an int, or None if it can't be read.
+    Read failure is deliberately distinct from a value -- the caller treats None
+    as 'do not margin'."""
+    try:
+        from sonic_platform.platform import Platform
+
+        raw = Platform().get_chassis().get_eeprom().eeprom_tlv_dict.get("0x26")
+        if raw is None:
+            return None
+        return int(str(raw).strip())
+    except Exception as e:
+        _log("could not read IDPROM device version: %s" % e)
+        return None
+
+
+def main():
+    syslog.openlog(TAG, syslog.LOG_PID, syslog.LOG_USER)
+    dry_run = "--dry-run" in sys.argv[1:]
+
+    dv = _read_device_version()
+    if dv is None:
+        _log("device version unavailable -- not margining (fail-safe)")
+        return 0
+    if dv != 0:
+        _log("device version %d != 0 -- no boot-time margining required" % dv)
+        return 0
+
+    _log("device version 0 -- margining configured core-VDDC rails low")
+    try:
+        rails = vm.load_config()
+    except vm.VoltageMarginError as e:
+        _log("no voltage-margin config -- nothing to do: %s" % e)
+        return 0
+
+    for name in sorted(rails):
+        try:
+            vm.set_rail(name, vm.get_rail(rails, name), vm.LEVEL_LOW, dry_run=dry_run)
+            _log("margined %s low%s" % (name, " [dry-run]" if dry_run else ""))
+        except vm.VoltageMarginError as e:
+            _log("! %s: failed to margin low: %s" % (name, e))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
#### Why I did it
Add a voltage margin init service to apply margin config that persists across reboots.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added voltage-margin-init.service‎ that margins the Q3D core rails to 0.715 V at bootup 

#### How to verify it
Tested on NH-5010

Confirmed margining is applied to a system with device version 0
Confirmed margining is not applied to a system with device version 1

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
Add margin init service to NH-5010