### PR TITLE
[Mellanox] Configure the BMC NOS account on Redfish auth failure

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/bmc.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/bmc.py
@@ -27,7 +27,10 @@ try:
     import sys
     import importlib.util
     import os
+    import io
+    import contextlib
     from sonic_platform_base.bmc_base import BMCBase
+    from sonic_platform_base.redfish_client import RedfishClient
     from sonic_py_common.logger import Logger
 except ImportError as e:
     raise ImportError (str(e) + "- required module not found")
@@ -91,6 +94,7 @@ class BMC(BMCBase):
         super().__init__(addr)
         self._bmc_nos_account_username = bmc_nos_account_username
         self._bmc_root_account_default_password = bmc_root_account_default_password
+        self._nos_account_provisioning_tried = False
 
     @staticmethod
     def get_instance():
@@ -109,6 +113,43 @@ class BMC(BMCBase):
 
     def _get_default_root_password(self):
         return self._bmc_root_account_default_password
+
+    def _login(self):
+        if self._nos_account_provisioning_tried:
+            return super()._login()
+        # ERR_CODE_AUTH_FAILURE on the first login is expected when the BMC NOS account has not been
+        # provisioned yet, so report it as an error only if the recovery below fails.
+        ret = self.rf_client.login(log_errors=False)
+        if ret == RedfishClient.ERR_CODE_OK:
+            return ret
+        if ret != RedfishClient.ERR_CODE_AUTH_FAILURE:
+            logger.log_error(f"Failed to login to the BMC: {ret}")
+            return ret
+        # If the NOS account has not been provisioned yet, call hw_management_redfish_client.py to do it.
+        self._nos_account_provisioning_tried = True
+        if not self._configure_nos_account():
+            return ret
+        return super()._login()
+
+    def _configure_nos_account(self):
+        logger.log_notice("Configuring the BMC NOS account from hw_management_redfish_client.py")
+        # hw_management_redfish_client reports the login flow on stdout/stderr,
+        # keep it out of the CLI output and re-emit it to syslog
+        output = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+                provisioning_ret = _get_hw_mgmt_redfish_client().BMCAccessor().login()
+        except Exception as e:
+            logger.log_error(f"Error configuring the BMC NOS account from hw_management_redfish_client.py: {str(e)}")
+            return False
+        finally:
+            for line in output.getvalue().splitlines():
+                logger.log_notice(f"hw_management_redfish_client: {line}")
+        if provisioning_ret != 0:
+            logger.log_error(f"Failed to configure the BMC NOS account from hw_management_redfish_client.py: {provisioning_ret}")
+            return False
+        logger.log_notice("BMC NOS account configured successfully")
+        return True
 
     def get_firmware_id(self):
         return BMC.BMC_FIRMWARE_ID


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The host communicates with an OpenBMC using the NOS account, and HW MGMT has been responsible for creating that account and rotating it off its factory password onto the TPM password. hw-mgmt commit 9083eba4 gated that flow behind "host OS is not SONiC", on the assumption that a SONiC host is always paired with a SONiC BMC. That is not true for the SONiC host + OpenBMC combination, which has been supported since the original integration.

The result is that nothing configures the NOS account on a SONiC host, so every Redfish request fails with "Invalid username or password" and "show platform bmc eeprom" stops working.

Only SONiC knows which BMC flavour it is paired with, so SONiC drives the account configuration itself instead of relying on hw-management to guess.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Override BMCBase._login() in the Mellanox BMC class. On ERR_CODE_AUTH_FAILURE, invoke hw-management's BMCAccessor().login(), which creates the NOS account or rotates it off the factory password, then retry the login once.

#### How to verify it
On a platform with an OpenBMC, set the NOS account back to its factory password and confirm "show platform bmc eeprom" succeeds, with the account configuration visible in the log. Repeat with the BMC unreachable and confirm the failure is reported without repeated configuration attempts.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
