### PR TITLE
[test-only][DO NOT MERGE] Pin sonic-sairedis to the MPLS VPP branch to build a test image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
 	url = https://github.com/sonic-net/sonic-linux-kernel
 [submodule "sonic-sairedis"]
 	path = src/sonic-sairedis
-	url = https://github.com/sonic-net/sonic-sairedis
+	url = https://github.com/augusdn/sonic-sairedis
+	branch = augusdn/vpp-mpls-inseg-25782
 [submodule "sonic-swss"]
 	path = src/sonic-swss
 	url = https://github.com/sonic-net/sonic-swss


### PR DESCRIPTION
### Description of PR

**This is a throwaway test-only PR. It must never be merged, and I will close it once the image has been built.**

It pins `src/sonic-sairedis` to the branch behind sonic-net/sonic-sairedis#2008 (commit `16005ff`) so the pipeline produces a real `sonic-vs`/vpp image containing the VPP SAI MPLS backend.

That image is needed to validate sonic-net/sonic-mgmt#26619 end to end **before** either PR merges. Without it the newly enabled `tests/mpls` cases have no backend to talk to, so `kvmtest-t1-lag-vpp` on that PR cannot pass no matter how correct the test code is.

Thanks to @lolyu for suggesting this approach (same mechanism as #27555).

### Type of change

- [x] Test only / not for merge

### Approach

#### What is the motivation for this PR?

sonic-buildimage#25782 asks for MPLS data-plane support on sonic-vpp. The work is split across two PRs:

* **sonic-net/sonic-sairedis#2008** — the VPP SAI MPLS backend (INSEG + IP-route push)
* **sonic-net/sonic-mgmt#26619** — enabling `tests/mpls` on the `t1-lag-vpp` testbed

They are mutually dependent for validation: the tests need the backend in the image, and the backend has no automated coverage without the tests. This PR breaks that cycle by building an image from the unmerged backend.

#### How did you do it?

Two changes only:

* `.gitmodules` — point the `sonic-sairedis` submodule at `augusdn/sonic-sairedis`, branch `augusdn/vpp-mpls-inseg-25782`
* `src/sonic-sairedis` — bump the submodule pointer to `16005ff1e744c4aa85964be6d3702e2635341d58`

#### How did you verify/test it?

The backend has already been validated on a local KVM testbed with the library installed into `syncd`:

```
mpls/test_mpls.py::TestBasicMpls::test_pop_label        PASSED
mpls/test_mpls.py::TestBasicMpls::test_swap_label       PASSED
mpls/test_mpls.py::TestBasicMpls::test_push_label       SKIPPED
mpls/test_mpls.py::TestBasicMpls::test_swap_labelstack  PASSED
```

and the full surrounding framework run on the same testbed was `17 passed, 5 skipped, 0 failed`. sonic-sairedis#2008's own CI is green across all nine build jobs plus ASAN, CodeQL and Semgrep.

This PR exists purely to produce the image artifact so the same result can be reproduced on Elastictest against a properly built image rather than a hot-swapped library.

### Documentation

No documentation change — test-only, not for merge.
