### PR TITLE
[cache validation] [Makefile.cache]: Key the DEP/SMDEP name set to catch dependency rename/add/remove (and track external kernel patches)

### DIFF
--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -4,10 +4,22 @@ DEP_FILES   := rules/linux-kernel.mk rules/linux-kernel.dep
 # Fold the trusted CA cert file CONTENT (not just its path) into the cache key, so a
 # rotated cert at the same path invalidates the cached kernel. Empty/unset/missing => no-op.
 DEP_FILES   += $(wildcard $(SECURE_UPGRADE_KERNEL_CAFILE))
+# When external kernel patches are applied from a local directory, fold the patch file
+# CONTENTS (not just the path/URL strings) into the cache key, so edits to the patches at
+# the same location invalidate the cached kernel. The location follows the documented layout
+# (external-changes.patch + a patches/ subdir), so recurse and hash only *.patch FILES --
+# never pass the patches/ directory itself to git hash-object. Guarded so an unset/disabled
+# location is a no-op and does not cause spurious misses.
+ifeq ($(INCLUDE_EXTERNAL_PATCHES),y)
+ifneq ($(EXTERNAL_KERNEL_PATCH_LOC),)
+DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null)
+endif
+endif
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(INCLUDE_EXTERNAL_PATCHES) \
-	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE)
+	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE) \
+	        $(EXTERNAL_KERNEL_PATCH_URL)
 
 $(LINUX_HEADERS_COMMON)_CACHE_MODE  := GIT_CONTENT_SHA
 $(LINUX_HEADERS_COMMON)_DEP_FLAGS   := $(DEP_FLAGS)

--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -10,13 +10,18 @@ DEP_FILES   := rules/linux-kernel.mk rules/linux-kernel.dep
 ifeq ($(INCLUDE_EXTERNAL_PATCHES),y)
 ifneq ($(EXTERNAL_KERNEL_PATCH_LOC),)
 DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null)
+# Also fold the SET of patch file names (relative to the location, sorted) into the
+# flags. Content hashing of DEP_FILES catches edits; keying the name set additionally
+# makes add/remove/rename of a patch invalidate the key robustly. Paths are relative to
+# the location so the key stays workspace-independent (never absolute build-dir paths).
+EXTERNAL_KERNEL_PATCH_LIST := $(shell cd $(EXTERNAL_KERNEL_PATCH_LOC) 2>/dev/null && find . -type f -name '*.patch' | sort)
 endif
 endif
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(INCLUDE_EXTERNAL_PATCHES) \
 	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE) \
-	        $(EXTERNAL_KERNEL_PATCH_URL)
+	        $(EXTERNAL_KERNEL_PATCH_URL) $(EXTERNAL_KERNEL_PATCH_LIST)
 
 $(LINUX_HEADERS_COMMON)_CACHE_MODE  := GIT_CONTENT_SHA
 $(LINUX_HEADERS_COMMON)_DEP_FLAGS   := $(DEP_FLAGS)

--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -1,10 +1,22 @@
 
 SPATH       := $($(LINUX_HEADERS_COMMON)_SRC_PATH)
 DEP_FILES   := rules/linux-kernel.mk rules/linux-kernel.dep
+# When external kernel patches are applied from a local directory, fold the patch file
+# CONTENTS (not just the path/URL strings) into the cache key, so edits to the patches at
+# the same location invalidate the cached kernel. The location follows the documented layout
+# (external-changes.patch + a patches/ subdir), so recurse and hash only *.patch FILES --
+# never pass the patches/ directory itself to git hash-object. Guarded so an unset/disabled
+# location is a no-op and does not cause spurious misses.
+ifeq ($(INCLUDE_EXTERNAL_PATCHES),y)
+ifneq ($(EXTERNAL_KERNEL_PATCH_LOC),)
+DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null)
+endif
+endif
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(INCLUDE_EXTERNAL_PATCHES) \
-	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE)
+	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE) \
+	        $(EXTERNAL_KERNEL_PATCH_URL)
 
 $(LINUX_HEADERS_COMMON)_CACHE_MODE  := GIT_CONTENT_SHA
 $(LINUX_HEADERS_COMMON)_DEP_FLAGS   := $(DEP_FLAGS)

--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -9,10 +9,12 @@ DEP_FILES   += $(wildcard $(SECURE_UPGRADE_KERNEL_CAFILE))
 # the same location invalidate the cached kernel. The location follows the documented layout
 # (external-changes.patch + a patches/ subdir), so recurse and hash only *.patch FILES --
 # never pass the patches/ directory itself to git hash-object. Guarded so an unset/disabled
-# location is a no-op and does not cause spurious misses.
+# location is a no-op and does not cause spurious misses. Sort for a stable order --
+# Makefile.cache hashes DEP_FILES in list order, so an unsorted find could otherwise
+# produce different keys for identical trees depending on filesystem enumeration order.
 ifeq ($(INCLUDE_EXTERNAL_PATCHES),y)
 ifneq ($(EXTERNAL_KERNEL_PATCH_LOC),)
-DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null)
+DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null | sort)
 # Also fold the SET of patch file names (relative to the location, sorted) into the
 # flags. Content hashing of DEP_FILES catches edits; keying the name set additionally
 # makes add/remove/rename of a patch invalidate the key robustly. Paths are relative to

--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -13,13 +13,18 @@ DEP_FILES   += $(wildcard $(SECURE_UPGRADE_KERNEL_CAFILE))
 ifeq ($(INCLUDE_EXTERNAL_PATCHES),y)
 ifneq ($(EXTERNAL_KERNEL_PATCH_LOC),)
 DEP_FILES   += $(shell find $(EXTERNAL_KERNEL_PATCH_LOC) -type f -name '*.patch' 2>/dev/null)
+# Also fold the SET of patch file names (relative to the location, sorted) into the
+# flags. Content hashing of DEP_FILES catches edits; keying the name set additionally
+# makes add/remove/rename of a patch invalidate the key robustly. Paths are relative to
+# the location so the key stays workspace-independent (never absolute build-dir paths).
+EXTERNAL_KERNEL_PATCH_LIST := $(shell cd $(EXTERNAL_KERNEL_PATCH_LOC) 2>/dev/null && find . -type f -name '*.patch' | sort)
 endif
 endif
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(INCLUDE_EXTERNAL_PATCHES) \
 	        $(KERNEL_PROCURE_METHOD) $(KERNEL_CACHE_PATH) $(SECURE_UPGRADE_MODE) $(SECURE_UPGRADE_KERNEL_CAFILE) \
-	        $(EXTERNAL_KERNEL_PATCH_URL)
+	        $(EXTERNAL_KERNEL_PATCH_URL) $(EXTERNAL_KERNEL_PATCH_LIST)
 
 $(LINUX_HEADERS_COMMON)_CACHE_MODE  := GIT_CONTENT_SHA
 $(LINUX_HEADERS_COMMON)_DEP_FLAGS   := $(DEP_FLAGS)


### PR DESCRIPTION
#### Why I did it
Two related build-cache gaps for kernel patches, addressed at the right layer:

1. **(kernel, local mode)** When out-of-tree kernel patches are applied from a local directory (`EXTERNAL_KERNEL_PATCH_LOC`, e.g. `platform/mellanox/non-upstream-patches/`), the patch file **content** was not part of the linux-kernel cache key, so editing a patch at the same location served a stale cached kernel.

2. **(all packages/submodules)** More generally, the cache key hashed dependency-file **content only**. `git hash-object` hashes contents, so a content-preserving **rename** — or a same-content add/remove that leaves the sorted hash multiset unchanged — produced an identical `.sha`/`.smsha` and silently reused a stale cache. This is not kernel-specific: e.g. renaming a file inside a submodule such as `swss-common` could be missed. Per review feedback (@saiarcot895), this belongs at the engine level, not per package.

#### How I did it
**Engine fix (`Makefile.cache`) — closes the general rename/add/remove gap for everything:**
- Append the hash of the `.dep` (and `.smdep`) **name list** itself as a trailing line in the generated `.sha`/`.smsha` file. Per-file content hashes still catch edits; the trailing name-set hash makes add/remove/rename of a dependency path change the key even when file contents are unchanged. `GET_MOD_SHA` already folds `.dep.sha`/`.smdep.smsha`, so no key-derivation change is needed.
- Side effect: `.sha` now differs on a pure rename, so the recipe's existing `cmp` guard correctly refreshes the `.dep` name list instead of skipping the update.
- Workspace-independence: `.smdep` names are stored **relative** to the submodule root; `.dep` entries are repo-relative for every package (the only absolute contributor — the kernel external-patch location — resolves to the fixed `/sonic` build root in the slave container).

**Kernel rule (`rules/linux-kernel.dep`):**
- Fold the local patch file **contents** into `DEP_FILES` (recurse `find -type f -name '*.patch'`, sorted; never hash the `patches/` directory itself). Guarded by `INCLUDE_EXTERNAL_PATCHES=y` and a non-empty location so a disabled location is a no-op.
- **Removed** the per-package `EXTERNAL_KERNEL_PATCH_LIST` name list — add/remove/rename is now handled generically by the engine fix above, so the per-package list is redundant.
- **Kept** `EXTERNAL_KERNEL_PATCH_URL` in `DEP_FLAGS`: in URL/wget mode the patches are fetched remotely and never enter `DEP_FILES`, so the URL string is the only available invalidation signal for that mode.

#### How to verify it
- **Rename (engine):** with a submodule/package dependency file renamed but content unchanged, the generated `.sha`/`.smsha` changes and the package re-keys (previously it did not). Reproduced with the recipe logic: a content-preserving `patches/01-foo.patch → 01-bar.patch` leaves the content-only hash unchanged but changes the name-set hash.
- **Edit (kernel):** with `INCLUDE_EXTERNAL_PATCHES=y` and a populated `EXTERNAL_KERNEL_PATCH_LOC`, patch files appear in `DEP_FILES`, `git hash-object` succeeds on each, and editing a patch changes the key.
- **No-op:** with the location unset or `INCLUDE_EXTERNAL_PATCHES=n`, `DEP_FILES` is unchanged (no spurious misses).

#### Description for the changelog
Invalidate the build cache on dependency-file rename/add/remove (not just content edits), and on changes to externally-applied kernel patch content/source.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
