### PR TITLE
[warmboot]: Fix counter snapshot restoration

### DIFF
--- a/files/image_config/warmboot-finalizer/finalize-warmboot.sh
+++ b/files/image_config/warmboot-finalizer/finalize-warmboot.sh
@@ -215,9 +215,10 @@ function restore_counters_folder()
     debug "Restoring counters folder after warmboot..."
 
     cache_counters_folder="/host/counters"
-    if [[ -d $cache_counters_folder ]]; then
-        mv $cache_counters_folder /tmp/cache
+    if [[ -d $cache_counters_folder/cache ]]; then
+        cp -rf $cache_counters_folder/cache /tmp/
         chown -R admin:admin /tmp/cache
+        rm -rf $cache_counters_folder
     fi
 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

## The bug

After warm-reboot, CLI counter clear baselines under `/tmp/cache` are not restored correctly.  
Counters cleared before reboot (e.g. `sonic-clear counters`) cannot show post-clear values after boot.  
The persisted snapshot is restored to the wrong path.

SONiC saves `/tmp/cache` to `/host/counters` before warm-reboot.  
It then restores that snapshot after warmboot finalization.

### Save path (before reboot)

`warm-reboot` / `fast-reboot` / `express-reboot` save the cache as follows:

```bash
# sonic-utilities/scripts/warm-reboot

function save_counters_folder() {
    if [[ "$REBOOT_TYPE" = "warm-reboot" ]]; then
        counters_folder="/host/counters"
        counters_cache="/tmp/cache"
        if [[ ! -d $counters_folder ]]; then
            mkdir $counters_folder
        fi
        if [[ -d $counters_cache ]]; then
           cp -rf $counters_cache $counters_folder
        fi
    fi
}
```

That produces:

```text
/tmp/cache/<app>/<uid>/...  →  /host/counters/cache/<app>/<uid>/...
```

### Broken restore path (after reboot)

`finalize-warmboot.sh` previously restored the snapshot like this:

```bash
# sonic-buildimage/files/image_config/warmboot-finalizer/finalize-warmboot.sh

cache_counters_folder="/host/counters"
if [[ -d $cache_counters_folder ]]; then
    mv $cache_counters_folder /tmp/cache
    chown -R admin:admin /tmp/cache
fi
```

The saved layout already contains a nested `cache/` directory.  
This move therefore yields:

```text
/tmp/cache/cache/<app>/<uid>/...
```

instead of the path expected by `UserCache`:

```text
/tmp/cache/<app>/<uid>/...
```

```python
# sonic-utilities/utilities_common/cli.py

class UserCache:
    CACHE_DIR = "/tmp/cache/"
```

CLI tools do not find the restored baselines.  
They treat counters as if they were never cleared.

### The fix

Restore must copy the nested `cache` directory back to `/tmp/`.  
Do not rename `/host/counters` itself:

```bash
# sonic-buildimage/files/image_config/warmboot-finalizer/finalize-warmboot.sh

cache_counters_folder="/host/counters"
if [[ -d $cache_counters_folder/cache ]]; then
    cp -rf $cache_counters_folder/cache /tmp/
    chown -R admin:admin /tmp/cache
    rm -rf $cache_counters_folder
fi
```

Resulting layout:

```text
/host/counters/cache/...  →  /tmp/cache/...
```

This matches the pre-reboot `UserCache` location.

#### Previous path layout (broken)

```
# Before reboot (save)
Saving counters folder before warmboot...
# /tmp/cache -> /host/counters/cache

# After reboot (broken restore)
Restoring counters folder after warmboot...
# /host/counters -> /tmp/cache
# resulting path: /tmp/cache/cache/...
```

#### New path layout (fixed)

```
# Before reboot (save)
Saving counters folder before warmboot...
# /tmp/cache -> /host/counters/cache

# After reboot (fixed restore)
Restoring counters folder after warmboot...
# /host/counters/cache -> /tmp/cache
# resulting path: /tmp/cache/<app>/<uid>/...
```

#### Why I did it

* Fixed counter clear baselines not surviving warm-reboot due to incorrect restore path

#### Work item tracking

* N/A

#### How I did it

* Updated `finalize-warmboot.sh` to restore `/host/counters/cache` into `/tmp/cache`
* Avoid moving `/host/counters` itself to `/tmp/cache`

#### How to verify it

1. Clear counters:
```
sonic-clear counters
sonic-clear dropcounters
sonic-clear pfccounters
sonic-clear queuecounters
sonic-clear rifcounters
```
2. Confirm cleared baselines are present under `/tmp/cache`
3. Perform warm-reboot
4. After boot, verify files are under `/tmp/cache/<app>/<uid>/...`
5. Confirm they are not under `/tmp/cache/cache/...`
6. Confirm cleared counter baselines remain in effect

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

* N/A

#### Description for the changelog

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

* N/A

#### Link to config_db schema for YANG module changes

<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

* N/A

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```