### PR TITLE
Issue-28715: [aspeed] Make hw-watchdog-mgrd IPC socket reachable inside pmon

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -837,6 +837,8 @@ start() {
 {%- if docker_container_name == "pmon" %}
         $(if [ -d /var/run/hw-management ]; then echo "-v /var/run/hw-management:/var/run/hw-management:rw"; fi) \
         $(if [ -f /usr/bin/hw-management-bmc-powerctrl.sh ]; then echo "-v /usr/bin/hw-management-bmc-powerctrl.sh:/usr/bin/hw-management-bmc-powerctrl.sh:ro"; fi) \
+        {#- sysfs (/sys) is already mounted into pmon unconditionally (see rules/docker-platform-monitor.mk), so only the IPC socket dir needs mounting. #}
+        -v /run/hw-watchdog-mgrd:/run/hw-watchdog-mgrd:rw \
 {%- endif %}
 {%- endif %}
 {%- if sonic_asic_platform != "mellanox" %}

--- a/platform/aspeed/aspeed-platform-services/scripts/hw-watchdog-mgrd.py
+++ b/platform/aspeed/aspeed-platform-services/scripts/hw-watchdog-mgrd.py
@@ -6,7 +6,10 @@ The Linux watchdog framework allows only a single open of /dev/watchdog0 at a
 time.  This daemon is the sole owner of the device: it opens it, pets it
 periodically while armed, and exposes an IPC interface over a Unix domain socket
 so that the SONiC watchdogutil platform API (sonic_platform/watchdog.py) can
-arm, disarm and query the watchdog without contending for the device file.
+arm, disarm and query the watchdog without contending for the device file.  The
+socket lives in a dedicated directory (SOCKET_DIR) so that directory can be
+bind-mounted into the pmon container (see docker_image_ctl.j2), letting
+watchdogutil run inside pmon as well as on the host.
 
 Boot-time arming policy is driven by platform.json (the "watchdog" section).
 On a fresh boot the "boot_arm" flag decides whether the daemon arms the
@@ -51,8 +54,11 @@ WDIOS_ENABLECARD = 0x0002
 WATCHDOG_DEVICE = "/dev/watchdog0"
 WATCHDOG_SYSFS_PATH = "/sys/class/watchdog/watchdog0/"
 
-# IPC socket shared with the platform API (sonic_platform/watchdog.py).
-SOCKET_PATH = "/run/hw-watchdog-mgrd.sock"
+# IPC socket shared with the platform API.  A whole directory (not a single
+# file) is used so the pmon bind mount survives the daemon restart that unlinks
+# and recreates the socket inode.
+SOCKET_DIR = "/run/hw-watchdog-mgrd"
+SOCKET_PATH = os.path.join(SOCKET_DIR, "hw-watchdog-mgrd.sock")
 
 # Runtime arming intent.  JSON: {"armed": bool, "timeout": int}.  Written on
 # arm/disarm and read on startup.  Lives on tmpfs (/run) so it survives a daemon
@@ -281,6 +287,11 @@ class WatchdogManager:
         return {"error": "unknown command: %s" % cmd}
 
     def _create_socket(self):
+        # Ensure the socket directory exists before binding.  It is normally
+        # created on first start, but a directory bind-mount into pmon may have
+        # (re)created it as an empty dir, and the daemon may restart after a
+        # crash; makedirs(exist_ok) covers both.
+        os.makedirs(os.path.dirname(SOCKET_PATH), exist_ok=True)
         try:
             os.unlink(SOCKET_PATH)
         except OSError:

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/watchdog.py
@@ -24,8 +24,8 @@ except ImportError as e:
 
 # IPC socket served by the hw-watchdog-mgrd daemon.  This must match
 # SOCKET_PATH in
-# platform/aspeed/aspeed-platform-services/scripts/hw-watchdog-mgrd.py
-SOCKET_PATH = "/run/hw-watchdog-mgrd.sock"
+# platform/aspeed/aspeed-platform-services/scripts/hw-watchdog-mgrd.py.
+SOCKET_PATH = "/run/hw-watchdog-mgrd/hw-watchdog-mgrd.sock"
 SOCKET_TIMEOUT = 5  # seconds
 
 # Read-only sysfs view of the hardware watchdog state.  Used only as a fallback


### PR DESCRIPTION
watchdogutil talks to the hw-watchdog-mgrd daemon over a Unix domain socket, but the socket lived directly under /run and was not visible inside the pmon container, so watchdogutil could not run there.

Move the socket into a dedicated directory
(/run/hw-watchdog-mgrd/hw-watchdog-mgrd.sock) and bind-mount that whole directory into pmon. A directory bind-mount (rather than a single-file one) keeps working across a daemon restart, which unlinks and recreates the socket inode, and does not require the socket to already exist when pmon starts.

- hw-watchdog-mgrd.py: introduce SOCKET_DIR and makedirs() it before binding the socket.
- sonic_platform/watchdog.py: update the client SOCKET_PATH to match.
- docker_image_ctl.j2: bind-mount /run/hw-watchdog-mgrd into pmon for aspeed. sysfs (/sys) is already mounted into pmon, so the is_armed() sysfs fallback works there too.

Fixes sonic-net/sonic-buildimage#28715

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
