### PR TITLE
[cache validation] [Makefile.cache]: Fold slave-image identity (SLAVE_BASE_TAG) into every package cache key

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -111,6 +111,16 @@ SONIC_COMMON_FILES_LIST :=  $(if $(wildcard cache.skip.common),, .platform rules
 SONIC_DEVICE_FILES_LIST := $(shell git ls-files -s device | grep -v ^120000 | grep -Eo device.*)
 # NOTE: DOCKER_DEFAULT_PLATFORM changes the architecture recorded in every docker
 # image produced, so images cached under a different value must not be reused.
+# NOTE: SLAVE_BASE_TAG identifies the build-slave container image (hash of the slave
+# Dockerfile + sources.list.* + apt version pins). Folding it in ensures that a
+# toolchain change in the slave (new compiler/libc, an apt version-pin bump, or a
+# slave Dockerfile edit) invalidates every package cached under the previous slave.
+# It is passed in from Makefile.work. After #27649 removed the user-specific slave
+# container, the build runs directly inside SLAVE_BASE_IMAGE:SLAVE_BASE_TAG, so
+# SLAVE_BASE_TAG is the sole build-container identity and the correct value to fold
+# in here. SLAVE_TAG is deliberately NOT used: post-#27649 it identifies no build
+# container and still embeds $(USER)/$(PWD), which would fracture cross-machine/CI
+# cache sharing.
 SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(CONFIGURED_PLATFORM) \
                             $(CONFIGURED_ARCH) \
@@ -123,7 +133,18 @@ SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(BUILD_PUBLIC_URL) \
                             $(MIRROR_SNAPSHOT) $(SONIC_VERSION_CONTROL_COMPONENTS) \
                             $(CROSS_BUILD_ENVIRON) $(MULTIARCH_QEMU_ENVIRON) \
-                            $(TRUSTED_GPG_URLS)
+                            $(TRUSTED_GPG_URLS) \
+                            $(SLAVE_BASE_TAG)
+# Guard: when dpkg caching is enabled, SLAVE_BASE_TAG must be populated (passed in
+# from Makefile.work). An empty value would silently drop slave/toolchain identity
+# from every package cache key and re-open the stale-toolchain gap, so fail loudly.
+ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
+ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+ifeq ($(strip $(SLAVE_BASE_TAG)),)
+$(error [CACHE] SLAVE_BASE_TAG is empty but SONIC_DPKG_CACHE_METHOD=$(SONIC_DPKG_CACHE_METHOD); it must be passed from Makefile.work so slave/toolchain identity is folded into every package cache key)
+endif
+endif
+endif
 SONIC_COMMON_DPKG_LIST  :=  debian/control debian/changelog debian/rules \
                             debian/compat debian/install debian/copyright
 SONIC_COMMON_BASE_FILES_LIST  := sonic-slave-jessie/Dockerfile.j2 \

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -111,6 +111,12 @@ SONIC_COMMON_FILES_LIST :=  $(if $(wildcard cache.skip.common),, .platform rules
 SONIC_DEVICE_FILES_LIST := $(shell git ls-files -s device | grep -v ^120000 | grep -Eo device.*)
 # NOTE: DOCKER_DEFAULT_PLATFORM changes the architecture recorded in every docker
 # image produced, so images cached under a different value must not be reused.
+# NOTE: SLAVE_BASE_TAG identifies the build-slave container image (hash of the slave
+# Dockerfile + sources.list.* + apt version pins). Folding it in ensures that a
+# toolchain change in the slave (new compiler/libc, an apt version-pin bump, or a
+# slave Dockerfile edit) invalidates every package cached under the previous slave.
+# It is passed in from Makefile.work. SLAVE_TAG is deliberately NOT used here because
+# it embeds $(USER)/$(PWD), which would fracture cross-machine/CI cache sharing.
 SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(CONFIGURED_PLATFORM) \
                             $(CONFIGURED_ARCH) \
@@ -118,7 +124,18 @@ SONIC_COMMON_FLAGS_LIST :=  $(SONIC_CACHE_RECIPE_VER) \
                             $(MIRROR_URLS) $(MIRROR_SECURITY_URLS) \
                             $(SONIC_DEBUGGING_ON) \
                             $(SONIC_PROFILING_ON) \
-                            $(DOCKER_DEFAULT_PLATFORM)
+                            $(DOCKER_DEFAULT_PLATFORM) \
+                            $(SLAVE_BASE_TAG)
+# Guard: when dpkg caching is enabled, SLAVE_BASE_TAG must be populated (passed in
+# from Makefile.work). An empty value would silently drop slave/toolchain identity
+# from every package cache key and re-open the stale-toolchain gap, so fail loudly.
+ifneq ($(SONIC_DPKG_CACHE_METHOD),none)
+ifneq ($(SONIC_DPKG_CACHE_METHOD),)
+ifeq ($(strip $(SLAVE_BASE_TAG)),)
+$(error [CACHE] SLAVE_BASE_TAG is empty but SONIC_DPKG_CACHE_METHOD=$(SONIC_DPKG_CACHE_METHOD); it must be passed from Makefile.work so slave/toolchain identity is folded into every package cache key)
+endif
+endif
+endif
 SONIC_COMMON_DPKG_LIST  :=  debian/control debian/changelog debian/rules \
                             debian/compat debian/install debian/copyright
 SONIC_COMMON_BASE_FILES_LIST  := sonic-slave-jessie/Dockerfile.j2 \

--- a/Makefile.work
+++ b/Makefile.work
@@ -595,6 +595,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
                            SONIC_IMAGE_VERSION=$(SONIC_IMAGE_VERSION) \
                            SLAVE_TAG=$(SLAVE_TAG) \
+                           SLAVE_BASE_TAG=$(SLAVE_BASE_TAG) \
                            ENABLE_ZTP=$(ENABLE_ZTP) \
                            INCLUDE_PDE=$(INCLUDE_PDE) \
                            SHUTDOWN_BGP_ON_START=$(SHUTDOWN_BGP_ON_START) \

--- a/Makefile.work
+++ b/Makefile.work
@@ -593,6 +593,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
                            BUILD_TIMESTAMP=$(BUILD_TIMESTAMP) \
                            SONIC_IMAGE_VERSION=$(SONIC_IMAGE_VERSION) \
                            SLAVE_TAG=$(SLAVE_TAG) \
+                           SLAVE_BASE_TAG=$(SLAVE_BASE_TAG) \
                            ENABLE_ZTP=$(ENABLE_ZTP) \
                            INCLUDE_PDE=$(INCLUDE_PDE) \
                            SHUTDOWN_BGP_ON_START=$(SHUTDOWN_BGP_ON_START) \


### PR DESCRIPTION
#### Why I did it

Per-package cache keys (deb / wheel / docker) are built from `SONIC_COMMON_FLAGS_LIST`
plus each package's own `_DEP_FILES`/`DEPENDS`. That flag list carries platform, arch,
`BLDENV`, mirror URLs and a few toggles — **but nothing identifying the build-slave
container** the package is compiled in.

**Consequence:** a package built inside slave-image *v1* (toolchain X — gcc/glibc/
binutils, headers, build deps) is served from cache when the slave later becomes *v2*
(toolchain Y), as long as the package's own sources/deps are unchanged. Verified at
`9914efc028`:

- `SONIC_COMMON_FLAGS_LIST` (Makefile.cache L114-121) contains no `SLAVE_TAG` /
  `SLAVE_BASE_TAG` / base digest.
- Reproducible-build version pins `files/build/versions/**` are folded **only** into
  `$(docker)_DEP_FILES` (L643-647) — plain debs/wheels get zero toolchain signal;
  docker keys capture only their apt contents, not the slave toolchain.
- `SONIC_COMMON_BASE_FILES_LIST` holds only the slave `Dockerfile.j2` *templates*,
  whose text does not move on a version-pin bump.

#### How I did it

Fold the slave-image identity into `SONIC_COMMON_FLAGS_LIST` via **`SLAVE_BASE_TAG`**
= `sha1(rendered slave Dockerfile + sources.list.* + apt version pins)`. Any slave
Dockerfile edit or version-pin change now invalidates every package cached under the
previous slave.

- **`SLAVE_BASE_TAG`, not `SLAVE_TAG`** — `SLAVE_TAG` additionally hashes
  `$(USER)/$(PWD)`, which would make every key machine/workspace-specific and break
  cross-machine / CI cache sharing (`SONIC_DPKG_CACHE_SOURCE`). `SLAVE_BASE_TAG`
  excludes user/pwd and is stable across machines for identical inputs.
- `SLAVE_BASE_TAG` is computed in `Makefile.work` (outside the container); it is now
  also passed into the slave build (`SONIC_BUILD_INSTRUCTION`, alongside `SLAVE_TAG`)
  so it is in scope when `slave.mk` includes `Makefile.cache`.
- A guard `$(error …)`s if `SLAVE_BASE_TAG` is empty while `SONIC_DPKG_CACHE_METHOD`
  is enabled, so slave identity can never be silently dropped from the key.

Distinct from #28763 (which added `CROSS_BUILD_ENVIRON` / `MULTIARCH_QEMU_ENVIRON`
build-*mode* selectors — not slave-image identity).

#### How to verify it

Make-harness against the guard/flags block:
- caching enabled + `SLAVE_BASE_TAG` empty → build **errors and stops** (no silent
  weakening);
- caching enabled + `SLAVE_BASE_TAG=<hash>` → hash is folded into the flags list;
- `SONIC_DPKG_CACHE_METHOD=none` → no error, no fold.

Functionally: change a `sonic-slave-*/Dockerfile.j2` or its version pins → the slave
rebuilds with a new `SLAVE_BASE_TAG` → all package `.flags` differ → caches miss and
rebuild, instead of reusing artifacts from the old toolchain.

#### Known limitation / follow-up

This does **not** by itself close staleness from a **moving base-image tag** (e.g.
`debian:bookworm` advancing under an unchanged Dockerfile), because `SLAVE_BASE_TAG`
is derived from the Dockerfile *source text*, not the resolved base-image digest.
Pinning the slave base images (and QEMU stages) by `@sha256` is a separate, larger
change (and overlaps the reproducible-build/`MIRROR_SNAPSHOT` mechanism); it will be
handled in a follow-up PR.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202xxx

#### Description for the changelog

Fold the build-slave image identity (`SLAVE_BASE_TAG`) into every package cache key so
a toolchain/slave change invalidates packages cached under the previous slave.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

