### PR TITLE
[cache validation] Track host-rootfs build inputs in RFS_DEP_FILES

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -427,6 +427,8 @@ RFS_DEP_FILES := $(wildcard \
 	$(shell git ls-files files/dhcp) \
 	src/sonic-build-hooks/buildinfo/trusted.gpg.d \
 	platform/$(CONFIGURED_PLATFORM)/modules  \
+	platform/$(CONFIGURED_PLATFORM)/sonic_fit.its \
+	platform/pensando/install_file \
 	files/docker/docker.service.conf \
 	files/build_templates/default_users.json.j2 \
 	files/build_scripts/generate_asic_config_checksum.py \

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -438,7 +438,6 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/sed_config.conf.j2 \
 	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
 	src/sonic-build-hooks/scripts/utils.sh \
-	files/build/versions \
 	$(shell git ls-files files/build/versions-public/default files/build/versions-public/host-image files/build/versions-public/host-base-image) \
 	build_debian.sh onie-image.conf)
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -432,6 +432,9 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/sonic_version.yml.j2 \
 	files/docker/docker-netfilter-ready.sh \
 	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
+	src/sonic-build-hooks/scripts/utils.sh \
+	files/build/versions \
+	$(shell git ls-files files/build/versions-public/default files/build/versions-public/host-image files/build/versions-public/host-base-image) \
 	build_debian.sh onie-image.conf)
 
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -431,6 +431,12 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/default_users.json.j2 \
 	files/build_scripts/generate_asic_config_checksum.py \
 	files/scripts/core_cleanup.py \
+	functions.sh \
+	files/build_templates/bmc_config.json.j2 \
+	files/build_templates/organization_extensions.sh \
+	files/build_templates/sonic_version.yml.j2 \
+	files/docker/docker-netfilter-ready.sh \
+	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
 	build_debian.sh onie-image.conf)
 
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -426,6 +426,12 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/default_users.json.j2 \
 	files/build_scripts/generate_asic_config_checksum.py \
 	files/scripts/core_cleanup.py \
+	functions.sh \
+	files/build_templates/bmc_config.json.j2 \
+	files/build_templates/organization_extensions.sh \
+	files/build_templates/sonic_version.yml.j2 \
+	files/docker/docker-netfilter-ready.sh \
+	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
 	build_debian.sh onie-image.conf)
 
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -428,7 +428,7 @@ RFS_DEP_FILES := $(wildcard \
 	src/sonic-build-hooks/buildinfo/trusted.gpg.d \
 	platform/$(CONFIGURED_PLATFORM)/modules  \
 	platform/$(CONFIGURED_PLATFORM)/sonic_fit.its \
-	platform/pensando/install_file \
+	$(if $(filter pensando,$(CONFIGURED_PLATFORM)),platform/pensando/install_file) \
 	files/docker/docker.service.conf \
 	files/build_templates/default_users.json.j2 \
 	files/build_scripts/generate_asic_config_checksum.py \

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -437,6 +437,9 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/sonic_version.yml.j2 \
 	files/docker/docker-netfilter-ready.sh \
 	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
+	src/sonic-build-hooks/scripts/utils.sh \
+	files/build/versions \
+	$(shell git ls-files files/build/versions-public/default files/build/versions-public/host-image files/build/versions-public/host-base-image) \
 	build_debian.sh onie-image.conf)
 
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -435,7 +435,7 @@ RFS_DEP_FILES := $(wildcard \
 	files/build_templates/bmc_config.json.j2 \
 	files/build_templates/organization_extensions.sh \
 	files/build_templates/sonic_version.yml.j2 \
-	files/docker/docker-netfilter-ready.sh \
+	files/build_templates/sed_config.conf.j2 \
 	$(addprefix scripts/, build-optimize-fs-size.py collect_host_image_version_files.sh efi-sign.sh secure_boot_signature_verification.sh signing_kernel_modules.sh signing_secure_boot_dev.sh versions_manager.py) \
 	src/sonic-build-hooks/scripts/utils.sh \
 	files/build/versions \


### PR DESCRIPTION
### Why I did it
The host rootfs / squashfs cache target (`SONIC_RFS_TARGETS`) keys only on `SONIC_COMMON_BASE_FILES_LIST` + `RFS_DEP_FILES` (`GIT_CONTENT_SHA`, `Makefile.cache` ~L452-458). `build_debian.sh` — and scripts it invokes — consume several in-repo files that shape the produced rootfs but are **not** in that keyed set, so editing them serves a stale rootfs from cache.

Confirmed consumed on the rootfs build path (file:line):
| File | Consumed at |
|---|---|
| `functions.sh` | `build_debian.sh:22` (`. functions.sh`) |
| `files/build_templates/bmc_config.json.j2` | `build_debian.sh:596` (rendered into `$FILESYSTEM_ROOT`) |
| `files/build_templates/organization_extensions.sh` | `build_debian.sh:672` |
| `files/build_templates/sonic_version.yml.j2` | `build_debian.sh:664` |
| `files/build_templates/sed_config.conf.j2` | `build_debian.sh:604` (rendered into `$FILESYSTEM_ROOT`, gated on SED TPM bank addresses) |
| `scripts/build-optimize-fs-size.py` | `build_debian.sh:891` (gated `BUILD_REDUCE_IMAGE_SIZE`) |
| `scripts/collect_host_image_version_files.sh` | `build_debian.sh:835` |
| `scripts/efi-sign.sh` | via `signing_secure_boot_dev.sh:71/119` ← `build_debian.sh:732` |
| `scripts/secure_boot_signature_verification.sh` | `build_debian.sh:753/758` |
| `scripts/signing_kernel_modules.sh` | via `signing_secure_boot_dev.sh:119` |
| `scripts/signing_secure_boot_dev.sh` | `build_debian.sh:732` |
| `scripts/versions_manager.py` | via `build_debian_base_system.sh:66` / `prepare_debian_image_buildinfo.sh:26` (its output is folded only into *docker* keys, not RFS) |
| `src/sonic-build-hooks/scripts/utils.sh` | sourced by the build hooks that `versions_manager.py` drives while pinning apt/pip versions during the rootfs build |
| `files/build/versions-public/{default,host-image,host-base-image}/*` | the host/base-image version-lock files consumed by the version manager to pin exact package versions into the rootfs |
| `platform/$(CONFIGURED_PLATFORM)/sonic_fit.its` | arm64 FIT-image template copied into `$FILESYSTEM_ROOT/boot/` (`build_debian.sh:841/847`); keyed per-platform so only the built platform's template participates |
| `platform/pensando/install_file` | copied into `$FILESYSTEM_ROOT/boot/` for pensando (`build_debian.sh:804`); gated on `$(filter pensando,$(CONFIGURED_PLATFORM))` so it only keys pensando builds |

### How I did it
Add the missing files inside the existing `$(wildcard ...)` block of `RFS_DEP_FILES` — the rootfs-shaping scripts/templates above, `src/sonic-build-hooks/scripts/utils.sh`, and the host version-lock inputs. Because the target uses `GIT_CONTENT_SHA`, config-gated scripts (secure-boot signing, `BUILD_REDUCE_IMAGE_SIZE`, organization extensions) still invalidate correctly when edited, without per-flag conditionals — and `$(wildcard ...)` cleanly drops any path that is absent.

The version-lock files under `files/build/versions-public/{default,host-image,host-base-image}` are enumerated with `git ls-files` (they pin the exact apt/pip versions baked into the rootfs). The `files/build/versions` symlink itself is intentionally **not** added to the key — `git hash-object` cannot hash a symlink that resolves to a directory — and it is unnecessary, since hashing the enumerated target files already invalidates the cache on any version-lock change.

### Scope notes
- **`files/scripts/network_setup` and `network_setup.sh` are deliberately excluded.** They are copied to the **build host** `/etc/initramfs-tools/…` (no `$FILESYSTEM_ROOT` prefix, `build_debian.sh:424,430`), but the image initramfs is generated via `chroot $FILESYSTEM_ROOT update-initramfs -u` (`build_debian.sh:774`) which reads the *chroot* config — so these host hooks never enter the artifact and editing them cannot produce a stale rootfs. (Separately, this looks like a latent functional bug — the network_setup hook is not actually installed into the image — but that is out of scope here.)
- Coverage of the associated flag **values** (`SECURE_UPGRADE_MODE`, `BUILD_REDUCE_IMAGE_SIZE`, `enable_organization_extensions`) is a separate concern tracked under the inline-recipe-env / untracked-mk-flag work, not this PR.

### How to verify it
All added paths are git-tracked and hash cleanly (`git hash-object`), so each participates in the rootfs key. After merge, editing any of them changes the RFS `GIT_CONTENT_SHA` and forces a rootfs rebuild.

### Which release branch to backport (provide reason below if selected)
- [ ] 202xxx

### Description for the changelog
Track additional host-rootfs build inputs (templates, signing/secure-boot scripts, version manager, build-hook utils, and the host version-lock files) in `RFS_DEP_FILES` so editing them invalidates the rootfs cache.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


