### PR TITLE
[Mellanox] Fix off-by-one in ASIC ready SFP change events

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/chassis.py
@@ -696,8 +696,14 @@ class Chassis(ChassisBase):
                 ready_asic_val = True
                 self._enable_polling_for_asic(asic_id)
             self.module_host_mgmt_initializer.set_asic_ready_value(asic_index, ready_asic_val)
+            # sdk_index is 0-based, but the change event dict is keyed by the 1-based
+            # physical port index (same convention as get_change_event_legacy() and
+            # SFP.fill_change_event(), which both emit sdk_index + 1). Without the
+            # conversion the whole map is shifted by one: the event for sdk_index 0 is
+            # emitted as port 0 and dropped by xcvrd, and the last module of the ASIC
+            # never receives an event at all.
             for i in sfp_indices:
-                changes[str(i)] = value
+                changes[str(i + 1)] = value
 
         return changes
 

--- a/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_chassis.py
@@ -525,7 +525,8 @@ class TestChassis:
              mock.patch.object(DeviceDataManager, 'is_module_host_management_mode', return_value=True):
             changes = chassis.get_asic_change_event(timeout=1)
 
-        assert changes == {'0': '0'}
+        # keyed by 1-based physical port index, i.e. sdk_index + 1
+        assert changes == {'1': '0'}
         wait_ready_task.cancel_wait.assert_called_once_with(0)
         chassis._disable_polling_for_asic.assert_called_once_with('asic0')
         chassis._enable_polling_for_asic.assert_not_called()
@@ -554,7 +555,8 @@ class TestChassis:
              mock.patch.object(DeviceDataManager, 'is_module_host_management_mode', return_value=True):
             changes = chassis.get_asic_change_event(timeout=1)
 
-        assert changes == {'0': '1'}
+        # keyed by 1-based physical port index, i.e. sdk_index + 1
+        assert changes == {'1': '1'}
         chassis._enable_polling_for_asic.assert_called_once_with('asic0')
         chassis._disable_polling_for_asic.assert_not_called()
         wait_ready_task.cancel_wait.assert_not_called()


### PR DESCRIPTION
#### Why I did it

Fix degradation caused by https://github.com/sonic-net/sonic-buildimage/pull/26678
`Chassis.get_asic_change_event()` keys the synthesized module change events by the **0-based** `sdk_index`, while the change event dict is consumed as a **1-based** physical port index.

Both other producers of that dict convert correctly:

- `get_change_event_legacy()` emits `port_dict[sfp_index + 1]`
- `SFP.fill_change_event()` emits `port_dict[self.sdk_index + 1]`

and `xcvrd` resolves the key through `port_mapping`, which is built from the 1-based `index` column of `port_config.ini`.

So on every `asicN_ready` transition the whole module map is shifted by one:

- the event for `sdk_index` 0 is emitted as physical port `0` and dropped by xcvrd with `Got unknown FP port index 0, ignored`
- every other event lands on the cage below the intended one
- **the last module of the ASIC never receives an event at all**

When syncd restarts, the ASIC goes not-ready and then ready again, and this path is what removes and then re-adds every module of that ASIC. That makes it the recovery mechanism for a module which the sysfs poller transiently reported as unplugged while the SDK was re-initialising. Because the last cage is never re-added, such a module stays marked as removed and its `STATE_DB` `TRANSCEIVER_INFO` entry is never repopulated.

Concretely, on a 65-cage `Mellanox-SN6600_LD-P64O128C2`, `TRANSCEIVER_INFO` for the two cage-65 subports (`Ethernet512` / `Ethernet513`) stayed missing indefinitely after `systemctl restart swss`, while the module was present and the link was up.

Note the two cage populations are not symmetric: cages 1..N-1 are covered by both the sysfs poller and the ASIC-ready path, so a transient misread is always corrected. The last cage is only ever reachable by the poller, and the poller arms its notification on the `present` sysfs node while deciding from the `status` node — since `present` does not change when the module was never physically removed, no further event is ever generated for it.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Key the events by `sdk_index + 1` in `get_asic_change_event()` so every module of the ASIC, including the last one, is reported to xcvrd — matching the convention already used by `get_change_event_legacy()` and `SFP.fill_change_event()`.

Two existing unit tests asserted the 0-based keys (`{'0': '0'}` / `{'0': '1'}`) and are updated to `{'1': '0'}` / `{'1': '1'}`.

#### How to verify it

Unit tests:

```
cd platform/mellanox/mlnx-platform-api
pytest tests/test_chassis.py tests/test_change_event.py
```

On a switch running the legacy (non module-host-management) SFP path — i.e. an hwsku whose `sai.profile` does not set `SAI_INDEPENDENT_MODULE_MODE` — with the highest cage populated:

```
systemctl restart swss
```

Then, over the syslog window for that restart:

- `Got unknown FP port index 0, ignored` should no longer appear
- every port with a transceiver should appear in the `received plug out` / `received plug in` waves, including the subports of the highest cage
- `TRANSCEIVER_INFO` should be repopulated for every such port

Measured on a `Mellanox-SN6600_LD-P64O128C2` (65 cages, 136 ports with transceivers), comparing the same box before and after the change, in restart windows where the sysfs poller produced no events so that only the ASIC-ready path was active:

| per `systemctl restart swss` | before | after |
| --- | --- | --- |
| `unknown FP port index 0, ignored` | 2 | 0 |
| distinct ports plugged out | 134 | 136 |
| distinct ports plugged in | 134 | 136 |
| plug events for the highest cage | 0 | 4 |

Also covered by `platform_tests/test_sequential_restart.py::test_restart_swss`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: day-one issue of `get_asic_change_event()`

Reason for backport: the affected code is present and identical on 202605, where the issue was originally observed.

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

Unit tests were run on this branch (master). The switch-level before/after measurement above was run on a 202605-based image, where `get_asic_change_event()` is identical to master.

