### PR TITLE
[docker-macsec] Accept a raw hex CAK in "config macsec profile add"

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_config_macsec.py
@@ -83,6 +83,36 @@ class TestConfigMACsec(object):
         if "rekey_period" in profile_map:
             assert profile_table["rekey_period"] == str(profile_map["rekey_period"])
 
+    def test_macsec_raw_cak_profile(self, mock_cfgdb):
+        cfgdb = mock_cfgdb
+        runner = CliRunner()
+
+        def type7_decode(encoded):
+            salt = int(encoded[:2])
+            return "".join(
+                chr(int(encoded[i:i + 2], 16) ^ ord(macsec.TYPE7_KEY[(salt + (i - 2) // 2) % len(macsec.TYPE7_KEY)]))
+                for i in range(2, len(encoded), 2))
+
+        # A raw 32 hex chars CAK for a 128-bit cipher suite is stored type7 encoded
+        raw_cak_128 = "00112233445566778899aabbccddeeff"
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test128",
+                "--primary_cak=" + raw_cak_128, "--primary_ckn=" + primary_ckn,
+                "--cipher_suite=GCM-AES-128"], obj=cfgdb)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        stored_cak = cfgdb.get_entry("MACSEC_PROFILE", "test128")["primary_cak"]
+        assert stored_cak == "040B5B575E731E1D5A4D5142475D5A537D737C716A34231105150005525C5D5552"
+        assert type7_decode(stored_cak) == raw_cak_128
+
+        # A raw 64 hex chars CAK for a 256-bit cipher suite is stored type7 encoded
+        raw_cak_256 = raw_cak_128 * 2
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test256",
+                "--primary_cak=" + raw_cak_256, "--primary_ckn=" + primary_ckn,
+                "--cipher_suite=GCM-AES-XPN-256"], obj=cfgdb)
+        assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        stored_cak = cfgdb.get_entry("MACSEC_PROFILE", "test256")["primary_cak"]
+        assert len(stored_cak) == 130
+        assert type7_decode(stored_cak) == raw_cak_256
+
     def test_macsec_invalid_profile(self, mock_cfgdb):
         cfgdb = mock_cfgdb
         runner = CliRunner()
@@ -97,10 +127,28 @@ class TestConfigMACsec(object):
                 "--cipher_suite=GCM-AES-128"], obj=cfgdb)
         assert result.exit_code != 0
 
-        # Invalid primary cak length
+        # Signs, prefixes and whitespace accepted by int(x, 16) are not valid hex keys
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test",
+                "--primary_cak=+0x1234567890123456789012345678 9","--primary_ckn=01234567890123456789012345678912",
+                "--cipher_suite=GCM-AES-128"], obj=cfgdb)
+        assert result.exit_code != 0
+
+        # Invalid primary cak length (raw 128-bit CAK with a 256-bit cipher suite)
         result = runner.invoke(macsec.macsec, ["profile", "add", "test",
                 "--primary_cak=01234567890123456789012345678912","--primary_ckn=01234567890123456789012345678912",
                 "--cipher_suite=GCM-AES-256"], obj=cfgdb)
+        assert result.exit_code != 0
+
+        # Invalid primary cak length (neither raw nor type7 encoded)
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test",
+                "--primary_cak=0123456789012345678901234567890123456789","--primary_ckn=01234567890123456789012345678912",
+                "--cipher_suite=GCM-AES-128"], obj=cfgdb)
+        assert result.exit_code != 0
+
+        # Type7 encoded cak whose salt prefix is not two decimal digits
+        result = runner.invoke(macsec.macsec, ["profile", "add", "test",
+                "--primary_cak=ab63647040534355560e000802065d574d400e000e030307075f0e5050000e55","--primary_ckn=01234567890123456789012345678912",
+                "--cipher_suite=GCM-AES-128"], obj=cfgdb)
         assert result.exit_code != 0
 
 

--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -1,3 +1,5 @@
+import string
+
 import click
 import utilities_common.cli as clicommon
 from sonic_py_common import multi_asic
@@ -99,11 +101,24 @@ def macsec_profile():
 
 
 def is_hexstring(hexstring: str):
-    try:
-        int(hexstring, 16)
-        return True
-    except ValueError:
-        return False
+    return len(hexstring) > 0 and all(c in string.hexdigits for c in hexstring)
+
+
+# CONFIG_DB stores the CAK obfuscated with the Cisco "type7" scheme, which
+# macsecmgr decodes before handing the key to the MKA daemon (see decodeKey
+# in sonic-swss cfgmgr/macsecmgr.cpp): two decimal salt digits, followed by
+# two hex digits per character of the raw hex key, XORed against a fixed
+# constant. A fixed salt keeps the encoding deterministic so repeated
+# configuration of the same key yields the same CONFIG_DB entry.
+TYPE7_KEY = "dsfd;kfoA,.iyewrkldJKDHSUBsgvca69834ncxv9873254k;fg87"
+TYPE7_SALT = 4
+
+
+def type7_encode(raw_key: str, salt: int = TYPE7_SALT) -> str:
+    encoded = "{:02d}".format(salt)
+    for i, char in enumerate(raw_key):
+        encoded += "{:02X}".format(ord(char) ^ ord(TYPE7_KEY[(salt + i) % len(TYPE7_KEY)]))
+    return encoded
 
 
 #
@@ -113,8 +128,8 @@ def is_hexstring(hexstring: str):
 @click.argument('profile', metavar='<profile_name>', required=True)
 @click.option('--priority', metavar='<priority>', required=False, default=255, show_default=True, type=click.IntRange(0, 255), help="For Key server election. In 0-255 range with 0 being the highest priority.")
 @click.option('--cipher_suite', metavar='<cipher_suite>', required=False, default="GCM-AES-128", show_default=True, type=click.Choice(["GCM-AES-128", "GCM-AES-256", "GCM-AES-XPN-128", "GCM-AES-XPN-256"]), help="The cipher suite for MACsec.")
-@click.option('--primary_cak', metavar='<primary_cak>', required=True, type=str, help="Primary Connectivity Association Key.")
-@click.option('--primary_ckn', metavar='<primary_cak>', required=True, type=str, help="Primary CAK Name.")
+@click.option('--primary_cak', metavar='<primary_cak>', required=True, type=str, help="Primary Connectivity Association Key: either a raw hex key (32 hex characters for a 128-bit cipher suite, 64 for a 256-bit one), which will be stored type7 encoded, or an already type7 encoded key (66/130 characters).")
+@click.option('--primary_ckn', metavar='<primary_ckn>', required=True, type=str, help="Primary CAK Name.")
 @click.option('--policy', metavar='<policy>', required=False, default="security", show_default=True, type=click.Choice(["integrity_only", "security"]), help="MACsec policy. INTEGRITY_ONLY: All traffic, except EAPOL, will be converted to MACsec packets without encryption.  SECURITY: All traffic, except EAPOL, will be encrypted by SecY.")
 @click.option('--enable_replay_protect/--disable_replay_protect', metavar='<replay_protect>', required=False, default=False, show_default=True, is_flag=True, help="Whether enable replay protect.")
 @click.option('--replay_window', metavar='<enable_replay_protect>', required=False, default=0, show_default=True, type=click.IntRange(0, 2**32), help="Replay window size that is the number of packets that could be out of order. This field works only if ENABLE_REPLAY_PROTECT is true.")
@@ -138,15 +153,25 @@ def add_profile(profile, priority, cipher_suite, primary_cak, primary_ckn, polic
     profile_table["cipher_suite"] = cipher_suite
 
     if "128" in cipher_suite:
-        if len(primary_cak) != 66:
-            ctx.fail("Expect the length of CAK is 66, but got {}".format(len(primary_cak)))
+        raw_cak_len, encoded_cak_len = 32, 66
     elif "256" in cipher_suite:
-        if len(primary_cak) != 130:
-            ctx.fail("Expect the length of CAK is 130, but got {}".format(len(primary_cak)))
+        raw_cak_len, encoded_cak_len = 64, 130
+    else:
+        ctx.fail("Unknown cipher suite {}".format(cipher_suite))
+
     if not is_hexstring(primary_cak):
         ctx.fail("Expect the primary_cak is valid hex string")
     if not is_hexstring(primary_ckn):
         ctx.fail("Expect the primary_ckn is valid hex string")
+
+    if len(primary_cak) == raw_cak_len:
+        primary_cak = type7_encode(primary_cak)
+    elif len(primary_cak) == encoded_cak_len:
+        if not primary_cak[:2].isdigit():
+            ctx.fail("Expect a type7 encoded CAK to start with two decimal salt digits")
+    else:
+        ctx.fail("Expect the length of CAK is {} (raw hex) or {} (type7 encoded), but got {}".format(
+            raw_cak_len, encoded_cak_len, len(primary_cak)))
     profile_table["primary_cak"] = primary_cak
     profile_table["primary_ckn"] = primary_ckn
 


### PR DESCRIPTION
#### Why I did it

Since https://github.com/sonic-net/sonic-swss/pull/2892, `macsecmgr` expects the CAK in CONFIG_DB to be Cisco type7 encoded, and https://github.com/sonic-net/sonic-buildimage/pull/16388 changed `config macsec profile add` to require the encoded length. An operator who passes a plain hex CAK now gets:

```
admin@sonic:~$ sudo config macsec profile add PROFILE --cipher_suite GCM-AES-128 \
    --primary_cak 2f7711afd884e8ede2c1262d4e75dca1 --primary_ckn 700b0fccec77eff5a312258bfd833c18
Error: Expect the length of CAK is 66, but got 32
```

There is no hint that the value must be pre-encoded, `--help` still describes the option as a plain key, no encode tool ships with SONiC, and the MACsec HLD still shows raw hex examples. The confusion is compounded by `--primary_ckn` remaining a plain hex string.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Let the CLI accept both forms, keeping the CONFIG_DB format (and therefore the YANG model and `macsecmgr`) unchanged:

- A raw hex CAK (32 hex characters for 128-bit cipher suites, 64 for 256-bit) is type7 encoded with a fixed salt before it is written to CONFIG_DB. The lengths cannot collide with the encoded form (66/130 per cipher suite), so detection is unambiguous.
- An already type7 encoded CAK (66/130 characters) keeps working unchanged, preserving backwards compatibility. Its two leading salt digits are now validated to be decimal, since `macsecmgr`'s `stoi` would otherwise throw at decode time.
- The encoding is the exact inverse of `decodeKey` in sonic-swss `cfgmgr/macsecmgr.cpp`. A fixed salt keeps the encoding deterministic, so re-applying the same key produces the same CONFIG_DB entry (type7 is obfuscation, not encryption — a fixed salt does not weaken it).
- `is_hexstring` now rejects sign/prefix/whitespace characters that `int(x, 16)` tolerates, so strings like `+0x1c...` can no longer reach CONFIG_DB.
- `--primary_cak` help text documents both accepted formats; fixed the copy-pasted `metavar` on `--primary_ckn`.

#### How to verify it

- `dockers/docker-macsec/cli-plugin-tests/` pass (existing cases unchanged; new `test_macsec_raw_cak_profile` verifies a raw 32/64 hex character CAK is stored type7 encoded, with an independent decode round-trip and a hardcoded golden vector; new negative cases cover bad lengths, a non-decimal salt prefix, and non-hex input).
- Verified on a physical SONiC switch (Broadcom DNX) by dropping the patched plugin over the installed one — see Test result below for the before/after transcript.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: cli-plugin unit tests (`dockers/docker-macsec/cli-plugin-tests/`) pass.
- On-device before/after on a physical SONiC switch running a master-derived build (`main.Nexthop.137261`; the installed plugin matches upstream master in every region this PR touches). The patched `macsec.py` was applied over `/usr/local/lib/python3.13/dist-packages/config/plugins/macsec.py` and the original restored afterwards.

Before (stock image):

```
$ sudo config macsec profile add TEST_NOS11444 --priority 64 --cipher_suite GCM-AES-128 \
      --primary_cak 2f7711afd884e8ede2c1262d4e75dca1 --primary_ckn 700b0fccec77eff5a312258bfd833c18 --policy security
Error: Expect the length of CAK is 66, but got 32          # exit code 2

# encoded input works (baseline for backwards compatibility)
$ sudo config macsec profile add TEST_ENC ... --primary_cak 04090D5158701D4F0F1D5D4F460E54012E2E762B6267744103420656035D5B5205
$ sonic-db-cli CONFIG_DB hget "MACSEC_PROFILE|TEST_ENC" primary_cak
04090D5158701D4F0F1D5D4F460E54012E2E762B6267744103420656035D5B5205
```

After (patched plugin):

```
# raw 32 hex char CAK now accepted; stored value is the type7 encoding
$ sudo config macsec profile add TEST_NOS11444 --priority 64 --cipher_suite GCM-AES-128 \
      --primary_cak 2f7711afd884e8ede2c1262d4e75dca1 --primary_ckn 700b0fccec77eff5a312258bfd833c18 --policy security
$ sonic-db-cli CONFIG_DB hget "MACSEC_PROFILE|TEST_NOS11444" primary_cak
04090D5158701D4F0F1D5D4F460E54012E2E762B6267744103420656035D5B5205

# byte-identical to the pre-encoded value above, which was validated end-to-end
# (macsecmgr decode + MKA establishment) with this same key pair — so the stored
# result is known-good, not just well-formed.

# already-encoded input: still stored verbatim (backwards compatible)
$ sudo config macsec profile add TEST_ENC ... --primary_cak 04090D51...5205
$ sonic-db-cli CONFIG_DB hget "MACSEC_PROFILE|TEST_ENC" primary_cak
04090D5158701D4F0F1D5D4F460E54012E2E762B6267744103420656035D5B5205

# raw 64 hex char CAK with GCM-AES-XPN-256: accepted, stored as 130 chars
$ sudo config macsec profile add TEST_256 --cipher_suite GCM-AES-XPN-256 --primary_cak 00112233...eeff

# negative: invalid length
Error: Expect the length of CAK is 32 (raw hex) or 66 (type7 encoded), but got 40   # exit code 2

# negative: 66 chars with a non-decimal salt prefix (would crash macsecmgr's stoi)
Error: Expect a type7 encoded CAK to start with two decimal salt digits             # exit code 2
```

#### Description for the changelog

`config macsec profile add` now accepts a raw hex CAK and stores it type7 encoded; previously only pre-encoded CAKs were accepted with a misleading length error.

#### Link to config_db schema for YANG module changes

N/A — no YANG changes; the CONFIG_DB format is unchanged (type7 encoded CAK, 66/130 characters).
