### PR TITLE
[libnl3] Fix teamsyncd NULL-link crash in rtnl_link_get_kernel()

### DIFF
--- a/src/libnl3/patch/0004-rtnl_link_get_kernel-fail-on-null-link.patch
+++ b/src/libnl3/patch/0004-rtnl_link_get_kernel-fail-on-null-link.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yatish Koul <yatishkoul@microsoft.com>
+Date: Mon, 3 Aug 2026 00:00:00 +0000
+Subject: [PATCH] rtnl_link_get_kernel: fail instead of returning a NULL link
+
+rtnl_link_get_kernel() sends an RTM_GETLINK request and parses the reply
+into an rtnl_link. When the requested interface has just been removed
+(e.g. LAG/team ports churning while teamd is restarted), the kernel can
+reply without a link object, yet nl_pickup() still returns success. In
+that case the function does "*result = NULL; return 0;".
+
+Callers that (correctly) only check the return code then treat rc == 0 as
+"valid link" and dereference a NULL rtnl_link. Concretely, libteam's
+port/ifinfo handling does:
+
+    rc = rtnl_link_get_kernel(sk, ifindex, name, &link);
+    if (rc) goto skip;                 /* checks rc, not link */
+    rtnl_link_get_name(link);          /* SIGSEGV: link == NULL */
+    rtnl_link_get_master(link);
+    rtnl_link_get_addr(link);
+
+which crashes teamsyncd (SIGSEGV, core dumped) on high-PortChannel-count
+topologies during the process_monitoring test.
+
+Report the "no object" case as -NLE_OBJ_NOTFOUND so existing return-code
+checks take the not-found path instead of dereferencing NULL. Validated
+on hardware: with this behaviour libteam skips the vanished port and the
+teamsyncd crash no longer occurs.
+
+Signed-off-by: Yatish Koul <yatishkoul@microsoft.com>
+---
+ lib/route/link.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/lib/route/link.c b/lib/route/link.c
+index 1111111..2222222 100644
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -958,7 +958,17 @@
+ 	/* If an object has been returned, we also need to wait for the ACK */
+ 	if (err == 0 && link)
+ 		wait_for_ack(sk);
+ 
++	/* The kernel can reply without an object (e.g. the interface was just
++	 * removed) while nl_pickup() still reports success. Returning 0 with a
++	 * NULL *result makes callers that only check the return code (e.g.
++	 * libteam) dereference a NULL rtnl_link. Report it as not-found, and
++	 * clear *result so even callers that ignore the return code see NULL. */
++	if (!link) {
++		*result = NULL;
++		return -NLE_OBJ_NOTFOUND;
++	}
++
+ 	*result = _nl_steal_pointer(&link);
+ 	return 0;
+ }
+-- 
+2.34.1

--- a/src/libnl3/patch/0004-rtnl_link_get_name-guard-against-NULL.patch
+++ b/src/libnl3/patch/0004-rtnl_link_get_name-guard-against-NULL.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yatish Koul <yatishkoul@microsoft.com>
+Date: Fri, 1 Aug 2026 00:00:00 +0000
+Subject: [PATCH] rtnl_link_get_name: guard against a NULL link
+
+teamsyncd, via libteam's team/port event handling, can call
+rtnl_link_get_name() with a NULL "struct rtnl_link *" while a team port
+is being torn down under heavy LAG churn (e.g. teamd container
+kill/restart on a high-PortChannel-count topology).  rtnl_link_get_name()
+dereferences link->ce_mask unconditionally, so a NULL link causes a
+SIGSEGV (fault at address 0x31, the offset of ce_mask) that crashes
+teamsyncd and drops a core.
+
+Guard the getter so it returns NULL for a NULL link.  This matches the
+existing "no name set" contract of the function (it already returns NULL
+when LINK_ATTR_IFNAME is not set), which callers already handle, and
+turns a hard crash into a graceful NULL return.
+
+Signed-off-by: Yatish Koul <yatishkoul@microsoft.com>
+---
+ lib/route/link.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/lib/route/link.c b/lib/route/link.c
+index 1111111..2222222 100644
+--- a/lib/route/link.c
++++ b/lib/route/link.c
+@@ -1075,6 +1075,8 @@
+  * @return Link name or NULL if name is not specified
+  */
+ char *rtnl_link_get_name(struct rtnl_link *link)
+ {
++	if (!link)
++		return NULL;
+ 	return link->ce_mask & LINK_ATTR_IFNAME ? link->l_name : NULL;
+ }
+-- 
+2.34.1

--- a/src/libnl3/patch/series
+++ b/src/libnl3/patch/series
@@ -1,4 +1,5 @@
 0003-Adding-support-for-RTA_NH_ID-attribute.patch
+0004-rtnl_link_get_name-guard-against-NULL.patch
 switch-to-debhelper.patch
 keep-symbol-versions-in-libraries.patch
 update-changelog.patch

--- a/src/libnl3/patch/series
+++ b/src/libnl3/patch/series
@@ -1,4 +1,5 @@
 0003-Adding-support-for-RTA_NH_ID-attribute.patch
+0004-rtnl_link_get_kernel-fail-on-null-link.patch
 switch-to-debhelper.patch
 keep-symbol-versions-in-libraries.patch
 update-changelog.patch


### PR DESCRIPTION
#### Why I did it
`teamsyncd` crashes with a SIGSEGV (core dumped) on high-PortChannel-count topologies while `teamd`/team ports churn (e.g. `teamd` container kill/restart). The repeated crash-restart of a critical process makes the `process_monitoring` tests (`test_orchagent_heartbeat`, `test_monitoring_critical_processes`) fail.

Root cause is in libnl's `rtnl_link_get_kernel()`: when the requested interface has just been removed, the kernel replies without a link object, yet the function still returns `0` (success) with `*result == NULL`. The caller (libteam, driven by teamsyncd) only checks the return code and then dereferences the NULL link:

```c
rc = rtnl_link_get_kernel(sk, ifindex, name, &link);
if (rc) goto skip;            /* checks rc, not link */
rtnl_link_get_name(link);     /* SIGSEGV: link == NULL */
rtnl_link_get_master(link);   /* reached unconditionally */
rtnl_link_get_addr(link);
```

Guarding only `rtnl_link_get_name()` is **insufficient** — disassembly of the shipped `libteam.so.5` shows it holds the same NULL link and unconditionally calls `rtnl_link_get_master()` and `rtnl_link_get_addr()` next, so the crash merely moves downstream. Fixing the source (`rtnl_link_get_kernel`) protects the entire getter chain via libteam's existing return-code check.

#### How I did it
In `rtnl_link_get_kernel()`, when the parsed link is NULL, clear `*result` and return `-NLE_OBJ_NOTFOUND` instead of `0`. This mirrors how the function already returns `-NLE_OPNOTSUPP` for another not-found case, and lets callers that check the return code take the not-found path instead of dereferencing NULL.

#### How to verify it
Validated on hardware (max-PortChannel-count topology): with this patch the `teamsyncd` crash no longer occurs and `process_monitoring` passes.

#### Which release branch to backport (provide reason below if selected)
<!-- - Note we only backport fixes -->

#### Description for the changelog
Fix teamsyncd NULL-link SIGSEGV by making libnl `rtnl_link_get_kernel()` return `-NLE_OBJ_NOTFOUND` when the kernel reply contains no link object.
