### PR TITLE
[cache validation] [Makefile.cache]: Guard docker build-recipe scripts against stale cache

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -99,10 +99,12 @@ SONIC_CACHE_RECIPE_FILES := slave.mk \
                             scripts/versions_manager.py \
                             scripts/docker_version_control.sh \
                             scripts/j2_include.py \
+                            scripts/j2cli/json_filter.py \
+                            files/build_templates/manifest.json.j2 \
                             build_debug_docker_j2.sh
 # Combined git object hash of SONIC_CACHE_RECIPE_FILES when SONIC_CACHE_RECIPE_VER
 # was last set/bumped. Used by the guard below to detect unreviewed recipe changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 70ef52fb140b40ba7ad115755c8d554e8c150c52
+SONIC_CACHE_RECIPE_VER_BASELINE := 3582fa415109273b484ce5795e22bc17c47f0b84
 
 # Guard: warn if any recipe file changed since SONIC_CACHE_RECIPE_VER was last
 # reviewed. This catches the case where someone modifies a build recipe (slave.mk or

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -80,25 +80,49 @@
 #   (e.g., dpkg build recipe changes, compiler flag changes, install logic changes).
 #
 SONIC_CACHE_RECIPE_VER := 1
-# Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
-# Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 348388b6882c0c90f4a1c7170d0e33cf9c0e645b
+# Build-recipe files whose changes can affect package build output but are NOT
+# auto-hashed into any per-package cache key: slave.mk and the helper scripts it
+# invokes from the per-docker / per-dbg-image build recipes to render the build
+# context (the untracked Dockerfile, Dockerfile.buildinfo, Dockerfile-dbg.j2) and to
+# pin package versions. Those rendered outputs are not tracked git files, so they
+# never appear in any docker _DEP_FILES; a change to one of these scripts can alter
+# what a cached image contains without invalidating its cache key, serving a stale
+# image. SONIC_CACHE_RECIPE_VER must be bumped when any of these genuinely changes
+# what a build produces.
+# NOTE: slave-container-scope recipe scripts (build_mirror_config.sh,
+# prepare_slave_container_buildinfo.sh) are intentionally omitted here: their outputs
+# (sources.list.*, buildinfo/versions*) are already hashed into SLAVE_BASE_TAG /
+# SLAVE_TAG (Makefile.work) and, for build_mirror_config.sh, into RFS_DEP_FILES.
+SONIC_CACHE_RECIPE_FILES := slave.mk \
+                            scripts/prepare_docker_buildinfo.sh \
+                            scripts/collect_docker_version_files.sh \
+                            scripts/versions_manager.py \
+                            scripts/docker_version_control.sh \
+                            scripts/j2_include.py \
+                            build_debug_docker_j2.sh
+# Combined git object hash of SONIC_CACHE_RECIPE_FILES when SONIC_CACHE_RECIPE_VER
+# was last set/bumped. Used by the guard below to detect unreviewed recipe changes.
+SONIC_CACHE_RECIPE_VER_BASELINE := 70ef52fb140b40ba7ad115755c8d554e8c150c52
 
-# Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
-# This catches the case where someone modifies slave.mk build recipes without
-# bumping the cache version, which could serve stale cached packages.
-# To resolve: review whether the slave.mk change affects package output.
+# Guard: warn if any recipe file changed since SONIC_CACHE_RECIPE_VER was last
+# reviewed. This catches the case where someone modifies a build recipe (slave.mk or
+# a script it invokes) without bumping the cache version, which could serve stale
+# cached packages. To resolve: review whether the change affects package output.
 #   - If yes: bump SONIC_CACHE_RECIPE_VER and update the baseline hash.
 #   - If no:  just update the baseline hash.
-SONIC_CACHE_SLAVE_HASH := $(if $(wildcard .git),$(shell git hash-object slave.mk 2>/dev/null))
-ifneq ($(SONIC_CACHE_SLAVE_HASH),)
-ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
+# $(wildcard ...) guards against a listed file being renamed/removed: git hash-object
+# aborts at the first missing path (silently truncating the combined hash under
+# 2>/dev/null), so pre-filter to existing files. A removed file still changes the
+# hash and fires the warning, as intended.
+SONIC_CACHE_RECIPE_HASH := $(if $(wildcard .git),$(shell git hash-object $(wildcard $(SONIC_CACHE_RECIPE_FILES)) 2>/dev/null | sha1sum | awk '{print $$1}'))
+ifneq ($(SONIC_CACHE_RECIPE_HASH),)
+ifneq ($(SONIC_CACHE_RECIPE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
 ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
 ifneq ($(SONIC_DPKG_CACHE_METHOD),)
-$(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
+$(warning [CACHE] A build recipe file changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] Review whether the change affects package build output:)
-$(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
-$(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
+$(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_RECIPE_HASH))
+$(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_RECIPE_HASH))
 endif
 endif
 endif

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -99,10 +99,12 @@ SONIC_CACHE_RECIPE_FILES := slave.mk \
                             scripts/versions_manager.py \
                             scripts/docker_version_control.sh \
                             scripts/j2_include.py \
+                            scripts/j2cli/json_filter.py \
+                            files/build_templates/manifest.json.j2 \
                             build_debug_docker_j2.sh
 # Combined git object hash of SONIC_CACHE_RECIPE_FILES when SONIC_CACHE_RECIPE_VER
 # was last set/bumped. Used by the guard below to detect unreviewed recipe changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 8eba92e0b6da38a562dc9467c24d8a19bae3b1ff
+SONIC_CACHE_RECIPE_VER_BASELINE := f9e949871cd24303ff469f35ea72b596d80d3d7b
 
 # Guard: warn if any recipe file changed since SONIC_CACHE_RECIPE_VER was last
 # reviewed. This catches the case where someone modifies a build recipe (slave.mk or

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -80,25 +80,49 @@
 #   (e.g., dpkg build recipe changes, compiler flag changes, install logic changes).
 #
 SONIC_CACHE_RECIPE_VER := 2
-# Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
-# Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 57a423c0b31ad2869422ec0d2c13ee0492b8ecb9
+# Build-recipe files whose changes can affect package build output but are NOT
+# auto-hashed into any per-package cache key: slave.mk and the helper scripts it
+# invokes from the per-docker / per-dbg-image build recipes to render the build
+# context (the untracked Dockerfile, Dockerfile.buildinfo, Dockerfile-dbg.j2) and to
+# pin package versions. Those rendered outputs are not tracked git files, so they
+# never appear in any docker _DEP_FILES; a change to one of these scripts can alter
+# what a cached image contains without invalidating its cache key, serving a stale
+# image. SONIC_CACHE_RECIPE_VER must be bumped when any of these genuinely changes
+# what a build produces.
+# NOTE: slave-container-scope recipe scripts (build_mirror_config.sh,
+# prepare_slave_container_buildinfo.sh) are intentionally omitted here: their outputs
+# (sources.list.*, buildinfo/versions*) are already hashed into SLAVE_BASE_TAG /
+# SLAVE_TAG (Makefile.work) and, for build_mirror_config.sh, into RFS_DEP_FILES.
+SONIC_CACHE_RECIPE_FILES := slave.mk \
+                            scripts/prepare_docker_buildinfo.sh \
+                            scripts/collect_docker_version_files.sh \
+                            scripts/versions_manager.py \
+                            scripts/docker_version_control.sh \
+                            scripts/j2_include.py \
+                            build_debug_docker_j2.sh
+# Combined git object hash of SONIC_CACHE_RECIPE_FILES when SONIC_CACHE_RECIPE_VER
+# was last set/bumped. Used by the guard below to detect unreviewed recipe changes.
+SONIC_CACHE_RECIPE_VER_BASELINE := 8eba92e0b6da38a562dc9467c24d8a19bae3b1ff
 
-# Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
-# This catches the case where someone modifies slave.mk build recipes without
-# bumping the cache version, which could serve stale cached packages.
-# To resolve: review whether the slave.mk change affects package output.
+# Guard: warn if any recipe file changed since SONIC_CACHE_RECIPE_VER was last
+# reviewed. This catches the case where someone modifies a build recipe (slave.mk or
+# a script it invokes) without bumping the cache version, which could serve stale
+# cached packages. To resolve: review whether the change affects package output.
 #   - If yes: bump SONIC_CACHE_RECIPE_VER and update the baseline hash.
 #   - If no:  just update the baseline hash.
-SONIC_CACHE_SLAVE_HASH := $(if $(wildcard .git),$(shell git hash-object slave.mk 2>/dev/null))
-ifneq ($(SONIC_CACHE_SLAVE_HASH),)
-ifneq ($(SONIC_CACHE_SLAVE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
+# $(wildcard ...) guards against a listed file being renamed/removed: git hash-object
+# aborts at the first missing path (silently truncating the combined hash under
+# 2>/dev/null), so pre-filter to existing files. A removed file still changes the
+# hash and fires the warning, as intended.
+SONIC_CACHE_RECIPE_HASH := $(if $(wildcard .git),$(shell git hash-object $(wildcard $(SONIC_CACHE_RECIPE_FILES)) 2>/dev/null | sha1sum | awk '{print $$1}'))
+ifneq ($(SONIC_CACHE_RECIPE_HASH),)
+ifneq ($(SONIC_CACHE_RECIPE_HASH),$(SONIC_CACHE_RECIPE_VER_BASELINE))
 ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
 ifneq ($(SONIC_DPKG_CACHE_METHOD),)
-$(warning [CACHE] slave.mk has changed since SONIC_CACHE_RECIPE_VER was last set.)
+$(warning [CACHE] A build recipe file changed since SONIC_CACHE_RECIPE_VER was last set.)
 $(warning [CACHE] Review whether the change affects package build output:)
-$(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
-$(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_SLAVE_HASH))
+$(warning [CACHE]   If YES: bump SONIC_CACHE_RECIPE_VER in Makefile.cache and update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_RECIPE_HASH))
+$(warning [CACHE]   If NO:  just update SONIC_CACHE_RECIPE_VER_BASELINE to: $(SONIC_CACHE_RECIPE_HASH))
 endif
 endif
 endif


### PR DESCRIPTION
#### Why I did it

`Makefile.cache` already ships a guard (`SONIC_CACHE_RECIPE_VER` +
`SONIC_CACHE_RECIPE_VER_BASELINE`) that warns when `slave.mk` is modified without a
cache-version bump, because `slave.mk` build recipes are **not** auto-hashed into any
per-package cache key. The exact same gap exists for the helper scripts that
`slave.mk` invokes from the per-docker / per-dbg-image build recipes:

| Script | Role in the recipe | Why a stale cache can be served |
|---|---|---|
| `scripts/prepare_docker_buildinfo.sh` | renders `Dockerfile.buildinfo` build context (slave.mk:1254) | rendered file is untracked → not in any docker `_DEP_FILES` |
| `scripts/collect_docker_version_files.sh` | collects/pins per-docker version files (slave.mk:1272) | version pins change image contents, unkeyed |
| `scripts/versions_manager.py` | version resolution (via `prepare_docker_buildinfo.sh`) | changes resolved pins, unkeyed |
| `scripts/docker_version_control.sh` | version-control logic (via `prepare_docker_buildinfo.sh`) | changes resolved pins, unkeyed |
| `scripts/j2_include.py` | renders the actual `Dockerfile` from `Dockerfile.j2` (slave.mk:1421) | rendered `Dockerfile` is untracked → unkeyed |
| `scripts/j2cli/json_filter.py` | j2 `--customize` filter used by `generate_manifest` (rules/functions:235) | rendered `manifest.json` is embedded into every image via `--label com.azure.sonic.manifest` (slave.mk:1446,1514) → unkeyed |
| `files/build_templates/manifest.json.j2` | manifest template rendered by `generate_manifest` | embedded into every image via `--label` → unkeyed |
| `build_debug_docker_j2.sh` | renders `Dockerfile-dbg.j2` for dbg images (slave.mk:1493) | rendered file is untracked → unkeyed |

Because each script's output is an **untracked** generated file, none of them appear
in any docker's `_DEP_FILES`, and none are in `SONIC_COMMON_FILES_LIST`. A change to
any of them can alter what a cached image contains **without** invalidating its cache
key — i.e. a stale image is served.

#### How I did it

Extended the existing guard to hash a combined set of recipe files
(`SONIC_CACHE_RECIPE_FILES` = `slave.mk` + the eight helper scripts/templates above)
instead of `slave.mk` alone, keeping the identical warn → review → bump-and-rebaseline
workflow.
This is deliberately consistent with upstream's choice **not** to auto-invalidate on
every recipe edit (most recipe edits are no-ops for output); adding the scripts to a
`_DEP_FILES` list would instead force mass cache invalidation on every edit.

- Renamed `SONIC_CACHE_SLAVE_HASH` → `SONIC_CACHE_RECIPE_HASH` (only referenced in
  the guard block).
- New baseline `3582fa415109273b484ce5795e22bc17c47f0b84` = combined `git hash-object`
  of the nine pristine files.
- Slave-container-scope scripts (`build_mirror_config.sh`,
  `prepare_slave_container_buildinfo.sh`) are intentionally excluded — their outputs
  are already hashed into `SLAVE_BASE_TAG` / `SLAVE_TAG` (and `RFS_DEP_FILES`).
- Uses `$(wildcard ...)` so a future rename/removal of a listed path doesn't make
  `git hash-object` abort at the first missing path (which would silently truncate
  the combined hash under `2>/dev/null`); a removed file still changes the hash and
  fires the warning.

#### How to verify it

On a clean tree the combined hash equals the baseline and **no** `[CACHE]` warning is
emitted. Editing (or renaming away) any listed recipe script makes the hash differ
from the baseline and fires the warning with the new hash to record:

```
$(warning [CACHE] A build recipe file changed since SONIC_CACHE_RECIPE_VER was last set.)
```

Validated in a standalone make harness against pristine upstream content: clean →
MATCH/no-warning; edit → warning + mismatch; rename-away → warning + mismatch (no git
abort).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202xxx

#### Description for the changelog

Extend the `SONIC_CACHE_RECIPE_VER` guard in `Makefile.cache` to also watch the
docker build-recipe helper scripts, so an unreviewed change to one of them is flagged
before it can serve a stale cached image.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
