### PR TITLE
[sonic-config-engine]: Support expected-output overrides

### DIFF
--- a/src/sonic-config-engine/tests/common_utils.py
+++ b/src/sonic-config-engine/tests/common_utils.py
@@ -11,6 +11,22 @@ PYvX_DIR = "py3" if PY3x else "py2"
 PYTHON_INTERPRETTER = "python3" if PY3x else "python2"
 YANG_MODELS_DIR = "/usr/local/yang-models"
 
+
+def get_sample_output_file(test_dir, relative_path):
+    """Resolve custom, versioned, then legacy expected-output paths."""
+    custom = os.path.join(
+        test_dir, "sample_output", "custom", PYvX_DIR, relative_path
+    )
+    if os.path.isfile(custom):
+        return custom
+    versioned = os.path.join(
+        test_dir, "sample_output", PYvX_DIR, relative_path
+    )
+    if os.path.isfile(versioned):
+        return versioned
+    return os.path.join(test_dir, "sample_output", relative_path)
+
+
 def tuple_to_str(tuplestr):
     """ Convert Python tuple '('elem1', 'elem2')' representation into string on the for "elem1|elem2" """
     def to_str(tupleobj):

--- a/src/sonic-config-engine/tests/test_common_utils.py
+++ b/src/sonic-config-engine/tests/test_common_utils.py
@@ -1,0 +1,44 @@
+import os
+
+import tests.common_utils as utils
+
+
+def test_sample_output_file_falls_back_to_legacy_path(tmpdir):
+    test_dir = str(tmpdir)
+
+    assert utils.get_sample_output_file(test_dir, "output.json") == os.path.join(
+        test_dir, "sample_output", "output.json"
+    )
+
+
+def test_sample_output_file_prefers_versioned_path(tmpdir):
+    test_dir = str(tmpdir)
+    versioned_dir = os.path.join(
+        test_dir, "sample_output", utils.PYvX_DIR
+    )
+    os.makedirs(versioned_dir)
+    versioned = os.path.join(versioned_dir, "output.json")
+    with open(versioned, "w"):
+        pass
+
+    assert utils.get_sample_output_file(test_dir, "output.json") == versioned
+
+
+def test_sample_output_file_prefers_custom_path(tmpdir):
+    test_dir = str(tmpdir)
+    custom_dir = os.path.join(
+        test_dir, "sample_output", "custom", utils.PYvX_DIR
+    )
+    versioned_dir = os.path.join(
+        test_dir, "sample_output", utils.PYvX_DIR
+    )
+    os.makedirs(custom_dir)
+    os.makedirs(versioned_dir)
+    custom = os.path.join(custom_dir, "output.json")
+    versioned = os.path.join(versioned_dir, "output.json")
+    with open(custom, "w"):
+        pass
+    with open(versioned, "w"):
+        pass
+
+    assert utils.get_sample_output_file(test_dir, "output.json") == custom

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -750,7 +750,9 @@ class TestJ2Files(TestCase):
         os.remove(buffers_config_file_new)
         self.remove_machine_conf(file_exist, dir_exist)
 
-        out_file_dir = os.path.join(self.test_dir, 'sample_output', utils.PYvX_DIR)
+        out_file_dir = os.path.dirname(
+            utils.get_sample_output_file(self.test_dir, expected)
+        )
         expected_files = [expected, self.modify_cable_len(expected, out_file_dir)]
         match = False
         diff = ''
@@ -893,8 +895,8 @@ class TestJ2Files(TestCase):
         }
         for _, v in test_list.items():
             argument = ["-m", v["graph"], "-p", v["port_config"], "-y", constants_yml, "-t", switch_template]
-            sample_output_file = os.path.join(
-                self.test_dir, 'sample_output', v["output"]
+            sample_output_file = utils.get_sample_output_file(
+                self.test_dir, v["output"]
             )
             self.run_script(argument, output_file=self.output_file)
             assert utils.cmp(sample_output_file, self.output_file), self.run_diff(sample_output_file, self.output_file)
@@ -921,8 +923,8 @@ class TestJ2Files(TestCase):
         for _, v in test_list.items():
             os.environ["NAMESPACE_ID"] = v["namespace_id"]
             argument = ["-m", self.t1_mlnx_minigraph, "-y", constants_yml, "-t", switch_template]
-            sample_output_file = os.path.join(
-                self.test_dir, 'sample_output', v["output"]
+            sample_output_file = utils.get_sample_output_file(
+                self.test_dir, v["output"]
             )
             self.run_script(argument, output_file=self.output_file)
             assert utils.cmp(sample_output_file, self.output_file), self.run_diff(sample_output_file, self.output_file)


### PR DESCRIPTION
#### Why I did it

Derived test environments may require expected outputs that differ by deployment or Python major version. Editing shared public fixtures directly creates recurring synchronization conflicts.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Added `get_sample_output_file()` with the following precedence:

1. `sample_output/custom/<py2|py3>/<relative-path>`
2. `sample_output/<py2|py3>/<relative-path>`
3. `sample_output/<relative-path>`

Updated switch-template and buffer-rendering tests to use the resolver. Existing public behavior remains unchanged when no custom or versioned fixture exists.

#### How to verify it

```bash
cd src/sonic-config-engine
python3 -m pytest -q -o addopts= tests/test_common_utils.py
```

Result: 3 tests passed.

#### Which release branch to backport (provide reason below if selected)

None.

#### Tested branch

- [x] master

#### Test result

- master: focused expected-output resolver tests passed.

#### Description for the changelog

sonic-config-engine: support deployment-specific and Python-version-specific expected-output fixtures.

#### Link to config_db schema for YANG module changes

N/A - no schema or YANG changes.