### PR TITLE
[device/accton] AS4630-54PE: raise stable_size so syncd can initialise with newer Broadcom SAI

### DIFF
--- a/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G.bcm
+++ b/device/accton/x86_64-accton_as4630_54pe-r0/Accton-AS4630-54PE/hx5-as4630-48x1G+4x25G+2x100G.bcm
@@ -1,4 +1,4 @@
-stable_size=76303168
+stable_size=268435456
 
 #polarity/lanemap is using TH2 style.
 core_clock_frequency=893


### PR DESCRIPTION
#### Why I did it

On an Edgecore/Accton AS4630-54PE, `syncd` and `swss` never start. The Broadcom SDK runs out of warm-boot scache while initialising the field (IFP/ACL) module, so `bcm_init` fails and the switch is never created:

```
syncd Scache on unit 0 exhausted the stable_size of 76303156
syncd 0:_bcm_modules_init: bcm_init failed in field (No resources for operation)
syncd INIT: Unable to initialize BCM driver on unit 0
SAI_API_SWITCH:platform_process_command:432 Platform command "init bcm" failed, rc = -1
SAI_API_SWITCH:brcm_sai_create_switch:2061 initializing SDK failed with error Operation failed (0xfffffff5)
swss#orchagent: :- handleSaiFailure: Aborting orchagent due to critical SAI API failure...
```

`syncd` returns `SAI_STATUS_FAILURE` on `SAI_SWITCH_ATTR_INIT_SWITCH`, orchagent aborts on the critical SAI failure, the `swss` container exits, systemd retries three times and gives up with `start-limit-hit`, and every service depending on swss (`bgp`, `teamd`, `radv`, `snmp`) stops with it.

This is easy to misdiagnose: all the affected containers report **`Exited (0)`**, which looks like a clean shutdown rather than a failure.

The platform's `stable_size` has been `76303168` (~72 MB) unchanged for years, but the Broadcom XGS SAI has moved on:

| Branch | LIBSAIBCM_XGS_VERSION |
|---|---|
| 202411 | 12.3.19.2 |
| 202505 | 13.2.1.36 |
| 202511 | 14.3.0.0.0.0.31.0 |
| master / 202605 | 15.2.0.0.0.0.11.2 |

The newer SDK's field module needs more scache than the platform budgets. Note that when the allocation fails only ~4.8 MB of scache is actually in use (`last_offset=0x0049b714`), so the field module is making a *single* request larger than the entire remaining budget, not gradually exhausting it.

The `.bcm` file is byte-identical in 202411, 202505, 202511, 202605 and master, so any AS4630-54PE on a build newer than 202411 should be affected.

#### How I did it

Raised `stable_size` from `76303168` to `268435456` (256 MB) in `hx5-as4630-48x1G+4x25G+2x100G.bcm`.

This is deliberate headroom rather than a tuned minimum — the true requirement is somewhere above ~72 MB. I did not bisect it, and I'd be happy to use a tighter value if a maintainer with visibility into the SDK's field-module sizing prefers one. The box has 16 GB of RAM, so the reservation is not a practical concern there.

#### How to verify it

On an AS4630-54PE:

```
# before
docker ps -a          # swss, syncd, bgp, teamd, radv, snmp all "Exited (0)"
systemctl --failed    # swss.service failed (start-limit-hit)
grep "exhausted the stable_size" /var/log/syslog

# after
docker ps             # all containers up and staying up
systemctl --failed    # empty
show interfaces status  # ports programmed
```

Verified on hardware running 202505 (`SONiC.202505.0`, SAI 13.2.1.36): before the change swss/syncd never start; after it all containers come up and survive cold reboots.

I only have 202505 hardware to test on. The change is mechanically identical on the other branches, but I have not run it on 14.3 or 15.2 SAI.

#### Which release branch to backport

- [x] 202505
- [x] 202511
- [x] 202605
