### PR TITLE
[Mellanox] platform_syncd_dump: read sai.profile from /tmp

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/platform_syncd_dump.sh
+++ b/platform/mellanox/docker-syncd-mlnx/platform_syncd_dump.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,7 +34,7 @@ gzip "$sai_dump_name".tar
 rm -rf $sai_dump_name
 
 # Update max failure dumps
-if grep -q SAI_DUMP_STORE_AMOUNT /usr/share/sonic/hwsku/sai.profile; then
-    SAI_MAX_FAILURE_DUMPS=$(grep SAI_DUMP_STORE_AMOUNT /usr/share/sonic/hwsku/sai.profile | cut -d '=' -f2)
+if grep -q SAI_DUMP_STORE_AMOUNT /tmp/sai.profile; then
+    SAI_MAX_FAILURE_DUMPS=$(grep SAI_DUMP_STORE_AMOUNT /tmp/sai.profile | cut -d '=' -f2)
 fi
 


### PR DESCRIPTION
The sai.profile consumed for SAI_DUMP_STORE_AMOUNT is generated under /tmp/sai.profile now, so read it from there instead of /usr/share/sonic/hwsku/sai.profile.

#### Why I did it
platform_syncd_dump.sh reads SAI_DUMP_STORE_AMOUNT to decide how many SAI failure dumps to keep. It was reading this value from /usr/share/sonic/hwsku/sai.profile, now SAI profile update to use /tmp/sai.profile.

#### How I did it
Changed both the grep -q check and the value extraction in platform_syncd_dump.sh to read from /tmp/sai.profile instead of /usr/share/sonic/hwsku/sai.profile.

#### How to verify it
1. Add SAI_DUMP_STORE_AMOUNT=10 to the SAI profile so it ends up in the generated /tmp/sai.profile inside the syncd container.
2. Execute platform_syncd_dump.sh and confirm SAI_MAX_FAILURE_DUMPS is populated with 10 from /tmp/sai.profile.
3. Verify the number of retained sai_sdk_dump_*.tar.gz files respects the configured SAI_DUMP_STORE_AMOUNT.

#### Which release branch to backport (provide reason below if selected)

#### Tested branch
- [x] master

#### Test result
master: PASS