### PR TITLE
[cache validation] [Makefile.cache]: Track build-env exports feeding the RFS/dpkg cache key

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -120,6 +120,7 @@ SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(SONIC_PROFILING_ON) \
                             $(DOCKER_DEFAULT_PLATFORM) \
                             $(BUILD_PACKAGES_URL) $(BUILD_SNAPSHOT_URL) \
+                            $(BUILD_PUBLIC_URL) \
                             $(MIRROR_SNAPSHOT) $(SONIC_VERSION_CONTROL_COMPONENTS) \
                             $(CROSS_BUILD_ENVIRON) $(MULTIARCH_QEMU_ENVIRON) \
                             $(TRUSTED_GPG_URLS)

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -118,7 +118,11 @@ SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(MIRROR_URLS) $(MIRROR_SECURITY_URLS) \
                             $(SONIC_DEBUGGING_ON) \
                             $(SONIC_PROFILING_ON) \
-                            $(DOCKER_DEFAULT_PLATFORM)
+                            $(DOCKER_DEFAULT_PLATFORM) \
+                            $(BUILD_PACKAGES_URL) $(BUILD_SNAPSHOT_URL) \
+                            $(MIRROR_SNAPSHOT) $(SONIC_VERSION_CONTROL_COMPONENTS) \
+                            $(CROSS_BUILD_ENVIRON) $(MULTIARCH_QEMU_ENVIRON) \
+                            $(TRUSTED_GPG_URLS)
 SONIC_COMMON_DPKG_LIST  :=  debian/control debian/changelog debian/rules \
                             debian/compat debian/install debian/copyright
 SONIC_COMMON_BASE_FILES_LIST  := sonic-slave-jessie/Dockerfile.j2 \


### PR DESCRIPTION
#### Why I did it
Several global build-environment variables that change the **content** of cached `.deb`/docker artifacts (apt sources, snapshot pins, component-version pinning, cross toolchain, apt trust anchors) are consumed by the build but were **not** part of `SONIC_COMMON_FLAGS_LIST`, so the dpkg/image cache key did not change when they changed — risking a stale cached artifact.

#### How I did it
Added only the build-env exports that genuinely affect built package/image content to `SONIC_COMMON_FLAGS_LIST` in `Makefile.cache`:
- `BUILD_PACKAGES_URL`, `BUILD_SNAPSHOT_URL`, `BUILD_PUBLIC_URL`, `MIRROR_SNAPSHOT` — apt source / snapshot pin → changes the packages pulled in at build time
- `SONIC_VERSION_CONTROL_COMPONENTS` — pins component versions → changes built content
- `CROSS_BUILD_ENVIRON`, `MULTIARCH_QEMU_ENVIRON` — selects the cross toolchain / qemu → changes produced binaries
- `TRUSTED_GPG_URLS` — apt trust anchors → changes which packages are accepted

Deliberately **not** added to the global list (would over-key every deb, or already covered):
- `SONIC_IMAGE_VERSION` — derived from `BUILD_TIMESTAMP`/`BUILD_NUMBER`, so it changes on **every build**; global keying would invalidate every package cache on every build (cache-destroying).
- `DEB_BUILD_OPTIONS`, `IMAGE_DISTRO`, `SONIC_OS_VERSION`, `KVERSION`, `ENABLE_ORGANIZATION_EXTENSIONS`, `SECURE_UPGRADE_PROD_*` — constants, already keyed elsewhere (`KVERSION` via `rules/linux-kernel.mk`), or affect only the final installer/image target (not cached debs/dockers). These belong in target-scoped keys if needed.
- `ENABLE_ASAN` — already keyed in the swss/syncd/sysmgr/orchagent `.dep` files.

The broader set above is deliberately excluded to avoid over-keying the cache — in particular `SONIC_IMAGE_VERSION`, which would otherwise be cache-destroying.

#### How to verify it
- `make` parses `Makefile.cache` (syntax preserved; `SONIC_COMMON_DPKG_LIST` intact) and `SONIC_COMMON_FLAGS_LIST` expands to the intended set with no per-build value.

#### Description for the changelog
Track build-environment exports that affect built package/image content (apt sources, snapshot pins, component versions, cross toolchain, `TRUSTED_GPG_URLS`) in the common dpkg/image cache key so cached artifacts are correctly invalidated when these inputs change.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


