### PR TITLE
[installer]: Ship dockerfs outside the zip payload when it reaches 4GiB

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -941,4 +941,13 @@ fi
 
 ## Compress together with /boot, /var/lib/docker and $PLATFORM_DIR as an installer payload zip file
 pushd $FILESYSTEM_ROOT && sudo tar -I pigz -cf platform.tar.gz -C $PLATFORM_DIR . && sudo zip -n .gz $OLDPWD/$INSTALLER_PAYLOAD -r boot/ platform.tar.gz; popd
-sudo zip -g -n .squashfs:.gz $INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS $FILESYSTEM_DOCKERFS
+sudo zip -g -n .squashfs:.gz $INSTALLER_PAYLOAD $FILESYSTEM_SQUASHFS
+
+## A zip member of 4GiB or more forces the archive into the zip64 format, which the
+## busybox unzip shipped in ONIE cannot parse. Ship such a dockerfs next to the
+## payload instead of inside it; the installers pick up whichever layout is present.
+if [ $(stat -c %s $FILESYSTEM_DOCKERFS) -lt $((4 * 1024 * 1024 * 1024)) ]; then
+    sudo zip -g -n .squashfs:.gz $INSTALLER_PAYLOAD $FILESYSTEM_DOCKERFS
+else
+    echo "$FILESYSTEM_DOCKERFS is 4GiB or larger, shipping it outside $INSTALLER_PAYLOAD"
+fi

--- a/build_image.sh
+++ b/build_image.sh
@@ -198,6 +198,9 @@ elif [ "$IMAGE_TYPE" = "aboot" ]; then
     sudo rm -f $ABOOT_BOOT_IMAGE
     ## Add main payload
     cp $INSTALLER_PAYLOAD $OUTPUT_ABOOT_IMAGE
+    ## Aboot reads the dockerfs from the swi, so add it back when shipped separately
+    unzip -l $OUTPUT_ABOOT_IMAGE $FILESYSTEM_DOCKERFS > /dev/null 2>&1 || \
+        zip -g $OUTPUT_ABOOT_IMAGE $FILESYSTEM_DOCKERFS
     ## Add Aboot boot0 file
     j2 -f env files/Aboot/boot0.j2 ./onie-image.conf > files/Aboot/boot0
     sed -i -e "s/%%IMAGE_VERSION%%/$IMAGE_VERSION/g" files/Aboot/boot0
@@ -257,7 +260,13 @@ elif [ "$IMAGE_TYPE" = "dsc" ]; then
     j2 $dsc_installer_manifest.j2 > $dsc_installer_manifest
 
     cp $INSTALLER_PAYLOAD $dsc_installer_dir
-    tar cf $OUTPUT_DSC_IMAGE -C files/dsc $(basename $dsc_installer_manifest) $INSTALLER_PAYLOAD $(basename $dsc_installer)
+    ## dockerfs is shipped next to the payload when it is too large for zip
+    dsc_dockerfs=""
+    if ! unzip -l $INSTALLER_PAYLOAD $FILESYSTEM_DOCKERFS > /dev/null 2>&1; then
+        cp $FILESYSTEM_DOCKERFS $dsc_installer_dir
+        dsc_dockerfs="$FILESYSTEM_DOCKERFS"
+    fi
+    tar cf $OUTPUT_DSC_IMAGE -C files/dsc $(basename $dsc_installer_manifest) $INSTALLER_PAYLOAD $dsc_dockerfs $(basename $dsc_installer)
 
     echo "Build ONIE installer"
     mkdir -p `dirname $OUTPUT_ONIE_IMAGE`

--- a/files/dsc/install_debian.j2
+++ b/files/dsc/install_debian.j2
@@ -264,15 +264,26 @@ install_root_filesystem()
     mkdir -p $root_mnt/$image_dir
 
     # Decompress the file for the file system directly to the partition
+    # A dockerfs of 4GiB or more does not fit in the zip payload and is shipped next to it
+    if tar tf $PKG $FILESYSTEM_DOCKERFS > /dev/null 2>&1; then
+        dockerfs_standalone=y
+    else
+        dockerfs_standalone=n
+    fi
     if [ x"$docker_inram" = x"on" ]; then
         # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
         tar xfO $PKG $INSTALLER_PAYLOAD | unzip -o - -x "platform.tar.gz" -d $root_mnt/$image_dir
+        [ x"$dockerfs_standalone" = x"y" ] && tar xfO $PKG $FILESYSTEM_DOCKERFS > $root_mnt/$image_dir/$FILESYSTEM_DOCKERFS
     else
         tar xfO $PKG $INSTALLER_PAYLOAD | unzip -o - -x "$FILESYSTEM_DOCKERFS" "platform.tar.gz" -d $root_mnt/$image_dir
 
         TAR_EXTRA_OPTION="--numeric-owner"
         mkdir -p $root_mnt/$image_dir/$DOCKERFS_DIR
-        tar xfO $PKG $INSTALLER_PAYLOAD | unzip -op - "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $root_mnt/$image_dir/$DOCKERFS_DIR
+        if [ x"$dockerfs_standalone" = x"y" ]; then
+            tar xfO $PKG $FILESYSTEM_DOCKERFS | tar xz $TAR_EXTRA_OPTION -f - -C $root_mnt/$image_dir/$DOCKERFS_DIR
+        else
+            tar xfO $PKG $INSTALLER_PAYLOAD | unzip -op - "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $root_mnt/$image_dir/$DOCKERFS_DIR
+        fi
     fi
 
     create_bootloader_conf

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -218,9 +218,11 @@ else
 fi
 
 # Decompress the file for the file system directly to the partition
+# A dockerfs of 4GiB or more does not fit in the zip payload and is shipped next to it
 if [ x"$docker_inram" = x"on" ]; then
     # when disk is small, keep dockerfs.tar.gz in disk, expand it into ramfs during initrd
     unzip -o $INSTALLER_PAYLOAD -x "platform.tar.gz" -d $demo_mnt/$image_dir
+    [ -f $FILESYSTEM_DOCKERFS ] && cp $FILESYSTEM_DOCKERFS $demo_mnt/$image_dir/
 else
     unzip -o $INSTALLER_PAYLOAD -x "$FILESYSTEM_DOCKERFS" "platform.tar.gz" -d $demo_mnt/$image_dir
 
@@ -230,7 +232,11 @@ else
         TAR_EXTRA_OPTION="--numeric-owner --warning=no-timestamp"
     fi
     mkdir -p $demo_mnt/$image_dir/$DOCKERFS_DIR
-    unzip -op $INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    if [ -f $FILESYSTEM_DOCKERFS ]; then
+        tar xz $TAR_EXTRA_OPTION -f $FILESYSTEM_DOCKERFS -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    else
+        unzip -op $INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz $TAR_EXTRA_OPTION -f - -C $demo_mnt/$image_dir/$DOCKERFS_DIR
+    fi
 fi
 
 mkdir -p $demo_mnt/$image_dir/platform

--- a/onie-mk-demo.sh
+++ b/onie-mk-demo.sh
@@ -106,6 +106,12 @@ sed -i -e "s/%%DEMO_TYPE%%/$demo_type/g" \
 echo -n "."
 cp -r $onie_installer_payload $tmp_installdir || clean_up 1
 echo -n "."
+## A dockerfs of 4GiB or more is shipped next to the payload rather than inside it
+. ./onie-image.conf
+if ! unzip -l $onie_installer_payload $FILESYSTEM_DOCKERFS > /dev/null 2>&1; then
+    cp $FILESYSTEM_DOCKERFS $tmp_installdir || clean_up 1
+fi
+echo -n "."
 [ -r "$platform_conf" ] && {
     cp $platform_conf $tmp_installdir/platform.conf || clean_up 1
 }

--- a/platform/nvidia-bluefield/installer/create_sonic_image
+++ b/platform/nvidia-bluefield/installer/create_sonic_image
@@ -179,6 +179,9 @@ add_sonic_to_initramfs() {
 
     # Copy the INSTALLER payload
     cp $CDIR/$INSTALLER_PAYLOAD ./debian/
+    # A dockerfs of 4GiB or more is shipped next to the payload rather than inside it
+    unzip -l $CDIR/$INSTALLER_PAYLOAD $FILESYSTEM_DOCKERFS > /dev/null 2>&1 || \
+        cp $CDIR/$FILESYSTEM_DOCKERFS ./debian/
 
 cat > scripts/initrd-install << EOF
 #!/bin/bash

--- a/platform/nvidia-bluefield/installer/install.sh.j2
+++ b/platform/nvidia-bluefield/installer/install.sh.j2
@@ -226,7 +226,12 @@ mkdir -p /mnt/$image_dir
 export EXTRACT_UNSAFE_SYMLINKS=1
 ex unzip -o /debian/$INSTALLER_PAYLOAD -x $FILESYSTEM_DOCKERFS "platform.tar.gz" -d /mnt/$image_dir
 mkdir -p /mnt/$image_dir/$DOCKERFS_DIR
-unzip -op /debian/$INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz --warning=no-timestamp -f - -C /mnt/$image_dir/$DOCKERFS_DIR
+# A dockerfs of 4GiB or more is shipped next to the payload rather than inside it
+if [ -f /debian/$FILESYSTEM_DOCKERFS ]; then
+    tar xz --warning=no-timestamp -f /debian/$FILESYSTEM_DOCKERFS -C /mnt/$image_dir/$DOCKERFS_DIR
+else
+    unzip -op /debian/$INSTALLER_PAYLOAD "$FILESYSTEM_DOCKERFS" | tar xz --warning=no-timestamp -f - -C /mnt/$image_dir/$DOCKERFS_DIR
+fi
 
 mkdir -p /mnt/$image_dir/platform
 unzip -op /debian/$INSTALLER_PAYLOAD "platform.tar.gz" | tar xz --warning=no-timestamp -f - -C /mnt/$image_dir/platform


### PR DESCRIPTION
#### Why I did it

`master` has not produced a VS image since 07-31: `target/sonic-vs.img.gz` fails after `install_sonic.py` waits out its full 1200s timeout. The timeout is a symptom — the real failure happens earlier, inside ONIE:

```
Verifying image checksum ... OK.
Preparing image archive ... OK.
unzip: invalid zip magic AFFF5EDF
Failure: Unable to install image: file://dev/vdb/onie-installer.bin
```

ONIE then falls back to looking for an installer over the network and loops there until the build gives up.

`dockerfs.tar.gz` has grown past 4GiB, and a zip member of that size forces the archive into the zip64 format. The busybox unzip in ONIE does not implement zip64 — it reads the `0xFFFFFFFF` placeholder in the local file header as the real compressed size, skips past the end of the archive and hits garbage. Dumping the local file headers of a payload built the way `build_debian.sh` builds it shows only that one member is affected:

```
entry              csize field    zip64?
boot/vmlinuz       0xc00000       no
platform.tar.gz    0x1400000      no
fs.squashfs        0x1a000000     no
dockerfs.tar.gz    0xffffffff     YES
```

which matches the ONIE log exactly: everything ahead of `dockerfs.tar.gz` extracts or is skipped fine, and the read of its header is where it breaks.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Keep `dockerfs.tar.gz` next to the payload rather than inside it once it reaches 4GiB, so the payload never needs zip64. It travels in the same `sharch.tar` that already carries the payload, and tar has no such limit — that archive is already ~4.5GB and unpacks fine today.

The extracting side accepts either layout, so an image whose dockerfs still fits in the payload is byte-for-byte unaffected. Covered all four install paths: ONIE (`installer/install.sh`), Aboot (added back into the swi, so `boot0` is untouched), BlueField and DSC.

#### How to verify it

Build a VS image and install it — that alone reproduces the failure on current master.

To check the payload directly, dump the local file headers of `fs.zip` and confirm no member has `csize == 0xFFFFFFFF`.

I also built both layouts at real size (4200MB dockerfs) and ran busybox unzip against them:

| payload | zip64 member | busybox unzip |
|---|---|---|
| dockerfs inside (before) | `dockerfs.tar.gz csize=0xffffffff` | fails, 0 files extracted |
| dockerfs alongside (after) | none | exit 0 |

and verified end-to-end that both the normal and `docker_inram=on` paths recover the dockerfs contents under either layout. The same validation passed on the `202605` branch.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512

#### Tested branch (Please provide the tested image version)

- [x] 202605
- [ ] <!-- image version 2 -->

#### Test result

202605: The VS image build and installation completed successfully with the 4GiB+ `dockerfs.tar.gz` shipped outside `fs.zip`; ONIE no longer reports `invalid zip magic`.

#### Description for the changelog

Ship dockerfs.tar.gz outside the installer payload when it reaches 4GiB, so the payload never needs zip64, which busybox unzip in ONIE cannot read.