### PR TITLE
[cache validation] platform/nephos: add dpkg build-cache dependency tracking for SAI online deb

### DIFF
--- a/platform/nephos/rules.dep
+++ b/platform/nephos/rules.dep
@@ -1,0 +1,1 @@
+include $(PLATFORM_PATH)/sai.dep

--- a/platform/nephos/sai.dep
+++ b/platform/nephos/sai.dep
@@ -1,0 +1,17 @@
+DEP_FILES   := $(SONIC_COMMON_FILES_LIST) $(PLATFORM_PATH)/sai.mk $(PLATFORM_PATH)/sai.dep
+DEP_FILES   += $(SONIC_COMMON_BASE_FILES_LIST)
+
+# The Nephos SAI package is a version-pinned online deb: the SDK/SAI version and
+# download URL live entirely in sai.mk, so keying the .mk/.dep captures every
+# version change. NEPHOS_SAI_DEV is a derived package of NEPHOS_SAI and shares
+# its base cache entry, so only NEPHOS_SAI needs a dependency definition here.
+#
+# Only enable cache keying in the online (SONIC_ONLINE_DEBS) case. When
+# NEPHOS_SAI_DEB_LOCAL_URL is set (SAI_FROM_LOCAL=y) the deb is copied from a
+# local path outside the repo whose contents are not captured by hashing repo
+# files; leave the package uncached in that mode (its pre-existing behavior).
+ifneq ($(SAI_FROM_LOCAL),y)
+$(NEPHOS_SAI)_CACHE_MODE  := GIT_CONTENT_SHA
+$(NEPHOS_SAI)_DEP_FLAGS   := $(SONIC_COMMON_FLAGS_LIST)
+$(NEPHOS_SAI)_DEP_FILES   := $(DEP_FILES)
+endif


### PR DESCRIPTION
#### Why I did it

`platform/nephos/sai.mk` defines the Nephos SAI package (`NEPHOS_SAI`, version-pinned online deb `libsainps_<sdk>_sai_<sai>_<commit>_amd64.deb`, plus derived `NEPHOS_SAI_DEV`), but there was no cache dependency tracking for it — the `nephos` platform had no `rules.dep` at all. Without a `.dep`, `NEPHOS_SAI`'s cache module hash has an empty dependency-file list (a constant), so cached consumers (e.g. `syncd`) that depend on the Nephos SAI can remain a cache **HIT** even after the SAI version is bumped in `sai.mk` — serving a **stale** artifact.

The `nephos` platform is built in upstream CI (`.azure-pipelines/azure-pipelines-build.yml`).

#### How I did it

- Added `platform/nephos/sai.dep` following the blessed online version-pinned deb pattern (`platform/marvell-prestera/sai.dep`, `platform/barefoot/bfn-sai.dep`): keys `$(SONIC_COMMON_FILES_LIST)`, `sai.mk`, `sai.dep`, and `$(SONIC_COMMON_BASE_FILES_LIST)`.
- Enabled the keying only in the online case (`ifneq ($(SAI_FROM_LOCAL),y)`). When `NEPHOS_SAI_DEB_LOCAL_URL` is set, the deb is copied from a local path outside the repo (`SONIC_COPY_DEBS`) whose contents are not captured by hashing repo files; that mode is left uncached (its pre-existing behavior), avoiding any new stale-cache risk.
- Keyed only `NEPHOS_SAI`; `NEPHOS_SAI_DEV` is a derived package (`add_derived_package`) that shares the base package's cache entry, so it is invalidated together with `NEPHOS_SAI`.
- Created `platform/nephos/rules.dep` (the platform had none) that `include`s `sai.dep`. This is additive and only takes effect when building the nephos platform (`Makefile.cache` includes `$(PLATFORM_PATH)/rules.dep` for the selected platform only), so it cannot affect other platforms' builds.

#### How to verify it

Make-harness validation: `NEPHOS_SAI` → `CACHE_MODE=GIT_CONTENT_SHA`, `DEP_FILES=4`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Description for the changelog

Add dpkg build-cache dependency tracking for the Nephos SAI online deb so cached consumers correctly invalidate when the SAI version is bumped.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
