### PR TITLE
[build] Fix python version control for images built with uv

### DIFF
--- a/src/sonic-build-hooks/hooks/uv
+++ b/src/sonic-build-hooks/hooks/uv
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. /usr/local/share/buildinfo/scripts/buildinfo_base.sh
+
+REAL_COMMAND=$(get_command uv)
+if [ ! -x "$REAL_COMMAND" ]; then
+    echo "The command uv not found" 1>&2
+    exit 1
+fi
+
+# Only "uv pip" installs python packages, every other subcommand runs unchanged.
+if [ "$1" != "pip" ]; then
+    exec "$REAL_COMMAND" "$@"
+fi
+
+VERSION_FILE="$BUILDINFO_PATH/versions/versions-py3"
+
+PIP_VERSION_FILE=$VERSION_FILE ENABLE_VERSION_CONTROL_PY=$ENABLE_VERSION_CONTROL_PY3 \
+    REAL_COMMAND=$REAL_COMMAND PIP_TIMEOUT_UNSUPPORTED=y UV_HTTP_TIMEOUT=$PIP_HTTP_TIMEOUT \
+    run_pip_command "$@"

--- a/src/sonic-build-hooks/scripts/buildinfo_base.sh
+++ b/src/sonic-build-hooks/scripts/buildinfo_base.sh
@@ -293,7 +293,10 @@ download_packages()
 
 run_pip_command()
 {
-    declare -a parameters=("--default-timeout" "$PIP_HTTP_TIMEOUT" "$@")
+    # uv rejects --default-timeout and takes the timeout from UV_HTTP_TIMEOUT instead
+    declare -a parameters=()
+    [ "$PIP_TIMEOUT_UNSUPPORTED" != "y" ] && parameters+=("--default-timeout" "$PIP_HTTP_TIMEOUT")
+    parameters+=("$@")
     PIP_CACHE_PATH=${PKG_CACHE_PATH}/pip
     PKG_CACHE_OPTION="--cache-dir=${PIP_CACHE_PATH}"
 

--- a/src/sonic-build-hooks/scripts/collect_version_files
+++ b/src/sonic-build-hooks/scripts/collect_version_files
@@ -17,7 +17,13 @@ chmod a+rw $TARGET_PATH
 SKIP_VERSION_PACKAGE="libsaibcm|libpaibcm|linuxptp|@ file://"
 dpkg-query -W -f '${Package}==${Version}\n' | grep -Ev "${SKIP_VERSION_PACKAGE}" > "${TARGET_PATH}/versions-deb-${DIST}-${ARCH}"
 ([ -x "/usr/local/bin/pip2" ] || [ -x "/usr/bin/pip2" ]) && pip2 freeze --all| grep -Ev "${SKIP_VERSION_PACKAGE}" > "${TARGET_PATH}/versions-py2-${DIST}-${ARCH}"
-([ -x "/usr/local/bin/pip3" ] || [ -x "/usr/bin/pip3" ]) && pip3 freeze --all| grep -Ev "${SKIP_VERSION_PACKAGE}" > "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+# Images built with uv have no pip3 binary at all, so fall back to uv itself
+UV_COMMAND=$(get_command uv)
+if [ -x "/usr/local/bin/pip3" ] || [ -x "/usr/bin/pip3" ]; then
+    pip3 freeze --all| grep -Ev "${SKIP_VERSION_PACKAGE}" > "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+elif [ -x "$UV_COMMAND" ]; then
+    $UV_COMMAND pip freeze | grep -Ev "${SKIP_VERSION_PACKAGE}" > "${TARGET_PATH}/versions-py3-${DIST}-${ARCH}"
+fi
 
 [ -f "${BUILD_WEB_VERSION_FILE}" ] && cp ${BUILD_WEB_VERSION_FILE} ${TARGET_PATH}
 [ -f "${BUILD_GIT_VERSION_FILE}" ] && cp ${BUILD_GIT_VERSION_FILE} ${TARGET_PATH}


### PR DESCRIPTION
#### Why I did it

The docker-sonic-mgmt image was switched from pip to uv, and `uv venv` installs no pip binary at all. That silently disables python version control for the image in three places:

- `collect_version_files` only writes `versions-py3-*` when `/usr/local/bin/pip3` or `/usr/bin/pip3` exists. With uv neither path exists, so no python versions are recorded and the image reports none in its version manifest or SBOM.
- The build hooks provide wrappers for `pip`, `pip2` and `pip3` only. `uv pip install` is never intercepted, so frozen versions are never turned into a constraint file and the image cannot be pinned even when version files are supplied.
- `run_pip_command` always prepends `--default-timeout`, which uv rejects outright, so the existing helper cannot be reused for uv as it stands.

This was confirmed against a real build: the version files published by a master docker-sonic-mgmt build contain `versions-deb`, `versions-web` and `versions-mirror`, but no `versions-py3`, while docker-ptf, which still uses pip, records 278 python packages.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- added a `uv` build hook that routes `uv pip` through the existing `run_pip_command` logic, so the same constraint file mechanism applies. Any other subcommand, such as `uv venv` or `uv tool`, is `exec`ed straight to the real binary and behaves exactly as before
- let `collect_version_files` fall back to `uv pip freeze` when no pip3 binary is present. The output format is identical to `pip freeze`, and uv writes its informational line to stderr, so the version file is unaffected
- made the `--default-timeout` option in `run_pip_command` conditional. The uv hook sets `PIP_TIMEOUT_UNSUPPORTED=y` and passes the same value through `UV_HTTP_TIMEOUT`, which uv does accept

The hook is picked up automatically: the package Makefile copies everything under `hooks/`, and `symlink_build_hooks` links each one into `/usr/local/sbin`, which precedes the uv binary location on PATH.

#### How to verify it

Build any image that uses uv and confirm `versions-py3-*` now appears in its version files, then supply a pinned version file and confirm the pinned version is installed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
202511 and 202605 already carry the uv based docker-sonic-mgmt image and are affected by the same gap.

Failure type:

#### Tested branch

- [x] master

#### Test result

Verified in a container reproducing the image layout, ubuntu:24.04 with uv, a `/opt/venv` virtual environment and no pip binary, running the real hook scripts installed through `symlink_build_hooks`.

Behaviour:

| case | result |
| --- | --- |
| hook resolution | `which uv` resolves to the hook, real binary still found by `get_command` |
| `uv venv`, `uv --version` | pass through unchanged, exit 0 |
| version control disabled | package installs at latest, constraint file ignored |
| version control enabled | pinned constraint applied, six downgraded from 1.17.0 to 1.16.0 |
| version collection | `versions-py3-noble-amd64` produced, previously absent |

Regression on the shared helper, comparing the argument list built by `run_pip_command`:

| case | arguments |
| --- | --- |
| pip3, unchanged path | `--default-timeout 60 install six -c <file> --no-build-isolation` |
| uv | `pip install six -c <file> --no-build-isolation` |
| version control disabled | `install six` |

The pip3 case is byte for byte identical to what the helper produced before this change.

uv option compatibility was checked individually: `-c`, `--no-build-isolation` and `--cache-dir` are accepted, `--default-timeout` is not, which is why it is now conditional.

#### Description for the changelog

Fix python version control and version collection for images built with uv

#### Link to config_db schema for YANG module changes

N/A
