### PR TITLE
[cache validation] [rules/linux-kernel]: Fold secure-upgrade CA cert content into kernel cache key

### DIFF
--- a/rules/linux-kernel.dep
+++ b/rules/linux-kernel.dep
@@ -1,6 +1,9 @@
 
 SPATH       := $($(LINUX_HEADERS_COMMON)_SRC_PATH)
 DEP_FILES   := rules/linux-kernel.mk rules/linux-kernel.dep
+# Fold the trusted CA cert file CONTENT (not just its path) into the cache key, so a
+# rotated cert at the same path invalidates the cached kernel. Empty/unset/missing => no-op.
+DEP_FILES   += $(wildcard $(SECURE_UPGRADE_KERNEL_CAFILE))
 SMDEP_FILES := $(addprefix $(SPATH)/,$(shell cd $(SPATH) && git ls-files))
 
 DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(INCLUDE_EXTERNAL_PATCHES) \


### PR DESCRIPTION
#### Why I did it
The `linux-headers-common` cache key folds `SECURE_UPGRADE_KERNEL_CAFILE` only as a build **flag** — i.e. it captures the cert file **path**, not its contents. In `dev`/`prod` secure-upgrade mode the kernel build reads the cert file **content** into `CONFIG_SYSTEM_TRUSTED_KEYS` (`src/sonic-linux-kernel/manage-config`). So rotating the trusted cert at the same path produces the **same** cache key and a **stale cached kernel** that still embeds the old trust anchor.

#### How I did it
Fold the cafile **content** into `LINUX_HEADERS_COMMON` `DEP_FILES` (which are git-hashed under `GIT_CONTENT_SHA`) using `$(wildcard $(SECURE_UPGRADE_KERNEL_CAFILE))`:
- When the flag is empty/unset (the default `no_sign` build) or the path does not resolve, `$(wildcard ...)` expands to nothing → **no-op**, no key change for the common case.
- When set to an existing cert (mounted read-only into the slave via `Makefile.work`), its content is hashed, so a rotated cert invalidates the cached kernel.

The existing `DEP_FLAGS` entry (path) is kept unchanged.

#### How to verify it
1. Default build: `git diff` of the generated `linux-headers-common.dep` is unchanged (cafile empty).
2. With `SECURE_UPGRADE_MODE=dev` and a `SECURE_UPGRADE_KERNEL_CAFILE` set, the resolved `.dep.sha` now includes the cert blob hash; editing the cert content changes the kernel cache key.

#### Which release branch to backport (provide reason below if selected)
<!-- optional -->

#### Description for the changelog
Fold `SECURE_UPGRADE_KERNEL_CAFILE` content into the linux-headers cache key so a rotated cert invalidates the cached kernel.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
