### PR TITLE
[Nexthop] NH-5010-F-O32-C32: add missing egress_lossless_profile

### DIFF
--- a/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/buffers_defaults_t2.j2
+++ b/device/nexthop/x86_64-nexthop_5010-r0/NH-5010-F-O32-C32/buffers_defaults_t2.j2
@@ -24,8 +24,8 @@
 
 {%- macro generate_buffer_pool_and_profiles() %}
     "BUFFER_POOL": {
-        "ingress_pool": {
-            "size": "56441610000",
+        "ingress_lossless_pool": {
+            "size": "25766440000",
             "type": "both",
             "mode": "dynamic",
             "xoff": "4024103375"
@@ -33,34 +33,21 @@
     },
     "BUFFER_PROFILE": {
         "ingress_lossy_profile": {
-            "pool":"ingress_pool",
+            "pool":"ingress_lossless_pool",
             "size":"0",
-            "dynamic_th":"3"
+            "xon_offset": "0",
+            "dynamic_th":"0"
+        },
+        "egress_lossless_profile": {
+            "pool":"ingress_lossless_pool",
+            "size":"0",
+            "dynamic_th":"-1"
         },
         "egress_lossy_profile": {
-            "pool":"ingress_pool",
+            "pool":"ingress_lossless_pool",
             "size":"0",
-            "dynamic_th":"3"
+            "dynamic_th":"-6"
         }
     },
 {%- endmacro %}
 
-{%- macro generate_pg_profils(port_names_active) %}
-    "BUFFER_PG": {
-{% for port in port_names_active.split(',') %}
-        "{{ port }}|0-7": {
-            "profile" : "ingress_lossy_profile"
-        }{% if not loop.last %},{% endif %}
-{% endfor %}
-    },
-{%- endmacro %}
-
-{% macro generate_queue_buffers(port_names_active) %}
-    "BUFFER_QUEUE": {
-{% for port in port_names_active.split(',') %}
-        "{{ port }}|0-7": {
-            "profile" : "egress_lossy_profile"
-        }{% if not loop.last %},{% endif %}
-{% endfor %}
-    }
-{% endmacro %}


### PR DESCRIPTION
#### Why I did it

`NH-5010-F-O32-C32` renders a CONFIG_DB that cannot be loaded by the YANG models, so GCU (`config apply-patch`) fails outright, and with it any test framework that gates on a config validation step.

Reproduced on hardware (`NH-5010-F-O32-C32`, `switch_type: voq`):

```
admin@humm204:~$ echo '[]' | sudo config apply-patch /dev/stdin
sonic_yang(3):Data Loading Failed:failed to parse data tree: Invalid leafref value
"egress_lossless_profile" - no target instance
"/bpf:sonic-buffer-profile/bpf:BUFFER_PROFILE/bpf:BUFFER_PROFILE_LIST/bpf:name" with the same
value.: Data path: /sonic-buffer-queue:sonic-buffer-queue/BUFFER_QUEUE/VOQ_BUFFER_QUEUE_LIST
[hostname='humm204'][asic_name='Asic0'][port='Ethernet96'][qindex='3-4']/profile
```

Root cause is a disagreement between the generic and per-HWSKU buffer templates that only manifests on VOQ platforms.

`files/build_templates/buffers_config.j2` generates `BUFFER_QUEUE` for a VOQ chassis from a dedicated branch that does **not** call the HWSKU's `generate_queue_buffers` macro, and instead hardcodes the profile name:

```jinja
{% if voq_chassis %}
     "BUFFER_QUEUE": {
{% for system_port in SYSTEM_PORT_ALL %}
        "{{ system_port }}|3-4": {
            "profile" : "egress_lossless_profile"
```

So every VOQ HWSKU is implicitly required to define a `BUFFER_PROFILE` named `egress_lossless_profile`. `NH-5010-F-O32-C32` does not — it defines only `ingress_lossy_profile` and `egress_lossy_profile`. Confirmed on the device:

```
admin@humm204:~$ redis-cli -n 4 KEYS 'BUFFER_PROFILE|*' | sort
BUFFER_PROFILE|egress_lossy_profile
BUFFER_PROFILE|ingress_lossy_profile
admin@humm204:~$ redis-cli -n 4 HGET 'BUFFER_QUEUE|humm204|Asic0|Ethernet96|3-4' profile
egress_lossless_profile
```

The HWSKU does carry its own `generate_queue_buffers` macro mapping `port|0-7` to `egress_lossy_profile`, which would have been self-consistent — but the VOQ branch never calls it. That dead macro is why the gap went unnoticed: the file reads as coherent, and it *is* coherent on non-VOQ platforms.

The sibling HWSKU `NH-5010-F-O64` on the same platform already carries the corrected definitions, so this repo currently contains both the broken and the fixed version of the same macro under two HWSKUs of one platform.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Synced `generate_buffer_pool_and_profiles()` in `NH-5010-F-O32-C32/buffers_defaults_t2.j2` with `NH-5010-F-O64`. Every line added here already exists in this repo under `NH-5010-F-O64`.

- pool `ingress_pool` renamed to `ingress_lossless_pool`, size `56441610000` to `25766440000`
- added `egress_lossless_profile` with `dynamic_th: -1` — this is what resolves the leafref
- `ingress_lossy_profile`: added `xon_offset: 0`, `dynamic_th` `3` to `0`
- `egress_lossy_profile`: `dynamic_th` `3` to `-6`
- dropped the stale `generate_pg_profils` and `generate_queue_buffers` macros. `generate_queue_buffers` is dead code under `voq_chassis`. `generate_pg_profils` is honoured, so dropping it moves `BUFFER_PG` from `port|0-7` to `port|0`, matching `NH-5010-F-O64`.

Deliberately **not** changed: the `ports2cable` entries and the pool `xoff` value. Those were tuned later than the `NH-5010-F-O64` content this syncs from, and rewriting them would revert that tuning. `pg_profile_lookup.ini` already matches and is untouched.

Scope is deliberately limited to the one file that causes the validation failure and that was verified on hardware. The `BALANCED` variant already defines `egress_lossless_profile` and has no YANG failure, and the `qos.json.j2` files are also out of sync with `NH-5010-F-O64` — both are follow-up work that changes dataplane behaviour (buffer pool sizing, WRED/ECN, QoS maps) and needs traffic validation rather than a config-validation check.

Note for anyone applying this to a running device: because this renames the buffer pool, `config qos reload` alone is not sufficient. orchagent cannot tear down the old pool while profiles still reference it, and logs `processBufferPool: Can't remove object ingress_pool due to being referenced` followed by `SAI_API_BUFFER, status: SAI_STATUS_INVALID_PARAMETER` in a retry loop. A full `config reload` (or reboot) creates the pool once at init and is clean. This affects only in-place upgrades of an already-booted device, not normal boot.

#### How to verify it

On an `NH-5010-F-O32-C32` device, the YANG validation that previously failed now passes:

```
admin@humm204:~$ echo '[]' | sudo config apply-patch /dev/stdin
...
Patch Applier: localhost patch application completed.
Patch applied successfully.
```

Check the profile exists:

```
admin@humm204:~$ redis-cli -n 4 KEYS 'BUFFER_PROFILE|*' | sort
BUFFER_PROFILE|egress_lossless_profile
BUFFER_PROFILE|egress_lossy_profile
BUFFER_PROFILE|ingress_lossy_profile
BUFFER_PROFILE|pg_lossless_100000_120000m_profile
BUFFER_PROFILE|pg_lossless_100000_30m_profile
BUFFER_PROFILE|pg_lossless_400000_30m_profile
```

Confirm the buffer objects reach the ASIC:

```
admin@humm204:~$ redis-cli -n 1 KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_POOL:*' | wc -l
1
admin@humm204:~$ redis-cli -n 1 KEYS 'ASIC_STATE:SAI_OBJECT_TYPE_BUFFER_PROFILE:*' | wc -l
6
```

Template rendering can also be checked offline, without a device, by rendering `buffers.json.j2` for the HWSKU and asserting every `BUFFER_PG` / `BUFFER_QUEUE` profile reference resolves to a defined `BUFFER_PROFILE`. Before this change the render yields 32 dangling `|3-4` references; after it, zero. `NH-5010-F-O64` passes both before and after, as a control.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Reason: `202511` and `202605` both ship `NH-5010-F-O32-C32` with a `buffers_defaults_t2.j2` that omits `egress_lossless_profile`, so both produce a CONFIG_DB that fails YANG validation. Verified by rendering each branch: all three of master, 202511 and 202605 yield 32 dangling `BUFFER_QUEUE` references before this change and zero after. Every other release branch in the list above does not ship this HWSKU at all, so no further backports are needed. Cherry-picking this commit onto both 202511 and 202605 was tested and applies cleanly.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Verified on `NH-5010-F-O32-C32` hardware (`switch_type: voq`) — the only HWSKU affected — on community images of both requested branches.

**202511**: `SONiC.202511.Nexthop.137003-c073a6893` (build of `202511` HEAD `c073a6893`)

- Confirmed the on-device `buffers_defaults_t2.j2` is byte-identical to this branch's copy before any change (md5 `b86eae7d`), so the shipped template is what was under test.
- Before: `echo '[]' | sudo config apply-patch /dev/stdin` fails with `Data Loading Failed` / `Invalid leafref value "egress_lossless_profile"`.
- After cherry-picking this commit onto 202511 and a full `config reload`: exits `0` with `Patch applied successfully.`
- Health after: 10 ports up, 5/5 BGP neighbours established, 5 `BUFFER_PROFILE` entries programmed into ASIC_DB.

**202605**: `SONiC.202605.1179093-ee68f85f5`

- Before: same failure, exit `2`.
- After the change plus a full `config reload`: exit `0`, `Patch applied successfully.`
- Restoring the original template reproduces the failure again, confirming causality rather than a coincidental pass.
- Health after: 10 ports up, 3 PortChannels LACP-up, 5/5 BGP neighbours, and all 6 `BUFFER_PROFILE` entries programmed into ASIC_DB, up from 2 before.
- Additionally re-checked against the current branch HEAD build `SONiC.202605.Nexthop.137006-fc07ef80d`: the shipped template there is byte-identical to this branch's copy (md5 `7dddb430`) and reproduces the identical leafref failure.

`NH-5010-F-O32-C32/buffers_defaults_t2.j2` is byte-identical on master and 202605, and the cherry-picked 202511 result is byte-identical to the master version of this commit, so the change under test is the same on all three branches. The master image itself was not booted.

Note on applying this to an already-running device: renaming the buffer pool cannot be done with `config qos reload` alone. orchagent cannot tear down the old pool while profiles still reference it and will log `processBufferPool: Can't remove object ingress_pool due to being referenced` followed by `SAI_API_BUFFER, status: SAI_STATUS_INVALID_PARAMETER` until a full `config reload` recreates the pool at init. Both branch verifications above showed those errors confined to the hot-reload window and none after the clean reload. Normal boot is unaffected.

Scope of testing, stated plainly: this is a config-validation and control-plane result. No traffic was run, so congestion, PFC and ECN behaviour under load were not exercised.

#### Description for the changelog

Add the missing `egress_lossless_profile` buffer profile to `NH-5010-F-O32-C32`, fixing YANG validation of the generated CONFIG_DB.

#### Link to config_db schema for YANG module changes

No YANG module changes. The affected models are the existing [BUFFER_PROFILE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#buffer_profile) and [BUFFER_QUEUE](https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#buffer_queue) tables — this change makes the platform's generated config satisfy the leafref they already define.
