### PR TITLE
[Mellanox] Update SN6600-LD SKUs' DWRR weights and dynamic_th

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_objects.j2
@@ -1,1 +1,352 @@
-../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+{#
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Apache-2.0
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
+{% import 'traffic_config.j2' as traffic_config %}
+
+{%- set PORT_ALL = [] %}
+{%- set PORT_ACTIVE = [] %}
+{%- set PORT_UPLINK = [] %}
+{%- set PORT_DOWNLINK = [] %}
+
+{# Initialize PORT_ALL and PORT_ACTIVE #}
+{%- for port in PORT %}
+    {%- if not port.startswith('Ethernet-Rec') and not port.startswith('Ethernet-IB') %}
+        {%- if PORT_ALL.append(port) %}{% endif %}
+    {%- endif %}
+{%- endfor %}
+
+{%- if DEVICE_NEIGHBOR is not defined %}
+    {%- set PORT_ACTIVE = PORT_ALL %}
+{%- else %}
+    {%- for port in DEVICE_NEIGHBOR.keys() %}
+        {%- if PORT_ACTIVE.append(port) %}{%- endif %}
+    {%- endfor %}
+{%- endif %}
+
+{# Generate uplink and downlink port lists based on router type and neighbors #}
+{%- if DEVICE_METADATA is defined and DEVICE_METADATA['localhost'] is defined %}
+    {%- if 'type' in DEVICE_METADATA['localhost'] and DEVICE_NEIGHBOR is defined %}
+        {%- set local_router_type = DEVICE_METADATA['localhost']['type'] %}
+        {%- for port in PORT_ACTIVE %}
+            {%- if DEVICE_NEIGHBOR.get(port) and DEVICE_NEIGHBOR[port].name is defined and DEVICE_NEIGHBOR_METADATA is defined and DEVICE_NEIGHBOR[port].name in DEVICE_NEIGHBOR_METADATA %}
+                {%- set neighbor_info = DEVICE_NEIGHBOR_METADATA[DEVICE_NEIGHBOR[port].name] %}
+                {%- if 'LeafRouter' in local_router_type %}
+                    {%- if 'ToRRouter' in neighbor_info.type %}
+                        {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- elif 'SpineRouter' in neighbor_info.type %}
+                        {%- if PORT_UPLINK.append(port) %}{%- endif %}
+                    {%- endif %}
+                {%- elif 'ToRRouter' in local_router_type %}
+                    {%- if 'LeafRouter' in neighbor_info.type %}
+                        {%- if PORT_UPLINK.append(port) %}{%- endif %}
+                    {%- else %}
+                        {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+                    {%- endif %}
+                {%- endif %}
+            {%- else %}
+                {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+            {%- endif %}
+        {%- endfor %}
+    {%- else %}
+        {%- for port in PORT_ACTIVE %}
+            {%- if PORT_DOWNLINK.append(port) %}{%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{%- endif %}
+
+{%- macro generate_buffer_pool_and_profiles_with_inactive_ports(port_names_inactive) %}
+    "BUFFER_POOL": {
+        {% if dynamic_mode is not defined and port_names_inactive|length > 0 -%}
+        "ingress_zero_pool" : {
+            "mode": "static",
+            "type": "ingress",
+            "size": "0"
+        },
+        {% endif -%}
+        "ingress_lossless_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ ingress_lossless_pool_size }}",
+            {% endif -%}
+            "type": "ingress",
+            "mode": "dynamic"
+        },
+        "egress_lossless_pool": {
+            "size": "{{ egress_lossless_pool_size }}",
+            "type": "egress",
+            "mode": "dynamic"
+        },
+        "egress_lossy_pool": {
+            {% if dynamic_mode is not defined -%}
+            "size": "{{ egress_lossy_pool_size }}",
+            {% endif -%}
+            "type": "egress",
+            "mode": "dynamic"
+        }
+    },
+    "BUFFER_PROFILE": {
+        {% if dynamic_mode is not defined and port_names_inactive|length > 0 -%}
+        "ingress_lossy_pg_zero_profile" : {
+          "pool":"ingress_zero_pool",
+          "size":"0",
+          "static_th":"0"
+        },
+        "ingress_lossless_zero_profile" : {
+          "pool":"ingress_lossless_pool",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        "egress_lossy_zero_profile" : {
+          "pool":"egress_lossy_pool",
+          "size":"0",
+          "dynamic_th":"-8"
+        },
+        {% endif -%}
+        "ingress_lossy_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"7"
+        },
+        "egress_lossy_profile": {
+            "pool":"egress_lossy_pool",
+            "size":"9216",
+            "dynamic_th":"7"
+        },
+        "queue0_downlink_lossy_profile": {
+            "dynamic_th": "0",
+            "size": "0",
+            "pool": "egress_lossy_pool"
+        },
+        "queue1_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue2_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue3_downlink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue4_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "2"
+        },
+        "queue5_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-3"
+        },
+        "queue6_downlink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue0_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        },
+        "queue1_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue2_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue3_uplink_lossy_profile": {
+            {% if traffic_config.traffic_classification_enable %}
+            "packet_discard_action": "drop",
+            {% endif %}
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-2"
+        },
+        "queue4_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "2"
+        },
+        "queue5_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "-3"
+        },
+        "queue6_uplink_lossy_profile": {
+            "pool": "egress_lossy_pool",
+            "size": "0",
+            "dynamic_th": "0"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_profile_lists(port_names_active, port_names_inactive) %}
+    "BUFFER_PORT_INGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% if port_names_inactive|length > 0 %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "ingress_lossy_profile"
+{% else %}
+            "profile_list" : "ingress_lossless_zero_profile"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% endif %}
+    },
+    "BUFFER_PORT_EGRESS_PROFILE_LIST": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}": {
+            "profile_list" : "egress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% if port_names_inactive|length > 0 %}
+,
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}": {
+{% if dynamic_mode is defined %}
+            "profile_list" : "egress_lossy_profile"
+{% else %}
+            "profile_list" : "egress_lossy_zero_profile"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% endif %}
+    }
+{%- endmacro %}
+
+{%- macro generate_queue_buffers(port_names_active, port_names_inactive) %}
+    "BUFFER_QUEUE": {
+{% for port in port_names_active.split(',') %}
+    {%- set port_type = 'uplink' if port in PORT_UPLINK else 'downlink' %}
+        "{{ port }}|0": {
+            "profile" : "queue0_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|1": {
+            "profile" : "queue1_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|2": {
+            "profile" : "queue2_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|3": {
+            "profile" : "queue3_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|4": {
+            "profile" : "queue4_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|5": {
+            "profile" : "queue5_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|6": {
+            "profile" : "queue6_{{ port_type }}_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% if port_names_inactive|length > 0 %}
+{% if dynamic_mode is defined %}
+{% if port_names_active.split(',')|length > 0 %},{% endif %}
+{% for port in port_names_inactive.split(',') %}
+    {%- set port_type = 'uplink' if port in PORT_UPLINK else 'downlink' %}
+        "{{ port }}|0": {
+            "profile" : "queue0_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|1": {
+            "profile" : "queue1_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|2": {
+            "profile" : "queue2_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|3": {
+            "profile" : "queue3_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|4": {
+            "profile" : "queue4_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|5": {
+            "profile" : "queue5_{{ port_type }}_lossy_profile"
+        },
+        "{{ port }}|6": {
+            "profile" : "queue6_{{ port_type }}_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% else %}
+{% if port_names_active.split(',')|length > 0 %},{% endif %}
+{% for port in port_names_inactive.split(',') %}
+        "{{ port }}|0-6": {
+            "profile" : "egress_lossy_zero_profile"
+        }{% if not loop.last %},{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}
+    }
+{%- endmacro %}
+
+{%- macro generate_pg_profiles(port_names_active, port_names_inactive) %}
+    "BUFFER_PG": {
+{% for port in port_names_active.split(',') %}
+        "{{ port }}|0": {
+            "profile" : "ingress_lossy_profile"
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% if port_names_inactive|length > 0 %}
+{%- for port in port_names_inactive.split(',') %}
+       {%- if loop.first -%},{%- endif -%}
+       "{{ port }}|0": {
+{% if dynamic_mode is defined %}
+            "profile" : "ingress_lossy_profile"
+{% else %}
+            "profile" : "ingress_lossy_pg_zero_profile"
+{% endif %}
+        }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+{% endif %}
+    }
+{%- endmacro %}

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/qos.json.j2
@@ -1,1 +1,449 @@
-../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+{#
+    SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+    Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+    Apache-2.0
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+#}
+
+{% import 'traffic_config.j2' as traffic_config %}
+
+{%- macro generate_dscp_to_tc_map_per_sku() -%}
+    "DSCP_TO_TC_MAP": {
+        "AZURE": {
+            "0" : "0",
+            "1" : "1",
+            "2" : "1",
+            "3" : "2",
+            "4" : "2",
+            "5" : "3",
+            "6" : "3",
+            "7" : "0",
+            "8" : "0",
+            "9" : "0",
+            "10": "0",
+            "11": "4",
+            "12": "4",
+            "13": "4",
+            "14": "4",
+            "15": "4",
+            "16": "4",
+            "17": "4",
+            "18": "4",
+            "19": "4",
+            "20": "4",
+            "21": "4",
+            "22": "4",
+            "23": "4",
+            "24": "4",
+            "25": "4",
+            "26": "4",
+            "27": "4",
+            "28": "4",
+            "29": "4",
+            "30": "4",
+            "31": "4",
+            "32": "4",
+            "33": "4",
+            "34": "4",
+            "35": "4",
+            "36": "4",
+            "37": "4",
+            "38": "4",
+            "39": "4",
+            "40": "4",
+            "41": "5",
+            "42": "5",
+            "43": "5",
+            "44": "5",
+            "45": "5",
+            "46": "5",
+            "47": "5",
+            "48": "5",
+            "49": "5",
+            "50": "5",
+            "51": "0",
+            "52": "0",
+            "53": "0",
+            "54": "0",
+            "55": "0",
+            "56": "0",
+            "57": "0",
+            "58": "0",
+            "59": "0",
+            "60": "0",
+            "61": "0",
+            "62": "0",
+            "63": "0"
+        }
+    },
+{%- endmacro -%}
+{%- macro generate_tc_to_pg_map_per_sku() -%}
+    "TC_TO_PRIORITY_GROUP_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "0",
+            "2": "0",
+            "3": "0",
+            "4": "0",
+            "5": "0",
+            "6": "0",
+            "7": "0"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_scheduler_per_sku() -%}
+    "SCHEDULER": {
+        "scheduler_q0_downlink": {
+            "type": "DWRR",
+            "weight": "4"
+        },
+        "scheduler_q1_downlink": {
+            "type": "DWRR",
+            "weight": "8"
+        },
+        "scheduler_q2_downlink": {
+            "type": "DWRR",
+            "weight": "18"
+        },
+        "scheduler_q3_downlink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q4_downlink": {
+            "type": "DWRR",
+            "weight": "48"
+        },
+        "scheduler_q5_downlink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q6_downlink": {
+            "type": "DWRR",
+            "weight": "4"
+        },
+        "scheduler_q0_uplink": {
+            "type": "DWRR",
+            "weight": "4"
+        },
+        "scheduler_q1_uplink": {
+            "type": "DWRR",
+            "weight": "8"
+        },
+        "scheduler_q2_uplink": {
+            "type": "DWRR",
+            "weight": "18"
+        },
+        "scheduler_q3_uplink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q4_uplink": {
+            "type": "DWRR",
+            "weight": "48"
+        },
+        "scheduler_q5_uplink": {
+            "type": "DWRR",
+            "weight": "22"
+        },
+        "scheduler_q6_uplink": {
+            "type": "DWRR",
+            "weight": "4"
+        }
+    },
+{%- endmacro -%}
+
+{%- macro generate_direction_based_queue_per_sku(port, direction) -%}
+    "{{ port }}|0": {
+        "scheduler": "scheduler_q0_{{ direction }}"
+    },
+    "{{ port }}|1": {
+        "scheduler": "scheduler_q1_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q1"
+    },
+    "{{ port }}|2": {
+        "scheduler": "scheduler_q2_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q2"
+    },
+    "{{ port }}|3": {
+        "scheduler": "scheduler_q3_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q3"
+    },
+    "{{ port }}|4": {
+        "scheduler": "scheduler_q4_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q4"
+    },
+    "{{ port }}|5": {
+        "scheduler": "scheduler_q5_{{ direction }}",
+        "wred_profile": "AZURE_LOSSY_{{ direction.upper() }}_Q5"
+    },
+    "{{ port }}|6": {
+        "scheduler": "scheduler_q6_{{ direction }}"
+    }
+{%- endmacro -%}
+
+{%- macro generate_global_dscp_to_tc_map() %}
+{# This is an empty macro since the global DSCP_TO_TC map is not required #}
+{%- endmacro %}
+
+{%- macro generate_wred_profiles() %}
+    {# Default threshold values for both ToR and Leaf routers #}
+    {%- set min_threshold = "166912" %}
+    {%- set disable_wred = traffic_config.wred_threshold_limit %}
+
+    {%- set router_type = (
+        DEVICE_METADATA['localhost']['type']
+        if 'type' in DEVICE_METADATA['localhost'] and DEVICE_METADATA['localhost']['type']
+        else 'ToRRouter'
+    ) %}
+
+    {%- if 'ToRRouter' in router_type %}
+        {# ToR Router thresholds - only override if different from defaults #}
+        {%- set max_threshold = "282624" %}
+    {%- elif 'LeafRouter' in router_type %}
+        {# Leaf Router thresholds - only override if different from defaults #}
+        {%- set max_threshold = "239616" %}
+    {%- elif 'SpineRouter' in router_type %}
+        {# Spine Router thresholds. Defaulting to the LeafRouter value #}
+        {%- set max_threshold = "239616" %}
+    {%- endif %}
+
+    "WRED_PROFILE": {
+        "AZURE_LOSSY_DOWNLINK_Q1": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q2": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q3": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q4": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_DOWNLINK_Q5": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q1": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q2": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q3": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ max_threshold }}",
+            "green_min_threshold": "{{ min_threshold }}",
+            "yellow_max_threshold": "{{ max_threshold }}",
+            "yellow_min_threshold": "{{ min_threshold }}",
+            "red_max_threshold": "{{ max_threshold }}",
+            "red_min_threshold": "{{ min_threshold }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q4": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        },
+        "AZURE_LOSSY_UPLINK_Q5": {
+            "wred_green_enable": "false",
+            "wred_yellow_enable": "false",
+            "wred_red_enable": "false",
+            "ecn": "ecn_all",
+            "green_max_threshold": "{{ disable_wred }}",
+            "green_min_threshold": "{{ disable_wred }}",
+            "yellow_max_threshold": "{{ disable_wred }}",
+            "yellow_min_threshold": "{{ disable_wred }}",
+            "red_max_threshold": "{{ disable_wred }}",
+            "red_min_threshold": "{{ disable_wred }}",
+            "green_drop_probability": "5",
+            "yellow_drop_probability": "5",
+            "red_drop_probability": "5"
+        }
+    },
+{%- endmacro %}
+
+{%- macro generate_lossless_tc_list(lossless_tc_list) %}
+{#
+    This macro intentionally does nothing, leaving LOSSLESS_TC as an empty list
+    Use the following to generate other lists like 3, 4
+    {%- if lossless_tc_list.append('3') -%}{%- endif -%}
+    {%- if lossless_tc_list.append('4') -%}{%- endif -%}
+#}
+{%- endmacro %}
+
+{%- macro generate_tc_to_queue_map_per_sku() -%}
+    "TC_TO_QUEUE_MAP": {
+        "AZURE": {
+            "0": "0",
+            "1": "1",
+            "2": "2",
+            "3": "3",
+            "4": "4",
+            "5": "5",
+            "6": "6",
+            "7": "7"
+{%- if traffic_config.traffic_classification_enable %}
+            ,
+            "8": "4"
+{%- endif %}
+        }
+    },
+{%- endmacro -%}
+
+{% macro generate_tc_to_dscp_map_per_sku() %}
+{%- if traffic_config.traffic_classification_enable %}
+    "TC_TO_DSCP_MAP": {
+        {% if 'type' in DEVICE_METADATA['localhost'] %}
+            {%- if 'ToRRouter' in DEVICE_METADATA['localhost']['type'] -%}
+                "AZURE_DOWNLINK_BT0": {
+                    "8": "21"
+                },
+                "AZURE_UPLINK_BT0": {
+                    "8": "11"
+                }
+            {%- elif 'LeafRouter' in DEVICE_METADATA['localhost']['type'] -%}
+                "AZURE_DOWNLINK_BT1": {
+                    "8": "11"
+                }
+            {% endif %}
+        {% endif -%}
+    },
+{%- endif %}
+{%- endmacro -%}
+
+{%- macro generate_port_qos_map_per_sku(ports, direction) -%}
+{%- for port in ports.split(',') %}
+        "{{ port }}": {
+            "dscp_to_tc_map"  : "AZURE",
+            "tc_to_queue_map" : "AZURE",
+            "pfc_enable"      : "",
+            "pfcwd_sw_enable" : "",
+            {% if traffic_config.traffic_classification_enable %}
+                {% if direction == 'downlink' and 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_dscp_map": "AZURE_DOWNLINK_BT0"
+                {% elif direction == 'uplink' and 'ToRRouter' in DEVICE_METADATA['localhost']['type'] %}
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_dscp_map": "AZURE_UPLINK_BT0"
+                {% elif direction == 'downlink' and 'LeafRouter' in DEVICE_METADATA['localhost']['type'] %}
+                    "tc_to_pg_map": "AZURE",
+                    "tc_to_dscp_map": "AZURE_DOWNLINK_BT1"
+                {% else %}
+                    "tc_to_pg_map": "AZURE"
+                {% endif %}
+            {% else %}
+                "tc_to_pg_map": "AZURE"
+            {% endif %}
+        }{% if not loop.last %},{% endif %}
+{%- endfor %}
+{%- endmacro -%}
+
+{%- include 'qos_config.j2' %}

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_objects.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_objects.j2
@@ -1,1 +1,1 @@
-../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/buffers_defaults_objects.j2
+../Mellanox-SN6600_LD-P128C2/buffers_defaults_objects.j2

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/qos.json.j2
@@ -1,1 +1,1 @@
-../../x86_64-nvidia_sn5600-r0/Mellanox-SN5600-C256S1/qos.json.j2
+../Mellanox-SN6600_LD-P128C2/qos.json.j2


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
#### Why I did it

Align the SN6600-LD SPC6 queue scheduling and buffer allocation with the required DWRR weights and dynamic-threshold alpha values.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Created SPC6-specific QoS and buffer-object templates under the P128C2 SKU.
- Configured the uplink and downlink DWRR weights:
  - TC1: 8
  - TC2: 18
  - TC3: 22
  - TC4: 48
- Configured the uplink and downlink buffer thresholds:
  - TC1–TC3: `dynamic_th=-2`, corresponding to alpha 1/4.
  - TC4: `dynamic_th=2`, corresponding to alpha 4.
- Preserved the existing thresholds for TC0, TC5, and TC6.
- Updated the other SN6600-LD SKUs to reference the P128C2 templates.
- Left the shared SN5600 QoS and buffer templates unchanged.

#### How to verify it

- Verify that the QoS and buffer templates pass Jinja syntax validation.
- Render the SKU configuration and confirm:
  - DWRR weights for TC1–TC4 are 8, 18, 22, and 48.
  - Buffer alpha values for TC0–TC6 are 1, 1/4, 1/4, 1/4, 4, 1/8, and 1.
  - Uplink and downlink profiles contain identical values.
- On an SN6600-LD DUT, verify the scheduler weights and queue alpha values in CONFIG_DB and the SDK queue configuration.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
