### PR TITLE
[sonic-frr] Fix bgpd NHT stuck invalid after connected iface flap (FRRouting/frr#22780)

### DIFF
--- a/src/sonic-frr/patch/0117-bgpd-fix-NHT-stuck-invalid-after-connected-iface-flap.patch
+++ b/src/sonic-frr/patch/0117-bgpd-fix-NHT-stuck-invalid-after-connected-iface-flap.patch
@@ -1,0 +1,44 @@
+From 73264b05479701d47425852d78f8f5781988f968 Mon Sep 17 00:00:00 2001
+From: Nikhil Hegde <nikhilhegde@microsoft.com>
+Date: Wed, 29 Jul 2026 23:59:55 +0000
+Subject: [PATCH] bgpd: fix NHT stuck invalid after connected iface flap
+
+bgp_nht_ifp_table_handle() zeroes bnc->nexthop_num on interface-down, so
+the subsequent interface-up no longer matches the IPv4 connected-peer bnc
+(nexthop_num now 0, ifindex_ipv6_ll 0) and BGP_NEXTHOP_VALID is never
+restored, leaving all routes learned from that peer permanently invalid.
+Match interface-up on the saved bnc->nexthop->ifindex too.
+
+Fixes: FRRouting/frr#22780
+Signed-off-by: Nikhil Hegde <nikhilhegde@microsoft.com>
+---
+ bgpd/bgp_nht.c | 13 ++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/bgpd/bgp_nht.c b/bgpd/bgp_nht.c
+index ea517f0287..fa2718415a 100644
+--- a/bgpd/bgp_nht.c
++++ b/bgpd/bgp_nht.c
+@@ -810,8 +810,17 @@ static void bgp_nht_ifp_table_handle(struct bgp *bgp,
+ 	}
+ 
+ 	frr_each (bgp_nexthop_cache, table, bnc) {
+-		if (!(bnc->nexthop_num == 1 && bnc->nexthop &&
+-		      bnc->nexthop->ifindex == ifp->ifindex) &&
++		/*
++		 * Re-match a connected-peer cache entry pinned to this interface.
++		 * On interface-down this handler zeroes bnc->nexthop_num, so the
++		 * historical "nexthop_num == 1" test no longer matches on the
++		 * subsequent interface-up for an IPv4 connected peer (whose
++		 * ifindex_ipv6_ll is 0), leaving BGP_NEXTHOP_VALID unrestored and
++		 * routes stuck invalid.  Match on the saved nexthop ifindex alone
++		 * (no nexthop_num constraint) so the up event re-validates it
++		 * (FRRouting/frr#22780).
++		 */
++		if (!(bnc->nexthop && bnc->nexthop->ifindex == ifp->ifindex) &&
+ 		    (bnc->ifindex_ipv6_ll != ifp->ifindex))
+ 			continue;
+ 
+-- 
+2.34.1
+

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -85,3 +85,4 @@
 0114-Provide-interface-when-installing-uninstalling-SRv6-uA-SIDs.patch
 0115-zebra-Update-promiscuity-flag-silently-without-route.patch
 0116-zebra-keep-route_node-lock-in-NB-RIB-route-lookup_next.patch
+0117-bgpd-fix-NHT-stuck-invalid-after-connected-iface-flap.patch


### PR DESCRIPTION
#### Why I did it

`FRRouting/frr#22780`: IPv4 routes learned from a directly-connected single-hop
eBGP peer get stuck **invalid** ("nexthop inaccessible / Must be Connected")
after a brief flap of that peer's connected interface, and never recover on
their own (`clear ip bgp` does not help; only a connected-route re-trigger does).

Root cause is a down/up asymmetry in `bgp_nht_ifp_table_handle()`
(`bgpd/bgp_nht.c`): interface-down zeroes `bnc->nexthop_num`, so on the
subsequent interface-up the same IPv4 connected-peer nexthop-cache entry no
longer matches the historical `nexthop_num == 1` test (and `ifindex_ipv6_ll`
is 0 for IPv4). The entry is skipped, `BGP_NEXTHOP_VALID` is never restored,
and every route from that peer stays invalid.

This is a regression since FRR 10.5.2 (`d1252ec2a6a8`, #20482), which broadened
the handler to IPv4 single-nexthop connected peers. SONiC currently ships
FRR 10.5.4 and inherits it.

Resolves: FRRouting/frr#22780

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Added FRR patch `0117-bgpd-fix-NHT-stuck-invalid-after-connected-iface-flap.patch`
to `src/sonic-frr/patch/` and registered it in `series`. The patch matches the
interface-up event on the saved `bnc->nexthop->ifindex` too, so the
connected-peer nexthop-cache entry is re-validated after the flap regardless of
the down-zeroed `nexthop_num`.

Carrying it as a local `src/sonic-frr` patch lets SONiC builds get the fix now,
ahead of the upstream FRR merge / a submodule bump. It is a small, contained
change confined to the connected-peer NHT up-event path in `bgp_nht.c`, and
should be dropped once upstream merges and the FRR submodule is bumped past that
commit.

#### How to verify it

Root-caused on a `docker-sonic-vs` DUT (FRR 10.5.4) with a directly-connected
single-hop eBGP peer: after a member-port bounce the peer's routes went
`Valid=0` while bgpd's nexthop stayed `invalid / "Must be Connected"` even though
zebra reported the nexthop resolved-connected -- matching FRRouting/frr#22780
exactly. Note the defect is timing-dependent (it trips only inside a narrow
RIB/NHT window), so building this patch into the image is what ensures the
nexthop is consistently re-validated after a connected-interface flap.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): FRRouting/frr#22780
Failure type: regression (since FRR 10.5.2)

#### Tested branch

- [x] master

#### Test result

- master (`docker-sonic-vs` / `vlab-01`, FRR 10.5.4): the #22780 signature was
  reproduced (bgpd nexthop stuck `invalid`/"Must be Connected" after a
  connected-iface flap while zebra reports it resolved-connected). The patch
  targets exactly that up-event match gap in `bgp_nht.c`; no functional change
  outside the connected-peer NHT up-event path.

#### Description for the changelog

sonic-frr: fix bgpd NHT stuck invalid after a connected-interface flap (FRRouting/frr#22780)
