### PR TITLE
[sonic-config-engine] Exclude Mellanox from the default FEC mode

### DIFF
--- a/src/sonic-config-engine/portconfig.py
+++ b/src/sonic-config-engine/portconfig.py
@@ -384,7 +384,8 @@ class BreakoutCfg(object):
                 }
                 
                 # If the lane speed is greater than 50G, enable FEC
-                if entry.default_speed // lanes_per_port >= 50000:
+                if entry.default_speed // lanes_per_port >= 50000 and \
+                        (device_info.get_sonic_version_info() or {}).get('asic_type') != 'mellanox':
                     port_config['fec'] = 'rs'
 
                 ports[interface_name] = port_config


### PR DESCRIPTION
#### Why I did it
Commit 2909a8a0c4ea (#23978) adds an explicit `"fec": "rs"` to every port entry generated from
`platform.json` / `hwsku.json` whose speed per lane is at least 50G. On Mellanox platforms the
generated port configuration should not carry a FEC mode, so exclude them from that change while
keeping the current behavior for every other platform.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
Added one condition to the existing check in `BreakoutCfg.get_config()` in
`src/sonic-config-engine/portconfig.py`, so the `fec` key is skipped when the `asic_type` read
from `/etc/sonic/sonic_version.yml` is `mellanox`. When that file is not present, as in the build
and unit test container, the current behavior is kept, so the tests added by #23978 are
unaffected.

#### How to verify it
On a Mellanox switch, generate the port table from the device files:

```
sonic-cfggen -k <hwsku> -p platform.json -S hwsku.json --print-data
```

No port carries a `fec` key, and `config interface breakout` produces child ports without one. On
any other platform the output is unchanged and still contains `"fec": "rs"`. Checked on an
SN5640: 0 of 514 ports carry `fec` with the change, against 512 of 514 without it, and no other
field differs.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [x] 202605


#### Description for the changelog
Exclude Mellanox from the default FEC mode in the generated port configuration.
