### PR TITLE
[cache validation] Harden slave.mk recipe-body cache-drift guard + re-baseline stamp

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -79,10 +79,10 @@
 #   Bump it when a slave.mk change genuinely affects package build output
 #   (e.g., dpkg build recipe changes, compiler flag changes, install logic changes).
 #
-SONIC_CACHE_RECIPE_VER := 1
+SONIC_CACHE_RECIPE_VER := 2
 # Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
 # Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 348388b6882c0c90f4a1c7170d0e33cf9c0e645b
+SONIC_CACHE_RECIPE_VER_BASELINE := adf63e623a30aaf4818528c925cc69f42fada6e4
 
 # Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
 # This catches the case where someone modifies slave.mk build recipes without
@@ -95,10 +95,20 @@ ifneq ($(SONIC_CACHE_SLAVE_HASH),)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
 ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
 ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+# In a cache-WRITING mode (cache/wcache/rwcache) an unreviewed slave.mk recipe change
+# is fatal: publishing a cache built from a drifted recipe can serve stale packages to
+# every downstream consumer. In read-only modes (rcache) it remains a warning so local
+# development is not blocked.
+ifneq ($(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD)),)
+$(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
+$(warning [CACHE] A cache-writing build must not publish caches built from an unreviewed recipe.)
+$(error  [CACHE] Review the change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE to $(SONIC_CACHE_SLAVE_HASH); if not, just set the baseline to that hash. Then re-run.)
+else
 $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] Review whether the change affects package build output:)
 $(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
 $(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
+endif
 endif
 endif
 endif

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -91,15 +91,23 @@ SONIC_CACHE_RECIPE_VER_BASELINE := adf63e623a30aaf4818528c925cc69f42fada6e4
 #   - If yes: bump SONIC_CACHE_RECIPE_VER and update the baseline hash.
 #   - If no:  just update the baseline hash.
 SONIC_CACHE_SLAVE_HASH := $(if $(wildcard .git),$(shell git hash-object slave.mk 2>/dev/null))
+# Effective set of cache methods that can be in force for THIS build. The global
+# SONIC_DPKG_CACHE_METHOD is not the whole story: per-package .dep files may set
+# $(PKG)_CACHE_OVERRIDE, and every in-tree override derives from the global
+# SONIC_DPKG_CACHE_METHOD_OVERRIDE (see rules/linux-kernel.dep, rules/p4lang.dep).
+# CHECK_WCACHE_ENABLED keys off $(or $(PKG)_CACHE_OVERRIDE,SONIC_DPKG_CACHE_METHOD),
+# so a package can WRITE the cache even when the global method is none/rcache. The
+# guard must therefore consider both globals or it silently misses drifted-recipe
+# cache publishing on override packages.
+SONIC_CACHE_METHODS_EFFECTIVE := $(SONIC_DPKG_CACHE_METHOD) $(SONIC_DPKG_CACHE_METHOD_OVERRIDE)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
-ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
-ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+ifneq ($(strip $(filter-out none,$(SONIC_CACHE_METHODS_EFFECTIVE))),)
 # In a cache-WRITING mode (cache/wcache/rwcache) an unreviewed slave.mk recipe change
 # is fatal: publishing a cache built from a drifted recipe can serve stale packages to
 # every downstream consumer. In read-only modes (rcache) it remains a warning so local
-# development is not blocked.
-ifneq ($(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD)),)
+# development is not blocked. Both the global method and any override are considered.
+ifneq ($(filter cache wcache rwcache,$(SONIC_CACHE_METHODS_EFFECTIVE)),)
 $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] A cache-writing build must not publish caches built from an unreviewed recipe.)
 $(error  [CACHE] Review the change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE to $(SONIC_CACHE_SLAVE_HASH); if not, just set the baseline to that hash. Then re-run.)
@@ -108,7 +116,6 @@ $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set
 $(warning [CACHE] Review whether the change affects package build output:)
 $(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
 $(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
-endif
 endif
 endif
 endif

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -91,15 +91,23 @@ SONIC_CACHE_RECIPE_VER_BASELINE := 88105f5cbcfe39c889d14120d0397ec923e9c2fa
 #   - If yes: bump SONIC_CACHE_RECIPE_VER and update the baseline hash.
 #   - If no:  just update the baseline hash.
 SONIC_CACHE_SLAVE_HASH := $(if $(wildcard .git),$(shell git hash-object slave.mk 2>/dev/null))
+# Effective set of cache methods that can be in force for THIS build. The global
+# SONIC_DPKG_CACHE_METHOD is not the whole story: per-package .dep files may set
+# $(PKG)_CACHE_OVERRIDE, and every in-tree override derives from the global
+# SONIC_DPKG_CACHE_METHOD_OVERRIDE (see rules/linux-kernel.dep, rules/p4lang.dep).
+# CHECK_WCACHE_ENABLED keys off $(or $(PKG)_CACHE_OVERRIDE,SONIC_DPKG_CACHE_METHOD),
+# so a package can WRITE the cache even when the global method is none/rcache. The
+# guard must therefore consider both globals or it silently misses drifted-recipe
+# cache publishing on override packages.
+SONIC_CACHE_METHODS_EFFECTIVE := $(SONIC_DPKG_CACHE_METHOD) $(SONIC_DPKG_CACHE_METHOD_OVERRIDE)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
-ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
-ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+ifneq ($(strip $(filter-out none,$(SONIC_CACHE_METHODS_EFFECTIVE))),)
 # In a cache-WRITING mode (cache/wcache/rwcache) an unreviewed slave.mk recipe change
 # is fatal: publishing a cache built from a drifted recipe can serve stale packages to
 # every downstream consumer. In read-only modes (rcache) it remains a warning so local
-# development is not blocked.
-ifneq ($(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD)),)
+# development is not blocked. Both the global method and any override are considered.
+ifneq ($(filter cache wcache rwcache,$(SONIC_CACHE_METHODS_EFFECTIVE)),)
 $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] A cache-writing build must not publish caches built from an unreviewed recipe.)
 $(error  [CACHE] Review the change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE to $(SONIC_CACHE_SLAVE_HASH); if not, just set the baseline to that hash. Then re-run.)
@@ -108,7 +116,6 @@ $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set
 $(warning [CACHE] Review whether the change affects package build output:)
 $(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
 $(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
-endif
 endif
 endif
 endif

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -82,7 +82,7 @@
 SONIC_CACHE_RECIPE_VER := 2
 # Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
 # Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 57a423c0b31ad2869422ec0d2c13ee0492b8ecb9
+SONIC_CACHE_RECIPE_VER_BASELINE := 88105f5cbcfe39c889d14120d0397ec923e9c2fa
 
 # Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
 # This catches the case where someone modifies slave.mk build recipes without
@@ -95,10 +95,20 @@ ifneq ($(SONIC_CACHE_SLAVE_HASH),)
 ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
 ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
 ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+# In a cache-WRITING mode (cache/wcache/rwcache) an unreviewed slave.mk recipe change
+# is fatal: publishing a cache built from a drifted recipe can serve stale packages to
+# every downstream consumer. In read-only modes (rcache) it remains a warning so local
+# development is not blocked.
+ifneq ($(filter cache wcache rwcache,$(SONIC_DPKG_CACHE_METHOD)),)
+$(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
+$(warning [CACHE] A cache-writing build must not publish caches built from an unreviewed recipe.)
+$(error  [CACHE] Review the change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE to $(SONIC_CACHE_SLAVE_HASH); if not, just set the baseline to that hash. Then re-run.)
+else
 $(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] Review whether the change affects package build output:)
 $(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
 $(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
+endif
 endif
 endif
 endif


### PR DESCRIPTION
### Why I did it
`slave.mk` recipe bodies (dpkg-buildpackage invocation, install logic, global compiler flags) are folded into every package cache key **only** through the manual `SONIC_CACHE_RECIPE_VER` stamp — `slave.mk` itself is intentionally excluded from the key to avoid 100% cache invalidation on every commit (see the design comment above the stamp, added in #25697).

Two problems make that manual mechanism ineffective today:
1. **The recorded baseline is stale.** `SONIC_CACHE_RECIPE_VER_BASELINE` was `348388b6…`, but `slave.mk` on `master` is now `adf63e62…`, while `SONIC_CACHE_RECIPE_VER` was never bumped from `1`. The drift includes **output-affecting** recipe changes — e.g. `ccache` PATH injection (`CCACHE_ENV = PATH=/usr/lib/ccache:$PATH …`) and the PTF Python default `mixed`→`py3`. Packages built from the newer recipe can therefore be served from caches keyed to the old recipe.
2. **The drift guard only `$(warning)`s**, so it is trivially ignored — which is exactly what happened (clean `master` is already drifted).

### How I did it
Three changes in `Makefile.cache`:
- **Re-baseline** `SONIC_CACHE_RECIPE_VER_BASELINE` → current `slave.mk` hash `adf63e62…`.
- **Bump** `SONIC_CACHE_RECIPE_VER` `1 → 2` to invalidate caches built from the drifted recipe once.
- **Harden the guard**: hard `$(error)` when the cache is in a **writing** mode (`cache`/`wcache`/`rwcache`) so an unreviewed recipe change can never *publish* a poisoned cache; keep `$(warning)` in read-only (`rcache`) mode so local development is not blocked.
- **Honor per-package cache overrides**: gate the guard on the effective set of cache methods — the union of the global `SONIC_DPKG_CACHE_METHOD` and `SONIC_DPKG_CACHE_METHOD_OVERRIDE` (from which every in-tree `$(pkg)_CACHE_OVERRIDE` derives). A package can write the cache via its override even when the global method is `none`/`rcache`, so considering the global method alone would silently miss drifted-recipe publishing on override packages.

Deliberately **not** doing: hashing all of `slave.mk` into the key (rejected upstream in #25697 — causes 100% invalidation on every slave.mk commit).

### How to verify it
- Guard logic validated with a GNU Make harness across all modes: no drift → silent; drift + `rcache` → warning, build proceeds; drift + `wcache`/`rwcache`/`cache` → fatal, build aborts; `none` → silent.
- After merge, on clean `master` the baseline matches `slave.mk`, so no warning/error fires until the next unreviewed recipe change.

### Which release branch to backport (provide reason below if selected)
- [ ] 202xxx

### Description for the changelog
Harden the `slave.mk` recipe-body cache-drift guard: re-baseline + bump the recipe version stamp, and fail the build on unreviewed drift in cache-writing modes.

### Open question for reviewers
The hard error is scoped to **cache-writing** modes only (keeps read-only local builds unblocked). If maintainers prefer it to fire in **all** cache-enabled modes (incl. `rcache`), that is a one-line change to the `$(filter …)` gate.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
