### PR TITLE
[Mellanox] Sync complete custom SAI headers

### DIFF
--- a/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
+++ b/platform/mellanox/scripts/sync_mlnx_sai_custom_headers.sh
@@ -4,12 +4,11 @@
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copy selected Mellanox vendor custom SAI headers into sonic-sairedis/SAI/custom/
+# Copy Mellanox vendor custom SAI headers into sonic-sairedis/SAI/custom/
 # before OCP saimetadata.c is generated for libsaimetadata.so.
 #
-# Only headers required for the libsaimetadata / libsai bind-point enum alignment
-# are synced (saitypescustom.h merges SAI_ACL_BIND_POINT_TYPE_CPU_PORT). Full vendor
-# custom headers are intentionally omitted until parse.pl can version them cleanly.
+# Sync the complete vendor custom-header set selected by saicustom.h. Custom object
+# types and APIs must be kept together so libsaimetadata matches the selected SAI.
 
 set -euo pipefail
 
@@ -62,14 +61,22 @@ else
     exit 1
 fi
 
-# Bind-point fix only: merge sai_acl_bind_point_type_custom_t (CPU_PORT) into OCP metadata.
-MLNX_SAI_METADATA_HEADERS=(
-    saitypescustom.h
+# Treat the vendor umbrella as the authoritative custom-header manifest. This
+# keeps custom object types (for example RBB_CLASSIFIER), their API declarations,
+# and custom enums (for example CPU_PORT) from being synced independently.
+if [ ! -f "$HEADER_SRC/saicustom.h" ]; then
+    echo "ERROR: required custom SAI umbrella not found: $HEADER_SRC/saicustom.h" >&2
+    exit 1
+fi
+
+mapfile -t included_headers < <(
+    sed -nE 's/^[[:space:]]*#include[[:space:]]*"([^"]+)".*/\1/p' \
+        "$HEADER_SRC/saicustom.h"
 )
 
-headers=()
+headers=( "$HEADER_SRC/saicustom.h" )
 missing=()
-for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
+for header in "${included_headers[@]}"; do
     if [ -f "$HEADER_SRC/$header" ]; then
         headers+=( "$HEADER_SRC/$header" )
     else
@@ -78,57 +85,58 @@ for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
 done
 
 if [ "${#missing[@]}" -ne 0 ]; then
-    echo "ERROR: required custom SAI headers not found under $HEADER_SRC: ${missing[*]}" >&2
+    echo "ERROR: custom SAI headers included by saicustom.h not found under $HEADER_SRC: ${missing[*]}" >&2
     exit 1
 fi
 
-# Only now that all required headers are confirmed present, drop stale vendor
-# headers from a previous sync (keep upstream README) and install the new set.
-# Deleting earlier would leave $CUSTOM_DIR empty if validation above failed.
-find "$CUSTOM_DIR" -maxdepth 1 -type f -name '*custom*.h' -delete
+# Only after the complete set is validated, replace headers from a previous sync
+# while preserving the upstream README.
+find "$CUSTOM_DIR" -maxdepth 1 -type f -name '*.h' -delete
 cp -f "${headers[@]}" "$CUSTOM_DIR"/
 
-# parse.pl always emits "#include <saicustom.h>" when custom/ is non-empty. Vendor
-# saicustom.h pulls in every *custom*.h header, which OCP parse.pl cannot version
-# cleanly; write a minimal umbrella instead. The custom #include lines are generated
-# from MLNX_SAI_METADATA_HEADERS so the umbrella can never drift from the curated set
-# that is actually synced above (add a header to that array and it is included here).
-# Include at least one @flags free enum so Doxygen/parse.pl get a valid sectiondef.
-{
-    cat <<'EOF'
-#ifndef __SAICUSTOM_H_
-#define __SAICUSTOM_H_
-
-#include <sai.h>
-#include <saitypes.h>
-EOF
-    for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
-        echo "#include \"$header\""
-    done
-    cat <<'EOF'
-
-/**
- * @brief Custom SAI APIs
- *
- * @flags free
- */
-typedef enum _sai_api_custom_t {
-    SAI_API_CUSTOM_RANGE_START = SAI_API_CUSTOM_RANGE_BASE,
-
-    /* Add new custom APIs above this line */
-
-    SAI_API_CUSTOM_RANGE_END
-} sai_api_custom_t;
-
-#endif /* __SAICUSTOM_H_ */
-EOF
-} > "$CUSTOM_DIR/saicustom.h"
-
 echo "Synced ${#headers[@]} Mellanox custom SAI header(s) into $CUSTOM_DIR:"
-for header in "${MLNX_SAI_METADATA_HEADERS[@]}"; do
-    echo "  $CUSTOM_DIR/$header"
+for header in "${headers[@]}"; do
+    echo "  $CUSTOM_DIR/$(basename "$header")"
 done
-echo "  $CUSTOM_DIR/saicustom.h (generated minimal umbrella)"
+
+# parse.pl expands custom ACL META_DATA_GROUP MIN..MAX ranges into synthetic _1.._N
+# attributes. Those are not literal enums, so attrversion.sh never versions them and
+# WriteMetaDataFiles treats the resulting warnings as fatal. Alias them to MIN the
+# same way upstream already does for USER_DEFINED_FIELD_GROUP_*.
+PARSE_PL="$SAI_META_DIR/parse.pl"
+if [ -f "$PARSE_PL" ] && ! grep -q 'SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META_DATA_GROUP_MIN' "$PARSE_PL"; then
+    python3 - "$PARSE_PL" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+text = path.read_text()
+needle = '''    $attr = "SAI_ACL_TABLE_ATTR_USER_DEFINED_FIELD_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_TABLE_ATTR_USER_DEFINED_FIELD_GROUP_\\d+$/);
+
+    if (not defined $ATTR_API_VER{$attr} and scalar(keys%ATTR_API_VER) != 0)'''
+insert = '''    $attr = "SAI_ACL_TABLE_ATTR_USER_DEFINED_FIELD_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_TABLE_ATTR_USER_DEFINED_FIELD_GROUP_\\d+$/);
+
+    # Mellanox custom ACL user-meta group ranges (saiaclcustom.h). parse.pl expands
+    # MIN..MAX into _1.._N; those synthetic values are not literals for attrversion.sh.
+    $attr = "SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META_DATA_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_ENTRY_ATTR_FIELD_ACL_USER_META_DATA_GROUP_\\d+$/);
+
+    $attr = "SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META_DATA_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_TABLE_ATTR_FIELD_ACL_USER_META_DATA_GROUP_\\d+$/);
+
+    $attr = "SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA_GROUP_\\d+$/);
+
+    $attr = "SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA_MASK_GROUP_MIN"
+        if ($attr =~ /^SAI_ACL_ENTRY_ATTR_ACTION_SET_ACL_META_DATA_MASK_GROUP_\\d+$/);
+
+    if (not defined $ATTR_API_VER{$attr} and scalar(keys%ATTR_API_VER) != 0)'''
+if needle not in text:
+    raise SystemExit(f"ERROR: unexpected parse.pl ProcessApiVersion format: {path}")
+path.write_text(text.replace(needle, insert, 1))
+print(f"Patched {path} for custom ACL META_DATA_GROUP version aliases")
+PY
+fi
 
 # Force saimetadata regeneration when custom headers change.
 rm -f \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

This PR must be backport to 202605 with https://github.com/sonic-net/sonic-buildimage/pull/28365

#### Why I did it

The Mellanox SAI metadata build synced only saitypescustom.h, which can expose custom object types without their corresponding custom API declarations. This causes parse.pl to fail generating metadata,
for example on SAI_OBJECT_TYPE_RBB_CLASSIFIER.

##### Work item tracking

- Microsoft ADO (number only):

#### How I did it

- Use the vendor saicustom.h include list as the authoritative custom-header manifest.
- Sync the complete referenced header set, keeping custom object types, APIs, and enums aligned.
- Preserve the vendor umbrella header instead of generating a reduced replacement.
- Patch metadata version handling for generated Mellanox ACL META_DATA_GROUP attributes before regenerating SAI metadata.

#### How to verify it

- Build the Mellanox image:

make target/sonic-mellanox.bin

- Confirm libsairedis metadata generation completes without:

SAI_OBJECT_TYPE_RBB_CLASSIFIER is not defined in OBJTOAPIMAP

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
