### PR TITLE
[cache validation] rules/grpc: add grpc.dep so grpc and its dependents invalidate the dpkg cache correctly

### DIFF
--- a/rules/grpc.dep
+++ b/rules/grpc.dep
@@ -1,0 +1,17 @@
+
+# grpc is only built in the bullseye environment (see rules/grpc.mk).
+# Guard the dependency definitions so that $(GRPC) is non-empty; otherwise
+# $(shell git ls-files $(SPATH)) would run with an empty path and hash the
+# entire repository.
+ifeq ($(BLDENV),bullseye)
+
+SPATH       := $($(GRPC)_SRC_PATH)
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) rules/grpc.mk rules/grpc.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+DEP_FILES   += $(shell git ls-files $(SPATH))
+
+$(GRPC)_CACHE_MODE  := GIT_CONTENT_SHA
+$(GRPC)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(GRPC)_DEP_FILES   := $(DEP_FILES)
+
+endif


### PR DESCRIPTION
#### Why I did it

`rules/grpc.mk` defines the `grpc` package family (`libgrpc10` + 5 derived packages, built from source in the bullseye environment) but has **no sibling `rules/grpc.dep`**.

In the dpkg build-cache engine (`Makefile.cache`), a package that has a `.mk` but no `.dep` gets an **empty `DEP_FILES`**, which makes its `$(GRPC)_MOD_HASH` a **constant** that never changes when grpc's pinned version or build recipe changes. Every cached consumer that folds `$(GRPC)_MOD_HASH` into its own cache key (grpc's dependents — e.g. p4lang/PI, gnmi, dash, sonic-p4rt) therefore stays a cache **HIT** even after grpc is bumped, and can serve a **stale** artifact linked against the previous grpc.

This is the grpc instance of the broader "`.mk` with no `.dep`" class.

#### How I did it

Added `rules/grpc.dep` following the existing blessed convention (`rules/thrift.dep`, `rules/libnl3.dep`): key the package on the common file lists, `rules/grpc.mk`, `rules/grpc.dep`, and the tracked source under `$(GRPC)_SRC_PATH` (`src/grpc`), using `CACHE_MODE := GIT_CONTENT_SHA`.

grpc is built **only** in the bullseye environment, so `$(GRPC)` is empty in other envs. The whole `.dep` body is wrapped in `ifeq ($(BLDENV),bullseye)` — without the guard, `git ls-files $(SPATH)` would run with an empty path and hash the entire repository in non-bullseye builds.

grpc's build output is fully determined by:
- `GRPC_VERSION_FULL` (in the now-keyed `rules/grpc.mk`),
- the build recipe `src/grpc/Makefile` (now keyed; the only tracked file under `src/grpc`; grpc source is fetched via `dget` from Debian at the pinned version, no local patches),
- `CONFIGURED_ARCH`, and
- its dependency edges (`PROTOBUF`, `PROTOC32`, ...) which are already folded automatically via `_DEPENDS`.

So the `.dep` is complete: the cache now correctly invalidates grpc **and** its dependents on any grpc version/recipe/dependency change.

#### How to verify it

- Bump `GRPC_VERSION` / `GRPC_VERSION_FULL` in `rules/grpc.mk` (or edit `src/grpc/Makefile`) and confirm grpc **and** its dependents rebuild instead of restoring from cache.
- Confirm no behavior change outside bullseye: in bookworm/trixie the `.dep` body is skipped by the `ifeq` guard.

#### Which release branch to backport (provide reason below if selected)

<!-- - [ ] 202XXX -->

#### Description for the changelog

`[cache]: Add rules/grpc.dep so grpc and its dependents correctly invalidate the dpkg build cache on grpc version/recipe changes.`

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
