### PR TITLE
[docker-ptf] Build gobgpd/gobgp and its Python gRPC stubs into the PTF image

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -103,7 +103,7 @@ RUN apt-get update          \
         quilt               \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go toolchain for building grpcurl and gnmic from source
+# Install Go toolchain for building grpcurl, gnmic and gobgp from source
 # to ensure they use a patched Go stdlib (GO-2026-4970, GO-2026-5856)
 {% if CONFIGURED_ARCH == "armhf" %}
 RUN GO_ARCH=armv6l \
@@ -444,6 +444,33 @@ RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
     && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build
+
+# Build gobgpd + gobgp (v4.7.0) from source; opt-in GoBGP PTF speaker engine.
+# Tag pinned + SHA-verified: a force-moved tag fails the build.
+# grpc/x/net/x/text raised above v4.7.0 floors to clear Trivy MEDIUM+ findings.
+# The Python gRPC stubs come from the same checkout into /usr/local/lib/gobgp-api,
+# so the binaries and the stubs always describe the same gobgp version. They are
+# skipped on the mixed-python image, whose protobuf runtime predates the gencode
+# grpcio-tools emits.
+RUN GOBGP_VERSION=v4.7.0 \
+    && GOBGP_COMMIT=8b5edc2c55cbec9e7df33123a07811a119d44542 \
+    && git clone --depth 1 --branch "${GOBGP_VERSION}" https://github.com/osrg/gobgp.git /tmp/gobgp \
+    && cd /tmp/gobgp \
+    && test "$(git rev-parse HEAD)" = "${GOBGP_COMMIT}" \
+    && go get google.golang.org/grpc@v1.82.1 golang.org/x/net@v0.57.0 golang.org/x/text@v0.40.0 \
+    && go mod tidy \
+    && go build -o /usr/local/bin/gobgpd ./cmd/gobgpd \
+    && go build -o /usr/local/bin/gobgp ./cmd/gobgp \
+    && chmod +x /usr/local/bin/gobgpd /usr/local/bin/gobgp \
+{%- if PTF_ENV_PY_VER != "mixed" %}
+    && mkdir -p /usr/local/lib/gobgp-api \
+    && python3 -m grpc_tools.protoc -Iproto \
+        --python_out=/usr/local/lib/gobgp-api --grpc_python_out=/usr/local/lib/gobgp-api \
+        api/gobgp.proto api/attribute.proto api/capability.proto \
+        api/common.proto api/extcom.proto api/nlri.proto \
+    && PYTHONPATH=/usr/local/lib/gobgp-api python3 -c "from api import gobgp_pb2_grpc" \
+{%- endif %}
+    && rm -rf /tmp/gobgp /root/go/pkg/mod /root/.cache/go-build
 
 # Remove Go toolchain to reduce image size
 RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -103,7 +103,7 @@ RUN apt-get update          \
         quilt               \
     && rm -rf /var/lib/apt/lists/*
 
-# Install the latest stable Go toolchain for building grpcurl and gnmic. The
+# Install the latest stable Go toolchain for building grpcurl, gnmic and gobgp. The
 # hooked metadata and archive downloads are recorded in versions-web, allowing
 # version-controlled builds to reproduce the selected release.
 RUN GO_ARCH=amd64 \
@@ -442,6 +442,36 @@ RUN GNMIC_REV=653dc5dd4ddcd3bd4197317875a10c1ce8b06653 \
     && go build -o /usr/local/bin/gnmic . \
     && chmod +x /usr/local/bin/gnmic \
     && rm -rf /tmp/gnmic /root/go/pkg/mod /root/.cache/go-build
+
+# Build gobgpd + gobgp from source; opt-in GoBGP PTF speaker engine.
+# Tracks the latest release. Version control pins the exact commit via
+# versions-git and the git build hook resets the clone to it, which a shallow
+# clone would not contain.
+# grpc/x/net/x/text are raised above the release floors to clear Trivy MEDIUM+
+# findings; minimal version selection preserves them across a version bump.
+# The Python gRPC stubs are generated from the same checkout into
+# /usr/local/lib/gobgp-api, so the binaries and the stubs always describe the
+# same gobgp version. They are skipped on the mixed-python image, whose
+# protobuf runtime predates the gencode grpcio-tools emits.
+RUN curl --fail --show-error --location -o /tmp/gobgp-release.json "https://api.github.com/repos/osrg/gobgp/releases/latest" \
+    && GOBGP_VERSION=$(python3 -c 'import json; print(json.load(open("/tmp/gobgp-release.json"))["tag_name"])') \
+    && git clone --branch "${GOBGP_VERSION}" https://github.com/osrg/gobgp.git /tmp/gobgp \
+    && cd /tmp/gobgp \
+    && echo "gobgp $(git describe --tags --always) $(git rev-parse HEAD)" \
+    && go get google.golang.org/grpc@v1.82.1 golang.org/x/net@v0.57.0 golang.org/x/text@v0.40.0 \
+    && go mod tidy \
+    && go build -o /usr/local/bin/gobgpd ./cmd/gobgpd \
+    && go build -o /usr/local/bin/gobgp ./cmd/gobgp \
+    && chmod +x /usr/local/bin/gobgpd /usr/local/bin/gobgp \
+{%- if PTF_ENV_PY_VER != "mixed" %}
+    && mkdir -p /usr/local/lib/gobgp-api \
+    && python3 -m grpc_tools.protoc -Iproto \
+        --python_out=/usr/local/lib/gobgp-api --grpc_python_out=/usr/local/lib/gobgp-api \
+        api/gobgp.proto api/attribute.proto api/capability.proto \
+        api/common.proto api/extcom.proto api/nlri.proto \
+    && PYTHONPATH=/usr/local/lib/gobgp-api python3 -c "from api import gobgp_pb2_grpc" \
+{%- endif %}
+    && rm -rf /tmp/gobgp /tmp/gobgp-release.json /root/go/pkg/mod /root/.cache/go-build
 
 # Remove Go toolchain to reduce image size
 RUN rm -rf /usr/local/go "$(go env GOPATH 2>/dev/null || echo $HOME/go)"


### PR DESCRIPTION
#### Why I did it

Add a build-from-source step for the gobgp daemon (`gobgpd`) and CLI (`gobgp`) to the docker-ptf image, and generate the Python gRPC stubs for the gobgp API from that same checkout. `gobgpd` is the BGP-speaker engine for the GoBGP-backed sonic-mgmt PTF route speaker — an opt-in, scalable replacement for the ExaBGP speaker (via `bgp_speaker=gobgp`; ExaBGP stays the default) that streams 100k+ prefixes/neighbor over gRPC. Design: HLD [sonic-net/sonic-mgmt#26382](https://github.com/sonic-net/sonic-mgmt/pull/26382).

The image carries the two binaries plus the generated stubs under `/usr/local/lib/gobgp-api`. The shim that drives them ships in sonic-mgmt and is deployed at runtime, mirroring `http_api.py`. Generating the stubs here rather than committing them to sonic-mgmt keeps them on the same gobgp version as the daemon that serves them, and keeps generated code out of the test repo: a gobgp bump moves the binaries and the stubs together, and a `grpcio-tools`/`protobuf` bump is picked up automatically at image build. Neither requires a regeneration PR in sonic-mgmt.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

The recipe follows the existing `grpcurl` and `gnmic` blocks in the same file: reuse the patched Go toolchain already installed earlier, build both commands, and sit before the Go-toolchain-removal step.

- The version is resolved from the latest upstream release rather than hardcoded, using the same `releases/latest` idiom the `grpcurl`, `sflowtool` and `nanomsg` blocks in this file already use, so the version-refresh build picks up gobgp security fixes on its own cadence and freezes the exact commit in `versions-git` — the same way `gnmic` and `grpcurl` are tracked today. Ordinary builds run with version control on and are pinned to that recorded commit, so a bump reaches master as a reviewable versions PR rather than moving underneath a build.
- Tracking the release rather than a fixed tag is safe because a bump is gated by the PTF test path, not merged on trust. The version files are part of docker-ptf's cache dependencies, so a recorded-commit change forces the image to rebuild, which sets `PTF_MODIFIED` and publishes the image as `ptf-<PR#>` for that PR's tests to run against. A gobgp bump that breaks the speaker therefore surfaces as a test failure on the version-refresh PR rather than in a nightly. Until the speaker is wired on it is opt-in and unused, so a bump has no blast radius in the interim.
- The clone is deliberately not shallow, the one deviation from those blocks. The `git` build hook applies the pin by resetting the clone to the recorded commit, and a `--depth 1` clone does not contain it; the reset then fails without failing the build, leaving the pin silently ineffective.
- `google.golang.org/grpc`, `golang.org/x/net` and `golang.org/x/text` are raised above the versions the release's `go.mod` selects, clearing the MEDIUM+ findings the docker-ptf Trivy job reports against the stock build. They are minimum versions, so Go's minimal version selection keeps these floors in effect across a gobgp bump rather than being regressed by it.
- Building from source rather than downloading a release keeps the Go stdlib patched for security/CVE scans, and provides the `.proto` sources the stubs are generated from.
- The stubs are generated with `python3 -m grpc_tools.protoc -Iproto` over the six `api/*.proto` files into `/usr/local/lib/gobgp-api`. Compiling with `-Iproto` (rather than flattening the protos) yields a proper `api` package whose cross-imports resolve unmodified, so no generated code needs editing. `grpcio-tools` is already installed in the image.
- An import check (`from api import gobgp_pb2_grpc`) runs immediately after generation, so a mismatch between the emitted gencode and the image's protobuf runtime fails the build instead of surfacing at test time.
- The mixed-python image pins a protobuf runtime older than the gencode `grpcio-tools` emits, so stub generation is skipped there — the same gating the existing gnxi regeneration step in this file uses.
- The resolved tag and commit are echoed into the build log, so the effective version is recorded even though it is no longer literal in the Dockerfile and may be rolled back by the version-control reset.
- The Go toolchain and module cache are removed at the end of the step, so only the binaries and the stubs persist.

ExaBGP is retained unchanged.

**Image size:** adds ~55 MB of binaries — `gobgpd` ~31 MB (the speaker daemon) + `gobgp` ~25 MB (CLI, kept for on-container debugging) — plus ~0.35 MB of generated Python, to the ~4.37 GB docker-ptf image: a ~1.2% increase.

#### How to verify it

The template was rendered for both `PTF_ENV_PY_VER` variants and the resulting shell syntax-checked: both parse, and the stub-generation step is present for `py3` and absent for `mixed`. The version resolver and clone were run verbatim under `dash` (the shell `RUN` uses), selecting `v4.8.0`. The pin mechanism was verified directly: a full clone can `git reset --hard` to an older recorded commit while a `--depth 1` clone of the same tag cannot, which is what the non-shallow clone protects against.

The recipe was then compile-verified end to end at the resolved tag (`go get` grpc + `golang.org/x/*` floors, `go mod tidy`, build both commands), with the floors observably applied (`x/net 0.55.0 => 0.57.0`, `x/text 0.37.0 => 0.40.0`); `gobgpd --version` / `gobgp --version` report `version 4.8.0`. The protoc invocation was run against that same clone, producing 12 modules under `api/`, and the import check was mutation-tested — it exits 0 against protobuf 7.35.1 and non-zero against 4.21.12 and 6.33.5, confirming it fails the build on a gencode/runtime mismatch rather than passing silently.

Functionally, the generated stubs were driven against a live `gobgpd` from the same build through the sonic-mgmt shim: 50 IPv4 and 50 IPv6 prefixes announced and withdrawn, verified in the global RIB with AS_PATH, LOCAL_PREF, MED, and standard/large/extended communities intact and the RIB draining to empty on withdraw (14/14 checks). In the built image `gobgpd`/`gobgp` are on `PATH` and the existing ExaBGP tooling is unaffected.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] N/A

#### Test result

- master: template renders for both python variants with valid shell syntax; version resolver selects `v4.8.0` under `dash`; `gobgpd` + `gobgp` build with the dependency floors applied and report `version 4.8.0`; stub generation and the post-generation import check verified against that checkout; live announce/withdraw of 100 prefixes (v4 + v6) through the shim against that `gobgpd` passes 14/14 checks.

#### Description for the changelog

Build gobgpd/gobgp and the gobgp Python gRPC stubs into the docker-ptf image for the GoBGP PTF route speaker.

#### Link to config_db schema for YANG module changes

N/A — no YANG changes.

#### A picture of a cute animal (not mandatory but encouraged)

🐤 (gobgp's mascot is a bird — fitting for a BGP speaker)
