### PR TITLE
[Nexthop] Enable warm/fast reboot plumbing on NH-4010 and NH-4210

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/sai.profile
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-128x400G-2x25G/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/nh4010-r1-128x400-M_2x25.yaml
 SAI_NUM_ECMP_MEMBERS=128
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/sai.profile
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010-256x200G-2x25G/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/nh4010-r1-256x200-M_2x25.yaml
 SAI_NUM_ECMP_MEMBERS=128
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin

--- a/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/sai.profile
+++ b/device/nexthop/x86_64-nexthop_4010-r1/NH-4010/sai.profile
@@ -1,2 +1,4 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/nh4010-r1-64x800-M_2x25.yaml
 SAI_NUM_ECMP_MEMBERS=128
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin

--- a/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/sai.profile
+++ b/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-O256/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/nh4210-r0021-F-O256.yaml
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin

--- a/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-P128/sai.profile
+++ b/device/nexthop/x86_64-nexthop_4210-r0021/NH-4210-F-P128/sai.profile
@@ -1,1 +1,3 @@
 SAI_INIT_CONFIG_FILE=/usr/share/sonic/hwsku/nh4210-r0021-F-P128.yaml
+SAI_KEY_WARM_BOOT_WRITE_FILE=/var/warmboot/sai-warmboot.bin
+SAI_KEY_WARM_BOOT_READ_FILE=/var/warmboot/sai-warmboot.bin

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/pcie_lib.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/nexthop/pcie_lib.py
@@ -1,10 +1,43 @@
 #!/usr/bin/env python3
 
 import functools
+import re
 import subprocess
+import types
 import yaml
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
 
 PLATFORM_FOLDER = "/usr/share/sonic/platform"
+
+
+class PcieDeviceType(str, Enum):
+    ASIC = "asic"
+
+
+# Maps each device type to the regex its pcie-variables.yaml variable names
+# follow, so a variable can be classified by name alone. An ASIC's
+# upstream-bridge secondary bus number is exposed as `asic_bus` (single-ASIC
+# platforms) or `asic_<N>_bus` (multi-slot platforms).
+_DEVICE_TYPE_VAR_PATTERNS: Mapping[PcieDeviceType, re.Pattern] = types.MappingProxyType({
+    PcieDeviceType.ASIC: re.compile(r"^asic(_\d+)?_bus$"),
+})
+
+
+def device_type_for_var_name(var_name: str) -> PcieDeviceType | None:
+    """Classify a pcie-variables.yaml variable name by its naming convention.
+
+    Returns the matching PcieDeviceType, or None if the name matches no
+    known device-type pattern. For example, an ASIC's upstream-bridge
+    secondary bus number is exposed as `asic_bus` (single-ASIC platforms) or
+    `asic_<N>_bus` (multi-slot platforms), both of which map to
+    PcieDeviceType.ASIC; unrelated names like `cpu_card_fpga_bdf` map to None.
+    """
+    for device_type, pattern in _DEVICE_TYPE_VAR_PATTERNS.items():
+        if pattern.match(var_name):
+            return device_type
+    return None
 
 
 @functools.cache
@@ -93,3 +126,136 @@ def get_switchcard_fpga_0_bdf(vars_filepath=f"{PLATFORM_FOLDER}/pcie-variables.y
     return get_pcie_variables(vars_filepath, vars_to_get={"switchcard_fpga_0_bdf"}).get(
         "switchcard_fpga_0_bdf"
     )
+
+
+def setpci_read(bdf: str, offset_with_width: str) -> str:
+    """Run `setpci -s <bdf> <offset.width>` and return the raw hex string
+    (bare hex digits, no leading 0x).
+
+    Raises RuntimeError if the command fails or returns empty output, and
+    propagates FileNotFoundError if setpci is not installed. Callers are
+    responsible for logging and deciding how to react.
+    """
+    result = subprocess.run(
+        ["setpci", "-s", bdf, offset_with_width],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"setpci read {bdf} {offset_with_width} failed: {result.stderr.strip()}"
+        )
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError(f"setpci read {bdf} {offset_with_width} returned empty output")
+    return value
+
+
+def setpci_write(bdf: str, offset_with_width: str, value: str) -> None:
+    """Run `setpci -s <bdf> <offset.width>=<hex>`.
+
+    Raises RuntimeError if the command fails, and propagates
+    FileNotFoundError if setpci is not installed.
+    """
+    result = subprocess.run(
+        ["setpci", "-s", bdf, f"{offset_with_width}={value}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"setpci write {bdf} {offset_with_width}={value} failed: "
+            f"{result.stderr.strip()}"
+        )
+
+
+def apply_word_mask(old: int, *, set_mask: int = 0, clear_mask: int = 0) -> int:
+    """OR in `set_mask`, then AND out `clear_mask` from a config-space word."""
+    return (old | set_mask) & ~clear_mask
+
+
+def pci_device_present(bdf: str) -> bool:
+    """Return True if `lspci -n` reports a device at the given BDF.
+
+    Raises RuntimeError if lspci fails, and propagates FileNotFoundError if
+    lspci is not installed.
+    """
+    result = subprocess.run(["lspci", "-n"], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"lspci -n failed: {result.stderr.strip()}")
+    return bdf in result.stdout
+
+
+# Generic PCI config-space register definitions, from include/uapi/linux/pci_regs.h.
+PCI_COMMAND = 0x04  # 16-bit Command register
+PCI_COMMAND_INTX_DISABLE = 0x0400  # bit 10: INTx Emulation Disable
+PCI_CAPABILITY_LIST = 0x34  # 8-bit pointer to the first capability
+PCI_CAP_ID_MSI = 0x05  # Message Signalled Interrupts capability
+PCI_CAP_ID_MSIX = 0x11  # MSI-X capability
+PCI_MSI_FLAGS = 0x02  # Message Control register, offset within the MSI cap
+PCI_MSI_FLAGS_ENABLE = 0x0001  # bit 0: MSI enable
+PCI_MSIX_FLAGS = 0x02  # Message Control register, offset within the MSI-X cap
+PCI_MSIX_FLAGS_ENABLE = 0x8000  # bit 15: MSI-X enable
+
+
+@dataclass(frozen=True)
+class PciWordChange:
+    """The before/after value of a 16-bit PCI config-space word write."""
+
+    old: int
+    new: int
+
+
+def find_pci_capability(bdf: str, cap_id: int) -> int | None:
+    """Walk the PCI capabilities list of `bdf` and return the config-space
+    offset of the capability whose ID is `cap_id`, or None if not present.
+
+    The list starts at PCI_CAPABILITY_LIST; each node stores its capability ID
+    at offset +0 and the pointer to the next node at +1, with the low two bits
+    of every pointer reserved (masked off). Raises (via setpci_read) if setpci
+    fails. Bounded against malformed/looping lists.
+    """
+    # Capabilities are dword-aligned, so the low two bits of every pointer are
+    # reserved -- mask them off (& 0xFC == & ~0x3) to get the real offset.
+    ptr = int(setpci_read(bdf, f"0x{PCI_CAPABILITY_LIST:02x}.b"), 16) & 0xFC
+    seen: set[int] = set()
+    while ptr and ptr not in seen:
+        seen.add(ptr)
+        if int(setpci_read(bdf, f"0x{ptr:02x}.b"), 16) == cap_id:
+            return ptr
+        ptr = int(setpci_read(bdf, f"0x{ptr + 1:02x}.b"), 16) & 0xFC
+    return None
+
+
+def _modify_pci_word(bdf: str, offset: int, *, set_mask: int = 0, clear_mask: int = 0) -> PciWordChange:
+    """Read the 16-bit config word at `offset`, apply the masks, write it back,
+    and return the before/after values. Raises (via setpci) on failure.
+    """
+    word = f"0x{offset:02x}.w"
+    old = int(setpci_read(bdf, word), 16)
+    new = apply_word_mask(old, set_mask=set_mask, clear_mask=clear_mask)
+    setpci_write(bdf, word, f"{new:04x}")
+    return PciWordChange(old=old, new=new)
+
+
+def disable_intx(bdf: str) -> PciWordChange:
+    """Set the INTx Disable bit in the PCI Command register (always present)."""
+    return _modify_pci_word(bdf, PCI_COMMAND, set_mask=PCI_COMMAND_INTX_DISABLE)
+
+
+def disable_msi(bdf: str) -> PciWordChange | None:
+    """Clear the MSI Enable bit. Returns None if the device has no MSI cap."""
+    cap = find_pci_capability(bdf, PCI_CAP_ID_MSI)
+    if cap is None:
+        return None
+    return _modify_pci_word(bdf, cap + PCI_MSI_FLAGS, clear_mask=PCI_MSI_FLAGS_ENABLE)
+
+
+def disable_msix(bdf: str) -> PciWordChange | None:
+    """Clear the MSI-X Enable bit. Returns None if the device has no MSI-X cap."""
+    cap = find_pci_capability(bdf, PCI_CAP_ID_MSIX)
+    if cap is None:
+        return None
+    return _modify_pci_word(bdf, cap + PCI_MSIX_FLAGS, clear_mask=PCI_MSIX_FLAGS_ENABLE)

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/utils/asic_init_wrapper.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/utils/asic_init_wrapper.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Boot-time wrapper around asic_init.sh, called from pre_pddf_init.sh:
+
+  - warm-reboot post-kexec (SONIC_BOOT_TYPE=warm on cmdline): preserve
+    dataplane, disable stale ASIC interrupts at the PCI level, skip
+    asic_init.sh.
+  - Otherwise (cold boot or fast-reboot post-kexec): exec asic_init.sh
+    for a full ASIC reset.
+
+The interrupt-disable step is the reason this wrapper exists: after a
+warm reboot the ASIC driver is reloaded by opennsl-modules.service, and
+if interrupts are still enabled from the pre-kexec kernel an IRQ can
+fire before userspace remaps and updates the BARs, panicking the kernel.
+"""
+
+import os
+import re
+import sys
+import syslog
+
+from nexthop import pcie_lib
+
+ASIC_INIT_SCRIPT = "/usr/local/bin/asic_init.sh"
+PROC_CMDLINE = "/proc/cmdline"
+
+# SONIC_BOOT_TYPE=warm — warm-reboot post-kexec marker on the kernel
+# cmdline. fast-reboot uses SONIC_BOOT_TYPE=fast-reboot and is
+# intentionally NOT treated as warm here: fast-reboot post-kexec gets a
+# full ASIC reset.
+WARM_BOOT_CMDLINE_RE = re.compile(r"(?:^|\s)SONIC_BOOT_TYPE=warm(?:\s|$)")
+
+
+def log_info(msg: str) -> None:
+    syslog.syslog(syslog.LOG_INFO, msg)
+
+
+def log_err(msg: str) -> None:
+    syslog.syslog(syslog.LOG_ERR, msg)
+
+
+def is_warm_boot_post_kexec() -> bool:
+    try:
+        with open(PROC_CMDLINE) as f:
+            cmdline = f.read()
+    except OSError as e:
+        log_err(f"Cannot read {PROC_CMDLINE}: {e}")
+        return False
+    return bool(WARM_BOOT_CMDLINE_RE.search(cmdline))
+
+
+def get_asic_bdfs() -> list[str]:
+    """Look up every candidate ASIC BDF (e.g. "01:00.0") from the
+    platform's pcie-variables.yaml. The yaml exposes each ASIC bridge's
+    secondary bus number as `asic_bus` or `asic_<N>_bus`; the ASIC itself
+    enumerates as device 0, function 0 on that bus.
+    """
+    try:
+        name_to_cmd = pcie_lib.get_var_name_to_cmd_map(
+            f"{pcie_lib.PLATFORM_FOLDER}/pcie-variables.yaml"
+        )
+    except Exception as e:
+        # Catch broadly: a missing/corrupt pcie-variables.yaml must NOT
+        # prevent the cold-boot fallback to asic_init.sh.
+        log_err(f"Failed to read pcie-variables.yaml: {e}")
+        return []
+
+    bdfs: list[str] = []
+    for name, cmd in name_to_cmd.items():
+        if pcie_lib.device_type_for_var_name(name) != pcie_lib.PcieDeviceType.ASIC:
+            continue
+        try:
+            bus = pcie_lib.get_cmd_output(cmd)
+        except Exception as e:
+            # Tolerate per-slot lookup failures: an unpopulated slot on a
+            # multi-ASIC platform can legitimately fail to resolve.
+            log_err(f"Failed to resolve {name}: {e}")
+            continue
+        if bus:
+            bdfs.append(f"{bus}:00.0")
+    return bdfs
+
+
+def asic_present_on_pci_bus(bdf: str) -> bool:
+    """Return True if `lspci -n` reports a device at the given BDF. Logs and
+    returns False on any failure so the boot path can fall back gracefully.
+    """
+    try:
+        return pcie_lib.pci_device_present(bdf)
+    except Exception as e:
+        log_err(f"lspci check for {bdf} failed: {e}")
+        return False
+
+
+def _log_disable(bdf: str, label: str, disable_fn) -> None:
+    """Run one pcie_lib interrupt-disable function and log the outcome. The
+    pcie_lib functions are syslog-free and either return a PciWordChange,
+    return None when the capability is absent, or raise on setpci failure --
+    this wrapper owns all the logging and never propagates.
+    """
+    try:
+        change = disable_fn(bdf)
+    except Exception as e:
+        log_err(f"Warm boot: {label} failed: {e}")
+        return
+    if change is None:
+        log_info(f"Warm boot: {label} skipped (capability not present)")
+        return
+    log_info(f"Warm boot: {label} (was: 0x{change.old:04x}, now: 0x{change.new:04x})")
+
+
+def disable_asic_pci_interrupts(bdf: str) -> None:
+    """Disable INTx, MSI-X, and MSI on the ASIC endpoint. The driver may
+    have left interrupts enabled from before kexec; if it loads with them
+    still enabled, an IRQ can fire before userspace maps the PIO memory
+    and panic the kernel.
+    """
+    log_info("Warm boot: Disabling all PCI interrupts")
+    _log_disable(bdf, "INTx disabled via PCI Command", pcie_lib.disable_intx)
+    _log_disable(bdf, "MSI-X disabled", pcie_lib.disable_msix)
+    _log_disable(bdf, "MSI disabled", pcie_lib.disable_msi)
+    log_info(
+        "Warm boot: PCI interrupts disabled, "
+        "module load deferred to opennsl-modules.service"
+    )
+
+
+def handle_warm_boot_post_kexec() -> bool:
+    """Returns True iff warm-boot interrupt cleanup succeeded for at
+    least one ASIC and the caller should skip asic_init.sh.
+    """
+    candidate_bdfs = get_asic_bdfs()
+    if not candidate_bdfs:
+        log_err("Warm boot: Cannot determine ASIC BDF")
+        return False
+
+    present_bdfs = [bdf for bdf in candidate_bdfs if asic_present_on_pci_bus(bdf)]
+    if not present_bdfs:
+        log_err(f"Warm boot: no ASIC found at any of {candidate_bdfs}")
+        return False
+
+    for bdf in present_bdfs:
+        log_info(f"Warm boot: ASIC found at {bdf}")
+        disable_asic_pci_interrupts(bdf)
+    return True
+
+
+def main(argv: list[str]) -> int:
+    syslog.openlog("asic_init_wrapper")
+
+    if is_warm_boot_post_kexec():
+        log_info(
+            "Warm boot post-kexec: disabling stale interrupts, skipping asic_init.sh"
+        )
+        if handle_warm_boot_post_kexec():
+            return 0
+        log_err("Warm boot interrupt disable failed, falling back to full ASIC init")
+
+    log_info("Cold boot or fast-reboot post-kexec: running asic_init.sh")
+    os.execv(ASIC_INIT_SCRIPT, [ASIC_INIT_SCRIPT, *argv[1:]])
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/utils/pre_pddf_init.sh
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/utils/pre_pddf_init.sh
@@ -10,7 +10,16 @@ log() {
   logger -t "pre_pddf_init" "$@"
 }
 
-ASIC_INIT_PATH="/usr/local/bin/asic_init.sh"
+PRIMARY="/usr/local/bin/asic_init_wrapper.py"
+FALLBACK="/usr/local/bin/asic_init.sh"
+if [[ -f "$PRIMARY" ]]; then
+  ASIC_INIT_PATH="$PRIMARY"
+  log "$PRIMARY found"
+else
+  ASIC_INIT_PATH="$FALLBACK"
+  log "$PRIMARY not found; setting ASIC_INIT_PATH=$FALLBACK as fallback"
+fi
+
 if [ -f "$ASIC_INIT_PATH" ]; then
   log "$ASIC_INIT_PATH found. Executing..."
   "$ASIC_INIT_PATH"

--- a/platform/broadcom/sonic-platform-modules-nexthop/common/utils/syncd_post_stop.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/utils/syncd_post_stop.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+syncd.service ExecStopPost hook for Nexthop platforms.
+
+When syncd stops, power-cycle the ASIC via /usr/local/bin/asic_init.sh to
+recover from any errors potentially.Skip the power-cycle if
+warm-reboot or fast-reboot orchestration is in progress — in that case
+the ASIC must be left intact for the upcoming kexec.
+
+Wired in via a per-platform syncd.service.d/*.conf override:
+    [Service]
+    ExecStopPost=/usr/local/bin/syncd_post_stop.py
+"""
+
+import os
+import subprocess
+import sys
+import syslog
+
+ASIC_INIT = "/usr/local/bin/asic_init.sh"
+WARMBOOT_DUMP_RDB = "/host/warmboot/dump.rdb"
+SONIC_DB_CLI = "sonic-db-cli"
+DB_CLI_TIMEOUT_S = 5
+
+WARM_RESTART_ENABLE_KEY = ("WARM_RESTART_ENABLE_TABLE|system", "enable")
+FAST_RESTART_ENABLE_KEY = ("FAST_RESTART_ENABLE_TABLE|system", "enable")
+
+
+def _state_db_hget(key, field):
+    try:
+        result = subprocess.run(
+            [SONIC_DB_CLI, "STATE_DB", "hget", key, field],
+            capture_output=True,
+            text=True,
+            timeout=DB_CLI_TIMEOUT_S,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        syslog.syslog(syslog.LOG_WARNING, f"sonic-db-cli STATE_DB hget {key} {field} failed: {e}")
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def is_warm_or_fast_reboot_in_progress():
+    for key, field in (WARM_RESTART_ENABLE_KEY, FAST_RESTART_ENABLE_KEY):
+        if _state_db_hget(key, field) == "true":
+            syslog.syslog(syslog.LOG_INFO, f"{key} {field}=true in STATE_DB")
+            return True
+
+    if os.path.isfile(WARMBOOT_DUMP_RDB):
+        syslog.syslog(syslog.LOG_INFO, f"{WARMBOOT_DUMP_RDB} present")
+        return True
+
+    return False
+
+
+def main():
+    syslog.openlog("syncd_post_stop")
+
+    if is_warm_or_fast_reboot_in_progress():
+        syslog.syslog(syslog.LOG_INFO, "syncd stop during warm/fast reboot: leaving ASIC up for kexec")
+        return 0
+
+    syslog.syslog(syslog.LOG_INFO, "syncd stop without warm/fast reboot: power-cycling ASIC to reinitialize")
+    os.execv(ASIC_INIT, [ASIC_INIT])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-4010/etc/systemd/system/syncd.service.d/ge-override.conf
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-4010/etc/systemd/system/syncd.service.d/ge-override.conf
@@ -1,2 +1,2 @@
 [Service]
-ExecStopPost=/usr/local/bin/asic_init.sh
+ExecStopPost=/usr/local/bin/syncd_post_stop.py

--- a/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/etc/systemd/system/syncd.service.d/sea-eagle-override.conf
+++ b/platform/broadcom/sonic-platform-modules-nexthop/nh-4210/etc/systemd/system/syncd.service.d/sea-eagle-override.conf
@@ -1,3 +1,2 @@
 [Service]
-ExecStopPost=/usr/local/bin/asic_init.sh
-
+ExecStopPost=/usr/local/bin/syncd_post_stop.py

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_pcie_lib.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_pcie_lib.py
@@ -5,6 +5,8 @@
 
 import textwrap
 import tempfile
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 
@@ -117,3 +119,143 @@ def test_get_var_name_to_cmd_map_raises_on_invalid_yaml(pcie_lib_module, input_y
         f.flush()
         with pytest.raises(Exception):
             pcie_lib_module.get_var_name_to_cmd_map(f.name)
+
+
+class TestDeviceTypeForVarName:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "asic_bus",
+            "asic_0_bus",
+            "asic_1_bus",
+            "asic_10_bus",
+        ],
+    )
+    def test_matches_asic_bus(self, pcie_lib_module, name):
+        assert (
+            pcie_lib_module.device_type_for_var_name(name)
+            is pcie_lib_module.PcieDeviceType.ASIC
+        )
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "asic_0_device_id",
+            "asic_1_device_id",
+            "switchcard_fpga_0_bus",
+            "cpu_card_fpga_bus",
+            "nvme_bus",
+            "amd_soc_group_0_bus",
+            "asic",
+            "",
+        ],
+    )
+    def test_does_not_match_unrelated_vars(self, pcie_lib_module, name):
+        assert pcie_lib_module.device_type_for_var_name(name) is None
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    result = MagicMock()
+    result.returncode = returncode
+    result.stdout = stdout
+    result.stderr = stderr
+    return result
+
+
+class TestSetpciRead:
+    def test_returns_stripped_hex(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(stdout="0146\n")) as run:
+            assert pcie_lib_module.setpci_read("01:00.0", "0x04.w") == "0146"
+        run.assert_called_once_with(
+            ["setpci", "-s", "01:00.0", "0x04.w"], capture_output=True, text=True, check=False
+        )
+
+    def test_nonzero_returncode_raises(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(returncode=1, stderr="boom")):
+            with pytest.raises(RuntimeError):
+                pcie_lib_module.setpci_read("01:00.0", "0x04.w")
+
+    def test_empty_output_raises(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(stdout="  \n")):
+            with pytest.raises(RuntimeError):
+                pcie_lib_module.setpci_read("01:00.0", "0x04.w")
+
+    def test_missing_binary_propagates(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, side_effect=FileNotFoundError):
+            with pytest.raises(FileNotFoundError):
+                pcie_lib_module.setpci_read("01:00.0", "0x04.w")
+
+
+class TestSetpciWrite:
+    def test_success_does_not_raise(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed()) as run:
+            pcie_lib_module.setpci_write("01:00.0", "0x04.w", "0546")
+        run.assert_called_once_with(
+            ["setpci", "-s", "01:00.0", "0x04.w=0546"], capture_output=True, text=True, check=False
+        )
+
+    def test_failure_raises(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(returncode=1, stderr="nope")):
+            with pytest.raises(RuntimeError):
+                pcie_lib_module.setpci_write("01:00.0", "0x04.w", "0546")
+
+
+class TestApplyWordMask:
+    def test_set_mask(self, pcie_lib_module):
+        assert pcie_lib_module.apply_word_mask(0x0146, set_mask=0x0400) == 0x0546
+
+    def test_clear_mask(self, pcie_lib_module):
+        assert pcie_lib_module.apply_word_mask(0x8001, clear_mask=0x8000) == 0x0001
+
+    def test_set_and_clear(self, pcie_lib_module):
+        assert pcie_lib_module.apply_word_mask(0x8000, set_mask=0x0001, clear_mask=0x8000) == 0x0001
+
+    def test_noop(self, pcie_lib_module):
+        assert pcie_lib_module.apply_word_mask(0x1234) == 0x1234
+
+
+class TestPciDevicePresent:
+    def test_present(self, pcie_lib_module):
+        out = "01:00.0 0200: 14e4:b900\n02:00.0 0c03: 1022:149c\n"
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(stdout=out)):
+            assert pcie_lib_module.pci_device_present("01:00.0") is True
+
+    def test_absent(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(stdout="02:00.0 ...\n")):
+            assert pcie_lib_module.pci_device_present("01:00.0") is False
+
+    def test_lspci_failure_raises(self, pcie_lib_module):
+        with patch.object(pcie_lib_module.subprocess, "run", autospec=True, return_value=_completed(returncode=1, stderr="err")):
+            with pytest.raises(RuntimeError):
+                pcie_lib_module.pci_device_present("01:00.0")
+
+
+def _config_reader(config):
+    """Build a setpci_read side_effect from an {offset_with_width: hex} map."""
+    def _read(bdf, offset_with_width):
+        return config[offset_with_width]
+
+    return _read
+
+
+class TestFindPciCapability:
+    # Capability list: 0x34 -> 0x40 (MSI, id 0x05) -> 0x50 (MSI-X, id 0x11) -> end.
+    CAP_LIST = {
+        "0x34.b": "40",
+        "0x40.b": "05", "0x41.b": "50",
+        "0x50.b": "11", "0x51.b": "00",
+    }
+
+    def test_finds_each_capability(self, pcie_lib_module):
+        with patch.object(pcie_lib_module, "setpci_read", autospec=True, side_effect=_config_reader(self.CAP_LIST)):
+            assert pcie_lib_module.find_pci_capability("01:00.0", pcie_lib_module.PCI_CAP_ID_MSI) == 0x40
+            assert pcie_lib_module.find_pci_capability("01:00.0", pcie_lib_module.PCI_CAP_ID_MSIX) == 0x50
+
+    def test_absent_capability_returns_none(self, pcie_lib_module):
+        config = {"0x34.b": "40", "0x40.b": "05", "0x41.b": "00"}
+        with patch.object(pcie_lib_module, "setpci_read", autospec=True, side_effect=_config_reader(config)):
+            assert pcie_lib_module.find_pci_capability("01:00.0", pcie_lib_module.PCI_CAP_ID_MSIX) is None
+
+    def test_no_capabilities_list_returns_none(self, pcie_lib_module):
+        with patch.object(pcie_lib_module, "setpci_read", autospec=True, side_effect=_config_reader({"0x34.b": "00"})):
+            assert pcie_lib_module.find_pci_capability("01:00.0", pcie_lib_module.PCI_CAP_ID_MSI) is None

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/utils/test_asic_init_wrapper.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/utils/test_asic_init_wrapper.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for asic_init_wrapper: ASIC BDF discovery and the PCI
+config-space read-modify-write helper. The setpci/lspci mechanics and the
+asic-bus classifier live in nexthop.pcie_lib and are tested there; here we
+exercise the wrapper's error-handling/logging policy on top of them.
+"""
+
+import importlib.machinery
+import importlib.util
+import os
+import sys
+from unittest.mock import mock_open, patch
+
+import pytest
+
+sys.dont_write_bytecode = True
+
+
+@pytest.fixture(scope="function")
+def wrapper():
+    """Load the asic_init_wrapper.py script as a module with syslog silenced.
+
+    The import is performed inside the fixture so the autouse
+    patch_dependencies fixture (which makes `nexthop` importable) is active.
+    """
+    test_dir = os.path.dirname(os.path.realpath(__file__))
+    script_path = os.path.join(test_dir, "../../../common/utils/asic_init_wrapper.py")
+    loader = importlib.machinery.SourceFileLoader("asic_init_wrapper", script_path)
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    try:
+        spec.loader.exec_module(module)
+        with patch.object(module, "syslog", autospec=True):
+            yield module
+    finally:
+        sys.modules.pop(loader.name, None)
+
+
+class TestIsWarmBootPostKexec:
+    def test_warm_boot_detected(self, wrapper):
+        cmdline = "BOOT_IMAGE=/boot/vmlinuz SONIC_BOOT_TYPE=warm rw\n"
+        with patch("builtins.open", mock_open(read_data=cmdline)):
+            assert wrapper.is_warm_boot_post_kexec() is True
+
+    def test_cold_boot(self, wrapper):
+        with patch("builtins.open", mock_open(read_data="BOOT_IMAGE=/boot/vmlinuz rw\n")):
+            assert wrapper.is_warm_boot_post_kexec() is False
+
+    def test_fast_reboot_is_not_warm(self, wrapper):
+        cmdline = "BOOT_IMAGE=/boot/vmlinuz SONIC_BOOT_TYPE=fast-reboot rw\n"
+        with patch("builtins.open", mock_open(read_data=cmdline)):
+            assert wrapper.is_warm_boot_post_kexec() is False
+
+
+class TestGetAsicBdfs:
+    def test_collects_asic_bus_vars_only(self, wrapper):
+        name_to_cmd = {
+            "asic_bus": "cmd_a",
+            "asic_0_bus": "cmd_b",
+            "cpu_card_fpga_bdf": "cmd_ignored",
+        }
+        bus_for_cmd = {"cmd_a": "01", "cmd_b": "0a"}
+        with (
+            patch.object(wrapper.pcie_lib, "get_var_name_to_cmd_map", autospec=True, return_value=name_to_cmd),
+            patch.object(wrapper.pcie_lib, "get_cmd_output", autospec=True, side_effect=lambda c: bus_for_cmd[c]),
+        ):
+            assert wrapper.get_asic_bdfs() == ["01:00.0", "0a:00.0"]
+
+    def test_skips_empty_bus(self, wrapper):
+        with (
+            patch.object(wrapper.pcie_lib, "get_var_name_to_cmd_map", autospec=True, return_value={"asic_bus": "c"}),
+            patch.object(wrapper.pcie_lib, "get_cmd_output", autospec=True, return_value=""),
+        ):
+            assert wrapper.get_asic_bdfs() == []
+
+    def test_yaml_read_failure_returns_empty(self, wrapper):
+        with patch.object(wrapper.pcie_lib, "get_var_name_to_cmd_map", autospec=True, side_effect=FileNotFoundError):
+            assert wrapper.get_asic_bdfs() == []
+
+
+class TestDisableAsicPciInterrupts:
+    def test_calls_each_disabler_and_tolerates_outcomes(self, wrapper):
+        # Exercise all three _log_disable branches in one go: a real change
+        # (INTx), an absent capability (MSI-X -> None), and a failure (MSI ->
+        # raises). disable_asic_pci_interrupts must not propagate.
+        change = wrapper.pcie_lib.PciWordChange(old=0x0142, new=0x0542)
+        with (
+            patch.object(wrapper.pcie_lib, "disable_intx", autospec=True, return_value=change) as intx,
+            patch.object(wrapper.pcie_lib, "disable_msix", autospec=True, return_value=None) as msix,
+            patch.object(wrapper.pcie_lib, "disable_msi", autospec=True, side_effect=RuntimeError("boom")) as msi,
+        ):
+            wrapper.disable_asic_pci_interrupts("01:00.0")
+        intx.assert_called_once_with("01:00.0")
+        msix.assert_called_once_with("01:00.0")
+        msi.assert_called_once_with("01:00.0")
+
+
+class TestAsicPresentOnPciBus:
+    def test_present(self, wrapper):
+        with patch.object(wrapper.pcie_lib, "pci_device_present", autospec=True, return_value=True):
+            assert wrapper.asic_present_on_pci_bus("01:00.0") is True
+
+    def test_failure_returns_false(self, wrapper):
+        with patch.object(wrapper.pcie_lib, "pci_device_present", autospec=True, side_effect=RuntimeError("lspci")):
+            assert wrapper.asic_present_on_pci_bus("01:00.0") is False


### PR DESCRIPTION
#### Why I did it

Resolves #28655

Warm and fast reboot are non-functional on the Nexthop NH-4010 and NH-4210 platforms:

1. The hwsku `sai.profile` files are missing the Broadcom SAI warm-boot state file keys, so SAI never writes/restores `/var/warmboot/sai-warmboot.bin` across the kexec.
2. The per-platform `syncd.service.d` overrides run `ExecStopPost=/usr/local/bin/asic_init.sh` unconditionally, power-cycling the ASIC on every syncd stop — including during warm/fast reboot orchestration, which destroys the preserved dataplane.
3. On the post-kexec boot, `pre_pddf_init.sh` runs `asic_init.sh` unconditionally, fully resetting the ASIC after a warm reboot and destroying the dataplane state the shutdown side preserved. In addition, ASIC interrupts left enabled by the pre-kexec kernel can fire when the driver reloads — before userspace remaps the BARs — and panic the kernel.

Note: this PR fixes the missing plumbing itself (SAI state preservation, no ASIC power-cycle mid-orchestration, warm-aware boot-time init). The `test_fast_reboot` reboot-cause failure seen in CI on 202512-based images turned out to have an additional cause — a hard reset ~55s after the kexec boot, under separate investigation — so this PR alone is not expected to flip that test; it is a prerequisite for correct warm/fast reboot behavior.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Add `SAI_KEY_WARM_BOOT_WRITE_FILE` / `SAI_KEY_WARM_BOOT_READ_FILE` (`/var/warmboot/sai-warmboot.bin`) to the NH-4010 (x86_64-nexthop_4010-r1) and NH-4210 (x86_64-nexthop_4210-r0021) sai.profiles.
- Add `common/utils/syncd_post_stop.py` and point the `ge-override.conf` / `sea-eagle-override.conf` `ExecStopPost` at it. The script checks STATE_DB `WARM_RESTART_ENABLE_TABLE|system` / `FAST_RESTART_ENABLE_TABLE|system` (and `/host/warmboot/dump.rdb`) and skips the ASIC power-cycle while warm/fast reboot is in progress; on any other syncd stop it execs `asic_init.sh` exactly as before. Scripts in `common/utils/` are installed to `/usr/local/bin` by the existing debian rules.
- Add `common/utils/asic_init_wrapper.py`, invoked from `pre_pddf_init.sh` in place of `asic_init.sh`. On `SONIC_BOOT_TYPE=warm` it skips the ASIC reset and disables the ASIC's INTx/MSI/MSI-X at the PCI config-space level so a stale interrupt cannot fire while the driver reloads; on cold boot or fast-reboot post-kexec (`SONIC_BOOT_TYPE=fast-reboot`) it execs `asic_init.sh` exactly as before, and any wrapper failure falls back to the full ASIC init. The supporting setpci/interrupt-disable helpers live in `nexthop/pcie_lib.py`, with unit tests for both the library and the wrapper.

Cold boot and syncd-crash recovery behavior is unchanged.

#### How to verify it

Validated internally on NH-4210 (O256): with these changes `fast-reboot` completes successfully and sonic-mgmt `platform_tests/test_reboot.py::test_fast_reboot` passes, including the `show reboot-cause` check. Without them the ASIC is power-cycled during shutdown and the test fails as described above. NH-4010 has been running this configuration internally with warm/fast reboot tests enabled in nightly CI.

Additionally, the CI image built from this PR (Azure build 1177884, `master-28656.1177884`) was installed on NH-4010 hardware via ONIE and the plumbing verified in place: the warm-boot keys land in the sai.profiles, `syncd_post_stop.py` is installed and wired as the syncd `ExecStopPost`, and on a plain (non-warm) syncd stop it logs `syncd stop without warm/fast reboot: power-cycling ASIC to reinitialize` and runs the full ASIC init exactly as before. The `asic_init_wrapper.py` paths were exercised on the same hardware: ASIC BDF discovery from the platform `pcie-variables.yaml`, the warm-path INTx/MSI/MSI-X disable (verified via the PCI Command register), and the cold-path fallthrough to `asic_init.sh`. `test/unit` for `sonic-platform-modules-nexthop` passes (369 tests).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608

Reason: Nexthop NH-4010/NH-4210 ship on 202512-based images, which currently lack this plumbing entirely (verified: no warm-boot keys in the sai.profiles, unconditional asic_init.sh ExecStopPost). The change only touches Nexthop vendor directories (`device/nexthop`, `platform/broadcom/sonic-platform-modules-nexthop`) — no common code, no other platforms affected.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #28655
Failure type: product bug (warm/fast reboot non-functional on Nexthop platforms)

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: the CI image built from this PR was installed on NH-4010 hardware via ONIE and the plumbing verified in place (see "How to verify it"). Also validated on NH-4210 (O256) hardware running an internal image built from master with these changes — `fast-reboot` completes successfully, and sonic-mgmt `platform_tests/test_reboot.py::test_fast_reboot` passes including the `show reboot-cause` check. NH-4010 runs this configuration in internal nightly CI with warm/fast reboot tests enabled.
- 202512: applied these exact files on NH-4210 (P128) hardware running an image built from the 202512 branch — configuration applies cleanly, syncd picks up the warm-boot keys, cold boot and BGP/interface health unaffected. End-to-end `test_fast_reboot` on this branch is currently blocked by a separate platform issue (an unexpected reset ~55s after the kexec boot, pending the watchdog upstreaming); A/B runs confirmed this PR neither causes nor masks that issue.

#### Description for the changelog

[Nexthop] Enable warm/fast reboot on NH-4010 and NH-4210: add SAI warm-boot state file keys, skip the syncd-stop ASIC power-cycle during warm/fast reboot orchestration, and make boot-time ASIC init warm-aware (skip re-init and quiesce stale PCI interrupts on the post-kexec boot).

#### Link to config_db schema for YANG module changes

N/A — no YANG/config_db changes.
