### PR TITLE
[cache validation] [rules/docker-base]: Fold INSTALL_DEBUG_TOOLS into the docker-base cache key

### DIFF
--- a/rules/docker-base.dep
+++ b/rules/docker-base.dep
@@ -5,6 +5,11 @@ DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
 DEP_FILES   += $(shell git ls-files $(DPATH))
 
 $(DOCKER_BASE)_CACHE_MODE  := GIT_CONTENT_SHA 
-$(DOCKER_BASE)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+# INSTALL_DEBUG_TOOLS gates $(DOCKER_BASE)_DBG_PACKAGES in rules/docker-base.mk, which is
+# rendered into the docker-base Dockerfile (installs gdb/vim/... via apt). Unlike
+# _DBG_IMAGE_PACKAGES / _DBG_DEPENDS, _DBG_PACKAGES is NOT folded into the cache key by
+# GET_MOD_DEP_SHA, so toggling INSTALL_DEBUG_TOOLS would otherwise reuse a stale image.
+# Fold the flag into the key so a change forces a rebuild.
+$(DOCKER_BASE)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST) $(INSTALL_DEBUG_TOOLS)
 $(DOCKER_BASE)_DEP_FILES   := $(DEP_FILES)
 


### PR DESCRIPTION
#### Why I did it

`INSTALL_DEBUG_TOOLS` is used in a `.mk` conditional but not folded into any
cache key. After review, most such flags were false positives (they only toggle
`_DEPENDS`/`_DBG_DEPENDS`/`_DBG_IMAGE_PACKAGES`, all of which are already folded
into the key by `GET_MOD_DEP_SHA`). **`docker-base` is the exception.**

`rules/docker-base.mk` sets `$(DOCKER_BASE)_DBG_PACKAGES` (gdb, gdbserver, vim,
openssh-client, sshpass, strace) when `INSTALL_DEBUG_TOOLS=y`. `slave.mk` exports
that list as `docker_base_dbgs`, and `dockers/docker-base/Dockerfile.j2` renders
it into `apt-get install` lines — so the flag changes the contents of the main
`docker-base.gz` image.

`_DBG_PACKAGES` (unlike `_DBG_DEPENDS` / `_DBG_IMAGE_PACKAGES`) is **not** folded
into the cache key by `GET_MOD_DEP_SHA`, and `INSTALL_DEBUG_TOOLS` is not in
`SONIC_COMMON_FLAGS_LIST`. So a `docker-base` cached with `INSTALL_DEBUG_TOOLS=y`
and one cached with `=n` share the same cache filename → a stale image can be
reused across a flag toggle.

#### How I did it

Add `$(INSTALL_DEBUG_TOOLS)` to `$(DOCKER_BASE)_DEP_FLAGS` in
`rules/docker-base.dep`, so the flag becomes part of the docker-base cache key
and a change forces a rebuild. Blast radius is limited to re-keying the
`docker-base` image only.

#### How to verify it

1. Build `target/docker-base.gz` with `INSTALL_DEBUG_TOOLS=y`, note the cache
   filename in `target/docker-base.gz.log` (`docker-base-<dep_sha>-<mod_hash>.tgz`).
2. Rebuild with `INSTALL_DEBUG_TOOLS=n`.
3. Before this change the two runs share a cache key (stale-hit risk); after this
   change the `dep_sha` differs, so the second run rebuilds instead of reusing the
   first image.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Description for the changelog

Fold `INSTALL_DEBUG_TOOLS` into the `docker-base` build-cache key so toggling the
flag no longer reuses a stale image.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
