### PR TITLE
[cache validation] [platform]: Track include'd docker-syncd/gbsyncd template .mk in the docker cache key

### DIFF
--- a/platform/broadcom/docker-syncd-brcm.dep
+++ b/platform/broadcom/docker-syncd-brcm.dep
@@ -1,6 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/broadcom/docker-syncd-brcm.mk platform/broadcom/docker-syncd-brcm.dep platform/broadcom/sai-xgs.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/cisco/docker-gbsyncd-cisco.dep
+++ b/platform/cisco/docker-gbsyncd-cisco.dep
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-gbsyncd-cisco.mk $(PLATFORM_PATH)/docker-gbsyncd-cisco.dep
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(addprefix $(PLATFORM_PATH)/,$(shell cd $(PLATFORM_PATH) && git ls-files $(DOCKER_GBSYNCD_BASE_STEM)))
 

--- a/platform/cisco/docker-syncd-cisco.dep
+++ b/platform/cisco/docker-syncd-cisco.dep
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-cisco.mk $(PLATFORM_PATH)/docker-syncd-cisco.dep
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 # N.B. we need to enter the platform directory first, since it's a git submodule
 DEP_FILES   += $(addprefix $(PLATFORM_PATH)/,$(shell cd $(PLATFORM_PATH) && git ls-files $(DOCKER_SYNCD_BASE_STEM)))

--- a/platform/clounix/docker-syncd-clounix.dep
+++ b/platform/clounix/docker-syncd-clounix.dep
@@ -1,6 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/clounix/docker-syncd-clounix.mk platform/clounix/docker-syncd-clounix.dep platform/clounix/sai.mk 
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-base.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/components/docker-gbsyncd-credo.dep
+++ b/platform/components/docker-gbsyncd-credo.dep
@@ -2,7 +2,7 @@ DPATH       := $($(DOCKER_GBSYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST)
 DEP_FILES   += platform/components/docker-gbsyncd-credo.mk
 DEP_FILES   += platform/components/docker-gbsyncd-credo.dep
-DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-bookworm.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/components/docker-gbsyncd-credo.dep
+++ b/platform/components/docker-gbsyncd-credo.dep
@@ -2,6 +2,7 @@ DPATH       := $($(DOCKER_GBSYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST)
 DEP_FILES   += platform/components/docker-gbsyncd-credo.mk
 DEP_FILES   += platform/components/docker-gbsyncd-credo.dep
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera.dep
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera.dep
@@ -1,6 +1,6 @@
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mrvl-prestera.mk $(PLATFORM_PATH)/docker-syncd-mrvl-prestera.dep $(PLATFORM_PATH)/sai.mk
-DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera.dep
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera.dep
@@ -1,5 +1,6 @@
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mrvl-prestera.mk $(PLATFORM_PATH)/docker-syncd-mrvl-prestera.dep $(PLATFORM_PATH)/sai.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/marvell-teralynx/docker-syncd-mrvl-teralynx.dep
+++ b/platform/marvell-teralynx/docker-syncd-mrvl-teralynx.dep
@@ -1,5 +1,6 @@
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mrvl-teralynx.mk $(PLATFORM_PATH)/docker-syncd-mrvl-teralynx.dep $(PLATFORM_PATH)/sai.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files -- $(DPATH))
 

--- a/platform/mellanox/docker-syncd-mlnx.dep
+++ b/platform/mellanox/docker-syncd-mlnx.dep
@@ -2,6 +2,7 @@
 
 DPATH := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/docker-syncd-mlnx.mk $(PLATFORM_PATH)/docker-syncd-mlnx.dep platform/mellanox/mlnx-sai.mk
+DEP_FILES += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES += $(shell git ls-files -- $(DPATH))
 

--- a/platform/nokia-vs/docker-syncd-vs.dep
+++ b/platform/nokia-vs/docker-syncd-vs.dep
@@ -1,6 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/nokia-vs/docker-syncd-vs.mk platform/nokia-vs/docker-syncd-vs.dep   
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/nvidia-bluefield/recipes/docker-syncd-bluefield.dep
+++ b/platform/nvidia-bluefield/recipes/docker-syncd-bluefield.dep
@@ -1,6 +1,7 @@
 
 DPATH := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/$(RECIPE_DIR)/docker-syncd-bluefield.mk $(PLATFORM_PATH)/$(RECIPE_DIR)/docker-syncd-bluefield.dep
+DEP_FILES += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES += $(shell git ls-files -- $(DPATH))
 

--- a/platform/vs/docker-gbsyncd-vs.dep
+++ b/platform/vs/docker-gbsyncd-vs.dep
@@ -1,7 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_GBSYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/vs/docker-gbsyncd-vs.mk platform/vs/docker-gbsyncd-vs.dep   
-DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-bookworm.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/vs/docker-gbsyncd-vs.dep
+++ b/platform/vs/docker-gbsyncd-vs.dep
@@ -1,6 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_GBSYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/vs/docker-gbsyncd-vs.mk platform/vs/docker-gbsyncd-vs.dep   
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-gbsyncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/vs/docker-syncd-vs.dep
+++ b/platform/vs/docker-syncd-vs.dep
@@ -1,7 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/vs/docker-syncd-vs.mk platform/vs/docker-syncd-vs.dep   
-DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 

--- a/platform/vs/docker-syncd-vs.dep
+++ b/platform/vs/docker-syncd-vs.dep
@@ -1,6 +1,7 @@
 #DPKG FRK
 DPATH       := $($(DOCKER_SYNCD_BASE)_PATH)
 DEP_FILES   := $(SONIC_COMMON_FILES_LIST) platform/vs/docker-syncd-vs.mk platform/vs/docker-syncd-vs.dep   
+DEP_FILES   += $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
 DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 


### PR DESCRIPTION
#### Why I did it
Each platform's syncd/gbsyncd docker `.mk` `include`'s a shared recipe fragment `platform/template/docker-(gb)syncd-<distro>.mk`. That template supplies build-shaping variables — most notably `_CONTAINER_NAME`, which is passed to the build as `--build-arg docker_container_name` (`slave.mk`) and baked into the image wherever the `Dockerfile.j2` consumes that ARG.

The paired `.dep` files did **not** list the template in `DEP_FILES` (it lives outside `$(DPATH)`, so `git ls-files $(DPATH)` never sees it, and it is not in `SONIC_COMMON_FILES_LIST`). Under `GIT_CONTENT_SHA` cache mode, editing the template therefore changed the built image **without** invalidating the docker cache key — risking reuse of a stale cached image.

Note on scope: the bulkiest template content is already covered elsewhere — `_LOAD_DOCKERS` (base image) is folded into the key via `MOD_DEP_PKGS`/`GET_MOD_DEP_SHA`, and `_RUN_OPT` is runtime-only. The genuinely un-keyed build-affecting variable is `_CONTAINER_NAME`. This is a low-frequency gap (template churn is rare) but a real one, and the fix is mechanical.

#### How I did it
Added the include'd template to `DEP_FILES` in each affected `.dep`, matching the existing convention (e.g. `platform/mellanox/docker-syncd-mlnx.dep` already lists `mlnx-sai.mk`). The added entry uses `$(PLATFORM_PATH)/../template/docker-(gb)syncd-<distro>.mk` to mirror the `.mk` `include` line verbatim, guaranteeing both resolve to the same file.

Affected `.dep` files (12): broadcom, cisco (syncd + gbsyncd), clounix, components (gbsyncd-credo), marvell-prestera, marvell-teralynx, mellanox, nokia-vs, nvidia-bluefield, vs (syncd + gbsyncd).

#### How to verify it
- `PLATFORM_PATH = platform/$(CONFIGURED_PLATFORM)` and a platform's `.dep` is only loaded when that platform is built (`slave.mk` includes only `$(PLATFORM_PATH)/rules.mk`), so `$(PLATFORM_PATH)/../template/...` resolves to `platform/template/...` in every case.
- `make` parses each edited `.dep` (verified); each file changes by exactly one added line.

#### Which release branch to backport (provide reason below if selected)
<!-- optional -->

#### Description for the changelog
Track the include'd `platform/template/docker-(gb)syncd-*.mk` recipe fragment in each platform syncd/gbsyncd docker cache key so a template edit correctly invalidates the cached image.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

