### PR TITLE
out-of-band ZTP config for SONiC BMC platforms

### DIFF
--- a/device/arista/arm64-arista_goldfinch-r0/default_ztp_cfg.json
+++ b/device/arista/arm64-arista_goldfinch-r0/default_ztp_cfg.json
@@ -1,0 +1,4 @@
+{
+    "admin-mode": true,
+    "feat-inband": false
+}

--- a/device/aspeed/arm64-aspeed_ast2700_evb-r0/default_ztp_cfg.json
+++ b/device/aspeed/arm64-aspeed_ast2700_evb-r0/default_ztp_cfg.json
@@ -1,0 +1,4 @@
+{
+    "admin-mode": true,
+    "feat-inband": false
+}

--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/default_ztp_cfg.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/default_ztp_cfg.json
@@ -1,0 +1,4 @@
+{
+    "admin-mode": true,
+    "feat-inband": false
+}

--- a/device/nexthop/arm64-nexthop_b27-r0/default_ztp_cfg.json
+++ b/device/nexthop/arm64-nexthop_b27-r0/default_ztp_cfg.json
@@ -1,0 +1,4 @@
+{
+    "admin-mode": true,
+    "feat-inband": false
+}

--- a/device/nokia/arm64-nokia_bmc_h6_128-r0/default_ztp_cfg.json
+++ b/device/nokia/arm64-nokia_bmc_h6_128-r0/default_ztp_cfg.json
@@ -1,0 +1,4 @@
+{
+    "admin-mode": true,
+    "feat-inband": false
+}


### PR DESCRIPTION
Why: BMC device variants have no ASIC and no front-panel ports. They are provisioned over the eth0 management interface, so ZTP must not attempt discovery on in-band interfaces.

How:
- Add a per-device default_ztp_cfg.json to each BMC device variant setting "feat-inband": false (with "admin-mode": true).
- Config-only change, scoped to BMC devices
- no shared code paths are touched.

How to Verify:
- Confirm every BMC device directory ships the file and the flag: git show --stat HEAD grep -r feat-inband device/*/arm64-*/default_ztp_cfg.json

- On a booted BMC, /host/ztp/ztp_cfg.json should carry "feat-inband": false, which is the value the ZTP engine reads via getCfg('feat-inband').

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
