### PR TITLE
Fix for Failed - APPL_DB not re-synced to kernel MAC on Dual-ToR

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -146,8 +146,13 @@ while /bin/true; do
         if [[ $kernel_mac != $appl_db_mac ]]; then
             logger -p warning "MAC mismatch for ${ip} on ${intf} - kernel: ${kernel_mac}, APPL_DB: ${appl_db_mac}"
             ip neigh flush $ip
-            run_with_retry_cmd "mac mismatch ping to $ip" \
-                timeout 0.2 ping -c1 -w1 "$ip" >/dev/null 2>&1
+            if [[ $ip == *":"* ]]; then
+                ping_prefix=ping6
+            else
+                ping_prefix=ping
+            fi
+            run_with_retry_cmd "mac mismatch ping to $ip on $intf" \
+                timeout 0.2 $ping_prefix -I "$intf" -n -q -i 0 -c 1 -W 1 "$ip" >/dev/null 2>&1
         fi
   done
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Failed: APPL_DB not re-synced to kernel MAC - on testcase - arp/test_kernel_asic_mac_mismatch[tor-dut-0-ipv4], arp/test_kernel_asic_mac_mismatch[tor-dut-0-ipv6] execution in dual-ToR.

##### Work item tracking
- https://github.com/sonic-net/sonic-buildimage/issues/28994#:~:text=%C2%A0%23-,28994,-New%20issue

#### How I did it
Testcase updates a invalid MAC and calls arp_update for recovery.
arp_update MAC-mismatch recovery on dualtor standby ToR flushes the kernel neighbor and ping that cannot reach the server from the standby ToR, results in deleting the APPL_DB entry instead of restoring the kernel MAC.

Modified arp_update to initiate ping with -I interface to ensure ping from standby is successful.

#### How to verify it
Validated with arp/test_arp_update::test_kernel_asic_mac_mismatch

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->
Regression
#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
[test_arp_update.py::test_kernel_asic_mac_mismatch_2026-08-11-11-04-59.log](https://github.com/user-attachments/files/30943324/test_arp_update.py.test_kernel_asic_mac_mismatch_2026-08-11-11-04-59.log)

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
