### PR TITLE
[sonic-config-engine]: Add optional minigraph parser adapter

### DIFF
--- a/src/sonic-config-engine/minigraph_ext.py
+++ b/src/sonic-config-engine/minigraph_ext.py
@@ -1,0 +1,22 @@
+try:
+    from importlib.util import find_spec
+except ImportError:
+    from pkgutil import find_loader
+
+    def find_spec(module_name):
+        return find_loader(module_name)
+
+import minigraph
+
+
+if find_spec("minigraph_custom") is not None:
+    import minigraph_custom
+else:
+    minigraph_custom = None
+
+
+def parse_xml(*args, **kwargs):
+    """Parse a minigraph through an optional deployment-specific adapter."""
+    if minigraph_custom and hasattr(minigraph_custom, "parse_xml"):
+        return minigraph_custom.parse_xml(minigraph.parse_xml, *args, **kwargs)
+    return minigraph.parse_xml(*args, **kwargs)

--- a/src/sonic-config-engine/setup.py
+++ b/src/sonic-config-engine/setup.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import glob
+import os
 import sys
 
 from setuptools import setup
@@ -46,11 +47,15 @@ else:
 py_modules = [
     'config_samples',
     'minigraph',
+    'minigraph_ext',
     'openconfig_acl',
     'portconfig',
     'smartswitch_config',
     'asic_sensors_config'
 ]
+if os.path.isfile(os.path.join(os.path.dirname(__file__), 'minigraph_custom.py')):
+    py_modules.append('minigraph_custom')
+
 if sys.version_info.major == 3:
     # Python 3-only modules
     py_modules += [

--- a/src/sonic-config-engine/sonic-cfggen
+++ b/src/sonic-config-engine/sonic-cfggen
@@ -31,7 +31,8 @@ import base64
 from collections import OrderedDict
 from config_samples import generate_sample_config, get_available_config
 from functools import partial
-from minigraph import minigraph_encoder, parse_xml, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type, parse_hostname
+from minigraph import minigraph_encoder, parse_device_desc_xml, parse_asic_sub_role, parse_asic_switch_type, parse_hostname
+from minigraph_ext import parse_xml
 from portconfig import get_port_config, get_breakout_mode
 from sonic_py_common.multi_asic import get_asic_id_from_name, get_asic_device_id, is_multi_asic, get_asic_sub_role
 from sonic_py_common import device_info

--- a/src/sonic-config-engine/tests/test_minigraph_custom.py
+++ b/src/sonic-config-engine/tests/test_minigraph_custom.py
@@ -1,0 +1,40 @@
+from mock import MagicMock
+
+import minigraph_ext
+
+
+class MinigraphCustom:
+    @staticmethod
+    def parse_xml(parse_xml, *args, **kwargs):
+        results = parse_xml(*args, **kwargs)
+        results["CUSTOM"] = {"enabled": "true"}
+        return results
+
+
+def test_default_parser_adapter_is_noop(monkeypatch):
+    expected = {"DEVICE_METADATA": {"localhost": {}}}
+    parse_xml = MagicMock(return_value=expected)
+    monkeypatch.setattr(minigraph_ext, "minigraph_custom", None)
+    monkeypatch.setattr(minigraph_ext.minigraph, "parse_xml", parse_xml)
+
+    assert minigraph_ext.parse_xml("minigraph.xml") is expected
+    parse_xml.assert_called_once_with("minigraph.xml")
+
+
+def test_optional_parser_adapter(monkeypatch):
+    parse_xml = MagicMock(
+        return_value={"DEVICE_METADATA": {"localhost": {}}}
+    )
+    monkeypatch.setattr(minigraph_ext, "minigraph_custom", MinigraphCustom)
+    monkeypatch.setattr(minigraph_ext.minigraph, "parse_xml", parse_xml)
+
+    results = minigraph_ext.parse_xml(
+        "minigraph.xml",
+        port_config_file="port_config.ini",
+    )
+
+    assert results["CUSTOM"] == {"enabled": "true"}
+    parse_xml.assert_called_once_with(
+        "minigraph.xml",
+        port_config_file="port_config.ini",
+    )


### PR DESCRIPTION
#### Why I did it

Derived images sometimes need deployment-specific minigraph policy. Modifying the protected `minigraph.py` parser directly creates recurring synchronization conflicts and is rejected by the public protected-file check.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added `minigraph_ext.parse_xml()` as an optional adapter at the `sonic-cfggen` caller boundary.
- Public behavior delegates directly to `minigraph.parse_xml()` when no custom module is installed.
- A derived image may provide `minigraph_custom.parse_xml(parse_xml, *args, **kwargs)` to wrap the original parser without patching `minigraph.py`.
- Conditionally packages `minigraph_custom.py` when a downstream tree provides it.
- Import failures from an existing custom module are surfaced; only an absent module is treated as optional.
- Added focused unit coverage for default and customized behavior.

`minigraph.py` is not changed by this PR.

#### How to verify it

```bash
cd src/sonic-config-engine
python3 -m pytest -q -o addopts= tests/test_minigraph_custom.py
```

Result: 2 tests passed.

#### Which release branch to backport (provide reason below if selected)

None.

#### Tested branch

- [x] master

#### Test result

- master: focused parser-adapter tests passed.

#### Description for the changelog

sonic-config-engine: add an optional minigraph parser adapter for derived images.

#### Link to config_db schema for YANG module changes

N/A - no schema or YANG changes.