### PR TITLE
[cache validation] [Makefile.cache]: Fold RFS inline recipe env vars into the rootfs cache key

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -456,24 +456,34 @@ $(foreach pkg, $(SONIC_INSTALL_PKGS), \
 
 # The RFS (rootfs) recipe in slave.mk passes a block of inline (non-export) Make
 # variables to ./build_debian.sh whose VALUES change the produced rootfs content
-# (admin/BMC account identity, kubernetes-master component versions, image type).
-# These values were absent from the RFS cache key (_DEP_FLAGS folded only
-# SONIC_COMMON_FLAGS_LIST), so changing one did not update the RFS .flags/.dep and an
-# incremental build could reuse a stale rootfs. Fold the non-secret values directly.
+# (admin/BMC account identity, kubernetes-master component versions, image type,
+# trusted GPG/apt sources). These values were absent from the RFS cache key
+# (_DEP_FLAGS folded only SONIC_COMMON_FLAGS_LIST), so changing one did not update
+# the RFS .flags/.dep and an incremental build could reuse a stale rootfs. Fold the
+# non-secret values directly.
 # For secret-valued vars (PASSWORD, BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD) fold only a
 # short fingerprint, so plaintext secrets never land in the on-disk <pkg>.flags /
 # <pkg>.log cache-key artifacts. DBGOPT is intentionally NOT keyed: it only toggles
 # `set -x` tracing in helper scripts and does not alter rootfs bytes.
-rfs_secret_fp = $(if $(strip $(1)),$(shell printf '%s' '$(1)' | sha1sum | cut -c1-16))
+#
+# rfs_secret_fp shell-escapes the value (each ' -> '\'') before wrapping it in a
+# single-quoted shell string, so a secret containing a single quote cannot break the
+# printf command or corrupt the fingerprint.
+rfs_sq := '
+rfs_shell_escape = $(subst $(rfs_sq),$(rfs_sq)\$(rfs_sq)$(rfs_sq),$(1))
+rfs_secret_fp = $(if $(strip $(1)),$(shell printf '%s' '$(call rfs_shell_escape,$(1))' | sha1sum | cut -c1-16))
+# IMAGE_TYPE is intentionally NOT in this static list: it is a per-installer value
+# ($($(installer)_IMAGE_TYPE), see slave.mk) and is folded per RFS target below.
 RFS_INLINE_ENV_FLAGS := $(USERNAME) $(CHANGE_DEFAULT_PASSWORD) $(BMC_NOS_ACCOUNT_USERNAME) \
-                        $(IMAGE_TYPE) $(MASTER_KUBERNETES_VERSION) $(MASTER_CRI_DOCKERD) \
+                        $(MASTER_KUBERNETES_VERSION) $(MASTER_CRI_DOCKERD) \
+                        $(TRUSTED_GPG_URLS) $(BUILD_PACKAGES_URL) \
                         $(call rfs_secret_fp,$(PASSWORD)) \
                         $(call rfs_secret_fp,$(BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD))
 
 $(foreach pkg, $(SONIC_RFS_TARGETS), \
         $(eval $(pkg)_DST_PATH := $(if $($(pkg)_DST_PATH), $($(pkg)_DST_PATH), $(TARGET_PATH))) \
         $(eval $(pkg)_CACHE_MODE := GIT_CONTENT_SHA) \
-        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(RFS_INLINE_ENV_FLAGS)) \
+        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(RFS_INLINE_ENV_FLAGS) $($($(pkg)_INSTALLER)_IMAGE_TYPE)) \
         $(eval $(pkg)_DEP_FILES := $(SONIC_COMMON_BASE_FILES_LIST) $(RFS_DEP_FILES)) \
         $(eval $(TARGET_PATH)/$(pkg)_TARGET := $(pkg)) )
 

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -454,10 +454,26 @@ $(foreach pkg, $(SONIC_INSTALL_PKGS), \
         $(eval $(pkg)_DST_PATH := $(if $($(pkg)_DST_PATH), $($(pkg)_DST_PATH), $(FSROOT_PATH))) \
 		$(eval $(FSROOT_PATH)/$(pkg)_TARGET := $(pkg)) )
 
+# The RFS (rootfs) recipe in slave.mk passes a block of inline (non-export) Make
+# variables to ./build_debian.sh whose VALUES change the produced rootfs content
+# (admin/BMC account identity, kubernetes-master component versions, image type).
+# These values were absent from the RFS cache key (_DEP_FLAGS folded only
+# SONIC_COMMON_FLAGS_LIST), so changing one did not update the RFS .flags/.dep and an
+# incremental build could reuse a stale rootfs. Fold the non-secret values directly.
+# For secret-valued vars (PASSWORD, BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD) fold only a
+# short fingerprint, so plaintext secrets never land in the on-disk <pkg>.flags /
+# <pkg>.log cache-key artifacts. DBGOPT is intentionally NOT keyed: it only toggles
+# `set -x` tracing in helper scripts and does not alter rootfs bytes.
+rfs_secret_fp = $(if $(strip $(1)),$(shell printf '%s' '$(1)' | sha1sum | cut -c1-16))
+RFS_INLINE_ENV_FLAGS := $(USERNAME) $(CHANGE_DEFAULT_PASSWORD) $(BMC_NOS_ACCOUNT_USERNAME) \
+                        $(IMAGE_TYPE) $(MASTER_KUBERNETES_VERSION) $(MASTER_CRI_DOCKERD) \
+                        $(call rfs_secret_fp,$(PASSWORD)) \
+                        $(call rfs_secret_fp,$(BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD))
+
 $(foreach pkg, $(SONIC_RFS_TARGETS), \
         $(eval $(pkg)_DST_PATH := $(if $($(pkg)_DST_PATH), $($(pkg)_DST_PATH), $(TARGET_PATH))) \
         $(eval $(pkg)_CACHE_MODE := GIT_CONTENT_SHA) \
-        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST)) \
+        $(eval $(pkg)_DEP_FLAGS := $(SONIC_COMMON_FLAGS_LIST) $(RFS_INLINE_ENV_FLAGS)) \
         $(eval $(pkg)_DEP_FILES := $(SONIC_COMMON_BASE_FILES_LIST) $(RFS_DEP_FILES)) \
         $(eval $(TARGET_PATH)/$(pkg)_TARGET := $(pkg)) )
 


### PR DESCRIPTION
#### Why I did it

The rootfs (RFS) recipe in `slave.mk` passes a block of inline (non-`export`) Make variables to `./build_debian.sh` whose **values** change the produced rootfs content:

| Var | Effect on rootfs |
|---|---|
| `USERNAME` | primary admin account name (`useradd`) |
| `PASSWORD` (secret) | admin account password (`chpasswd`) |
| `CHANGE_DEFAULT_PASSWORD` | forces password expiry on first login |
| `BMC_NOS_ACCOUNT_USERNAME` | BMC NOS account name |
| `BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD` (secret) | BMC root password |
| `IMAGE_TYPE` | aboot vs onie image layout / `--image-type` |
| `MASTER_KUBERNETES_VERSION` | kubernetes-master package version installed |
| `MASTER_CRI_DOCKERD` | cri-dockerd version downloaded/installed |
| `TRUSTED_GPG_URLS` | apt trust anchors for the rootfs |
| `BUILD_PACKAGES_URL` | apt package source for the rootfs |

None of these appear in `SONIC_COMMON_FLAGS_LIST` (the only thing folded into the RFS `$(pkg)_DEP_FLAGS`), nor in any file hashed via `$(pkg)_DEP_FILES`. So changing any of them does **not** update the RFS `.flags`/`.dep`, and an incremental build can silently reuse a **stale rootfs squashfs** built with the previous values (e.g. old admin username, old k8s version).

#### How I did it

Fold the eight content-affecting values into the **RFS-scoped** `_DEP_FLAGS`:

- Non-secret values are folded verbatim. `IMAGE_TYPE` is folded **per RFS target** as `$($(installer)_IMAGE_TYPE)` (its value is per-installer), not as a single global value.
- The two secret-valued vars (`PASSWORD`, `BMC_ROOT_ACCOUNT_DEFAULT_PASSWORD`) are folded only as a short **sha1 fingerprint** via a `rfs_secret_fp` helper — the on-disk `<pkg>.flags` / `<pkg>.log` cache-key artifacts (uploaded by CI) must never contain plaintext secrets. The helper shell-escapes the value (each `'` → `'\''`) before hashing, so a secret containing a single quote cannot corrupt the fingerprint.
- `DBGOPT` is intentionally **not** keyed: it only toggles `set -x` tracing in helper scripts and does not alter rootfs bytes.

The change is confined to the `SONIC_RFS_TARGETS` foreach; the shared `SONIC_COMMON_FLAGS_LIST` is untouched, so no other package caches are affected.

#### How to verify it

Validated the key-assembly logic in a standalone Make harness:
- changing `USERNAME` / `IMAGE_TYPE` / `MASTER_KUBERNETES_VERSION` changes the RFS key;
- changing `PASSWORD` changes only its fingerprint field, and no plaintext appears in the key;
- changing `DBGOPT` leaves the key identical;
- empty secret values expand to nothing (no spurious hash, no error).

#### Which release branch to backport (provide reason below if selected)

<!-- - [ ] 202305 etc -->

#### Tested branch (Please provide the tested image version)

<!-- master -->

#### Description for the changelog

Fold RFS inline recipe env vars (admin/BMC account identity, image type, kubernetes-master versions) into the rootfs cache key; secret-valued vars folded as sha1 fingerprints to avoid plaintext leakage into cache-key artifacts.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
