### PR TITLE
[cache validation] [slave.mk]: Add source prerequisite to SONIC_COPY_FILES staging rule

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -679,7 +679,7 @@ SONIC_TARGET_LIST += $(addprefix $(DEBS_PATH)/, $(SONIC_COPY_DEBS))
 #     SOME_NEW_FILE = some_new_file
 #     $(SOME_NEW_FILE)_PATH = path/to/some_new_file
 #     SONIC_COPY_FILES += $(SOME_NEW_FILE)
-$(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES)) : $(FILES_PATH)/% : .platform
+$(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES)) : $(FILES_PATH)/% : $$($$*_PATH)/$$* .platform
 	$(HEADER)
 	cp $($*_PATH)/$* $(FILES_PATH)/ $(LOG) || exit 1
 	$(FOOTER)


### PR DESCRIPTION
#### Why I did it
The rule that stages `SONIC_COPY_FILES` into `target/files/<bldenv>/` lists only `.platform` as a prerequisite:

```make
$(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES)) : $(FILES_PATH)/% : .platform
	cp $($*_PATH)/$* $(FILES_PATH)/ ...
```

Its recipe copies `$($*_PATH)/$*` but does not **depend** on that source. In a long-lived **incremental** workspace, editing a copied source (e.g. a `files/build_templates/*.j2`) updates the package **cache key** — `Makefile.cache` folds the resolved source path into the docker `_DEP_FILES` (git-hashed) — yet the **staged copy** under `target/files/` is not refreshed, so the next build can package the **old** content. The cache key moves but the staged artifact is stale.

Clean CI workers are unaffected (the target does not yet exist, so it is always copied); it primarily bites incremental local/dev workspaces.

#### How I did it
Add the resolved source as a prerequisite via secondary expansion (already enabled, `.SECONDEXPANSION:`), consistent with the neighboring `SONIC_MAKE_FILES` / docker `_FILES` rules:

```make
$(addprefix $(FILES_PATH)/, $(SONIC_COPY_FILES)) : $(FILES_PATH)/% : $$($$*_PATH)/$$* .platform
```

Every `SONIC_COPY_FILES` entry already defines `$(file)_PATH` (the recipe relies on it), so no entry regresses.

#### How to verify it
With a populated workspace:
```
touch files/build_templates/swss_vars.j2
make -n target/files/trixie/swss_vars.j2   # now re-runs the cp (was "up to date" before)
```
`make -pn` shows the staged target now lists its source as a prerequisite:
`target/files/trixie/swss_vars.j2: files/build_templates/swss_vars.j2 .platform`.

#### Which release branch to backport (provide reason below if selected)
<!-- optional -->

#### Description for the changelog
Add the source file as a prerequisite of the `SONIC_COPY_FILES` staging rule so edited sources are re-staged in incremental workspaces.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
