### PR TITLE
[cache validation] [scripts/dpkg-cache]: Static build-cache-key completeness analysis and CI pipelines

### DIFF
--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -79,7 +79,7 @@ stages:
         make clean
         make configure PLATFORM=${{ parameters.platform }}
         make SONIC_DPKG_CACHE_METHOD=rcache \
-             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache \
+             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/${{ parameters.platform }} \
              SONIC_BUILD_JOBS=$(nproc) ${{ parameters.buildTarget }}
         mkdir -p "$(Build.ArtifactStagingDirectory)/treeC"
         cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -108,7 +108,7 @@ stages:
           platform: marvell-prestera
           arch: arm64
           cacheNs: marvell-prestera-arm64
-          buildTarget: target/sonic-marvell-prestera.bin
+          buildTarget: target/sonic-marvell-prestera-arm64.bin
         nvidia-bluefield:
           platform: nvidia-bluefield
           arch: arm64
@@ -131,6 +131,6 @@ stages:
           platform: marvell-prestera
           arch: armhf
           cacheNs: marvell-prestera-armhf
-          buildTarget: target/sonic-marvell-prestera.bin
+          buildTarget: target/sonic-marvell-prestera-armhf.bin
     steps:
     - template: cache-equivalence-steps.yml

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -18,21 +18,16 @@
 #      regression and fails the pipeline.
 #   6. Publish the baseline + comparison + audit reports as pipeline artifacts.
 #
-# Scope is intentionally narrow (vs / one arch) to keep runtime bounded; widen
-# via the parameters once it is proven.
+# Scope: ALL amd64 ASIC platforms. Each platform runs as its own matrix leg
+# (A/B/C build + compare), so a cache regression on any platform turns THIS
+# pipeline red without gating developer PRs. The legs are independent and run
+# in parallel up to `maxParallel`. arm64/armhf platforms (e.g. pensando,
+# centec-arm64, marvell armhf) and vendor-SDK-gated platforms (cisco) are
+# omitted because they need a different agent pool / restricted SDK access;
+# add a leg with the appropriate `pool` when that hardware is available.
 #
 # Modeled on the existing .azure-pipelines/official-build-cache.yml conventions
 # (self-hosted 1ES pool, GitHub resource, schedule-only trigger).
-
-parameters:
-- name: platform
-  displayName: 'Platform to build'
-  type: string
-  default: vs
-- name: buildTarget
-  displayName: 'Make target to compare'
-  type: string
-  default: target/sonic-vs.img.gz
 
 schedules:
 - cron: "0 6 * * 0"            # weekly, Sunday 06:00 UTC
@@ -60,6 +55,35 @@ stages:
   - job: equivalence
     displayName: 'Fresh (no-cache) vs cached (rcache) equivalence'
     timeoutInMinutes: 600      # from-scratch build is slow by design
+    strategy:
+      # One leg per amd64 ASIC platform. `platform` feeds `make PLATFORM=` and
+      # the NFS cache namespace; `buildTarget` is the installer target compared.
+      maxParallel: 4
+      matrix:
+        vs:
+          platform: vs
+          buildTarget: target/sonic-vs.img.gz
+        broadcom:
+          platform: broadcom
+          buildTarget: target/sonic-broadcom.bin
+        mellanox:
+          platform: mellanox
+          buildTarget: target/sonic-mellanox.bin
+        marvell-prestera:
+          platform: marvell-prestera
+          buildTarget: target/sonic-marvell-prestera.bin
+        marvell-teralynx:
+          platform: marvell-teralynx
+          buildTarget: target/sonic-marvell-teralynx.bin
+        barefoot:
+          platform: barefoot
+          buildTarget: target/sonic-barefoot.bin
+        centec:
+          platform: centec
+          buildTarget: target/sonic-centec.bin
+        nephos:
+          platform: nephos
+          buildTarget: target/sonic-nephos.bin
     workspace:
       clean: all
     steps:
@@ -70,9 +94,9 @@ stages:
     - script: |
         set -e
         make init
-        make configure PLATFORM=${{ parameters.platform }}
+        make configure PLATFORM=$(platform)
         make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
-             ${{ parameters.buildTarget }}
+             $(buildTarget)
         mkdir -p "$(Build.ArtifactStagingDirectory)/treeA"
         cp -r target "$(Build.ArtifactStagingDirectory)/treeA/"
       displayName: 'Build A (from scratch, no cache)'
@@ -82,9 +106,9 @@ stages:
     - script: |
         set -e
         make clean
-        make configure PLATFORM=${{ parameters.platform }}
+        make configure PLATFORM=$(platform)
         make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
-             ${{ parameters.buildTarget }}
+             $(buildTarget)
         mkdir -p "$(Build.ArtifactStagingDirectory)/treeB"
         cp -r target "$(Build.ArtifactStagingDirectory)/treeB/"
       displayName: 'Build B (from scratch, no cache — baseline pair)'
@@ -93,10 +117,10 @@ stages:
     - script: |
         set -e
         make clean
-        make configure PLATFORM=${{ parameters.platform }}
+        make configure PLATFORM=$(platform)
         make SONIC_DPKG_CACHE_METHOD=rcache \
-             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/${{ parameters.platform }} \
-             SONIC_BUILD_JOBS=$(nproc) ${{ parameters.buildTarget }}
+             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(platform) \
+             SONIC_BUILD_JOBS=$(nproc) $(buildTarget)
         mkdir -p "$(Build.ArtifactStagingDirectory)/treeC"
         cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"
       displayName: 'Build C (rcache)'
@@ -128,12 +152,12 @@ stages:
       displayName: 'Verify cache equivalence (A vs C, this-run baseline)'
 
     - publish: $(Build.ArtifactStagingDirectory)/baseline
-      artifact: cache-equivalence-baseline
+      artifact: cache-equivalence-baseline-$(platform)
       displayName: 'Publish this-run non-determinism baseline'
       condition: always()
 
     - publish: $(Build.ArtifactStagingDirectory)/report
-      artifact: cache-equivalence-report
+      artifact: cache-equivalence-report-$(platform)
       displayName: 'Publish comparison report'
       condition: always()
 
@@ -155,6 +179,6 @@ stages:
       condition: always()
 
     - publish: $(Build.ArtifactStagingDirectory)/audit
-      artifact: cache-key-audit-report
+      artifact: cache-key-audit-report-$(platform)
       displayName: 'Publish cache-key audit report'
       condition: always()

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -144,7 +144,7 @@ stages:
     # that the per-PR Tier 1 gate did not (e.g. gaps merged before it was armed).
     # Whole-tree mode exits 0 by design; this step is a report, not a gate.
     - script: |
-        set -e
+        set -eo pipefail
         chmod +x scripts/audit_dep_completeness.sh
         mkdir -p "$(Build.ArtifactStagingDirectory)/audit"
         ./scripts/audit_dep_completeness.sh --json \

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -1,0 +1,107 @@
+# Tier 2 - Standalone scheduled dpkg cache-equivalence pipeline.
+#
+# Sole purpose: prove that a cache-accelerated build is equivalent to a fresh
+# from-scratch build. This is DELIBERATELY a separate pipeline (not part of the
+# PR/build pipelines): it is expensive (hours), runs on a schedule, and is OFF
+# the PR critical path - a mismatch marks THIS pipeline red and notifies owners,
+# it never gates a developer's PR.
+#
+# Flow:
+#   1. Build a target set FROM SCRATCH (no cache)      -> tree A ("truth")
+#   2. Build the same target set WITH cache (rcache)   -> tree C ("what devs get")
+#   3. Compare A vs C with scripts/verify_cache_equivalence.sh against a pinned
+#      fresh-vs-fresh non-determinism baseline
+#   4. Publish the comparison report as a pipeline artifact
+#   5. Any SEMANTIC diff (not explained by the baseline) fails the pipeline
+#
+# Scope is intentionally narrow (vs / one arch) to keep runtime bounded; widen
+# via the parameters once it is proven.
+#
+# Modeled on the existing .azure-pipelines/official-build-cache.yml conventions
+# (self-hosted 1ES pool, GitHub resource, schedule-only trigger).
+
+parameters:
+- name: platform
+  displayName: 'Platform to build'
+  type: string
+  default: vs
+- name: buildTarget
+  displayName: 'Make target to compare'
+  type: string
+  default: target/sonic-vs.img.gz
+
+schedules:
+- cron: "0 6 * * 0"            # weekly, Sunday 06:00 UTC
+  displayName: Weekly cache-equivalence check
+  branches:
+    include:
+    - master
+  always: true
+
+resources:
+  repositories:
+  - repository: buildimage
+    type: github
+    name: sonic-net/sonic-buildimage
+    ref: master
+    endpoint: sonic-net
+
+trigger: none                  # never runs on push
+pr: none                       # never runs on PRs
+
+stages:
+- stage: CacheEquivalence
+  pool: sonicso1ES-amd64
+  jobs:
+  - job: equivalence
+    displayName: 'Fresh (no-cache) vs cached (rcache) equivalence'
+    timeoutInMinutes: 600      # from-scratch build is slow by design
+    workspace:
+      clean: all
+    steps:
+    - checkout: buildimage
+      submodules: recursive
+
+    # --- Tree A: fresh, from scratch (NO cache) ---
+    - script: |
+        set -e
+        make init
+        make configure PLATFORM=${{ parameters.platform }}
+        make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
+             ${{ parameters.buildTarget }}
+        mkdir -p "$(Build.ArtifactStagingDirectory)/treeA"
+        cp -r target "$(Build.ArtifactStagingDirectory)/treeA/"
+      displayName: 'Build A (from scratch, no cache)'
+
+    # --- Tree C: same targets, WITH cache (rcache) ---
+    - script: |
+        set -e
+        make clean
+        make configure PLATFORM=${{ parameters.platform }}
+        make SONIC_DPKG_CACHE_METHOD=rcache \
+             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache \
+             SONIC_BUILD_JOBS=$(nproc) ${{ parameters.buildTarget }}
+        mkdir -p "$(Build.ArtifactStagingDirectory)/treeC"
+        cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"
+      displayName: 'Build C (rcache)'
+
+    # --- Compare A vs C (fails on SEMANTIC diff not explained by baseline) ---
+    - script: |
+        set -e
+        chmod +x scripts/verify_cache_equivalence.sh
+        BASELINE_ARG=""
+        if [ -f scripts/cache-equivalence-baseline.json ]; then
+          BASELINE_ARG="--baseline scripts/cache-equivalence-baseline.json"
+        fi
+        ./scripts/verify_cache_equivalence.sh \
+          --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
+          --dir-b "$(Build.ArtifactStagingDirectory)/treeC/target" \
+          --level 1,2,3,5 \
+          $BASELINE_ARG \
+          --json --output-dir "$(Build.ArtifactStagingDirectory)/report"
+      displayName: 'Verify cache equivalence (A vs C)'
+
+    - publish: $(Build.ArtifactStagingDirectory)/report
+      artifact: cache-equivalence-report
+      displayName: 'Publish comparison report'
+      condition: always()

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -105,3 +105,25 @@ stages:
       artifact: cache-equivalence-report
       displayName: 'Publish comparison report'
       condition: always()
+
+    # --- Weekly static audit: surface NEW cache-key completeness gaps ---
+    # Complements the equivalence proof above: the equivalence run shows whether
+    # today's cache is honest, while this static audit tracks the completeness
+    # backlog (P1/P2/P3) week over week so owners can spot newly introduced gaps
+    # that the per-PR Tier 1 gate did not (e.g. gaps merged before it was armed).
+    # Whole-tree mode exits 0 by design; this step is a report, not a gate.
+    - script: |
+        set -e
+        chmod +x scripts/audit_dep_completeness.sh
+        mkdir -p "$(Build.ArtifactStagingDirectory)/audit"
+        ./scripts/audit_dep_completeness.sh --json \
+          > "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.json"
+        ./scripts/audit_dep_completeness.sh --verbose 2>&1 \
+          | tee "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.txt"
+      displayName: 'Audit dep completeness (whole-tree gap report)'
+      condition: always()
+
+    - publish: $(Build.ArtifactStagingDirectory)/audit
+      artifact: cache-key-audit-report
+      displayName: 'Publish cache-key audit report'
+      condition: always()

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -18,13 +18,18 @@
 #      regression and fails the pipeline.
 #   6. Publish the baseline + comparison + audit reports as pipeline artifacts.
 #
-# Scope: ALL amd64 ASIC platforms. Each platform runs as its own matrix leg
-# (A/B/C build + compare), so a cache regression on any platform turns THIS
-# pipeline red without gating developer PRs. The legs are independent and run
-# in parallel up to `maxParallel`. arm64/armhf platforms (e.g. pensando,
-# centec-arm64, marvell armhf) and vendor-SDK-gated platforms (cisco) are
-# omitted because they need a different agent pool / restricted SDK access;
-# add a leg with the appropriate `pool` when that hardware is available.
+# Scope: ALL platforms that have a populated dpkg cache (the official cache
+# allow-list in azure-pipelines-image-template.yml). Each platform runs as its
+# own matrix leg (A/B/C build + compare), so a cache regression on any platform
+# turns THIS pipeline red without gating developer PRs. Because Azure DevOps
+# selects the agent pool per-job, the legs are grouped into one job per arch:
+#   amd64 (sonicso1ES-amd64): vs, broadcom, mellanox, vpp, alpinevs
+#   arm64 (sonicso1ES-arm64): marvell-prestera-arm64, nvidia-bluefield
+#   armhf (sonicso1ES-armhf): marvell-prestera-armhf
+# Platforms with NO populated cache (barefoot, centec, nephos, marvell-teralynx,
+# plain marvell-prestera, pensando, ...) are intentionally excluded: their
+# "cached" build would just be another fresh build, so an A-vs-C comparison
+# proves nothing. Add a leg here if/when such a platform starts being cached.
 #
 # Modeled on the existing .azure-pipelines/official-build-cache.yml conventions
 # (self-hosted 1ES pool, GitHub resource, schedule-only trigger).
@@ -50,135 +55,82 @@ pr: none                       # never runs on PRs
 
 stages:
 - stage: CacheEquivalence
-  pool: sonicso1ES-amd64
   jobs:
-  - job: equivalence
-    displayName: 'Fresh (no-cache) vs cached (rcache) equivalence'
+  # --- amd64 platforms -------------------------------------------------------
+  - job: equivalence_amd64
+    displayName: 'Cache equivalence (amd64)'
+    pool: sonicso1ES-amd64
     timeoutInMinutes: 600      # from-scratch build is slow by design
+    workspace:
+      clean: all
     strategy:
-      # One leg per amd64 ASIC platform. `platform` feeds `make PLATFORM=` and
-      # the NFS cache namespace; `buildTarget` is the installer target compared.
-      maxParallel: 4
+      maxParallel: 3
       matrix:
         vs:
           platform: vs
+          arch: amd64
+          cacheNs: vs
           buildTarget: target/sonic-vs.img.gz
         broadcom:
           platform: broadcom
+          arch: amd64
+          cacheNs: broadcom
           buildTarget: target/sonic-broadcom.bin
         mellanox:
           platform: mellanox
+          arch: amd64
+          cacheNs: mellanox
           buildTarget: target/sonic-mellanox.bin
-        marvell-prestera:
-          platform: marvell-prestera
-          buildTarget: target/sonic-marvell-prestera.bin
-        marvell-teralynx:
-          platform: marvell-teralynx
-          buildTarget: target/sonic-marvell-teralynx.bin
-        barefoot:
-          platform: barefoot
-          buildTarget: target/sonic-barefoot.bin
-        centec:
-          platform: centec
-          buildTarget: target/sonic-centec.bin
-        nephos:
-          platform: nephos
-          buildTarget: target/sonic-nephos.bin
+        vpp:
+          platform: vpp
+          arch: amd64
+          cacheNs: vpp
+          buildTarget: target/sonic-vpp.img.gz
+        alpinevs:
+          platform: alpinevs
+          arch: amd64
+          cacheNs: alpinevs
+          buildTarget: target/sonic-alpinevs.img.gz
+    steps:
+    - template: cache-equivalence-steps.yml
+
+  # --- arm64 platforms -------------------------------------------------------
+  - job: equivalence_arm64
+    displayName: 'Cache equivalence (arm64)'
+    pool: sonicso1ES-arm64
+    timeoutInMinutes: 600
     workspace:
       clean: all
+    strategy:
+      maxParallel: 2
+      matrix:
+        marvell-prestera-arm64:
+          platform: marvell-prestera
+          arch: arm64
+          cacheNs: marvell-prestera-arm64
+          buildTarget: target/sonic-marvell-prestera.bin
+        nvidia-bluefield:
+          platform: nvidia-bluefield
+          arch: arm64
+          cacheNs: nvidia-bluefield
+          buildTarget: target/sonic-nvidia-bluefield.bin
     steps:
-    - checkout: buildimage
-      submodules: recursive
+    - template: cache-equivalence-steps.yml
 
-    # --- Tree A: fresh, from scratch (NO cache) ---
-    - script: |
-        set -e
-        make init
-        make configure PLATFORM=$(platform)
-        make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
-             $(buildTarget)
-        mkdir -p "$(Build.ArtifactStagingDirectory)/treeA"
-        cp -r target "$(Build.ArtifactStagingDirectory)/treeA/"
-      displayName: 'Build A (from scratch, no cache)'
-
-    # --- Tree B: a SECOND fresh, from-scratch build (NO cache) ---
-    # Used to compute the non-determinism baseline for THIS run (A vs B).
-    - script: |
-        set -e
-        make clean
-        make configure PLATFORM=$(platform)
-        make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
-             $(buildTarget)
-        mkdir -p "$(Build.ArtifactStagingDirectory)/treeB"
-        cp -r target "$(Build.ArtifactStagingDirectory)/treeB/"
-      displayName: 'Build B (from scratch, no cache — baseline pair)'
-
-    # --- Tree C: same targets, WITH cache (rcache) ---
-    - script: |
-        set -e
-        make clean
-        make configure PLATFORM=$(platform)
-        make SONIC_DPKG_CACHE_METHOD=rcache \
-             SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(platform) \
-             SONIC_BUILD_JOBS=$(nproc) $(buildTarget)
-        mkdir -p "$(Build.ArtifactStagingDirectory)/treeC"
-        cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"
-      displayName: 'Build C (rcache)'
-
-    # --- Compute the non-determinism baseline for THIS run: fresh A vs fresh B ---
-    # Any SEMANTIC diff between two from-scratch builds is inherent build
-    # non-determinism (timestamps, ar/tar ordering, gzip metadata, ...), NOT a
-    # cache bug. Regenerated every run, so it never goes stale.
-    - script: |
-        set -e
-        chmod +x scripts/verify_cache_equivalence.sh
-        ./scripts/verify_cache_equivalence.sh \
-          --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
-          --dir-b "$(Build.ArtifactStagingDirectory)/treeB/target" \
-          --level 1,2,3,5 \
-          --generate-baseline \
-          --json --output-dir "$(Build.ArtifactStagingDirectory)/baseline"
-      displayName: 'Generate non-determinism baseline (fresh A vs fresh B)'
-
-    # --- Compare A vs C (fails on SEMANTIC diff not explained by baseline) ---
-    - script: |
-        set -e
-        ./scripts/verify_cache_equivalence.sh \
-          --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
-          --dir-b "$(Build.ArtifactStagingDirectory)/treeC/target" \
-          --level 1,2,3,5 \
-          --baseline "$(Build.ArtifactStagingDirectory)/baseline/equivalence-report.json" \
-          --json --output-dir "$(Build.ArtifactStagingDirectory)/report"
-      displayName: 'Verify cache equivalence (A vs C, this-run baseline)'
-
-    - publish: $(Build.ArtifactStagingDirectory)/baseline
-      artifact: cache-equivalence-baseline-$(platform)
-      displayName: 'Publish this-run non-determinism baseline'
-      condition: always()
-
-    - publish: $(Build.ArtifactStagingDirectory)/report
-      artifact: cache-equivalence-report-$(platform)
-      displayName: 'Publish comparison report'
-      condition: always()
-
-    # --- Weekly static audit: surface NEW cache-key completeness gaps ---
-    # Complements the equivalence proof above: the equivalence run shows whether
-    # today's cache is honest, while this static audit tracks the completeness
-    # backlog (P1/P2/P3) week over week so owners can spot newly introduced gaps
-    # that the per-PR Tier 1 gate did not (e.g. gaps merged before it was armed).
-    # Whole-tree mode exits 0 by design; this step is a report, not a gate.
-    - script: |
-        set -eo pipefail
-        chmod +x scripts/audit_dep_completeness.sh
-        mkdir -p "$(Build.ArtifactStagingDirectory)/audit"
-        ./scripts/audit_dep_completeness.sh --json \
-          > "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.json"
-        ./scripts/audit_dep_completeness.sh --verbose 2>&1 \
-          | tee "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.txt"
-      displayName: 'Audit dep completeness (whole-tree gap report)'
-      condition: always()
-
-    - publish: $(Build.ArtifactStagingDirectory)/audit
-      artifact: cache-key-audit-report-$(platform)
-      displayName: 'Publish cache-key audit report'
-      condition: always()
+  # --- armhf platforms -------------------------------------------------------
+  - job: equivalence_armhf
+    displayName: 'Cache equivalence (armhf)'
+    pool: sonicso1ES-armhf
+    timeoutInMinutes: 600
+    workspace:
+      clean: all
+    strategy:
+      maxParallel: 1
+      matrix:
+        marvell-prestera-armhf:
+          platform: marvell-prestera
+          arch: armhf
+          cacheNs: marvell-prestera-armhf
+          buildTarget: target/sonic-marvell-prestera.bin
+    steps:
+    - template: cache-equivalence-steps.yml

--- a/.azure-pipelines/azure-pipelines-cache-equivalence.yml
+++ b/.azure-pipelines/azure-pipelines-cache-equivalence.yml
@@ -8,11 +8,15 @@
 #
 # Flow:
 #   1. Build a target set FROM SCRATCH (no cache)      -> tree A ("truth")
-#   2. Build the same target set WITH cache (rcache)   -> tree C ("what devs get")
-#   3. Compare A vs C with scripts/verify_cache_equivalence.sh against a pinned
-#      fresh-vs-fresh non-determinism baseline
-#   4. Publish the comparison report as a pipeline artifact
-#   5. Any SEMANTIC diff (not explained by the baseline) fails the pipeline
+#   2. Build the SAME target set FROM SCRATCH again     -> tree B ("second truth")
+#   3. Build the same target set WITH cache (rcache)   -> tree C ("what devs get")
+#   4. Compute the non-determinism baseline THIS RUN as the SEMANTIC diffs of the
+#      two fresh builds (A vs B) via --generate-baseline. Nothing is committed or
+#      pinned, so the baseline can never go stale against toolchain/tree drift.
+#   5. Compare A vs C, downgrading any diff already present in the A-vs-B baseline
+#      (inherent non-determinism). Any remaining SEMANTIC diff = a cache-induced
+#      regression and fails the pipeline.
+#   6. Publish the baseline + comparison + audit reports as pipeline artifacts.
 #
 # Scope is intentionally narrow (vs / one arch) to keep runtime bounded; widen
 # via the parameters once it is proven.
@@ -73,6 +77,18 @@ stages:
         cp -r target "$(Build.ArtifactStagingDirectory)/treeA/"
       displayName: 'Build A (from scratch, no cache)'
 
+    # --- Tree B: a SECOND fresh, from-scratch build (NO cache) ---
+    # Used to compute the non-determinism baseline for THIS run (A vs B).
+    - script: |
+        set -e
+        make clean
+        make configure PLATFORM=${{ parameters.platform }}
+        make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
+             ${{ parameters.buildTarget }}
+        mkdir -p "$(Build.ArtifactStagingDirectory)/treeB"
+        cp -r target "$(Build.ArtifactStagingDirectory)/treeB/"
+      displayName: 'Build B (from scratch, no cache — baseline pair)'
+
     # --- Tree C: same targets, WITH cache (rcache) ---
     - script: |
         set -e
@@ -85,21 +101,36 @@ stages:
         cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"
       displayName: 'Build C (rcache)'
 
-    # --- Compare A vs C (fails on SEMANTIC diff not explained by baseline) ---
+    # --- Compute the non-determinism baseline for THIS run: fresh A vs fresh B ---
+    # Any SEMANTIC diff between two from-scratch builds is inherent build
+    # non-determinism (timestamps, ar/tar ordering, gzip metadata, ...), NOT a
+    # cache bug. Regenerated every run, so it never goes stale.
     - script: |
         set -e
         chmod +x scripts/verify_cache_equivalence.sh
-        BASELINE_ARG=""
-        if [ -f scripts/cache-equivalence-baseline.json ]; then
-          BASELINE_ARG="--baseline scripts/cache-equivalence-baseline.json"
-        fi
+        ./scripts/verify_cache_equivalence.sh \
+          --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
+          --dir-b "$(Build.ArtifactStagingDirectory)/treeB/target" \
+          --level 1,2,3,5 \
+          --generate-baseline \
+          --json --output-dir "$(Build.ArtifactStagingDirectory)/baseline"
+      displayName: 'Generate non-determinism baseline (fresh A vs fresh B)'
+
+    # --- Compare A vs C (fails on SEMANTIC diff not explained by baseline) ---
+    - script: |
+        set -e
         ./scripts/verify_cache_equivalence.sh \
           --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
           --dir-b "$(Build.ArtifactStagingDirectory)/treeC/target" \
           --level 1,2,3,5 \
-          $BASELINE_ARG \
+          --baseline "$(Build.ArtifactStagingDirectory)/baseline/equivalence-report.json" \
           --json --output-dir "$(Build.ArtifactStagingDirectory)/report"
-      displayName: 'Verify cache equivalence (A vs C)'
+      displayName: 'Verify cache equivalence (A vs C, this-run baseline)'
+
+    - publish: $(Build.ArtifactStagingDirectory)/baseline
+      artifact: cache-equivalence-baseline
+      displayName: 'Publish this-run non-determinism baseline'
+      condition: always()
 
     - publish: $(Build.ArtifactStagingDirectory)/report
       artifact: cache-equivalence-report

--- a/.azure-pipelines/cache-equivalence-steps.yml
+++ b/.azure-pipelines/cache-equivalence-steps.yml
@@ -1,0 +1,104 @@
+# Shared steps for one cache-equivalence matrix leg. Consumed by each per-pool
+# job in azure-pipelines-cache-equivalence.yml. All per-platform values arrive as
+# runtime matrix variables:
+#   platform    -> make PLATFORM= (the source platform name, e.g. marvell-prestera)
+#   arch        -> make PLATFORM_ARCH= (amd64 / arm64 / armhf)
+#   cacheNs     -> dpkg cache namespace under /nfs/dpkg_cache/ (official GROUP_NAME,
+#                  e.g. marvell-prestera-arm64) and the unique artifact suffix
+#   buildTarget -> installer make target compared (e.g. target/sonic-broadcom.bin)
+steps:
+- checkout: buildimage
+  submodules: recursive
+
+# --- Tree A: fresh, from scratch (NO cache) ---
+- script: |
+    set -e
+    make init
+    make configure PLATFORM=$(platform) PLATFORM_ARCH=$(arch)
+    make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
+         $(buildTarget)
+    mkdir -p "$(Build.ArtifactStagingDirectory)/treeA"
+    cp -r target "$(Build.ArtifactStagingDirectory)/treeA/"
+  displayName: 'Build A (from scratch, no cache)'
+
+# --- Tree B: a SECOND fresh, from-scratch build (NO cache) ---
+# Used to compute the non-determinism baseline for THIS run (A vs B).
+- script: |
+    set -e
+    make clean
+    make configure PLATFORM=$(platform) PLATFORM_ARCH=$(arch)
+    make SONIC_DPKG_CACHE_METHOD=none SONIC_BUILD_JOBS=$(nproc) \
+         $(buildTarget)
+    mkdir -p "$(Build.ArtifactStagingDirectory)/treeB"
+    cp -r target "$(Build.ArtifactStagingDirectory)/treeB/"
+  displayName: 'Build B (from scratch, no cache — baseline pair)'
+
+# --- Tree C: same targets, WITH cache (rcache) ---
+- script: |
+    set -e
+    make clean
+    make configure PLATFORM=$(platform) PLATFORM_ARCH=$(arch)
+    make SONIC_DPKG_CACHE_METHOD=rcache \
+         SONIC_DPKG_CACHE_SOURCE=/nfs/dpkg_cache/$(cacheNs) \
+         SONIC_BUILD_JOBS=$(nproc) $(buildTarget)
+    mkdir -p "$(Build.ArtifactStagingDirectory)/treeC"
+    cp -r target "$(Build.ArtifactStagingDirectory)/treeC/"
+  displayName: 'Build C (rcache)'
+
+# --- Compute the non-determinism baseline for THIS run: fresh A vs fresh B ---
+# Any SEMANTIC diff between two from-scratch builds is inherent build
+# non-determinism (timestamps, ar/tar ordering, gzip metadata, ...), NOT a
+# cache bug. Regenerated every run, so it never goes stale.
+- script: |
+    set -e
+    chmod +x scripts/verify_cache_equivalence.sh
+    ./scripts/verify_cache_equivalence.sh \
+      --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
+      --dir-b "$(Build.ArtifactStagingDirectory)/treeB/target" \
+      --level 1,2,3,5 \
+      --generate-baseline \
+      --json --output-dir "$(Build.ArtifactStagingDirectory)/baseline"
+  displayName: 'Generate non-determinism baseline (fresh A vs fresh B)'
+
+# --- Compare A vs C (fails on SEMANTIC diff not explained by baseline) ---
+- script: |
+    set -e
+    ./scripts/verify_cache_equivalence.sh \
+      --dir-a "$(Build.ArtifactStagingDirectory)/treeA/target" \
+      --dir-b "$(Build.ArtifactStagingDirectory)/treeC/target" \
+      --level 1,2,3,5 \
+      --baseline "$(Build.ArtifactStagingDirectory)/baseline/equivalence-report.json" \
+      --json --output-dir "$(Build.ArtifactStagingDirectory)/report"
+  displayName: 'Verify cache equivalence (A vs C, this-run baseline)'
+
+- publish: $(Build.ArtifactStagingDirectory)/baseline
+  artifact: cache-equivalence-baseline-$(cacheNs)
+  displayName: 'Publish this-run non-determinism baseline'
+  condition: always()
+
+- publish: $(Build.ArtifactStagingDirectory)/report
+  artifact: cache-equivalence-report-$(cacheNs)
+  displayName: 'Publish comparison report'
+  condition: always()
+
+# --- Weekly static audit: surface NEW cache-key completeness gaps ---
+# Complements the equivalence proof above: the equivalence run shows whether
+# today's cache is honest, while this static audit tracks the completeness
+# backlog (P1/P2/P3) week over week so owners can spot newly introduced gaps
+# that the per-PR Tier 1 gate did not (e.g. gaps merged before it was armed).
+# Whole-tree mode exits 0 by design; this step is a report, not a gate.
+- script: |
+    set -eo pipefail
+    chmod +x scripts/audit_dep_completeness.sh
+    mkdir -p "$(Build.ArtifactStagingDirectory)/audit"
+    ./scripts/audit_dep_completeness.sh --json \
+      > "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.json"
+    ./scripts/audit_dep_completeness.sh --verbose 2>&1 \
+      | tee "$(Build.ArtifactStagingDirectory)/audit/audit_dep_completeness.txt"
+  displayName: 'Audit dep completeness (whole-tree gap report)'
+  condition: always()
+
+- publish: $(Build.ArtifactStagingDirectory)/audit
+  artifact: cache-key-audit-report-$(cacheNs)
+  displayName: 'Publish cache-key audit report'
+  condition: always()

--- a/.azure-pipelines/cache-key-lint.yml
+++ b/.azure-pipelines/cache-key-lint.yml
@@ -6,11 +6,18 @@
 # reflected in a target's dpkg cache key - the class of bug that lets a cache
 # hit serve a stale artifact.
 #
-# The audit script exits 1 on a P0 finding (a real cache-key gap), 0 otherwise.
+# The audit script exits 1 only on a P0 finding, and P0 is emitted only in
+# diff mode: a P0 is a build-affecting input that a SPECIFIC PR leaves untracked
+# (see DIFF_MODE in scripts/audit_dep_completeness.sh). To gate on PR-introduced
+# gaps, the production stage must pass --base <target-branch> (e.g.
+# --base origin/$(System.PullRequest.TargetBranchName)). A whole-tree run
+# WITHOUT --base (as in this standalone staging definition) reports the existing
+# P1/P2/P3 backlog and exits 0 - it is a report, not a gate.
 #
 # NOTE: this is provided as a standalone pipeline definition for staging/testing.
 # The intended production form is a STAGE added to the PR pipeline
-# (azure-pipelines.yml) so it runs on every pull request.
+# (azure-pipelines.yml) so it runs on every pull request, passing --base so the
+# P0 exit-1 gate is actually armed.
 
 trigger: none
 pr: none
@@ -27,5 +34,7 @@ jobs:
   - script: |
       set -e
       chmod +x scripts/audit_dep_completeness.sh
+      # Whole-tree report (P1/P2/P3, exit 0). In the production PR stage, add
+      # --base origin/$(System.PullRequest.TargetBranchName) to arm the P0 gate.
       ./scripts/audit_dep_completeness.sh --verbose
-    displayName: 'Run audit_dep_completeness.sh (fails on P0 cache-key gap)'
+    displayName: 'Run audit_dep_completeness.sh (whole-tree report; P0 gate needs --base)'

--- a/.azure-pipelines/cache-key-lint.yml
+++ b/.azure-pipelines/cache-key-lint.yml
@@ -15,9 +15,11 @@
 # P1/P2/P3 backlog and exits 0 - it is a report, not a gate.
 #
 # NOTE: this is provided as a standalone pipeline definition for staging/testing.
-# The intended production form is a STAGE added to the PR pipeline
-# (azure-pipelines.yml) so it runs on every pull request, passing --base so the
-# P0 exit-1 gate is actually armed.
+# The production gate is now implemented as the `CacheKeyLint` stage in
+# azure-pipelines.yml: it runs on every pull request and passes
+# --base origin/$(System.PullRequest.TargetBranchName), so the P0 exit-1 gate is
+# armed there. This standalone definition is retained only for manual/staging
+# runs of the whole-tree report.
 
 trigger: none
 pr: none

--- a/.azure-pipelines/cache-key-lint.yml
+++ b/.azure-pipelines/cache-key-lint.yml
@@ -1,0 +1,31 @@
+# Tier 1 - Static dpkg cache-key completeness lint.
+#
+# Purpose: cheap, per-PR guardrail. Runs scripts/audit_dep_completeness.sh, a
+# static analysis (no build) over rules/*.mk and rules/*.dep. It fails when a
+# build-affecting input (feature flag, source file, derived package) is NOT
+# reflected in a target's dpkg cache key - the class of bug that lets a cache
+# hit serve a stale artifact.
+#
+# The audit script exits 1 on a P0 finding (a real cache-key gap), 0 otherwise.
+#
+# NOTE: this is provided as a standalone pipeline definition for staging/testing.
+# The intended production form is a STAGE added to the PR pipeline
+# (azure-pipelines.yml) so it runs on every pull request.
+
+trigger: none
+pr: none
+
+pool:
+  vmImage: 'ubuntu-22.04'
+
+jobs:
+- job: cache_key_lint
+  displayName: 'dpkg cache-key completeness lint'
+  timeoutInMinutes: 10
+  steps:
+  - checkout: self
+  - script: |
+      set -e
+      chmod +x scripts/audit_dep_completeness.sh
+      ./scripts/audit_dep_completeness.sh --verbose
+    displayName: 'Run audit_dep_completeness.sh (fails on P0 cache-key gap)'

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,8 @@ sources.list.*
 
 # Generated mirror configs
 apt-retries-count
+
+# dpkg cache-validation script outputs
+poc-results/
+cache-validation-out/
+poc-run.log

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,36 @@ variables:
     value: $(Build.SourceBranchName)
 
 stages:
+# Tier 1 - per-PR dpkg cache-key completeness gate. Static analysis (no build)
+# over rules/*.mk, rules/*.dep, slave.mk and Makefile.cache. In --base (diff)
+# mode the audit emits a P0 (exit 1) for any build-affecting input the PR
+# changes that is NOT reflected in the target package's dpkg cache key - the
+# class of bug that lets a cache hit serve a stale artifact. Cheap (minutes),
+# runs in parallel with the builds (dependsOn: []), and only on pull requests.
+- stage: CacheKeyLint
+  displayName: 'dpkg cache-key completeness (PR gate)'
+  dependsOn: []
+  condition: eq(variables['Build.Reason'], 'PullRequest')
+  pool:
+    vmImage: 'ubuntu-22.04'
+  jobs:
+  - job: cache_key_lint
+    displayName: 'Audit PR for untracked build-cache inputs'
+    timeoutInMinutes: 15
+    steps:
+    - checkout: self
+      fetchDepth: 0          # full history so --base merge-base resolves
+    - script: |
+        set -e
+        TARGET="$(System.PullRequest.TargetBranchName)"
+        # Ensure the PR target branch is present as origin/<target> for the diff.
+        git fetch --no-tags --prune origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
+        chmod +x scripts/audit_dep_completeness.sh
+        # --base scopes the audit to what THIS PR changes and arms the P0 exit-1
+        # gate; a build-affecting input the PR touches but does not track -> P0.
+        ./scripts/audit_dep_completeness.sh --verbose --base "origin/${TARGET}"
+      displayName: 'audit_dep_completeness.sh --base origin/<target> (fails on new P0)'
+
 - stage: BuildVS
   pool: sonicso1ES-amd64
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,6 +98,7 @@ stages:
 
 - stage: BuildVS
   pool: sonicso1ES-amd64
+  dependsOn: []
   jobs:
   - template: .azure-pipelines/azure-pipelines-build.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -80,9 +80,14 @@ stages:
     steps:
     - checkout: self
       fetchDepth: 0          # full history so --base merge-base + base worktree resolve
+      submodules: recursive  # submodule-owned .mk/.dep (e.g. platform/vpp) must be present for the audit to see them
     - script: |
         set -e
         TARGET="$(System.PullRequest.TargetBranchName)"
+        if [ -z "$TARGET" ]; then
+          echo "##[error]System.PullRequest.TargetBranchName is empty; CacheKeyLint must run on a pull request."
+          exit 1
+        fi
         # Ensure the PR target branch is present as origin/<target> for the diff.
         git fetch --no-tags --prune origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
         chmod +x scripts/audit_dep_completeness.sh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,10 +61,12 @@ variables:
 stages:
 # Tier 1 - per-PR dpkg cache-key completeness gate. Static analysis (no build)
 # over rules/*.mk, rules/*.dep, slave.mk and Makefile.cache. In --base (diff)
-# mode the audit emits a P0 (exit 1) for any build-affecting input the PR
-# changes that is NOT reflected in the target package's dpkg cache key - the
-# class of bug that lets a cache hit serve a stale artifact. Cheap (minutes),
-# runs in parallel with the builds (dependsOn: []), and only on pull requests.
+# mode the audit fails (P0, exit 1) on any completeness gap THIS PR introduces,
+# of ANY class: it re-runs itself against the merge-base tree and escalates every
+# finding that is new at HEAD, while the pre-existing whole-tree backlog stays
+# non-blocking. This catches the class of bug that lets a cache hit serve a stale
+# artifact. Static (no build), runs in parallel with the builds (dependsOn: []),
+# only on pull requests.
 - stage: CacheKeyLint
   displayName: 'dpkg cache-key completeness (PR gate)'
   dependsOn: []
@@ -74,20 +76,20 @@ stages:
   jobs:
   - job: cache_key_lint
     displayName: 'Audit PR for untracked build-cache inputs'
-    timeoutInMinutes: 15
+    timeoutInMinutes: 30       # two static scans (HEAD + merge-base) + a base checkout
     steps:
     - checkout: self
-      fetchDepth: 0          # full history so --base merge-base resolves
+      fetchDepth: 0          # full history so --base merge-base + base worktree resolve
     - script: |
         set -e
         TARGET="$(System.PullRequest.TargetBranchName)"
         # Ensure the PR target branch is present as origin/<target> for the diff.
         git fetch --no-tags --prune origin "+refs/heads/${TARGET}:refs/remotes/origin/${TARGET}"
         chmod +x scripts/audit_dep_completeness.sh
-        # --base scopes the audit to what THIS PR changes and arms the P0 exit-1
-        # gate; a build-affecting input the PR touches but does not track -> P0.
+        # --base arms the P0 exit-1 gate: any completeness gap this PR introduces
+        # (a finding absent at origin/<target>), across all checks, fails here.
         ./scripts/audit_dep_completeness.sh --verbose --base "origin/${TARGET}"
-      displayName: 'audit_dep_completeness.sh --base origin/<target> (fails on new P0)'
+      displayName: 'audit_dep_completeness.sh --base origin/<target> (fails on PR-introduced P0)'
 
 - stage: BuildVS
   pool: sonicso1ES-amd64

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -317,6 +317,16 @@ pkg_label() {
     esac
 }
 
+# True (0) if $1 is a real package .dep (declares cache directives) rather than a
+# pure include-aggregator fragment. Several platforms ship a rules.dep whose whole
+# body is `include $(PLATFORM_PATH)/<pkg>.dep` lines — it defines no package and
+# intentionally carries no CACHE_MODE/DEP_FILES, so per-package checks must not
+# treat it as a package (doing so yields spurious "no CACHE_MODE" / exclusion
+# findings). Decided structurally from the file's own directives, not by name.
+is_package_dep() {
+    grep -qE '(DEP_FILES|SMDEP_FILES|_CACHE_MODE|_DEP_FLAGS)' "$1" 2>/dev/null
+}
+
 # Run the comprehensive whole-tree scanner ONCE (live) and cache its output. The
 # gate classifies on every run from live code — there is no committed trust-store
 # to drift out of date. Output rows: variable<TAB>disposition<TAB>evidence.
@@ -748,15 +758,19 @@ check_exclusion_patterns() {
             continue
         fi
 
+        # Skip pure include-aggregator .dep fragments (not real packages).
+        is_package_dep "$dep_file" || { log_verbose "$base: include-aggregator .dep — skipping"; continue; }
+
         # Look for grep -Ev or grep -v (exclusion patterns)
         local exclusions
         exclusions=$(grep -oP 'grep\s+-[Ev]+\s+"[^"]*"' "$dep_file" 2>/dev/null || true)
 
         if [[ -n "$exclusions" ]]; then
             # Filter out benign patterns:
-            # - `grep -v " "` just removes filenames with spaces (sanitization)
+            # - `grep -v " "` / `grep -Ev " "` just remove filenames with spaces
+            #   (sanitization). Match any -v/-Ev/-vE flag cluster, not just bare -v.
             local is_benign=false
-            if echo "$exclusions" | grep -qP 'grep\s+-v\s+" "'; then
+            if echo "$exclusions" | grep -qP 'grep\s+-[Ev]*v[Ev]*\s+" "'; then
                 is_benign=true
                 log_verbose "$base: Exclusion is just space-filtering (benign)"
             fi
@@ -791,6 +805,9 @@ check_cache_modes() {
         if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
             continue
         fi
+
+        # Skip pure include-aggregator .dep fragments (not real packages).
+        is_package_dep "$dep_file" || { log_verbose "$base: include-aggregator .dep — skipping"; continue; }
 
         if grep -q "GIT_CONTENT_SHA" "$dep_file"; then
             ((content_sha_count++))

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -101,6 +101,30 @@
 #           (c) a second `DEP_FILES :=` (colon-equals, not `+=`) that discards the
 #               already-accumulated common/rule files (rules/eventd.dep).
 #
+# ── Checks 16–17 extend the same "recipe consumes an input outside the key"
+#    principle to the two build targets whose inputs are NOT declared in a
+#    rules/*.dep at all (so Checks 1–15 never look at them): the host
+#    root-filesystem image, and the shared docker build-context tooling. ──
+#
+# Check 16: Host root-filesystem (SONIC_RFS_TARGETS) files consumed by
+#           build_debian.sh (or a script it invokes) but absent from the
+#           hand-maintained RFS_DEP_FILES list in Makefile.cache. The rootfs key
+#           is GIT_CONTENT_SHA over RFS_DEP_FILES, yet build_debian.sh sources
+#           functions.sh, copies files/scripts/*, renders extra
+#           files/build_templates/*.j2, and runs several scripts/*.{sh,py} — none
+#           tracked, so editing them reuses a stale squashfs. Data-driven: parses
+#           the actual RFS_DEP_FILES globs and the actual recipe's file reads.
+#
+# Check 17: Docker build-context generators consumed by EVERY docker image build
+#           but hashed into NO docker cache key. slave.mk runs
+#           scripts/prepare_docker_buildinfo.sh, which invokes
+#           scripts/versions_manager.py / docker_version_control.sh and copies
+#           src/sonic-build-hooks/buildinfo/* into the context. None are in
+#           SONIC_COMMON_FILES_LIST (only .platform rules/functions Makefile.cache)
+#           nor under any image's $(DPATH), so editing them silently reuses stale
+#           images. (The version OUTPUT under files/build/versions/** IS folded in
+#           at Makefile.cache; only the generator logic is untracked.)
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1453,6 +1477,166 @@ check_dep_files_structural() {
         || echo -e "  ${YELLOW}$found structural DEP_FILES bug(s)${NC}"
 }
 
+# --- Check 16: Host root-filesystem files consumed by build_debian.sh but untracked ---
+# The RFS target (SONIC_RFS_TARGETS) keys off a hand-maintained RFS_DEP_FILES
+# wildcard in Makefile.cache — NOT a rules/*.dep — so Checks 1–15 never see it.
+# We parse the real RFS_DEP_FILES coverage (explicit files + `git ls-files DIR`
+# globs) and diff it against the in-repo files build_debian.sh (and the scripts it
+# invokes, transitively over *.sh) actually consumes. Every consumed, git-tracked
+# file outside the coverage is a rootfs cache-key gap.
+check_rfs_untracked_files() {
+    echo -e "\n${CYAN}=== Check 16: Host rootfs files consumed by build_debian.sh but untracked ===${NC}"
+    local found=0
+    if [[ ! -f "$REPO_ROOT/build_debian.sh" ]] || ! grep -qE '^RFS_DEP_FILES[[:space:]]*:?=' "$MAKEFILE_CACHE"; then
+        echo -e "  ${GREEN}N/A — no build_debian.sh / RFS_DEP_FILES in this tree${NC}"
+        return
+    fi
+    if [[ -n "$FILTER_PACKAGE" ]]; then
+        echo -e "  ${GREEN}Skipped (whole-image check) under --package${NC}"
+        return
+    fi
+
+    # 1) RFS_DEP_FILES coverage: explicit file tokens + globbed directories.
+    local block
+    block=$(awk '/^RFS_DEP_FILES[[:space:]]*:?=/{f=1}
+                 f{print}
+                 f && /\)[[:space:]]*$/ && $0 !~ /\\[[:space:]]*$/ {exit}' "$MAKEFILE_CACHE")
+    local glob_dirs explicit
+    glob_dirs=$(echo "$block" | grep -oP 'git ls-files[[:space:]]+\K[A-Za-z0-9._/-]+' | sort -u)
+    explicit=$(echo "$block" | grep -oP '(?<![\w./-])(?:\./)?(?:files|scripts)/[\w./-]+' | sed 's#^\./##' | sort -u)
+    # Expand $(addprefix PFX, a b c) — RFS_DEP_FILES lists some scripts this way,
+    # e.g. $(addprefix scripts/, build_debian_base_system.sh build_mirror_config.sh).
+    local addpre_line pfx items it
+    while IFS= read -r addpre_line; do
+        [[ -z "$addpre_line" ]] && continue
+        pfx="${addpre_line%%,*}"
+        items="${addpre_line#*,}"
+        for it in $items; do
+            [[ -n "$it" ]] && explicit+=$'\n'"${pfx}${it}"
+        done
+    done < <(echo "$block" | grep -oE '\$\(addprefix[[:space:]]+(files|scripts)/[^,]*,[^)]*' \
+                 | sed -E 's/\$\(addprefix[[:space:]]+//')
+
+    # 2) Transitively scan build_debian.sh over the *.sh scripts it invokes,
+    #    collecting every files/… or scripts/… path token it reads/copies/renders.
+    declare -A visited reported
+    local queue=("build_debian.sh") consumed=() cur f tok
+    while [[ ${#queue[@]} -gt 0 ]]; do
+        cur="${queue[0]}"; queue=("${queue[@]:1}")
+        [[ -n "${visited[$cur]:-}" ]] && continue
+        visited[$cur]=1
+        [[ -f "$REPO_ROOT/$cur" ]] || continue
+        f="$REPO_ROOT/$cur"
+        while IFS= read -r tok; do
+            tok="${tok#./}"
+            [[ -z "$tok" ]] && continue
+            consumed+=("$tok")
+            [[ "$tok" == *.sh && -z "${visited[$tok]:-}" ]] && queue+=("$tok")
+        done < <(grep -hoP '(?<![\w./-])(?:\./)?(?:files|scripts)/[\w./-]+' "$f" 2>/dev/null | sort -u)
+        # bare functions.sh consumed only when actually sourced ('. functions.sh')
+        if grep -qE '^[[:space:]]*(\.|source)[[:space:]]+functions\.sh([[:space:]]|$)' "$f" 2>/dev/null; then
+            consumed+=("functions.sh")
+        fi
+    done
+    [[ ${#consumed[@]} -gt 0 ]] || { echo -e "  ${GREEN}None${NC}"; return; }
+
+    # 3) Report each consumed, git-tracked, uncovered file.
+    local cf covered d
+    while IFS= read -r cf; do
+        [[ -z "$cf" || -n "${reported[$cf]:-}" ]] && continue
+        [[ -f "$REPO_ROOT/$cf" ]] || continue
+        [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$cf" 2>/dev/null)" ]] || continue
+        [[ "$cf" == "build_debian.sh" || "$cf" == "onie-image.conf" ]] && continue
+        echo "$explicit" | grep -qxF "$cf" && continue
+        covered=0
+        while IFS= read -r d; do
+            [[ -z "$d" ]] && continue
+            [[ "$cf" == "$d/"* ]] && { covered=1; break; }
+        done <<< "$glob_dirs"
+        [[ $covered -eq 1 ]] && continue
+        reported[$cf]=1
+        add_finding "P1" "sonic-rootfs (RFS)" \
+            "build_debian.sh (or a script it invokes) consumes in-repo file '$cf', but it is not in RFS_DEP_FILES / SONIC_COMMON_BASE_FILES_LIST — the host rootfs/squashfs cache key ignores it, so editing '$cf' reuses a stale image" \
+            "Add '$cf' to RFS_DEP_FILES in Makefile.cache (or a \$(shell git ls-files <dir>) glob that covers it)"
+        ((found++))
+    done < <(printf '%s\n' "${consumed[@]}" | sort -u)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — rootfs recipe inputs are all tracked${NC}" \
+        || echo -e "  ${YELLOW}$found rootfs input(s) consumed but untracked${NC}"
+}
+
+# --- Check 17: Docker build-context generators not hashed into any docker key ---
+# Every docker image build runs scripts/prepare_docker_buildinfo.sh (slave.mk),
+# which transitively invokes other scripts/*.{sh,py} and copies build-hooks
+# buildinfo into the image build context. None of these live under an image's
+# $(DPATH) nor in SONIC_COMMON_FILES_LIST, so they are in NO docker cache key —
+# editing the generator logic reuses stale images. Data-driven: seed from the
+# docker recipe in slave.mk, take the transitive closure over invoked scripts,
+# and flag any that the docker key (SONIC_COMMON_FILES_LIST) does not contain.
+check_docker_buildinfo_tracking() {
+    echo -e "\n${CYAN}=== Check 17: Docker build-context generators not in any docker key ===${NC}"
+    local found=0
+    [[ -f "$REPO_ROOT/slave.mk" ]] || { echo -e "  ${GREEN}N/A — no slave.mk${NC}"; return; }
+    if [[ -n "$FILTER_PACKAGE" ]]; then
+        echo -e "  ${GREEN}Skipped (whole-image check) under --package${NC}"
+        return
+    fi
+
+    # Docker-key common files (folded into every SONIC_DOCKER_IMAGES key).
+    local common_files
+    common_files=$(grep -E 'SONIC_COMMON_FILES_LIST[[:space:]]*:?=' "$MAKEFILE_CACHE" | head -1)
+
+    # Seed: the build-context preparer(s) the docker recipe runs in slave.mk.
+    local seeds
+    seeds=$(grep -hoP '(?<![\w./-])scripts/[\w./-]+\.(?:sh|py)' "$REPO_ROOT/slave.mk" 2>/dev/null \
+              | grep -iE 'docker.*buildinfo|buildinfo.*docker' | sort -u)
+    [[ -n "$seeds" ]] || { echo -e "  ${GREEN}None — no docker build-context preparer found${NC}"; return; }
+
+    # Transitive closure over invoked scripts + build-context copies from src/.
+    declare -A visited
+    local queue=() consumed_scripts=() consumed_trees=() s cur f ref
+    while IFS= read -r s; do [[ -n "$s" ]] && queue+=("$s"); done <<< "$seeds"
+    while [[ ${#queue[@]} -gt 0 ]]; do
+        cur="${queue[0]}"; queue=("${queue[@]:1}")
+        [[ -n "${visited[$cur]:-}" ]] && continue
+        visited[$cur]=1
+        [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$cur" 2>/dev/null)" ]] || continue
+        consumed_scripts+=("$cur")
+        f="$REPO_ROOT/$cur"
+        while IFS= read -r ref; do
+            [[ -n "$ref" && -z "${visited[$ref]:-}" ]] && queue+=("$ref")
+        done < <(grep -hoP '(?<![\w./-])scripts/[\w./-]+\.(?:sh|py)' "$f" 2>/dev/null | sort -u)
+        while IFS= read -r ref; do
+            [[ -n "$ref" ]] && consumed_trees+=("${ref%/}")
+        done < <(grep -hoE 'src/[A-Za-z0-9._/-]+/buildinfo(/[A-Za-z0-9._/-]*)?' "$f" 2>/dev/null | sort -u)
+    done
+
+    # Report each consumed script/tree not present in the docker key.
+    declare -A reported
+    local item base_tree
+    for item in "${consumed_scripts[@]}"; do
+        [[ -n "${reported[$item]:-}" ]] && continue
+        echo "$common_files" | grep -qE "(^| )$(printf '%s' "$item" | sed 's/[.[]/\\&/g')( |$)" && continue
+        reported[$item]=1
+        add_finding "P2" "docker-images (all)" \
+            "Docker build-context generator '$item' is invoked by every docker build (via scripts/prepare_docker_buildinfo.sh in slave.mk) but is not in any docker cache key (absent from SONIC_COMMON_FILES_LIST and every image's \$(DPATH)) — editing it changes the generated build context/version state without invalidating any image" \
+            "Fold the docker build-context generators into SONIC_COMMON_FILES_LIST (or a shared docker DEP_FILES list) in Makefile.cache"
+        ((found++))
+    done
+    # De-dup build-context trees to their top-level buildinfo dir.
+    for item in "${consumed_trees[@]}"; do
+        base_tree=$(echo "$item" | grep -oE 'src/[A-Za-z0-9._/-]+/buildinfo' | head -1)
+        [[ -z "$base_tree" || -n "${reported[$base_tree]:-}" ]] && continue
+        [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$base_tree" 2>/dev/null | head -1)" ]] || continue
+        reported[$base_tree]=1
+        add_finding "P2" "docker-images (all)" \
+            "Build-context tree '$base_tree/' is copied into every docker build context by scripts/prepare_docker_buildinfo.sh but is not in any docker cache key — editing these build hooks reuses stale images" \
+            "Hash '$base_tree' (git ls-files) into a shared docker DEP_FILES list in Makefile.cache"
+        ((found++))
+    done
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — docker build-context tooling is tracked${NC}" \
+        || echo -e "  ${YELLOW}$found docker build-context input(s) untracked${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -1557,6 +1741,8 @@ main() {
     check_untracked_source_tree
     check_moving_refs
     check_dep_files_structural
+    check_rfs_untracked_files
+    check_docker_buildinfo_tracking
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -231,6 +231,14 @@
 #           affected output without moving any cache key. Data-driven: enumerate the
 #           scripts referenced in recipes and verify each is hashed by a file list.
 #
+# Check 29: embed-without-edge. A package's debian/rules extracts a SIBLING built deb
+#           (dpkg -x of target/debs/<env>/<name>_*.deb) and copies content out of it,
+#           yet declares no _DEPENDS edge on <name>. The embedded binary is baked into
+#           the package but rebuilding <name> does not invalidate this package's key,
+#           so it is served stale. Data-driven: map each embedding debian/rules back to
+#           its owning rules .mk (via _SRC_PATH), and flag every embedded sibling whose
+#           name is absent from the aggregated _DEPENDS/_RDEPENDS of that package.
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2327,6 +2335,45 @@ check_recipe_invoked_scripts() {
         || echo -e "  ${YELLOW}$found untracked build-script(s)${NC}"
 }
 
+check_embedded_sibling_deb() {
+    echo -e "\n${CYAN}=== Check 29: package embeds a sibling deb with no _DEPENDS edge ===${NC}"
+    local found=0
+    # A debian/rules that dpkg-extracts a sibling built artifact
+    # (target/debs/<env>/<name>_*.deb) and copies content out of it bakes that binary
+    # into the package. Without a _DEPENDS edge on <name>, rebuilding <name> leaves
+    # this package's cache key unchanged and it is served stale.
+    local rulesfile srcdir base names name mk_all deplines candidates
+    candidates=$(grep -rlE "target/debs/[^ ]*_[^ ]*\.deb" \
+        "$REPO_ROOT"/src/*/debian/rules \
+        "$REPO_ROOT"/platform/*/*/debian/rules 2>/dev/null)
+    while IFS= read -r rulesfile; do
+        [[ -n "$rulesfile" ]] || continue
+        srcdir=$(dirname "$(dirname "$rulesfile")")      # strip /debian/rules
+        base=$(basename "$srcdir")
+        names=$(grep -oE "target/debs/[^ ]*/[a-z0-9.+_-]+_[^ ]*\.deb" "$rulesfile" \
+            | sed -E 's#.*/##; s/_.*//' | sort -u)
+        [[ -n "$names" ]] || continue
+        # Owning rules .mk(s): more than one platform .mk may reuse the same source
+        # dir, so aggregate the dependency edges declared across ALL of them.
+        mk_all=$(grep -rlE "_SRC_PATH[[:space:]]*[:+]?=.*$base" \
+            "$REPO_ROOT"/rules/*.mk "$REPO_ROOT"/platform/*/*.mk 2>/dev/null)
+        deplines=""
+        for mk in $mk_all; do
+            deplines+=$'\n'$(grep -hE "_R?DEPENDS" "$mk" 2>/dev/null)
+        done
+        for name in $names; do
+            # Dep edge present if any DEPENDS/RDEPENDS token names the sibling.
+            echo "$deplines" | grep -iq "$name" && continue
+            add_finding "P2" "$base" \
+                "$base's debian/rules extracts sibling artifact '$name' (dpkg -x of target/debs/.../${name}_*.deb) and copies content into the package, but declares no _DEPENDS edge on '$name' — rebuilding '$name' does not invalidate $base's cache key, serving a stale embed" \
+                "Add the '$name' package variable to $base's _DEPENDS so the embedded sibling participates in the cache key"
+            ((found++))
+        done
+    done <<< "$candidates"
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — embedded sibling debs have dep edges${NC}" \
+        || echo -e "  ${YELLOW}$found embed-without-edge gap(s)${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -2443,6 +2490,7 @@ main() {
     check_slave_toolchain_identity
     check_build_mode_selectors
     check_recipe_invoked_scripts
+    check_embedded_sibling_deb
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -125,19 +125,28 @@
 #           images. (The version OUTPUT under files/build/versions/** IS folded in
 #           at Makefile.cache; only the generator logic is untracked.)
 #
-# ── Checks 18–19 close two further "consumed input outside the key" gaps that an
+# ── Check 19 closes a further "consumed input outside the key" gap that an
 #    independent multi-model audit surfaced after Checks 16–17. ──
 #
-# Check 18: Docker _INSTALL_PYTHON_WHEELS / _INSTALL_DEBS packages are installed
-#           into the image by slave.mk's docker recipe, but Makefile.cache's
-#           docker dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) folds
-#           only _DEPENDS/_RDEPENDS/_WHEEL_DEPENDS/_PYTHON_DEBS/_PYTHON_WHEELS/
-#           _DBG_DEPENDS/_DBG_IMAGE_PACKAGES/_LOAD_DOCKERS — never the two
-#           _INSTALL_* lists. So a wheel/deb embedded via _INSTALL_* has its
-#           content SHA absent from the docker key (e.g. docker-eventd installs
-#           sonic-utilities + python3-swsscommon this way). Evidence-gated on the
-#           real MOD_DEP_PKGS body; packages also present in a folded role are not
-#           flagged.
+# Check 18: (invariant verifier — NOT a gap) Docker _INSTALL_PYTHON_WHEELS /
+#           _INSTALL_DEBS packages are NOT baked into the image, so Makefile.cache's
+#           docker dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) correctly
+#           omits them. A multi-model review (opus/gpt/gemini, unanimous) plus direct
+#           tracing established: slave.mk's docker recipe lists _INSTALL_* only as
+#           "%-install" PREREQUISITES (slave.mk ~L1237-1238); those %-install rules
+#           run `dpkg -i` / `pip install` on the build HOST, never inside the image.
+#           The image content is produced solely from the j2 vars _debs/_whls/_pydebs,
+#           which derive strictly from _DEPENDS/_RDEPENDS, _PYTHON_WHEELS and
+#           _PYTHON_DEBS (slave.mk ~L1263-1265) — _INSTALL_* is never referenced by
+#           any Dockerfile.j2 (proof: docker-gnmi-sidecar declares both _INSTALL_*
+#           lists yet its Dockerfile installs zero packages). Their real purpose is
+#           host-side provisioning for the build-time cli-plugin-tests pytest run
+#           (slave.mk ~L1270). Folding them into the docker key (as an earlier draft
+#           proposed) would only OVER-invalidate the image cache for zero correctness
+#           gain. This check therefore verifies the host-only invariant and flags ONLY
+#           the genuine defect: an _INSTALL_* package that IS also baked into the image
+#           (appears in an image-content role) yet is somehow not folded — a condition
+#           that does not currently occur.
 #
 # Check 19: An online-deb target that reuses another target's HTTP header
 #           fingerprint (wget --spider --server-response, used to defeat a moving
@@ -1751,27 +1760,48 @@ check_docker_buildinfo_tracking() {
         || echo -e "  ${YELLOW}$found docker build-context input(s) untracked${NC}"
 }
 
-# --- Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS not folded into the key ---
-# slave.mk's docker recipe makes each image depend on and install the packages named
-# in $(DOCKER)_INSTALL_PYTHON_WHEELS / _INSTALL_DEBS. But Makefile.cache's docker
-# dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) folds only _DEPENDS,
-# _RDEPENDS, _WHEEL_DEPENDS, _PYTHON_DEBS, _PYTHON_WHEELS, _DBG_DEPENDS,
-# _DBG_IMAGE_PACKAGES and _LOAD_DOCKERS — NOT the two _INSTALL_* lists. So a package
-# embedded via _INSTALL_* has its content SHA absent from the docker key: rebuilding
-# it (e.g. editing sonic-utilities) reuses a stale image. Evidence-gated: the check
-# first reads the real MOD_DEP_PKGS foreach; if the framework already folds the
-# _INSTALL_* lists it auto-silences. A package that ALSO appears in a folded role for
-# the same image is treated as covered (no false positive).
+# --- Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS host-only invariant ---
+# CORRECTED (was a false positive): a docker's $(DOCKER)_INSTALL_PYTHON_WHEELS /
+# _INSTALL_DEBS lists are NOT baked into the produced image, so Makefile.cache's docker
+# dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) is CORRECT to omit them.
+# Ground truth (multi-model review + direct tracing, unanimous):
+#   * slave.mk's docker recipe lists _INSTALL_* only as "%-install" PREREQUISITES
+#     (slave.mk ~L1237-1238). Those %-install rules run `dpkg -i` / `pip install` on the
+#     build HOST (slave.mk ~L940-960, ~L1076-1082), never inside the image.
+#   * The image content is generated solely from the j2 export vars _debs/_whls/_pydebs,
+#     which slave.mk populates strictly from _DEPENDS/_RDEPENDS, _PYTHON_WHEELS and
+#     _PYTHON_DEBS (slave.mk ~L1263-1265). No Dockerfile.j2 ever references _INSTALL_*
+#     (proof: docker-gnmi-sidecar declares both _INSTALL_* lists yet its Dockerfile
+#     installs zero packages).
+#   * Their real purpose is host-side provisioning for the build-time cli-plugin-tests
+#     pytest run (slave.mk ~L1270). Folding them into the docker key would only
+#     OVER-invalidate the image cache (busting e.g. every dhcp-relay/eventd/macsec image
+#     on any sonic-utilities change) for zero correctness gain.
+# This check therefore VERIFIES the host-only invariant. It stays silent in the normal
+# case and re-activates real gap detection ONLY if slave.mk is ever changed so that the
+# image-content j2 exports (_debs/_whls/_pydebs) start deriving from an _INSTALL_* list —
+# at which point those packages genuinely enter the image and must be folded into the key.
 check_docker_install_pkgs_unhashed() {
-    echo -e "\n${CYAN}=== Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS not folded into docker key ===${NC}"
+    echo -e "\n${CYAN}=== Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS host-only invariant ===${NC}"
     local found=0
     if [[ -n "$FILTER_PACKAGE" ]]; then
         echo -e "  ${GREEN}Skipped (whole-image check) under --package${NC}"; return
     fi
     [[ -f "$MAKEFILE_CACHE" ]] || { echo -e "  ${GREEN}N/A — no Makefile.cache${NC}"; return; }
+    local slave_mk="$REPO_ROOT/slave.mk"
+    [[ -f "$slave_mk" ]] || { echo -e "  ${GREEN}N/A — no slave.mk${NC}"; return; }
 
-    # Evidence gate: is the docker dependency-SHA rollup already folding the
-    # _INSTALL_* lists? If so, there is no gap (auto-silences once fixed).
+    # Invariant gate: are _INSTALL_* packages actually baked into the image? They are
+    # only if slave.mk's image-content j2 exports (_debs=/_whls=/_pydebs=) reference an
+    # _INSTALL_* list. In the current build they do not — the packages are host-only.
+    if ! grep -E '_(debs|whls|pydebs)[[:space:]]*=' "$slave_mk" | grep -q 'INSTALL_PYTHON_WHEELS\|INSTALL_DEBS'; then
+        echo -e "  ${GREEN}None — _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS install to the build host for cli-plugin-tests (pytest) and are never baked into the image; correctly excluded from the docker key.${NC}"
+        return
+    fi
+
+    # slave.mk now bakes _INSTALL_* content into the image -> those packages MUST be
+    # folded into the docker key. Re-apply gap detection, unless GET_MOD_DEP_SHA already
+    # folds the _INSTALL_* lists (auto-silences once fixed there too).
     local fold_block
     fold_block=$(grep -A8 '_MOD_DEP_PKGS[[:space:]]*:=' "$MAKEFILE_CACHE" | head -10)
     if echo "$fold_block" | grep -q 'INSTALL_PYTHON_WHEELS\|INSTALL_DEBS'; then
@@ -1804,14 +1834,14 @@ check_docker_install_pkgs_unhashed() {
         for key in "${!installed[@]}"; do
             var="${key%%|*}"; rest="${key#*|}"; kind="${rest%%|*}"; tok="${rest#*|}"
             add_finding "P1" "$(pkg_label "$mk")" \
-                "Docker '$var' installs package $tok into the image via _INSTALL_${kind} (slave.mk installs it at build time) but Makefile.cache GET_MOD_DEP_SHA does not fold _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS into the docker cache key — rebuilding $tok changes the image content without changing the docker key (stale-cache risk)" \
+                "Docker '$var' now bakes package $tok into the image via _INSTALL_${kind} (slave.mk image-content export references _INSTALL_*), but Makefile.cache GET_MOD_DEP_SHA does not fold _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS into the docker cache key — rebuilding $tok changes the image content without changing the docker key (stale-cache risk)" \
                 "Add \$(${var}_INSTALL_PYTHON_WHEELS) and \$(${var}_INSTALL_DEBS) to the MOD_DEP_PKGS foreach in Makefile.cache GET_MOD_DEP_SHA (or add $tok to \$(${var})_DEPENDS)"
             ((found++))
         done
     done < <(all_rule_mk_files)
 
     [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — installed wheels/debs are all folded into docker keys${NC}" \
-        || echo -e "  ${YELLOW}$found docker install-package(s) not folded into the docker key${NC}"
+        || echo -e "  ${YELLOW}$found docker install-package(s) baked into the image but not folded into the docker key${NC}"
 }
 
 # --- Check 19: Remote-content fingerprint reused by a target whose URL isn't sampled --

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -67,6 +67,40 @@
 #           Checks 3 and 8 cannot see them. Closes the "export-only" blind spot
 #           (e.g. ENABLE_FRR_TCMALLOC on frr, whose _DEP_FLAGS is common-only).
 #
+# ── The following checks close blind spots an independent multi-model LLM audit
+#    found that the flag-oriented checks above cannot model (file / dep-edge /
+#    non-determinism classes). Each is data-driven and evidence-gated. ──
+#
+# Check 11: Build flags consumed ONLY inside a package's source recipe
+#           (debian/rules, source Makefile, setup.py) but absent from _DEP_FLAGS.
+#           Checks 3/8 only read .mk ifeq blocks and slave.mk; a flag read straight
+#           from the environment inside the submodule recipe (e.g. ENABLE_ASAN in
+#           sonic-sairedis/debian/rules, ENABLE_GCOV in sonic-swss) is invisible to
+#           them, so toggling it silently reuses a stale artifact.
+#
+# Check 12: In-repo Jinja2 templates a Dockerfile.j2 {% include/import/from %}s
+#           but the image's .dep does not track. dockers/dockerfile-macros.j2 is
+#           imported by ~50 images yet lives outside each image's $(DPATH) glob, so
+#           editing the shared macro invalidates almost no image cache.
+#
+# Check 13: Package built from a real source tree (_SRC_PATH set) with caching ON
+#           but whose .dep hashes NO source at all (no _SMDEP_FILES and no
+#           `git ls-files` of the source) — the entire source is outside the key
+#           (e.g. bmcweb / sonic-dbus-bridge in rules/sonic-redfish.dep).
+#
+# Check 14: Moving-ref / non-deterministic fetch behind a stable cache key —
+#           raw/master|main URLs, :latest base images, unpinned `go get`, meson
+#           wrap revision=HEAD/main. The artifact changes upstream while the key
+#           does not, so a stale build is reused (e.g. gobgp `go get`).
+#
+# Check 15: Structural DEP_FILES bugs that silently drop source from the key:
+#           (a) aliasing another package's SPATH-derived DEP_FILES so the package's
+#               OWN source is never hashed (sflowtool/psample, libnss-radius);
+#           (b) `SPATH := $(PKG)_SRC_PATH` missing the inner `$(...)` so the glob
+#               resolves to nothing (platform/mellanox/rshim.dep);
+#           (c) a second `DEP_FILES :=` (colon-equals, not `+=`) that discards the
+#               already-accumulated common/rule files (rules/eventd.dep).
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -459,10 +493,78 @@ flag_forced_off_for_modern_bldenv() {
     ' "$REPO_ROOT/slave.mk" 2>/dev/null
 }
 
+# True (0) if $flag is used in an ifeq/ifneq/if(n)def conditional in the given .mk
+# file — i.e. Check 3 already models it FOR THIS PACKAGE, so Check 11 (source-recipe
+# scan) must not double-report it. Scoped per-package because Check 3 judges each
+# package against its OWN .mk; a flag conditional in a different package's .mk does
+# not cover this one.
+flag_in_mk_conditional() {
+    local flag="$1" mk="$2"
+    [[ -f "$mk" ]] || return 1
+    grep -qE "if(eq|neq|def|ndef)[[:space:]]*\(?\\\$\\(${flag}\\)" "$mk" 2>/dev/null
+}
+
+# True (0) if $flag is an EXPORTED build-env variable (Check 10's whole-tree export
+# scanner lists it), so Check 11 should defer to Check 10 for it (no duplication).
+flag_is_exported() {
+    compute_export_scan || return 1
+    awk -F'\t' -v v="$1" '$1==v {found=1} END{exit(found?0:1)}' <<< "$EXPORT_SCAN_CACHE"
+}
+
 # SONIC_COMMON_FLAGS_LIST contents, computed once (used by classifiers above).
 compute_common_flags_list() {
     COMMON_FLAGS_LIST_CACHE=$(sed -n '/^SONIC_COMMON_FLAGS_LIST/,/[^\\]$/p' "$MAKEFILE_CACHE" \
         | grep -oP '\$\(\w+\)' | tr -d '$()' | sort -u)
+}
+
+# Resolve the on-disk source directory a package's *_SRC_PATH points at, from its
+# .mk. Only the unambiguous `$(SRC_PATH)/<literal>` and `$(PLATFORM_PATH)/<literal>`
+# forms are resolved (SRC_PATH=src; PLATFORM_PATH=platform/<vendor>); nested-variable
+# forms (e.g. $($(X)_SRC_PATH)) are intentionally left unresolved and skipped so the
+# checks never guess. Echoes an absolute dir that exists, or nothing.
+resolve_src_path() {
+    local mk_file="$1"
+    local raw
+    raw=$(grep -hoP '_SRC_PATH\s*[:?]?=\s*\K\S.*' "$mk_file" 2>/dev/null | head -1)
+    [[ -n "$raw" ]] || return 0
+    local rel=""
+    if [[ "$raw" =~ ^\$\(SRC_PATH\)/([A-Za-z0-9._/-]+)$ ]]; then
+        rel="src/${BASH_REMATCH[1]}"
+    elif [[ "$raw" =~ ^\$\(PLATFORM_PATH\)/([A-Za-z0-9._/-]+)$ ]]; then
+        local vendor_rel="${mk_file#"$REPO_ROOT"/}"
+        vendor_rel="${vendor_rel%/*}"   # dir holding the .mk == PLATFORM_PATH
+        rel="${vendor_rel}/${BASH_REMATCH[1]}"
+    else
+        return 0
+    fi
+    rel="${rel%/}"
+    [[ -d "$REPO_ROOT/$rel" ]] && echo "$REPO_ROOT/$rel"
+}
+
+# The package variable names ($(FOO)) a .dep assigns cache directives to, e.g.
+# BMCWEB from `$(BMCWEB)_DEP_FILES`. Used to relate DEP_FILES/SPATH to packages.
+dep_pkg_vars() {
+    grep -oP '^\s*\$\(\K[A-Z0-9_]+(?=\)_(CACHE_MODE|DEP_FLAGS|DEP_FILES|SMDEP_FILES))' \
+        "$1" 2>/dev/null | sort -u
+}
+
+# Repo-relative source dir for a SPECIFIC package variable's *_SRC_PATH in a .mk,
+# resolving only the unambiguous $(SRC_PATH)/... and $(PLATFORM_PATH)/... forms
+# (else nothing). Used to prove two packages sharing one SPATH actually have
+# DIFFERENT source trees before flagging an aliasing bug (FP-safe).
+pkg_var_src_dir() {
+    local mk_file="$1" var="$2" raw rel=""
+    raw=$(grep -oP "\\\$\\($var\\)_SRC_PATH\s*[:?]?=\s*\K\S.*" "$mk_file" 2>/dev/null | head -1)
+    [[ -n "$raw" ]] || return 0
+    if [[ "$raw" =~ ^\$\(SRC_PATH\)/([A-Za-z0-9._/-]+)$ ]]; then
+        rel="src/${BASH_REMATCH[1]}"
+    elif [[ "$raw" =~ ^\$\(PLATFORM_PATH\)/([A-Za-z0-9._/-]+)$ ]]; then
+        local vendor_rel="${mk_file#"$REPO_ROOT"/}"; vendor_rel="${vendor_rel%/*}"
+        rel="${vendor_rel}/${BASH_REMATCH[1]}"
+    else
+        return 0
+    fi
+    echo "${rel%/}"
 }
 COMMON_FLAGS_LIST_CACHE=""
 
@@ -1096,6 +1198,261 @@ check_exported_flags() {
     [[ $waived_count -gt 0 ]] && log_verbose "$waived_count exported var(s) cleared by recorded waivers"
 }
 
+# --- Check 11: Build flags consumed only inside a package's source recipe ---
+check_submodule_recipe_flags() {
+    echo -e "\n${CYAN}=== Check 11: Build flags consumed only inside source recipes ===${NC}"
+    local found=0
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
+        is_package_dep "$dep_file" || continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep_file" && continue
+        local mk_file="${dep_file%.dep}.mk"
+        [[ -f "$mk_file" ]] || continue
+        local base; base=$(basename "$dep_file" .dep)
+        [[ -n "$FILTER_PACKAGE" && "$base" != "$FILTER_PACKAGE" ]] && continue
+        local src; src=$(resolve_src_path "$mk_file")
+        [[ -n "$src" ]] || continue
+
+        local recipes=() r
+        for r in "$src/debian/rules" "$src/Makefile" "$src/setup.py"; do
+            [[ -f "$r" ]] && recipes+=("$r")
+        done
+        [[ ${#recipes[@]} -gt 0 ]] || continue
+
+        # Flags the recipe CONSUMES as an actual make/env VARIABLE — $(FLAG),
+        # ${FLAG}, $$FLAG, or a python environ/getenv read. Matching only these
+        # consumption forms (never a bare token) avoids false hits on literal
+        # strings that merely contain the name, e.g. a sed replacement
+        # `s|ENABLE_SAITHRIFT=0|ENABLE_SAITHRIFT=1|` or a hardcoded CMake option
+        # `-DENABLE_REDIS=ON`. Scoped to the SONiC feature-flag convention
+        # (ENABLE_/INCLUDE_); INSTALL_/CROSS_/MULTIARCH_ are excluded (INSTALL_* is
+        # dominated by kernel-Kbuild/CMake internals; CROSS_*/MULTIARCH_* are
+        # exported build-env vars already owned by Check 10).
+        local ref_flags
+        ref_flags=$(
+            { grep -hoP '\$[({]\K(ENABLE_|INCLUDE_)[A-Z0-9_]+' "${recipes[@]}" 2>/dev/null
+              grep -hoP '\$\$\K(ENABLE_|INCLUDE_)[A-Z0-9_]+'   "${recipes[@]}" 2>/dev/null
+              grep -hoP '(?:environ(?:\.get)?[\[(]|getenv[[:space:]]*\()[[:space:]]*["'\'']\K(ENABLE_|INCLUDE_)[A-Z0-9_]+' "${recipes[@]}" 2>/dev/null
+            } | sort -u)
+
+        # This package's tracked flags (its own _DEP_FLAGS + the global list).
+        local dep_flags
+        dep_flags=$(grep "_DEP_FLAGS" "$dep_file" 2>/dev/null | grep -oP '\$\(\w+\)' | tr -d '$()')
+
+        local flag
+        while IFS= read -r flag; do
+            [[ -z "$flag" ]] && continue
+            # Skip recipe-LOCAL variables (assigned with = or := inside the recipe);
+            # those are internal, not an external toggle. (?= default is env-overridable
+            # and intentionally NOT skipped.)
+            grep -qE "^[[:space:]]*${flag}[[:space:]]*:?=" "${recipes[@]}" 2>/dev/null && continue
+            echo "$dep_flags" | grep -qx "$flag" && continue
+            echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx "$flag" && continue
+            # Skip flags already owned by other checks to avoid duplicate findings:
+            #   - exported vars are Check 10's domain (whole-tree export scan);
+            #   - flags used in an .mk ifeq/ifneq are Check 3/8's domain.
+            flag_is_exported "$flag" && continue
+            flag_in_mk_conditional "$flag" "$mk_file" && continue
+            local where
+            where=$(grep -nE "\b${flag}\b" "${recipes[@]}" 2>/dev/null | head -1 \
+                | sed "s|$REPO_ROOT/||" | cut -d: -f1-2)
+            if flag_forced_off_for_modern_bldenv "$flag"; then
+                add_finding "P3" "$(pkg_label "$dep_file")" \
+                    "Flag \$$flag consumed in source recipe ($where) but effectively deprecated (pinned off for modern BLDENV)" \
+                    "Low priority unless a legacy build env sets it"
+            else
+                add_finding "P1" "$(pkg_label "$dep_file")" \
+                    "Flag \$$flag consumed in source recipe ($where) but not in ${base}_DEP_FLAGS or SONIC_COMMON_FLAGS_LIST" \
+                    "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep"
+                ((found++))
+            fi
+        done <<< "$ref_flags"
+    done < <(all_dep_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — recipe-consumed flags are all tracked${NC}" \
+        || echo -e "  ${YELLOW}$found flag(s) consumed in source recipes but untracked${NC}"
+}
+
+# --- Check 12: Dockerfile.j2 template imports not tracked in .dep ---
+check_docker_template_imports() {
+    echo -e "\n${CYAN}=== Check 12: Dockerfile.j2 template imports not tracked in .dep ===${NC}"
+    local found=0
+    while IFS= read -r rel; do
+        [[ -n "$rel" ]] || continue
+        local j2="$REPO_ROOT/$rel"
+        local dockerdir; dockerdir=$(dirname "$rel")     # dockers/docker-xxx
+        local stem; stem=$(basename "$dockerdir")        # docker-xxx
+        local dep_file="$RULES_DIR/${stem}.dep"
+        [[ -f "$dep_file" ]] || continue
+        [[ -n "$FILTER_PACKAGE" && "$stem" != "$FILTER_PACKAGE" ]] && continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep_file" && continue
+
+        local refs
+        refs=$(grep -oP '\{%[-[:space:]]*(?:include|import|from)[[:space:]]+"\K[^"]+' "$j2" 2>/dev/null | sort -u)
+        [[ -n "$refs" ]] || continue
+
+        local ref
+        while IFS= read -r ref; do
+            [[ -z "$ref" ]] && continue
+            [[ -f "$REPO_ROOT/$ref" ]] || continue          # only in-repo templates
+            [[ "$ref" == "$dockerdir/"* ]] && continue       # covered by git ls-files $(DPATH)
+            grep -qF "$ref" "$dep_file" && continue          # named literally
+            grep -qF "$(basename "$ref")" "$dep_file" && continue
+            add_finding "P1" "$stem" \
+                "Dockerfile.j2 imports in-repo template '$ref' but $stem.dep does not track it (outside \$(DPATH))" \
+                "Add $ref to ${stem}_DEP_FILES (or a shared DEP_FILES list) in $stem.dep"
+            ((found++))
+        done <<< "$refs"
+    done < <(git -C "$REPO_ROOT" ls-files 'dockers/*/Dockerfile.j2' 2>/dev/null)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — imported templates are tracked${NC}" \
+        || echo -e "  ${YELLOW}$found untracked template import(s)${NC}"
+}
+
+# --- Check 13: Cached source-built package that hashes no source at all ---
+check_untracked_source_tree() {
+    echo -e "\n${CYAN}=== Check 13: Cached source-built package hashes no source ===${NC}"
+    local found=0
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
+        is_package_dep "$dep_file" || continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep_file" && continue
+        local mk_file="${dep_file%.dep}.mk"
+        [[ -f "$mk_file" ]] || continue
+        local base; base=$(basename "$dep_file" .dep)
+        [[ -n "$FILTER_PACKAGE" && "$base" != "$FILTER_PACKAGE" ]] && continue
+
+        # Skip if the .dep hashes source in any way.
+        grep -qE "git ls-files" "$dep_file" && continue
+        grep -qE "SMDEP_FILES" "$dep_file" && continue
+
+        local src; src=$(resolve_src_path "$mk_file")
+        [[ -n "$src" ]] || continue
+        # Must be a real, git-tracked source tree (submodule gitlink or files).
+        [[ -n "$(git -C "$REPO_ROOT" ls-files -- "${src#"$REPO_ROOT"/}" 2>/dev/null | head -1)" ]] || continue
+
+        add_finding "P1" "$(pkg_label "$dep_file")" \
+            "Built from source tree ${src#"$REPO_ROOT"/} with caching ON, but .dep hashes NO source (no git ls-files, no _SMDEP_FILES) — the entire source is outside the cache key" \
+            "Add DEP_FILES += \$(shell git ls-files \$(${base}_SRC_PATH)), or _SMDEP_FILES for a submodule source tree"
+        ((found++))
+    done < <(all_dep_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — cached source-built packages hash their source${NC}" \
+        || echo -e "  ${YELLOW}$found package(s) whose source is unhashed${NC}"
+}
+
+# --- Check 14: Moving-ref / non-deterministic fetches behind a stable key ---
+# True (0) if a file carrying a moving-ref fetch belongs to a CACHED package (so a
+# stale reuse is actually possible). This mechanically resolves the "non-cached
+# platforms can't serve stale" question: a platform .mk that declares a moving URL
+# is only a gap when its sibling .dep enables caching (marvell-prestera/clounix SAI
+# — cached), NOT when there is no caching sibling (nephos/barefoot/centec/teralynx).
+moving_ref_is_cached() {
+    local f="$1" rel="${1#"$REPO_ROOT"/}" sib
+    case "$rel" in
+        *.mk)
+            sib="${f%.mk}.dep"
+            [[ -f "$sib" ]] && is_package_dep "$sib" \
+                && ! grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$sib"
+            ;;
+        dockers/*/Dockerfile.j2)
+            sib="$RULES_DIR/$(basename "$(dirname "$rel")").dep"
+            [[ -f "$sib" ]] && ! grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$sib"
+            ;;
+        *)  # source-build recipe (src/*/Makefile, debian/rules, meson .wrap) — a
+            # source build fetched at build time is cached via its rules/platform .dep.
+            return 0 ;;
+    esac
+}
+
+check_moving_refs() {
+    echo -e "\n${CYAN}=== Check 14: Moving-ref / non-deterministic fetches behind a stable key ===${NC}"
+    local found=0
+    local rel f hits
+    while IFS= read -r rel; do
+        [[ -n "$rel" ]] || continue
+        f="$REPO_ROOT/$rel"
+        [[ -f "$f" ]] || continue
+        hits=""
+        grep -qEi 'raw/(master|main)/' "$f" 2>/dev/null && hits+="raw/master|main URL; "
+        grep -qEi '(^|[[:space:]])(FROM|docker[[:space:]]+pull)[^\n]*:latest([[:space:]]|$)' "$f" 2>/dev/null && hits+=":latest image ref; "
+        grep -qE 'go[[:space:]]+get([[:space:]]+-[^[:space:]]+)*[[:space:]]+[^@[:space:]]+$' "$f" 2>/dev/null && hits+="unpinned 'go get'; "
+        grep -qEi 'revision[[:space:]]*=[[:space:]]*(HEAD|main|master)([[:space:]]|$)' "$f" 2>/dev/null && hits+="wrap revision=HEAD/main/master; "
+        [[ -n "$hits" ]] || continue
+        # Only a gap if the artifact is actually cached (else it can't serve stale).
+        moving_ref_is_cached "$f" || { log_verbose "$rel: moving ref but package not cached — skipping"; continue; }
+        add_finding "P2" "$rel" \
+            "Non-deterministic fetch behind a stable cache key: ${hits%; }" \
+            "Pin to an immutable commit/tag/digest and fold it into the cache key (_DEP_FLAGS), or record & verify a SHA"
+        ((found++))
+    done < <(git -C "$REPO_ROOT" ls-files \
+                'src/*/Makefile' 'src/*/debian/rules' 'platform/*/Makefile' \
+                'platform/*/*/Makefile' 'dockers/*/Dockerfile.j2' \
+                'rules/*.mk' 'platform/*/*.mk' 'src/**/*.wrap' 2>/dev/null | sort -u)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — no moving-ref fetches detected${NC}" \
+        || echo -e "  ${YELLOW}$found file(s) with non-deterministic fetches${NC}"
+}
+
+# --- Check 15: Structural DEP_FILES bugs (aliasing / expansion / reassignment) ---
+check_dep_files_structural() {
+    echo -e "\n${CYAN}=== Check 15: Structural DEP_FILES bugs (aliasing / expansion / reassignment) ===${NC}"
+    local found=0
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
+        is_package_dep "$dep_file" || continue
+        local base; base=$(basename "$dep_file" .dep)
+        [[ -n "$FILTER_PACKAGE" && "$base" != "$FILTER_PACKAGE" ]] && continue
+        local mk_file="${dep_file%.dep}.mk"
+
+        # (b) make-expansion bug: SPATH := $(VAR)_SRC_PATH  (missing inner $()).
+        if grep -qE 'SPATH[[:space:]]*:?=[[:space:]]*\$\([A-Z0-9_]+\)_SRC_PATH([[:space:]]|$)' "$dep_file" 2>/dev/null; then
+            local bln; bln=$(grep -nE 'SPATH[[:space:]]*:?=[[:space:]]*\$\([A-Z0-9_]+\)_SRC_PATH' "$dep_file" | head -1 | cut -d: -f1)
+            add_finding "P1" "$(pkg_label "$dep_file")" \
+                "Make-expansion bug at $base.dep:$bln — 'SPATH := \$(VAR)_SRC_PATH' is missing the inner \$(): it expands to a literal '<deb-name>_SRC_PATH' so git ls-files hashes NO source" \
+                "Change to SPATH := \$(\$(VAR)_SRC_PATH)"
+            ((found++))
+        fi
+
+        # (a) aliasing bug: SPATH derived from package X's _SRC_PATH, but another
+        #     package Y in the same .dep assigns its DEP_FILES from that shared
+        #     SPATH/DEP_FILES while Y has a DIFFERENT source tree (proven below).
+        local spath_owner
+        spath_owner=$(grep -oP 'SPATH[[:space:]]*:?=[[:space:]]*\$\(\$\(\K[A-Z0-9_]+(?=\)_SRC_PATH)' "$dep_file" | head -1)
+        if [[ -n "$spath_owner" && -f "$mk_file" ]]; then
+            local owner_dir; owner_dir=$(pkg_var_src_dir "$mk_file" "$spath_owner")
+            local pv
+            while IFS= read -r pv; do
+                [[ -z "$pv" || "$pv" == "$spath_owner" ]] && continue
+                local y_dir; y_dir=$(pkg_var_src_dir "$mk_file" "$pv")
+                # Only flag when BOTH resolve and Y's tree is neither the owner's
+                # tree nor a subdir of it (so SPATH genuinely misses Y's source).
+                [[ -n "$owner_dir" && -n "$y_dir" ]] || continue
+                [[ "$y_dir" == "$owner_dir" || "$y_dir" == "$owner_dir"/* ]] && continue
+                add_finding "P1" "$(pkg_label "$dep_file")" \
+                    "DEP_FILES aliasing — \$($pv)_DEP_FILES reuses SPATH from \$($spath_owner)_SRC_PATH ($owner_dir), so $pv's own source ($y_dir) is never hashed" \
+                    "Recompute git ls-files from \$($pv)_SRC_PATH for \$($pv)_DEP_FILES"
+                ((found++))
+            done < <(grep -oP '^\s*\$\(\K[A-Z0-9_]+(?=\)_DEP_FILES[[:space:]]*:?=[[:space:]]*.*\$\((DEP_FILES|SPATH)\))' "$dep_file" | sort -u)
+        fi
+
+        # (c) reassignment bug: a `DEP_FILES :=` AFTER the first whose RHS neither
+        #     carries forward $(DEP_FILES) NOR re-includes a *COMMON_FILES_LIST —
+        #     it silently drops the accumulated common/rule files. Re-initialising
+        #     each package section to the common list (the standard idiom, e.g.
+        #     p4lang/tacacs/sai-modules) is safe and NOT flagged.
+        local idx=0 rln rline
+        while IFS= read -r rln; do
+            ((idx++))
+            [[ $idx -eq 1 ]] && continue          # first := is the legitimate init
+            rline=$(sed -n "${rln}p" "$dep_file")
+            echo "$rline" | grep -qE '\$\(DEP_FILES\)|COMMON_FILES_LIST' && continue
+            add_finding "P2" "$(pkg_label "$dep_file")" \
+                "DEP_FILES reassigned with ':=' at $base.dep:$rln (drops accumulated files: RHS carries neither \$(DEP_FILES) nor a *COMMON_FILES_LIST) — the SONIC_COMMON_FILES_LIST/rule files fall out of the key" \
+                "Use 'DEP_FILES +=' here so common and rule files are retained"
+            ((found++))
+        done < <(grep -nE '^[[:space:]]*DEP_FILES[[:space:]]*:=' "$dep_file" | cut -d: -f1)
+    done < <(all_dep_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — no structural DEP_FILES bugs${NC}" \
+        || echo -e "  ${YELLOW}$found structural DEP_FILES bug(s)${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -1195,6 +1552,11 @@ main() {
     check_common_flags_completeness
     check_nested_derived_packages
     check_exported_flags
+    check_submodule_recipe_flags
+    check_docker_template_imports
+    check_untracked_source_tree
+    check_moving_refs
+    check_dep_files_structural
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -2012,6 +2012,206 @@ check_inline_recipe_env_vars() {
     [[ $waived -gt 0 ]] && log_verbose "$waived inline env value(s) cleared by recorded waivers"
 }
 
+# --- Shared resolvers for the docker cache-key checks (22-24) ---------------
+# Repo-relative Dockerfile-context directory ($(DPATH)) for a docker .mk/.dep.
+# The docker recipe dir is named after the file stem: rules/docker-X.mk builds
+# dockers/docker-X, while a platform docker (platform/<vendor>/docker-X.mk) builds
+# platform/<vendor>/docker-X. Derived structurally, no per-target table.
+docker_dir_for_stem() {
+    local rel="$1" stem="$2"
+    case "$rel" in
+        rules/*) echo "dockers/$stem" ;;
+        *)       echo "$(dirname "$rel")/$stem" ;;
+    esac
+}
+
+# Map every file-key variable used in a docker $(PKG)_FILES list to its source
+# filename ($(VAR) value) and source dir ($(VAR)_PATH). Both live in rules/*.mk
+# (e.g. rules/scripts.mk): 'ARP_UPDATE_SCRIPT = arp_update' +
+# '$(ARP_UPDATE_SCRIPT)_PATH = files/scripts' -> files/scripts/arp_update. Built
+# once from the whole-tree .mk corpus; no evaluation of make.
+build_filekey_maps() {
+    [[ "${FILEKEYS_BUILT:-0}" == "1" ]] && return
+    declare -gA FILEKEY_VAL FILEKEY_DIR
+    FILEKEYS_BUILT=1
+    local line
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^[[:space:]]*\$\(([A-Za-z0-9_]+)\)_PATH[[:space:]]*[:+]?=[[:space:]]*([^[:space:]#]+) ]]; then
+            FILEKEY_DIR["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+        elif [[ "$line" =~ ^[[:space:]]*([A-Za-z0-9_]+)[[:space:]]*=[[:space:]]*([^[:space:]#]+)[[:space:]]*$ ]]; then
+            FILEKEY_VAL["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+        fi
+    done < <(all_rule_mk_files | tr '\n' '\0' | xargs -0 cat 2>/dev/null)
+}
+
+# Set of build-flag identifiers that at least one docker .dep folds into its own
+# _DEP_FLAGS beyond SONIC_COMMON_FLAGS_LIST (e.g. ENABLE_ASAN). A flag in this set
+# is a proven, keyed docker build input, so a sibling docker that consumes it in
+# its Dockerfile but omits it from its key is a real per-target collision (Check 23).
+build_docker_keyed_flags() {
+    [[ "${DKF_BUILT:-0}" == "1" ]] && return
+    declare -gA DOCKER_KEYED_FLAGS
+    DKF_BUILT=1
+    local dep line tok var
+    while IFS= read -r dep; do
+        [[ -f "$dep" ]] || continue
+        [[ "$(basename "$dep")" == docker-*.dep ]] || continue
+        while IFS= read -r line; do
+            [[ "$line" =~ _DEP_FLAGS[[:space:]]*[:+]?=(.*)$ ]] || continue
+            for tok in $(echo "${BASH_REMATCH[1]}" | grep -oE '\$\([A-Za-z0-9_]+\)'); do
+                var="${tok#\$(}"; var="${var%)}"
+                [[ "$var" == "SONIC_COMMON_FLAGS_LIST" ]] && continue
+                echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx "$var" && continue
+                DOCKER_KEYED_FLAGS["$var"]=1
+            done
+        done < "$dep"
+    done < <(all_dep_files)
+}
+
+# --- Check 22: Docker $(PKG)_FILES sources not folded into the docker key ---
+# slave.mk stages every file named in $(IMG)_FILES into the image build context
+# (COPY'd by the Dockerfile), but those sources live OUTSIDE the image's $(DPATH)
+# (typically files/scripts, files/build_templates, files/image_config, scripts/).
+# A docker key is SONIC_COMMON_FILES_LIST + rules/<img>.{mk,dep} + base list +
+# git ls-files $(DPATH) — so a _FILES source is in NO docker key: editing e.g.
+# files/scripts/arp_update reuses a stale image. Data-driven: resolve each _FILES
+# token to its $(VAR)/$(VAR)_PATH source, require it be git-tracked, outside
+# $(DPATH), not listed in the .dep, and actually referenced by the Dockerfile.
+# Distinct from Check 18 (_INSTALL_DEBS/_WHEELS) and Check 17 (buildinfo generators).
+check_docker_files_unhashed() {
+    echo -e "\n${CYAN}=== Check 22: Docker \$(IMG)_FILES sources not folded into the docker key ===${NC}"
+    local found=0
+    build_filekey_maps
+    local mk mk_rel stem ddir dep j2
+    while IFS= read -r mk; do
+        [[ -f "$mk" ]] || continue
+        grep -qE '\)_FILES[[:space:]]*[:+]?=' "$mk" || continue
+        mk_rel="${mk#"$REPO_ROOT"/}"
+        stem=$(basename "$mk_rel" .mk)
+        [[ -n "$FILTER_PACKAGE" && "$stem" != "$FILTER_PACKAGE" ]] && continue
+        ddir=$(docker_dir_for_stem "$mk_rel" "$stem")
+        j2="$REPO_ROOT/$ddir/Dockerfile.j2"
+        [[ -f "$j2" ]] || continue                       # gate: a real docker image target
+        dep="${mk%.mk}.dep"
+        [[ -f "$dep" ]] || continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep" && continue
+
+        local -a toks=()
+        mapfile -t toks < <(
+            awk '
+                !inf && /\)_FILES[[:space:]]*[:+]?=/ { sub(/^.*\)_FILES[[:space:]]*[:+]?=/,""); inf=1; print; if ($0 !~ /\\[[:space:]]*$/) inf=0; next }
+                inf { print; if ($0 !~ /\\[[:space:]]*$/) inf=0 }
+            ' "$mk" | grep -oE '\$\([A-Za-z0-9_]+\)' | sed -E 's/^\$\(//; s/\)$//' | sort -u
+        )
+        [[ ${#toks[@]} -gt 0 ]] || continue
+
+        local -a unhashed=()
+        local t val dir src bn
+        for t in "${toks[@]}"; do
+            val="${FILEKEY_VAL[$t]:-}"; dir="${FILEKEY_DIR[$t]:-}"
+            [[ -n "$val" && -n "$dir" ]] || continue
+            [[ "$dir" == *'$('* ]] && continue           # unresolved make var
+            src="$dir/$val"
+            [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$src" 2>/dev/null | head -1)" ]] || continue
+            [[ "$src" == "$ddir/"* ]] && continue         # under $(DPATH) -> already hashed
+            grep -qF "$src" "$dep" && continue            # listed explicitly in the key
+            bn=$(basename "$src")
+            grep -qF "$bn" "$j2" || continue              # consumed evidence in the Dockerfile
+            unhashed+=("$src")
+        done
+        [[ ${#unhashed[@]} -gt 0 ]] || continue
+        local list; list=$(printf '%s, ' "${unhashed[@]}"); list="${list%, }"
+        add_finding "P1" "$(pkg_label "$dep")" \
+            "Stages in-repo file(s) into the image build context via its _FILES list: ${list} — these live outside \$(DPATH) ($ddir) and are absent from the docker cache key (SONIC_COMMON_FILES_LIST + ${stem}.{mk,dep} + git ls-files \$(DPATH)); editing any of them restores a stale image" \
+            "Add the resolved _FILES source paths to ${stem}_DEP_FILES in ${stem}.dep, or fold \$(IMG)_FILES source paths into the docker dep SHA in Makefile.cache"
+        ((found++))
+    done < <(all_rule_mk_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — docker _FILES sources are hashed (or under \$(DPATH))${NC}" \
+        || echo -e "  ${YELLOW}$found docker(s) stage unhashed _FILES source(s) into the image${NC}"
+}
+
+# --- Check 23: Docker build-arg flag consumed by Dockerfile but not in its key --
+# A docker image's rendered Dockerfile.j2 can branch on a build flag ({% if FLAG %}
+# / {{FLAG}}). When sibling docker images DO fold that flag into their _DEP_FLAGS
+# (proving it is a real keyed build input — e.g. ENABLE_ASAN in docker-orchagent /
+# docker-syncd-mlnx) but THIS image omits it, the flag's two renderings collide on
+# one key. A class-level "is ENABLE_* known?" allow-list cannot catch a per-target
+# omission. Data-driven: the keyed-flag set is parsed from real docker _DEP_FLAGS.
+check_docker_flag_not_keyed() {
+    echo -e "\n${CYAN}=== Check 23: Docker Dockerfile build flag not in that image's _DEP_FLAGS ===${NC}"
+    local found=0
+    build_docker_keyed_flags
+    local dep dep_rel stem ddir j2 F
+    while IFS= read -r dep; do
+        [[ -f "$dep" ]] || continue
+        [[ "$(basename "$dep")" == docker-*.dep ]] || continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep" && continue
+        stem=$(basename "$dep" .dep)
+        [[ -n "$FILTER_PACKAGE" && "$stem" != "$FILTER_PACKAGE" ]] && continue
+        dep_rel="${dep#"$REPO_ROOT"/}"
+        ddir=$(docker_dir_for_stem "$dep_rel" "$stem")
+        j2="$REPO_ROOT/$ddir/Dockerfile.j2"
+        [[ -f "$j2" ]] || continue
+        for F in "${!DOCKER_KEYED_FLAGS[@]}"; do
+            grep -qE "\{[%{][^}]*\b${F}\b" "$j2" || continue          # consumed in a Jinja directive
+            grep -qE "_DEP_FLAGS[[:space:]]*[:+]?=.*\\\$\\(${F}\\)" "$dep" && continue  # keyed here
+            add_finding "P2" "$(pkg_label "$dep")" \
+                "Dockerfile.j2 branches on build flag \$($F) (which sibling docker images fold into their cache key) but ${stem}.dep _DEP_FLAGS omits it — a $F=y vs $F=n build renders a different image with an identical key (variant collision, silent stale reuse across the two)" \
+                "Append \$($F) to \$(IMG)_DEP_FLAGS in ${stem}.dep (as the sibling docker .dep files already do)"
+            ((found++))
+        done
+    done < <(all_dep_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — Dockerfile build flags are all keyed per image${NC}" \
+        || echo -e "  ${YELLOW}$found docker image(s) omit a consumed build flag from their key${NC}"
+}
+
+# --- Check 24: include'd recipe .mk fragment not tracked in the target's key ---
+# A rule/platform .mk can 'include' a shared recipe fragment (e.g. platform docker
+# targets include platform/template/docker-syncd-*.mk, which supplies _LOAD_DOCKERS/
+# _CONTAINER_NAME/_RUN_OPT that shape the built image). If that fragment is not in
+# the target's DEP_FILES (it lives outside $(DPATH)), editing it changes the build
+# without invalidating the cache key. Data-driven: resolve each include (expanding
+# $(PLATFORM_PATH)/$(DOCKERS_PATH)), require a git-tracked .mk, and flag those the
+# paired .dep does not list. Overlaps Check 15 (recipe body) but is file-scoped.
+check_included_mk_unhashed() {
+    echo -e "\n${CYAN}=== Check 24: include'd recipe .mk fragment not in the target's cache key ===${NC}"
+    local found=0
+    local mk mk_rel dep stem plat inc resolved rel bn
+    while IFS= read -r mk; do
+        [[ -f "$mk" ]] || continue
+        grep -qE '^[[:space:]]*include[[:space:]]+' "$mk" || continue
+        dep="${mk%.mk}.dep"
+        [[ -f "$dep" ]] || continue
+        is_package_dep "$dep" || continue
+        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep" && continue
+        mk_rel="${mk#"$REPO_ROOT"/}"
+        stem=$(basename "$mk_rel" .mk)
+        [[ -n "$FILTER_PACKAGE" && "$stem" != "$FILTER_PACKAGE" ]] && continue
+        plat=""
+        case "$mk_rel" in
+            platform/*) plat="platform/$(echo "$mk_rel" | cut -d/ -f2)" ;;
+        esac
+        while IFS= read -r inc; do
+            [[ -n "$inc" ]] || continue
+            resolved="${inc//\$(PLATFORM_PATH)/$plat}"
+            resolved="${resolved//\$(DOCKERS_PATH)/dockers}"
+            [[ "$resolved" == *'$('* ]] && continue        # unresolved make var
+            rel=$(realpath -m --relative-to="$REPO_ROOT" "$REPO_ROOT/$resolved" 2>/dev/null)
+            [[ -n "$rel" && "$rel" == *.mk ]] || continue
+            [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$rel" 2>/dev/null | head -1)" ]] || continue
+            grep -qF "$rel" "$dep" && continue             # tracked by full path
+            bn=$(basename "$rel")
+            grep -qF "$bn" "$dep" && continue              # tracked by basename
+            add_finding "P2" "$(pkg_label "$dep")" \
+                "${stem}.mk 'include's recipe fragment $rel (supplies build vars such as _LOAD_DOCKERS/_CONTAINER_NAME/_RUN_OPT) but ${stem}.dep does not track it (it lives outside \$(DPATH)) — editing the fragment changes the target's build output without invalidating its cache key" \
+                "Add $rel to ${stem}_DEP_FILES in ${stem}.dep (or hash every include'd .mk into the target key)"
+            ((found++))
+        done < <(grep -oP '^[[:space:]]*include[[:space:]]+\K\S+' "$mk")
+    done < <(all_rule_mk_files)
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — include'd recipe fragments are tracked${NC}" \
+        || echo -e "  ${YELLOW}$found include'd recipe fragment(s) not in the target key${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -2122,6 +2322,9 @@ main() {
     check_misscoped_remote_fingerprint
     check_unhashed_patch_content
     check_inline_recipe_env_vars
+    check_docker_files_unhashed
+    check_docker_flag_not_keyed
+    check_included_mk_unhashed
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -273,6 +273,50 @@ add_finding() {
     esac
 }
 
+# --- Whole-tree corpus helpers -------------------------------------------------
+# The original per-package checks (1,3,4,5,6,7,9) only scanned rules/*.mk and
+# rules/*.dep. Real build rules also live under platform/** (hundreds of .mk and
+# .dep files) and were structurally invisible — a package's cache-key gap in
+# platform/ could never be reported. These helpers return the FULL git-tracked
+# corpus (rules/ + platform/**) so every check applies the same whole-tree,
+# no-heuristic principle already used by the export scanner (Check 10).
+#
+# Output is one absolute path per line (git-tracked only; ordering is stable).
+# Results are computed once and memoised for the life of the process.
+CORPUS_MK_CACHE=""
+CORPUS_DEP_CACHE=""
+
+all_rule_mk_files() {
+    if [[ -z "$CORPUS_MK_CACHE" ]]; then
+        CORPUS_MK_CACHE=$(git -C "$REPO_ROOT" ls-files 2>/dev/null \
+            | grep -E '^(rules|platform)/.*\.mk$' \
+            | sed "s|^|$REPO_ROOT/|")
+    fi
+    printf '%s\n' "$CORPUS_MK_CACHE"
+}
+
+all_dep_files() {
+    if [[ -z "$CORPUS_DEP_CACHE" ]]; then
+        CORPUS_DEP_CACHE=$(git -C "$REPO_ROOT" ls-files 2>/dev/null \
+            | grep -E '^(rules|platform)/.*\.dep$' \
+            | sed "s|^|$REPO_ROOT/|")
+    fi
+    printf '%s\n' "$CORPUS_DEP_CACHE"
+}
+
+# Human-facing package label for a .mk/.dep path. rules/ files keep their bare
+# basename (stable, historically used). platform/** files carry their repo-
+# relative path (minus extension) because the SAME basename (e.g. libsaithrift-dev)
+# exists under many vendor dirs — a bare basename would be ambiguous and collapse
+# distinct packages together. Findings must be actionable to a specific file.
+pkg_label() {
+    local rel="${1#"$REPO_ROOT"/}"
+    case "$rel" in
+        rules/*) basename "$rel" | sed -E 's/\.(mk|dep)$//' ;;
+        *)       echo "${rel%.*}" ;;
+    esac
+}
+
 # Run the comprehensive whole-tree scanner ONCE (live) and cache its output. The
 # gate classifies on every run from live code — there is no committed trust-store
 # to drift out of date. Output rows: variable<TAB>disposition<TAB>evidence.
@@ -367,25 +411,28 @@ block_is_build_affecting() {
     echo "$1" | grep -qE "$BUILD_SIGNAL_RE"
 }
 
-# True (0) if $flag gates a package BUILD input anywhere in rules/*.mk or slave.mk.
+# True (0) if $flag gates a package BUILD input anywhere in the whole-tree corpus
+# (rules/ + platform/**) or slave.mk. Broadened from a rules-only scan so a flag
+# that is build-affecting only in a platform .mk is still recognised.
 flag_affects_build() {
     local flag="$1" f
-    for f in "$RULES_DIR"/*.mk "$REPO_ROOT/slave.mk"; do
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
         if block_is_build_affecting "$(flag_blocks_in_file "$flag" "$f")"; then
             return 0
         fi
-    done
+    done < <(all_rule_mk_files; echo "$REPO_ROOT/slave.mk")
     return 1
 }
 
 # True (0) if $flag is tracked in some cache key: SONIC_COMMON_FLAGS_LIST or any
-# per-package *_DEP_FLAGS in rules/*.dep.
+# per-package *_DEP_FLAGS across the whole-tree corpus (rules/ + platform/**).
 flag_tracked_anywhere() {
     local flag="$1"
     if echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx "$flag"; then
         return 0
     fi
-    grep -lE "_DEP_FLAGS" "$RULES_DIR"/*.dep 2>/dev/null \
+    all_dep_files | xargs -r grep -lE "_DEP_FLAGS" 2>/dev/null \
         | xargs -r grep -lE "\\\$\\(${flag}\\)" 2>/dev/null | grep -q . && return 0
     return 1
 }
@@ -415,10 +462,11 @@ check_missing_dep_files() {
     echo -e "\n${CYAN}=== Check 1: Packages without .dep files (never cached) ===${NC}"
 
     local count=0
-    for mk_file in "$RULES_DIR"/*.mk; do
+    while IFS= read -r mk_file; do
+        [[ -n "$mk_file" ]] || continue
         local base
         base=$(basename "$mk_file" .mk)
-        local dep_file="$RULES_DIR/$base.dep"
+        local dep_file="${mk_file%.mk}.dep"
 
         # Skip non-package mk files (config, functions, etc.)
         if [[ "$base" == "config" ]] || [[ "$base" == "functions" ]]; then
@@ -447,22 +495,22 @@ check_missing_dep_files() {
             for var in $defined_vars; do
                 # Skip common non-package variables
                 [[ "$var" =~ ^(SONIC_|BLDENV|CONFIGURED|PATH|SRC_PATH|VERSION) ]] && continue
-                if grep -rl "DEPENDS.*\$($var)" "$RULES_DIR"/*.mk "$PLATFORM_DIR"/*.mk 2>/dev/null | grep -qv "$mk_file"; then
+                if grep -rl "DEPENDS.*\$($var)" $(all_rule_mk_files) 2>/dev/null | grep -qv "$mk_file"; then
                     has_dependents=true
                     break
                 fi
             done
 
             if $has_dependents; then
-                add_finding "P1" "$base" "No .dep file — package is never cached (other cached packages depend on it)" "Create $dep_file to enable caching"
+                add_finding "P1" "$(pkg_label "$mk_file")" "No .dep file — package is never cached (other cached packages depend on it)" "Create $dep_file to enable caching"
             else
-                add_finding "P2" "$base" "No .dep file — package is never cached (performance only, no downstream dependents)" "Create $dep_file to enable caching"
+                add_finding "P2" "$(pkg_label "$mk_file")" "No .dep file — package is never cached (performance only, no downstream dependents)" "Create $dep_file to enable caching"
             fi
             if $VERBOSE; then
                 echo -e "  ${YELLOW}MISSING${NC}: $base.dep (targets defined in $base.mk)"
             fi
         fi
-    done
+    done < <(all_rule_mk_files)
 
     echo "  Found $count packages without .dep files"
 }
@@ -506,13 +554,17 @@ check_dep_flags_coverage() {
     common_flags_list=$(sed -n '/^SONIC_COMMON_FLAGS_LIST/,/[^\\]$/p' "$MAKEFILE_CACHE" | \
         grep -oP '\$\(\w+\)' | tr -d '$()' | sort -u)
 
-    for dep_file in "$RULES_DIR"/*.dep; do
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
         local base
         base=$(basename "$dep_file" .dep)
-        local mk_file="$RULES_DIR/$base.mk"
+        local mk_file="${dep_file%.dep}.mk"
 
         # Skip if no corresponding .mk
         [[ ! -f "$mk_file" ]] && continue
+
+        local label
+        label=$(pkg_label "$dep_file")
 
         # Filter if specific package requested
         if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
@@ -523,11 +575,21 @@ check_dep_flags_coverage() {
         local dep_flags
         dep_flags=$(grep "_DEP_FLAGS" "$dep_file" 2>/dev/null | grep -oP '\$\(\w+\)' | tr -d '$()')
 
-        # Extract conditional flags used in .mk (ifeq/ifneq patterns)
+        # Extract conditional flags used in .mk. The original check only saw
+        # ifeq/ifneq ($(FLAG)) directives; flags also gate builds via inline
+        # $(if $(FLAG),...) and $(filter ...,$(FLAG)) functions and in recipe
+        # value lines. Capture all of these forms so the coverage judgement is
+        # comprehensive rather than conditional-directive-only.
         local mk_flags
         mk_flags=$(grep -oP '(?<=ifeq \(\$\()[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
         mk_flags+=$'\n'
         mk_flags+=$(grep -oP '(?<=ifneq \(\$\()[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
+        mk_flags+=$'\n'
+        # Inline $(if $(FLAG),...) function calls
+        mk_flags+=$(grep -oP '\$\(if\s+\$\(\K[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
+        mk_flags+=$'\n'
+        # $(filter ...,$(FLAG)) / $(filter-out ...,$(FLAG)) selectors
+        mk_flags+=$(grep -oP '\$\(filter(?:-out)?[^,]*,\s*\$\(\K[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
 
         # Filter to build-affecting flags. INSTALL_ is included so that
         # INSTALL_DEBUG_TOOLS (which adds debug packages to docker image content,
@@ -552,7 +614,7 @@ check_dep_flags_coverage() {
             # dead code. Detected from slave.mk rather than a hardcoded name list.
             if flag_forced_off_for_modern_bldenv "$flag"; then
                 log_verbose "$base: \$$flag is pinned off for modern BLDENV — downgrading to P3"
-                add_finding "P3" "$base" \
+                add_finding "P3" "$label" \
                     "Flag \$$flag used but effectively deprecated (pinned to 'n' for bookworm/trixie in slave.mk)" \
                     "Low priority — only matters for legacy build envs where the flag can be 'y'"
                 continue
@@ -566,6 +628,18 @@ check_dep_flags_coverage() {
             block_content=$(flag_blocks_in_file "$flag" "$mk_file")
             if [[ -n "$block_content" ]] && ! block_is_build_affecting "$block_content"; then
                 log_verbose "$base: \$$flag only controls assembly/inclusion (no build signal) — skipping"
+                continue
+            fi
+
+            # Pattern 1b: The flag may have been picked up from an inline
+            # $(if $(FLAG),...) / $(filter ...,$(FLAG)) usage that has no ifeq
+            # block for Pattern 1 to inspect. Fall back to the whole-tree
+            # build-signal test: if the flag gates no package build input
+            # ANYWHERE (rules/ + platform/**), it is assembly/inclusion-only
+            # (e.g. SONIC_INSTALL_DOCKER_IMAGES, SONIC_PACKAGES_LOCAL) and is not
+            # a cache-key gap. Data-driven — no variable allow-list.
+            if [[ -z "$block_content" ]] && ! flag_affects_build "$flag"; then
+                log_verbose "$base: \$$flag has no build signal anywhere (assembly/inclusion only) — skipping"
                 continue
             fi
 
@@ -587,7 +661,7 @@ check_dep_flags_coverage() {
                        echo "$common_flags_list" | grep -q "^SONIC_${flag}$"; then
                         log_verbose "$base: $flag covered via SONIC_COMMON_FLAGS_LIST"
                     else
-                        add_finding "P1" "$base" \
+                        add_finding "P1" "$label" \
                             "Flag \$$flag used in .mk conditional but not in DEP_FLAGS or SONIC_COMMON_FLAGS_LIST" \
                             "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep, or add to SONIC_COMMON_FLAGS_LIST"
                         if $VERBOSE; then
@@ -595,13 +669,13 @@ check_dep_flags_coverage() {
                         fi
                     fi
                 else
-                    add_finding "P1" "$base" \
+                    add_finding "P1" "$label" \
                         "Flag \$$flag used in .mk conditional but not tracked in DEP_FLAGS" \
                         "Add \$($flag) to DEP_FLAGS in $base.dep"
                 fi
             fi
         done <<< "$build_flags"
-    done
+    done < <(all_dep_files)
 }
 
 # --- Check 4: _DEPENDS declared in .mk vs what .dep tracks ---
@@ -613,7 +687,8 @@ check_dependency_chain_coverage() {
 
     local missing_dep_count=0
 
-    for mk_file in "$RULES_DIR"/*.mk; do
+    while IFS= read -r mk_file; do
+        [[ -n "$mk_file" ]] || continue
         local base
         base=$(basename "$mk_file" .mk)
 
@@ -635,23 +710,25 @@ check_dependency_chain_coverage() {
         dep_packages=$(grep "_DEPENDS" "$mk_file" | grep -oP '\$\(\w+\)' | grep -v "_DEPENDS\|_RDEPENDS\|_UNINSTALLS" | tr -d '$()')
 
         for dep_pkg_var in $dep_packages; do
-            # Find which .mk defines this variable
+            # Find which .mk defines this variable (assignment may be `=`, `:=`,
+            # `+=` or `?=`), searching the whole corpus (rules/ + platform/**).
             local defining_mk
-            defining_mk=$(grep -l "^${dep_pkg_var}\s*=" "$RULES_DIR"/*.mk 2>/dev/null | head -1 || true)
+            defining_mk=$(grep -lP "^\s*${dep_pkg_var}\s*[:+?]?=" $(all_rule_mk_files) 2>/dev/null | head -1 || true)
 
             if [[ -n "$defining_mk" ]]; then
-                local dep_base
+                local dep_base dep_rel
                 dep_base=$(basename "$defining_mk" .mk)
-                if [[ ! -f "$RULES_DIR/$dep_base.dep" ]]; then
+                dep_rel="${defining_mk#"$REPO_ROOT"/}"
+                if [[ ! -f "${defining_mk%.mk}.dep" ]]; then
                     ((missing_dep_count++))
-                    add_finding "P2" "$base" \
-                        "Depends on \$($dep_pkg_var) (from $dep_base.mk) which has no .dep file" \
-                        "Cache key for $base may not reflect changes in $dep_base"
+                    add_finding "P2" "$(pkg_label "$mk_file")" \
+                        "Depends on \$($dep_pkg_var) (from $dep_rel) which has no .dep file" \
+                        "Cache key may not reflect changes in $dep_base"
                     log_verbose "$base depends on $dep_pkg_var → $dep_base has no .dep"
                 fi
             fi
         done
-    done
+    done < <(all_rule_mk_files)
 
     echo "  Found $missing_dep_count dependency chain gaps"
 }
@@ -662,7 +739,8 @@ check_dependency_chain_coverage() {
 check_exclusion_patterns() {
     echo -e "\n${CYAN}=== Check 5: Source file exclusion patterns in .dep files ===${NC}"
 
-    for dep_file in "$RULES_DIR"/*.dep; do
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
         local base
         base=$(basename "$dep_file" .dep)
 
@@ -684,7 +762,7 @@ check_exclusion_patterns() {
             fi
 
             if ! $is_benign; then
-                add_finding "P2" "$base" \
+                add_finding "P2" "$(pkg_label "$dep_file")" \
                     "Uses exclusion pattern: $exclusions" \
                     "Verify excluded files don't affect build output"
                 if $VERBOSE; then
@@ -692,7 +770,7 @@ check_exclusion_patterns() {
                 fi
             fi
         fi
-    done
+    done < <(all_dep_files)
 }
 
 # --- Check 6: CACHE_MODE analysis ---
@@ -703,8 +781,10 @@ check_cache_modes() {
     local content_sha_count=0
     local commit_sha_count=0
     local no_mode_count=0
+    local disabled_mode_count=0
 
-    for dep_file in "$RULES_DIR"/*.dep; do
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
         local base
         base=$(basename "$dep_file" .dep)
 
@@ -716,19 +796,24 @@ check_cache_modes() {
             ((content_sha_count++))
         elif grep -q "GIT_COMMIT_SHA" "$dep_file"; then
             ((commit_sha_count++))
-            add_finding "P3" "$base" \
+            add_finding "P3" "$(pkg_label "$dep_file")" \
                 "Uses GIT_COMMIT_SHA mode — any commit (even non-functional) invalidates cache" \
                 "Consider GIT_CONTENT_SHA if commit metadata doesn't affect output"
+        elif grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep_file"; then
+            # Explicitly opts out of caching — an intentional, clearly-set mode,
+            # not a "missing mode" gap.
+            ((disabled_mode_count++))
         else
             ((no_mode_count++))
-            add_finding "P3" "$base" \
+            add_finding "P3" "$(pkg_label "$dep_file")" \
                 "No explicit CACHE_MODE set (defaults may apply)" \
                 "Consider explicitly setting CACHE_MODE for clarity"
         fi
-    done
+    done < <(all_dep_files)
 
     echo "  GIT_CONTENT_SHA: $content_sha_count packages"
     echo "  GIT_COMMIT_SHA:  $commit_sha_count packages"
+    echo "  CACHE_MODE=none: $disabled_mode_count packages"
     echo "  No explicit mode: $no_mode_count packages"
 }
 
@@ -736,7 +821,9 @@ check_cache_modes() {
 check_docker_dep_tracking() {
     echo -e "\n${CYAN}=== Check 7: Docker image .dep file completeness ===${NC}"
 
-    for dep_file in "$RULES_DIR"/docker-*.dep; do
+    while IFS= read -r dep_file; do
+        [[ -n "$dep_file" ]] || continue
+        [[ "$(basename "$dep_file")" == docker-*.dep ]] || continue
         [[ ! -f "$dep_file" ]] && continue
         local base
         base=$(basename "$dep_file" .dep)
@@ -745,11 +832,19 @@ check_docker_dep_tracking() {
             continue
         fi
 
+        # If the package explicitly disables caching (CACHE_MODE := none) there is
+        # no stale-cache risk regardless of what the .dep tracks — skip it rather
+        # than raise a spurious "doesn't track dir contents" gap.
+        if grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep_file"; then
+            log_verbose "$base: CACHE_MODE=none (caching disabled) — not a tracking gap"
+            continue
+        fi
+
         # Check if dep tracks the Docker directory via git ls-files
         if ! grep -q "git ls-files" "$dep_file" && ! grep -q "shell.*ls" "$dep_file"; then
             # Check if it at least references the DPATH
             if ! grep -q "DPATH\|_PATH" "$dep_file"; then
-                add_finding "P1" "$base" \
+                add_finding "P1" "$(pkg_label "$dep_file")" \
                     "Docker .dep doesn't appear to track Dockerfile directory contents" \
                     "Add: DEP_FILES += \$(shell git ls-files \$(DPATH))"
             fi
@@ -758,7 +853,7 @@ check_docker_dep_tracking() {
         # Check for SMDEP_FILES (docker images usually don't have them — they use DEP_FILES)
         # This is expected behavior, not a gap
         log_verbose "$base: Docker dep structure OK"
-    done
+    done < <(all_dep_files)
 }
 
 # --- Check 8: Validate SONIC_COMMON_FLAGS_LIST against slave.mk usage ---
@@ -770,10 +865,24 @@ check_common_flags_completeness() {
     echo "  Current SONIC_COMMON_FLAGS_LIST:"
     echo "$common_flags" | sed 's/^/    /'
 
-    # Look for ENABLE_*/INCLUDE_*/INSTALL_*/SONIC_* vars used in slave.mk conditionals
+    # Look for ENABLE_*/INCLUDE_*/INSTALL_*/SONIC_* build flags used in slave.mk.
+    # The original check only saw ifeq directives; flags also gate builds via
+    # ifneq, inline $(if $(FLAG),...) and $(filter ...,$(FLAG)) forms. Capture
+    # all of them so a flag hidden in a function call isn't silently missed.
+    local slave_mk="$REPO_ROOT/slave.mk"
     local slave_flags
     slave_flags=$(grep -oP '(?<=ifeq \(\$\()(ENABLE_\w+|INCLUDE_\w+|INSTALL_\w+|SONIC_\w+)(?=\))' \
-        "$REPO_ROOT/slave.mk" 2>/dev/null | sort -u)
+        "$slave_mk" 2>/dev/null)
+    slave_flags+=$'\n'
+    slave_flags+=$(grep -oP '(?<=ifneq \(\$\()(ENABLE_\w+|INCLUDE_\w+|INSTALL_\w+|SONIC_\w+)(?=\))' \
+        "$slave_mk" 2>/dev/null)
+    slave_flags+=$'\n'
+    slave_flags+=$(grep -oP '\$\(if\s+\$\(\K(ENABLE_\w+|INCLUDE_\w+|INSTALL_\w+|SONIC_\w+)(?=\))' \
+        "$slave_mk" 2>/dev/null)
+    slave_flags+=$'\n'
+    slave_flags+=$(grep -oP '\$\(filter(?:-out)?[^,]*,\s*\$\(\K(ENABLE_\w+|INCLUDE_\w+|INSTALL_\w+|SONIC_\w+)(?=\))' \
+        "$slave_mk" 2>/dev/null)
+    slave_flags=$(echo "$slave_flags" | grep -v '^$' | sort -u)
 
     echo ""
     echo "  Flags used in slave.mk conditionals but NOT tracked in any cache key:"
@@ -823,7 +932,8 @@ check_nested_derived_packages() {
 
     local found=0
     local mk
-    for mk in "$RULES_DIR"/*.mk; do
+    while IFS= read -r mk; do
+        [[ -n "$mk" ]] || continue
         [[ -f "$mk" ]] || continue
         grep -q 'add_derived_package' "$mk" || continue
         if [[ -n "$FILTER_PACKAGE" && "$(basename "$mk" .mk)" != "$FILTER_PACKAGE" ]]; then
@@ -848,14 +958,14 @@ check_nested_derived_packages() {
                 local grandchildren
                 grandchildren=$(echo "$pairs" | awk -F, -v par="$p" '$1==par {print $2}' \
                     | sort -u | tr '\n' ' ')
-                add_finding "P1" "$(basename "$mk" .mk)" \
+                add_finding "P1" "$(pkg_label "$mk")" \
                     "Nested add_derived_package: \$$p is itself a derived deb; its derived debs ($grandchildren) are absent from the top-level package _DERIVED_DEBS and may be dropped from cache save/restore" \
                     "Register nested derived debs against the top-level main package, or confirm coverage with negative control NC-6"
                 echo -e "  ${RED}GAP${NC}: $(basename "$mk"): nested parent \$$p -> derived debs: $grandchildren"
                 ((found++))
             fi
         done
-    done
+    done < <(all_rule_mk_files)
 
     if [[ $found -eq 0 ]]; then
         echo -e "  ${GREEN}None — no nested add_derived_package chains found${NC}"
@@ -1046,8 +1156,8 @@ main() {
         exit 2
     fi
 
-    TOTAL_DEP_FILES=$(find "$RULES_DIR" -name "*.dep" | wc -l)
-    echo "  Total .dep files found: $TOTAL_DEP_FILES"
+    TOTAL_DEP_FILES=$(all_dep_files | grep -c .)
+    echo "  Total .dep files found: $TOTAL_DEP_FILES (rules/ + platform/**)"
 
     if [[ -n "$FILTER_PACKAGE" ]]; then
         echo -e "  ${CYAN}Filtering to package: $FILTER_PACKAGE${NC}"

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -125,6 +125,27 @@
 #           images. (The version OUTPUT under files/build/versions/** IS folded in
 #           at Makefile.cache; only the generator logic is untracked.)
 #
+# ── Checks 18–19 close two further "consumed input outside the key" gaps that an
+#    independent multi-model audit surfaced after Checks 16–17. ──
+#
+# Check 18: Docker _INSTALL_PYTHON_WHEELS / _INSTALL_DEBS packages are installed
+#           into the image by slave.mk's docker recipe, but Makefile.cache's
+#           docker dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) folds
+#           only _DEPENDS/_RDEPENDS/_WHEEL_DEPENDS/_PYTHON_DEBS/_PYTHON_WHEELS/
+#           _DBG_DEPENDS/_DBG_IMAGE_PACKAGES/_LOAD_DOCKERS — never the two
+#           _INSTALL_* lists. So a wheel/deb embedded via _INSTALL_* has its
+#           content SHA absent from the docker key (e.g. docker-eventd installs
+#           sonic-utilities + python3-swsscommon this way). Evidence-gated on the
+#           real MOD_DEP_PKGS body; packages also present in a folded role are not
+#           flagged.
+#
+# Check 19: An online-deb target that reuses another target's HTTP header
+#           fingerprint (wget --spider --server-response, used to defeat a moving
+#           upstream softlink) in its _DEP_FLAGS while its OWN artifact URL is
+#           never spidered — so its real moving remote identity is not in the key
+#           (e.g. BRCM_DNX_SAI reuses the XGS-derived SAI_FLAGS). Data-driven:
+#           parses the spidered URL set and the consuming targets from the recipe.
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1637,6 +1658,112 @@ check_docker_buildinfo_tracking() {
         || echo -e "  ${YELLOW}$found docker build-context input(s) untracked${NC}"
 }
 
+# --- Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS not folded into the key ---
+# slave.mk's docker recipe makes each image depend on and install the packages named
+# in $(DOCKER)_INSTALL_PYTHON_WHEELS / _INSTALL_DEBS. But Makefile.cache's docker
+# dependency-SHA rollup (GET_MOD_DEP_SHA -> MOD_DEP_PKGS) folds only _DEPENDS,
+# _RDEPENDS, _WHEEL_DEPENDS, _PYTHON_DEBS, _PYTHON_WHEELS, _DBG_DEPENDS,
+# _DBG_IMAGE_PACKAGES and _LOAD_DOCKERS — NOT the two _INSTALL_* lists. So a package
+# embedded via _INSTALL_* has its content SHA absent from the docker key: rebuilding
+# it (e.g. editing sonic-utilities) reuses a stale image. Evidence-gated: the check
+# first reads the real MOD_DEP_PKGS foreach; if the framework already folds the
+# _INSTALL_* lists it auto-silences. A package that ALSO appears in a folded role for
+# the same image is treated as covered (no false positive).
+check_docker_install_pkgs_unhashed() {
+    echo -e "\n${CYAN}=== Check 18: Docker _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS not folded into docker key ===${NC}"
+    local found=0
+    if [[ -n "$FILTER_PACKAGE" ]]; then
+        echo -e "  ${GREEN}Skipped (whole-image check) under --package${NC}"; return
+    fi
+    [[ -f "$MAKEFILE_CACHE" ]] || { echo -e "  ${GREEN}N/A — no Makefile.cache${NC}"; return; }
+
+    # Evidence gate: is the docker dependency-SHA rollup already folding the
+    # _INSTALL_* lists? If so, there is no gap (auto-silences once fixed).
+    local fold_block
+    fold_block=$(grep -A8 '_MOD_DEP_PKGS[[:space:]]*:=' "$MAKEFILE_CACHE" | head -10)
+    if echo "$fold_block" | grep -q 'INSTALL_PYTHON_WHEELS\|INSTALL_DEBS'; then
+        echo -e "  ${GREEN}None — _INSTALL_* lists are folded into the docker dep SHA${NC}"; return
+    fi
+
+    declare -A folded installed
+    local mk line var kind rhs tok key rest
+    while IFS= read -r mk; do
+        [[ -f "$mk" ]] || continue
+        grep -qE '_INSTALL_(PYTHON_WHEELS|DEBS)[[:space:]]*[:+]?=' "$mk" || continue
+        folded=(); installed=()
+        # Package tokens declared in a FOLDED role, per docker variable.
+        while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*\$\(([A-Za-z0-9_]+)\)_(DEPENDS|RDEPENDS|WHEEL_DEPENDS|PYTHON_DEBS|PYTHON_WHEELS|DBG_DEPENDS|DBG_IMAGE_PACKAGES|LOAD_DOCKERS)[[:space:]]*[:+]?=(.*)$ ]] || continue
+            var="${BASH_REMATCH[1]}"; rhs="${BASH_REMATCH[3]}"
+            for tok in $(echo "$rhs" | grep -oE '\$\([A-Za-z0-9_]+\)'); do
+                folded["$var|$tok"]=1
+            done
+        done < "$mk"
+        # Package tokens installed via _INSTALL_* but NOT also in a folded role.
+        while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*\$\(([A-Za-z0-9_]+)\)_INSTALL_(PYTHON_WHEELS|DEBS)[[:space:]]*[:+]?=(.*)$ ]] || continue
+            var="${BASH_REMATCH[1]}"; kind="${BASH_REMATCH[2]}"; rhs="${BASH_REMATCH[3]}"
+            for tok in $(echo "$rhs" | grep -oE '\$\([A-Za-z0-9_]+\)'); do
+                [[ -n "${folded["$var|$tok"]:-}" ]] && continue
+                installed["$var|$kind|$tok"]=1
+            done
+        done < "$mk"
+        for key in "${!installed[@]}"; do
+            var="${key%%|*}"; rest="${key#*|}"; kind="${rest%%|*}"; tok="${rest#*|}"
+            add_finding "P1" "$(pkg_label "$mk")" \
+                "Docker '$var' installs package $tok into the image via _INSTALL_${kind} (slave.mk installs it at build time) but Makefile.cache GET_MOD_DEP_SHA does not fold _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS into the docker cache key — rebuilding $tok changes the image content without changing the docker key (stale-cache risk)" \
+                "Add \$(${var}_INSTALL_PYTHON_WHEELS) and \$(${var}_INSTALL_DEBS) to the MOD_DEP_PKGS foreach in Makefile.cache GET_MOD_DEP_SHA (or add $tok to \$(${var})_DEPENDS)"
+            ((found++))
+        done
+    done < <(all_rule_mk_files)
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — installed wheels/debs are all folded into docker keys${NC}" \
+        || echo -e "  ${YELLOW}$found docker install-package(s) not folded into the docker key${NC}"
+}
+
+# --- Check 19: Remote-content fingerprint reused by a target whose URL isn't sampled --
+# Some online-deb targets defeat a moving upstream softlink by folding a shell-computed
+# HTTP header fingerprint (wget --spider --server-response of the artifact URL) into
+# their _DEP_FLAGS. That mitigation is only valid for the targets whose URL is actually
+# spidered. If a DIFFERENT target reuses the same fingerprint variable in its _DEP_FLAGS
+# while its own $(TARGET)_URL is never sampled, that target's real (moving) remote
+# identity is absent from its key — a re-published artifact at the same version string
+# reuses a stale cached deb. Data-driven: the sampled URL set and the consuming targets
+# are both parsed from the recipe; a target whose own _URL is in the sampled set (or
+# which has no _URL at all) is not flagged.
+check_misscoped_remote_fingerprint() {
+    echo -e "\n${CYAN}=== Check 19: Remote fingerprint reused by a target whose own URL is not sampled ===${NC}"
+    local found=0
+    local corpus f fvar block spidered_set t url_re
+    corpus=$( { all_rule_mk_files; all_dep_files; } | sort -u )
+
+    while IFS= read -r f; do
+        [[ -f "$f" ]] || continue
+        grep -qE 'wget[[:space:]]+--spider' "$f" || continue
+        while IFS= read -r fvar; do
+            [[ -z "$fvar" ]] && continue
+            # URLs actually spidered on the fingerprint assignment (+ continuation line).
+            block=$(grep -A1 -E "^[[:space:]]*$fvar[[:space:]]*:?=.*wget[[:space:]]+--spider" "$f")
+            spidered_set=$(echo "$block" | grep -oP '\$\(\$\(\K[A-Za-z0-9_]+(?=\)_URL\))' | sort -u)
+            # Targets that fold $(fvar) into their own _DEP_FLAGS (same line).
+            while IFS= read -r t; do
+                [[ -z "$t" ]] && continue
+                echo "$spidered_set" | grep -qxF "$t" && continue
+                # Gate: the target must define its own remote _URL (a distinct input).
+                url_re='\$\('"$t"'\)_URL[[:space:]]*[:+]?='
+                grep -hqE "$url_re" $corpus 2>/dev/null || continue
+                add_finding "P1" "$(pkg_label "$f")" \
+                    "Target '$t' folds the remote-content fingerprint \$($fvar) into its _DEP_FLAGS, but \$($fvar) is computed by 'wget --spider' of a URL set that does not include \$($t)_URL — the target's own (moving) remote artifact identity is never sampled, so a re-published artifact at the same version reuses a stale cached deb" \
+                    "Add \$($t)_URL to the 'wget --spider' URL list feeding $fvar (or compute a dedicated fingerprint from \$($t)_URL for \$($t)_DEP_FLAGS)"
+                ((found++))
+            done < <(grep -oP '\$\(\K[A-Za-z0-9_]+(?=\)_DEP_FLAGS[[:space:]]*[:+]?=.*\$\('"$fvar"'\))' "$f" | sort -u)
+        done < <(grep -oP '^[[:space:]]*\K[A-Za-z0-9_]+(?=[[:space:]]*:?=.*wget[[:space:]]+--spider)' "$f" | sort -u)
+    done < <(echo "$corpus")
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — remote fingerprints sample every consuming target's URL${NC}" \
+        || echo -e "  ${YELLOW}$found target(s) reuse a fingerprint that omits their own URL${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -1743,6 +1870,8 @@ main() {
     check_dep_files_structural
     check_rfs_untracked_files
     check_docker_buildinfo_tracking
+    check_docker_install_pkgs_unhashed
+    check_misscoped_remote_fingerprint
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -296,7 +296,9 @@
 #
 # Exit codes:
 #   0 = No P0 findings (P1 warnings may exist but are not blocking)
-#   1 = P0 findings present (confirmed stale cache risk)
+#   1 = P0 findings present (confirmed stale cache risk). In --base mode this
+#       includes ANY finding the PR introduces (a finding absent at the
+#       merge-base) as well as Check 10 exported-variable gaps the PR touches.
 #   2 = Script error (e.g., not run from repo root, missing Makefile.cache)
 #
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -378,6 +380,15 @@ DIFF_BASE=""
 DIFF_VARS_CACHE=""
 EXPORT_SCAN_CACHE=""
 
+# PR-introduced escalation state (see compute_base_finding_keys). When --base is
+# given, BASE_FINDING_KEYS holds the set of findings that ALREADY exist at the
+# merge-base (keyed by package + issue); any live finding whose key is absent is
+# new -> introduced by the PR -> escalated to P0 in add_finding. BASE_KEYS_READY
+# stays false if the base tree cannot be materialized, degrading to the prior
+# behavior (only Check 10 var-touch P0s) instead of failing on infra problems.
+BASE_KEYS_READY=false
+declare -A BASE_FINDING_KEYS=()
+
 # --- Argument Parsing ---
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -413,9 +424,12 @@ while [[ $# -gt 0 ]]; do
             echo "  --verbose, -v      Show detailed analysis for each .dep file"
             echo "  --json             Output findings as JSON (for programmatic consumption)"
             echo "  --package, -p      Only audit a specific package (e.g., 'swss')"
-            echo "  --base, -b REF     PR/diff mode: only judge packages and exported build"
-            echo "                     variables changed since git REF (e.g. origin/master)."
-            echo "                     Any not-provably-safe export the PR touches -> P0."
+            echo "  --base, -b REF     PR/diff mode: fail (P0) on any completeness gap this"
+            echo "                     PR INTRODUCES relative to git REF (e.g. origin/master)."
+            echo "                     Runs this audit against the merge-base tree and escalates"
+            echo "                     every finding new at HEAD, across all checks, to P0; the"
+            echo "                     pre-existing backlog stays non-blocking. Also flags any"
+            echo "                     not-provably-safe exported variable the PR touches (Check 10)."
             echo "  --refresh-registry Write an informational snapshot of the live export"
             echo "                     classification to scripts/cache_key_export_registry.tsv"
             echo "                     (scripts/cache_key_scan.py) and exit. The gate itself"
@@ -438,11 +452,33 @@ log_verbose() {
     fi
 }
 
+# Non-fatal warning to stderr (kept off stdout so it never corrupts --json).
+log_warn() {
+    echo -e "  ${YELLOW}[WARN]${NC} $1" >&2
+}
+
 add_finding() {
     local severity="$1"
     local package="$2"
     local issue="$3"
     local suggestion="$4"
+
+    # PR-introduced escalation: in --base (diff) mode, a finding whose key
+    # (package + issue) does NOT exist at the merge-base is one THIS PR
+    # introduced. Promote it to P0 so it arms the exit-1 gate, regardless of its
+    # standing severity and of WHICH check produced it. Pre-existing findings
+    # (same key at base) keep their backlog severity and never block the PR.
+    # Only upgrades; an existing P0 (e.g. Check 10 var-touch) is left as-is.
+    if $DIFF_MODE && $BASE_KEYS_READY && [[ "$severity" != "P0" ]]; then
+        local __key="${package}${FINDING_FS}${issue}"
+        # Path-stabilize: findings may embed the repo root (e.g. an absolute
+        # scanner path). The base set is computed in a different worktree, so
+        # strip the live root prefix to match the base's stripped keys.
+        __key="${__key//"$REPO_ROOT"/}"
+        if [[ -z "${BASE_FINDING_KEYS[$__key]:-}" ]]; then
+            severity="P0"
+        fi
+    fi
 
     FINDINGS+=("${severity}${FINDING_FS}${package}${FINDING_FS}${issue}${FINDING_FS}${suggestion}")
 
@@ -549,6 +585,87 @@ compute_diff_vars() {
 # True (0) if $1 is one of the variables the diff touched (see compute_diff_vars).
 diff_touches_var() {
     grep -qx "$1" <<< "$DIFF_VARS_CACHE"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PR-introduced finding detection — generalizes the --base gate to ALL checks.
+# ─────────────────────────────────────────────────────────────────────────────
+# In --base mode we want to fail a PR only for gaps IT introduces, of ANY class,
+# while leaving the pre-existing whole-tree backlog (hundreds of P1/P2/P3)
+# non-blocking. We do this the most general, check-agnostic way: run THIS
+# script's OWN detection against the merge-base tree and record the set of
+# findings that already exist there (keyed by package + issue). Back in the live
+# run, add_finding escalates any finding whose key is NOT in that base set to P0.
+#
+# The base run uses HEAD's tooling (this script + cache_key_scan.py + waivers)
+# against base *content* via a throwaway detached git worktree, so it is an
+# apples-to-apples comparison (same detector, older content) and works even when
+# the base predates this toolkit. It is guarded by _AUDIT_BASELINE_RUN so it can
+# never recurse. If the base cannot be materialized (no history / shallow clone /
+# worktree failure) we warn and leave BASE_KEYS_READY=false: the gate then
+# degrades to its prior behavior (Check 10 var-touch P0s only) rather than
+# failing a PR on an infrastructure problem.
+compute_base_finding_keys() {
+    $DIFF_MODE || return 0
+    [[ -n "${_AUDIT_BASELINE_RUN:-}" ]] && return 0   # never recurse into ourselves
+
+    local range="$DIFF_BASE"
+    if git -C "$REPO_ROOT" rev-parse --verify -q "$DIFF_BASE" >/dev/null 2>&1; then
+        local mb; mb=$(git -C "$REPO_ROOT" merge-base "$DIFF_BASE" HEAD 2>/dev/null)
+        [[ -n "$mb" ]] && range="$mb"
+    fi
+    local base_commit
+    base_commit=$(git -C "$REPO_ROOT" rev-parse --verify -q "${range}^{commit}" 2>/dev/null) || {
+        log_warn "PR-introduced escalation disabled: cannot resolve base commit for '$DIFF_BASE' — only Check 10 var-touch gating remains active"
+        return 0
+    }
+
+    local wt; wt=$(mktemp -d)
+    if ! git -C "$REPO_ROOT" worktree add --detach --quiet "$wt" "$base_commit" 2>/dev/null; then
+        log_warn "PR-introduced escalation disabled: 'git worktree add' failed for base $base_commit — need full history (shallow clone?); only Check 10 var-touch gating remains active"
+        rm -rf "$wt"
+        return 0
+    fi
+
+    # Run HEAD's tooling against base content (base may predate this toolkit).
+    mkdir -p "$wt/scripts"
+    cp -f "$SCRIPT_DIR/audit_dep_completeness.sh"    "$wt/scripts/" 2>/dev/null || true
+    cp -f "$SCRIPT_DIR/cache_key_scan.py"            "$wt/scripts/" 2>/dev/null || true
+    cp -f "$SCRIPT_DIR/cache_key_export_waivers.tsv" "$wt/scripts/" 2>/dev/null || true
+
+    local base_json=""
+    if [[ -f "$wt/Makefile.cache" ]]; then
+        base_json=$( cd "$wt" && _AUDIT_BASELINE_RUN=1 \
+            CONFIGURED_PLATFORM="${CONFIGURED_PLATFORM:-vs}" \
+            bash scripts/audit_dep_completeness.sh --json 2>/dev/null ) || true
+    else
+        log_warn "PR-introduced escalation disabled: base tree has no Makefile.cache"
+    fi
+
+    if [[ -n "$base_json" ]]; then
+        local k
+        while IFS= read -r k; do
+            # Strip the base worktree root so keys are comparable to the live
+            # run's root-stripped keys (see add_finding).
+            k="${k//"$wt"/}"
+            [[ -n "$k" ]] && BASE_FINDING_KEYS["$k"]=1
+        done < <( printf '%s' "$base_json" | FS="$FINDING_FS" python3 -c "
+import json, os, sys
+fs = os.environ['FS']
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for f in data:
+    sys.stdout.write(f.get('package','') + fs + f.get('issue','') + '\n')
+" 2>/dev/null )
+        BASE_KEYS_READY=true
+        log_verbose "PR-introduced escalation armed: ${#BASE_FINDING_KEYS[@]} pre-existing finding key(s) at base $base_commit"
+    else
+        log_warn "PR-introduced escalation disabled: base audit produced no findings JSON"
+    fi
+
+    git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
 }
 
 # Escape a string for safe embedding inside a JSON double-quoted value.
@@ -2551,6 +2668,7 @@ main() {
     # Precompute the global flag list once for the data-driven classifiers.
     compute_common_flags_list
     compute_diff_vars
+    compute_base_finding_keys
 
     # Run all checks
     check_missing_dep_files

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -380,14 +380,16 @@ DIFF_BASE=""
 DIFF_VARS_CACHE=""
 EXPORT_SCAN_CACHE=""
 
-# PR-introduced escalation state (see compute_base_finding_keys). When --base is
-# given, BASE_FINDING_KEYS holds the set of findings that ALREADY exist at the
-# merge-base (keyed by package + issue); any live finding whose key is absent is
-# new -> introduced by the PR -> escalated to P0 in add_finding. BASE_KEYS_READY
-# stays false if the base tree cannot be materialized, degrading to the prior
-# behavior (only Check 10 var-touch P0s) instead of failing on infra problems.
-BASE_KEYS_READY=false
-declare -A BASE_FINDING_KEYS=()
+# PR-introduced escalation state (see compute_changed_files). When --base is
+# given, CHANGED_FILES holds the set of repo-relative paths the PR changes vs the
+# merge-base (submodule bumps expanded to their inner files). A finding is
+# escalated to P0 in add_finding only when its provenance (the build input file
+# it is about) intersects CHANGED_FILES — i.e. the PR itself can cause a NEW
+# stale-cache artifact for that input. CHANGED_READY stays false if the base
+# commit cannot be resolved (shallow clone), degrading to the prior behavior
+# (only Check 10 var-touch P0s) instead of failing on infra problems.
+CHANGED_READY=false
+declare -A CHANGED_FILES=()
 
 # --- Argument Parsing ---
 while [[ $# -gt 0 ]]; do
@@ -426,8 +428,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --package, -p      Only audit a specific package (e.g., 'swss')"
             echo "  --base, -b REF     PR/diff mode: fail (P0) on any completeness gap this"
             echo "                     PR INTRODUCES relative to git REF (e.g. origin/master)."
-            echo "                     Runs this audit against the merge-base tree and escalates"
-            echo "                     every finding new at HEAD, across all checks, to P0; the"
+            echo "                     Deterministic: computes the PR's changed-file set vs the"
+            echo "                     merge-base (submodule bumps expanded) and escalates a"
+            echo "                     finding to P0 only when its provenance — the build input"
+            echo "                     it is about — is among the files the PR changes; the"
             echo "                     pre-existing backlog stays non-blocking. Also flags any"
             echo "                     not-provably-safe exported variable the PR touches (Check 10)."
             echo "  --refresh-registry Write an informational snapshot of the live export"
@@ -462,20 +466,18 @@ add_finding() {
     local package="$2"
     local issue="$3"
     local suggestion="$4"
+    local provenance="${5:-}"
 
-    # PR-introduced escalation: in --base (diff) mode, a finding whose key
-    # (package + issue) does NOT exist at the merge-base is one THIS PR
-    # introduced. Promote it to P0 so it arms the exit-1 gate, regardless of its
-    # standing severity and of WHICH check produced it. Pre-existing findings
-    # (same key at base) keep their backlog severity and never block the PR.
-    # Only upgrades; an existing P0 (e.g. Check 10 var-touch) is left as-is.
-    if $DIFF_MODE && $BASE_KEYS_READY && [[ "$severity" != "P0" ]]; then
-        local __key="${package}${FINDING_FS}${issue}"
-        # Path-stabilize: findings may embed the repo root (e.g. an absolute
-        # scanner path). The base set is computed in a different worktree, so
-        # strip the live root prefix to match the base's stripped keys.
-        __key="${__key//"$REPO_ROOT"/}"
-        if [[ -z "${BASE_FINDING_KEYS[$__key]:-}" ]]; then
+    # PR-introduced escalation (deterministic): in --base (diff) mode, a finding
+    # is promoted to P0 only when its PROVENANCE — the build-affecting input file(s)
+    # the finding is about, and/or the wiring that makes them an input — intersects
+    # the set of files THIS PR changes (CHANGED_FILES). That means the PR itself can
+    # introduce a NEW stale-cache artifact for this input, so the PR owner must fix
+    # it before merge. A finding with no provenance, or whose provenance the PR did
+    # not touch, keeps its backlog severity and never blocks. Only upgrades; an
+    # existing P0 (e.g. Check 10 var-touch) is left as-is.
+    if $DIFF_MODE && $CHANGED_READY && [[ "$severity" != "P0" ]] && [[ -n "$provenance" ]]; then
+        if provenance_in_diff "$provenance"; then
             severity="P0"
         fi
     fi
@@ -488,6 +490,28 @@ add_finding() {
         P2) ((FINDINGS_P2++)) ;;
         P3) ((FINDINGS_P3++)) ;;
     esac
+}
+
+# True (0) if any provenance path (space/newline-separated, repo-relative or
+# absolute) intersects the PR's changed-file set. A token matches when it equals a
+# changed file, is an ancestor directory of one, or (for a changed submodule root
+# not expanded to inner files) is under a changed path. Deterministic: depends only
+# on CHANGED_FILES.
+provenance_in_diff() {
+    local raw p c
+    for raw in $1; do
+        p="${raw#"$REPO_ROOT"/}"     # normalize absolute -> repo-relative
+        p="${p#./}"
+        p="${p%/}"                    # trim trailing slash
+        [[ -z "$p" ]] && continue
+        # exact file match, or p is a directory containing a changed file, or a
+        # changed submodule root is an ancestor of p.
+        [[ -n "${CHANGED_FILES[$p]:-}" ]] && return 0
+        for c in "${!CHANGED_FILES[@]}"; do
+            [[ "$c" == "$p/"* || "$p" == "$c/"* ]] && return 0
+        done
+    done
+    return 1
 }
 
 # --- Whole-tree corpus helpers -------------------------------------------------
@@ -634,115 +658,67 @@ diff_touches_var() {
 # ─────────────────────────────────────────────────────────────────────────────
 # PR-introduced finding detection — generalizes the --base gate to ALL checks.
 # ─────────────────────────────────────────────────────────────────────────────
-# In --base mode we want to fail a PR only for gaps IT introduces, of ANY class,
-# while leaving the pre-existing whole-tree backlog (hundreds of P1/P2/P3)
-# non-blocking. We do this the most general, check-agnostic way: run THIS
-# script's OWN detection against the merge-base tree and record the set of
-# findings that already exist there (keyed by package + issue). Back in the live
-# run, add_finding escalates any finding whose key is NOT in that base set to P0.
+# In --base mode we fail a PR only for gaps IT can introduce: a build-affecting
+# input the PR changes whose change the relevant cache key does not capture (a NEW
+# stale-cache artifact). We compute the PR's changed-file set ONCE, on the HEAD
+# side, from `git diff <merge-base> HEAD`. add_finding then escalates a finding to
+# P0 iff its provenance intersects that set (see provenance_in_diff).
 #
-# The base run uses HEAD's tooling (this script + cache_key_scan.py + waivers)
-# against base *content* via a throwaway detached git worktree, so it is an
-# apples-to-apples comparison (same detector, older content) and works even when
-# the base predates this toolkit. It is guarded by _AUDIT_BASELINE_RUN so it can
-# never recurse. If the base cannot be materialized (no history / shallow clone /
-# worktree failure) we warn and leave BASE_KEYS_READY=false: the gate then
-# degrades to its prior behavior (Check 10 var-touch P0s only) rather than
-# failing a PR on an infrastructure problem.
-compute_base_finding_keys() {
+# This replaces the old "materialize the merge-base in a second worktree, re-run
+# the whole audit there, and subtract" approach, which was NON-DETERMINISTIC: the
+# base worktree's submodule content could differ from HEAD's for reasons unrelated
+# to the PR (partial local fetch, pin resolution, list ordering), so a pre-existing
+# submodule-owned finding could look "new" and escalate to a spurious P0 in CI
+# while passing locally. Changed-file scoping has no second audit to disagree with:
+# same commit + same diff ⇒ same result on every run and machine.
+#
+# Submodule pin bumps: a gitlink change appears in the parent diff only as the
+# submodule pointer. We expand it to the submodule's own inner changed files (old
+# pin..new pin), path-prefixed, so a bump correctly counts its build inputs. If the
+# pins aren't both present locally we conservatively mark the whole submodule path
+# as changed (any provenance under it then matches) — still deterministic.
+compute_changed_files() {
     $DIFF_MODE || return 0
-    [[ -n "${_AUDIT_BASELINE_RUN:-}" ]] && return 0   # never recurse into ourselves
 
     local range="$DIFF_BASE"
     if git -C "$REPO_ROOT" rev-parse --verify -q "$DIFF_BASE" >/dev/null 2>&1; then
         local mb; mb=$(git -C "$REPO_ROOT" merge-base "$DIFF_BASE" HEAD 2>/dev/null)
         [[ -n "$mb" ]] && range="$mb"
     fi
-    local base_commit
-    base_commit=$(git -C "$REPO_ROOT" rev-parse --verify -q "${range}^{commit}" 2>/dev/null) || {
-        log_warn "PR-introduced escalation disabled: cannot resolve base commit for '$DIFF_BASE' — only Check 10 var-touch gating remains active"
-        return 0
-    }
-
-    local wt; wt=$(mktemp -d)
-    if ! git -C "$REPO_ROOT" worktree add --detach --quiet "$wt" "$base_commit" 2>/dev/null; then
-        log_warn "PR-introduced escalation disabled: 'git worktree add' failed for base $base_commit — need full history (shallow clone?); only Check 10 var-touch gating remains active"
-        rm -rf "$wt"
+    if ! git -C "$REPO_ROOT" rev-parse --verify -q "${range}^{commit}" >/dev/null 2>&1; then
+        log_warn "PR-introduced escalation disabled: cannot resolve base commit for '$DIFF_BASE' (shallow clone?) — no finding will be escalated to a blocking P0"
         return 0
     fi
 
-    # Initialize submodules in the base worktree to mirror CI's HEAD checkout
-    # (submodules: recursive). Without this the base audit cannot see submodule
-    # source trees (src/*/debian/rules, etc.), so submodule-owned findings are
-    # ABSENT from the baseline and every one is wrongly escalated to a blocking
-    # P0. Objects are already local from HEAD's recursive checkout, so this only
-    # populates working trees. If it fails, DISABLE escalation (fall back to
-    # Check 10 var-touch gating) rather than arm an incomplete baseline that
-    # would spuriously escalate submodule-owned findings to P0.
-    if ! git -C "$wt" submodule update --init --recursive --quiet 2>/dev/null; then
-        log_warn "PR-introduced escalation disabled: base-worktree submodule init failed — an incomplete baseline would falsely escalate submodule-owned findings to P0; only Check 10 var-touch gating remains active"
-        git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
-        return 0
-    fi
+    # Flat changed-file set (rename-aware: --name-only reports the new path).
+    local f
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && CHANGED_FILES["$f"]=1
+    done < <(git -C "$REPO_ROOT" diff --name-only "$range" HEAD 2>/dev/null)
 
-    # Run HEAD's tooling against base content (base may predate this toolkit).
-    mkdir -p "$wt/scripts"
-    cp -f "$SCRIPT_DIR/audit_dep_completeness.sh"    "$wt/scripts/" 2>/dev/null || true
-    cp -f "$SCRIPT_DIR/cache_key_scan.py"            "$wt/scripts/" 2>/dev/null || true
-    cp -f "$SCRIPT_DIR/cache_key_export_waivers.tsv" "$wt/scripts/" 2>/dev/null || true
-
-    local base_json=""
-    if [[ -f "$wt/Makefile.cache" ]]; then
-        base_json=$( cd "$wt" && _AUDIT_BASELINE_RUN=1 \
-            CONFIGURED_PLATFORM="${CONFIGURED_PLATFORM:-vs}" \
-            bash scripts/audit_dep_completeness.sh --json 2>/dev/null ) || true
-    else
-        log_warn "PR-introduced escalation disabled: base tree has no Makefile.cache"
-    fi
-
-    if [[ -n "$base_json" ]]; then
-        # Guard: only arm escalation if the base audit produced *valid* findings
-        # JSON. A non-empty but malformed/partial base_json (e.g. an interrupted
-        # base run) would otherwise extract zero keys yet still arm
-        # BASE_KEYS_READY, making every live finding look new and escalating the
-        # whole pre-existing backlog to spurious P0s. A genuinely empty list `[]`
-        # (clean base) is valid and DOES arm (all live findings are then
-        # correctly new). Parse-failure disables escalation instead.
-        if ! printf '%s' "$base_json" \
-             | python3 -c 'import json,sys; sys.exit(0 if isinstance(json.load(sys.stdin), list) else 1)' 2>/dev/null; then
-            log_warn "PR-introduced escalation disabled: base audit output is not valid findings JSON (partial/interrupted base run?) — only Check 10 var-touch gating remains active"
-            git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
-            return 0
+    # Expand changed submodule gitlinks to their inner changed files. `git diff
+    # --raw` exposes the old/new blob shas and the 160000 (gitlink) mode.
+    local oldmode newmode oldsha newsha status path inner g
+    while IFS=$'\t' read -r meta path _rest; do
+        [[ -n "$path" ]] || continue
+        # meta = ":<oldmode> <newmode> <oldsha> <newsha> <status>"
+        read -r oldmode newmode oldsha newsha status <<< "${meta#:}"
+        [[ "$oldmode" == 160000 || "$newmode" == 160000 ]] || continue
+        if [[ -d "$REPO_ROOT/$path/.git" || -f "$REPO_ROOT/$path/.git" ]] \
+           && inner=$(git -C "$REPO_ROOT/$path" diff --name-only "$oldsha" "$newsha" 2>/dev/null) \
+           && [[ -n "$inner" ]]; then
+            while IFS= read -r g; do
+                [[ -n "$g" ]] && CHANGED_FILES["$path/$g"]=1
+            done <<< "$inner"
+        else
+            # Pins not both available: conservatively treat the whole submodule as
+            # changed (provenance under $path/ then matches via provenance_in_diff).
+            CHANGED_FILES["$path"]=1
         fi
-        local k
-        while IFS= read -r -d '' k; do
-            # Strip the base worktree root so keys are comparable to the live
-            # run's root-stripped keys (see add_finding).
-            k="${k//"$wt"/}"
-            [[ -n "$k" ]] && BASE_FINDING_KEYS["$k"]=1
-        done < <( printf '%s' "$base_json" | FS="$FINDING_FS" python3 -c "
-import json, os, sys
-fs = os.environ['FS']
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
-for f in data:
-    # NUL-terminate records so a newline inside an issue string cannot split a key.
-    sys.stdout.write(f.get('package','') + fs + f.get('issue','') + '\0')
-" 2>/dev/null )
-        BASE_KEYS_READY=true
-        log_verbose "PR-introduced escalation armed: ${#BASE_FINDING_KEYS[@]} pre-existing finding key(s) at base $base_commit"
-    else
-        log_warn "PR-introduced escalation disabled: base audit produced no findings JSON"
-    fi
+    done < <(git -C "$REPO_ROOT" diff --raw --abbrev=40 "$range" HEAD 2>/dev/null)
 
-    # Remove the base worktree. Do NOT `git submodule deinit` here: a linked
-    # worktree shares the main checkout's .git/config, so deinit would strip the
-    # MAIN worktree's submodule.* entries and silently stop `git ls-files
-    # --recurse-submodules` from recursing in the live checks that follow.
-    # `worktree remove --force` cleans populated submodule trees on its own.
-    git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+    CHANGED_READY=true
+    log_verbose "PR changed-file scoping armed: ${#CHANGED_FILES[@]} path(s) changed vs $range"
 }
 
 # Escape a string for safe embedding inside a JSON double-quoted value.
@@ -955,7 +931,7 @@ check_missing_dep_files() {
             done
 
             if $has_dependents; then
-                add_finding "P1" "$(pkg_label "$mk_file")" "No .dep file — package is never cached (other cached packages depend on it)" "Create $dep_file to enable caching"
+                add_finding "P1" "$(pkg_label "$mk_file")" "No .dep file — package is never cached (other cached packages depend on it)" "Create $dep_file to enable caching" "$mk_file"
             else
                 add_finding "P2" "$(pkg_label "$mk_file")" "No .dep file — package is never cached (performance only, no downstream dependents)" "Create $dep_file to enable caching"
             fi
@@ -991,7 +967,8 @@ check_common_base_files() {
     while IFS= read -r slave_dir; do
         if ! echo "$tracked_slaves" | grep -q "^${slave_dir}$"; then
             add_finding "P1" "$slave_dir" "Missing from SONIC_COMMON_BASE_FILES_LIST in Makefile.cache" \
-                "Add ${slave_dir}/Dockerfile.j2 and ${slave_dir}/Dockerfile.user.j2 to the list"
+                "Add ${slave_dir}/Dockerfile.j2 and ${slave_dir}/Dockerfile.user.j2 to the list" \
+                "$slave_dir"
             echo -e "  ${RED}GAP${NC}: $slave_dir exists but is NOT tracked!"
         fi
     done <<< "$existing_slaves"
@@ -1116,7 +1093,8 @@ check_dep_flags_coverage() {
                     else
                         add_finding "P1" "$label" \
                             "Flag \$$flag used in .mk conditional but not in DEP_FLAGS or SONIC_COMMON_FLAGS_LIST" \
-                            "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep, or add to SONIC_COMMON_FLAGS_LIST"
+                            "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep, or add to SONIC_COMMON_FLAGS_LIST" \
+                            "$mk_file $dep_file"
                         if $VERBOSE; then
                             echo -e "  ${YELLOW}GAP${NC}: $base uses \$$flag but doesn't track it"
                         fi
@@ -1124,7 +1102,8 @@ check_dep_flags_coverage() {
                 else
                     add_finding "P1" "$label" \
                         "Flag \$$flag used in .mk conditional but not tracked in DEP_FLAGS" \
-                        "Add \$($flag) to DEP_FLAGS in $base.dep"
+                        "Add \$($flag) to DEP_FLAGS in $base.dep" \
+                        "$mk_file $dep_file"
                 fi
             fi
         done <<< "$build_flags"
@@ -1366,7 +1345,8 @@ check_docker_dep_tracking() {
             if ! grep -q "DPATH\|_PATH" "$dep_file"; then
                 add_finding "P1" "$(pkg_label "$dep_file")" \
                     "Docker .dep doesn't appear to track Dockerfile directory contents" \
-                    "Add: DEP_FILES += \$(shell git ls-files \$(DPATH))"
+                    "Add: DEP_FILES += \$(shell git ls-files \$(DPATH))" \
+                    "$dep_file"
             fi
         fi
 
@@ -1480,7 +1460,8 @@ check_nested_derived_packages() {
                     | sort -u | tr '\n' ' ')
                 add_finding "P1" "$(pkg_label "$mk")" \
                     "Nested add_derived_package: \$$p is itself a derived deb; its derived debs ($grandchildren) are absent from the top-level package _DERIVED_DEBS and may be dropped from cache save/restore" \
-                    "Register nested derived debs against the top-level main package, or confirm coverage with negative control NC-6"
+                    "Register nested derived debs against the top-level main package, or confirm coverage with negative control NC-6" \
+                    "$mk"
                 echo -e "  ${RED}GAP${NC}: $(basename "$mk"): nested parent \$$p -> derived debs: $grandchildren"
                 ((found++))
             fi
@@ -1664,7 +1645,8 @@ check_submodule_recipe_flags() {
             else
                 add_finding "P1" "$(pkg_label "$dep_file")" \
                     "Flag \$$flag consumed in source recipe ($where) but not in ${base}_DEP_FLAGS or SONIC_COMMON_FLAGS_LIST" \
-                    "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep"
+                    "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep" \
+                    "$dep_file $mk_file ${recipes[*]}"
                 ((found++))
             fi
         done <<< "$ref_flags"
@@ -1700,7 +1682,8 @@ check_docker_template_imports() {
             grep -qF "$(basename "$ref")" "$dep_file" && continue
             add_finding "P1" "$stem" \
                 "Dockerfile.j2 imports in-repo template '$ref' but $stem.dep does not track it (outside \$(DPATH))" \
-                "Add $ref to ${stem}_DEP_FILES (or a shared DEP_FILES list) in $stem.dep"
+                "Add $ref to ${stem}_DEP_FILES (or a shared DEP_FILES list) in $stem.dep" \
+                "$rel $ref $dep_file"
             ((found++))
         done <<< "$refs"
     done < <(git -C "$REPO_ROOT" ls-files 'dockers/*/Dockerfile.j2' 2>/dev/null)
@@ -1732,7 +1715,8 @@ check_untracked_source_tree() {
 
         add_finding "P1" "$(pkg_label "$dep_file")" \
             "Built from source tree ${src#"$REPO_ROOT"/} with caching ON, but .dep hashes NO source (no git ls-files, no _SMDEP_FILES) — the entire source is outside the cache key" \
-            "Add DEP_FILES += \$(shell git ls-files \$(${base}_SRC_PATH)), or _SMDEP_FILES for a submodule source tree"
+            "Add DEP_FILES += \$(shell git ls-files \$(${base}_SRC_PATH)), or _SMDEP_FILES for a submodule source tree" \
+            "$dep_file $mk_file ${src#"$REPO_ROOT"/}"
         ((found++))
     done < <(all_dep_files)
     [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — cached source-built packages hash their source${NC}" \
@@ -1807,7 +1791,8 @@ check_dep_files_structural() {
             local bln; bln=$(grep -nE 'SPATH[[:space:]]*:?=[[:space:]]*\$\([A-Z0-9_]+\)_SRC_PATH' "$dep_file" | head -1 | cut -d: -f1)
             add_finding "P1" "$(pkg_label "$dep_file")" \
                 "Make-expansion bug at $base.dep:$bln — 'SPATH := \$(VAR)_SRC_PATH' is missing the inner \$(): it expands to a literal '<deb-name>_SRC_PATH' so git ls-files hashes NO source" \
-                "Change to SPATH := \$(\$(VAR)_SRC_PATH)"
+                "Change to SPATH := \$(\$(VAR)_SRC_PATH)" \
+                "$dep_file"
             ((found++))
         fi
 
@@ -1828,7 +1813,8 @@ check_dep_files_structural() {
                 [[ "$y_dir" == "$owner_dir" || "$y_dir" == "$owner_dir"/* ]] && continue
                 add_finding "P1" "$(pkg_label "$dep_file")" \
                     "DEP_FILES aliasing — \$($pv)_DEP_FILES reuses SPATH from \$($spath_owner)_SRC_PATH ($owner_dir), so $pv's own source ($y_dir) is never hashed" \
-                    "Recompute git ls-files from \$($pv)_SRC_PATH for \$($pv)_DEP_FILES"
+                    "Recompute git ls-files from \$($pv)_SRC_PATH for \$($pv)_DEP_FILES" \
+                    "$dep_file"
                 ((found++))
             done < <(grep -oP '^\s*\$\(\K[A-Z0-9_]+(?=\)_DEP_FILES[[:space:]]*:?=[[:space:]]*.*\$\((DEP_FILES|SPATH)\))' "$dep_file" | sort -u)
         fi
@@ -1846,7 +1832,8 @@ check_dep_files_structural() {
             echo "$rline" | grep -qE '\$\(DEP_FILES\)|COMMON_FILES_LIST' && continue
             add_finding "P2" "$(pkg_label "$dep_file")" \
                 "DEP_FILES reassigned with ':=' at $base.dep:$rln (drops accumulated files: RHS carries neither \$(DEP_FILES) nor a *COMMON_FILES_LIST) — the SONIC_COMMON_FILES_LIST/rule files fall out of the key" \
-                "Use 'DEP_FILES +=' here so common and rule files are retained"
+                "Use 'DEP_FILES +=' here so common and rule files are retained" \
+                "$dep_file"
             ((found++))
         done < <(grep -nE '^[[:space:]]*DEP_FILES[[:space:]]*:=' "$dep_file" | cut -d: -f1)
     done < <(all_dep_files)
@@ -1934,7 +1921,8 @@ check_rfs_untracked_files() {
         reported[$cf]=1
         add_finding "P1" "sonic-rootfs (RFS)" \
             "build_debian.sh (or a script it invokes) consumes in-repo file '$cf', but it is not in RFS_DEP_FILES / SONIC_COMMON_BASE_FILES_LIST — the host rootfs/squashfs cache key ignores it, so editing '$cf' reuses a stale image" \
-            "Add '$cf' to RFS_DEP_FILES in Makefile.cache (or a \$(shell git ls-files <dir>) glob that covers it)"
+            "Add '$cf' to RFS_DEP_FILES in Makefile.cache (or a \$(shell git ls-files <dir>) glob that covers it)" \
+            "$cf"
         ((found++))
     done < <(printf '%s\n' "${consumed[@]}" | sort -u)
     [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — rootfs recipe inputs are all tracked${NC}" \
@@ -1996,7 +1984,8 @@ check_docker_buildinfo_tracking() {
         reported[$item]=1
         add_finding "P2" "docker-images (all)" \
             "Docker build-context generator '$item' is invoked by every docker build (via scripts/prepare_docker_buildinfo.sh in slave.mk) but is not in any docker cache key (absent from SONIC_COMMON_FILES_LIST and every image's \$(DPATH)) — editing it changes the generated build context/version state without invalidating any image" \
-            "Fold the docker build-context generators into SONIC_COMMON_FILES_LIST (or a shared docker DEP_FILES list) in Makefile.cache"
+            "Fold the docker build-context generators into SONIC_COMMON_FILES_LIST (or a shared docker DEP_FILES list) in Makefile.cache" \
+            "$item"
         ((found++))
     done
     # De-dup build-context trees to their top-level buildinfo dir.
@@ -2007,7 +1996,8 @@ check_docker_buildinfo_tracking() {
         reported[$base_tree]=1
         add_finding "P2" "docker-images (all)" \
             "Build-context tree '$base_tree/' is copied into every docker build context by scripts/prepare_docker_buildinfo.sh but is not in any docker cache key — editing these build hooks reuses stale images" \
-            "Hash '$base_tree' (git ls-files) into a shared docker DEP_FILES list in Makefile.cache"
+            "Hash '$base_tree' (git ls-files) into a shared docker DEP_FILES list in Makefile.cache" \
+            "$base_tree"
         ((found++))
     done
     [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — docker build-context tooling is tracked${NC}" \
@@ -2089,7 +2079,8 @@ check_docker_install_pkgs_unhashed() {
             var="${key%%|*}"; rest="${key#*|}"; kind="${rest%%|*}"; tok="${rest#*|}"
             add_finding "P1" "$(pkg_label "$mk")" \
                 "Docker '$var' now bakes package $tok into the image via _INSTALL_${kind} (slave.mk image-content export references _INSTALL_*), but Makefile.cache GET_MOD_DEP_SHA does not fold _INSTALL_PYTHON_WHEELS/_INSTALL_DEBS into the docker cache key — rebuilding $tok changes the image content without changing the docker key (stale-cache risk)" \
-                "Add \$(${var}_INSTALL_PYTHON_WHEELS) and \$(${var}_INSTALL_DEBS) to the MOD_DEP_PKGS foreach in Makefile.cache GET_MOD_DEP_SHA (or add $tok to \$(${var})_DEPENDS)"
+                "Add \$(${var}_INSTALL_PYTHON_WHEELS) and \$(${var}_INSTALL_DEBS) to the MOD_DEP_PKGS foreach in Makefile.cache GET_MOD_DEP_SHA (or add $tok to \$(${var})_DEPENDS)" \
+                "$mk"
             ((found++))
         done
     done < <(all_rule_mk_files)
@@ -2131,7 +2122,8 @@ check_misscoped_remote_fingerprint() {
                 grep -hqE "$url_re" $corpus 2>/dev/null || continue
                 add_finding "P1" "$(pkg_label "$f")" \
                     "Target '$t' folds the remote-content fingerprint \$($fvar) into its _DEP_FLAGS, but \$($fvar) is computed by 'wget --spider' of a URL set that does not include \$($t)_URL — the target's own (moving) remote artifact identity is never sampled, so a re-published artifact at the same version reuses a stale cached deb" \
-                    "Add \$($t)_URL to the 'wget --spider' URL list feeding $fvar (or compute a dedicated fingerprint from \$($t)_URL for \$($t)_DEP_FLAGS)"
+                    "Add \$($t)_URL to the 'wget --spider' URL list feeding $fvar (or compute a dedicated fingerprint from \$($t)_URL for \$($t)_DEP_FLAGS)" \
+                    "$f"
                 ((found++))
             done < <(grep -oP '\$\(\K[A-Za-z0-9_]+(?=\)_DEP_FLAGS[[:space:]]*[:+]?=.*\$\('"$fvar"'\))' "$f" | sort -u)
         done < <(grep -oP '^[[:space:]]*\K[A-Za-z0-9_]+(?=[[:space:]]*:?=.*wget[[:space:]]+--spider)' "$f" | sort -u)
@@ -2208,7 +2200,8 @@ check_unhashed_patch_content() {
                 [[ -n "$coveredby" ]] && continue
                 add_finding "P1" "$(basename "$base")" \
                     "quilt patch series '$D' is applied to \$(...)_SRC_PATH='$base' by slave.mk before the build (QUILT_PATCHES=... quilt push -a), but '$base' is a submodule root so the sibling '$D' lives in the parent repo: _SMDEP_FILES runs 'git ls-files' INSIDE '$base' and cannot see it, and no _DEP_FILES enumerates it -- editing/adding/removing a patch reuses a stale cached artifact" \
-                    "Fold the patch dir into the package cache key, e.g. DEP_FILES += \$(shell git ls-files $D) in the package .dep (or \$(wildcard \$(<pkg>_SRC_PATH).patch/*) globally in Makefile.cache)"
+                    "Fold the patch dir into the package cache key, e.g. DEP_FILES += \$(shell git ls-files $D) in the package .dep (or \$(wildcard \$(<pkg>_SRC_PATH).patch/*) globally in Makefile.cache)" \
+                    "$D $base"
                 ((found++))
             done < <(git -C "$REPO_ROOT" ls-files '*.patch/series')
         fi
@@ -2238,7 +2231,8 @@ check_unhashed_patch_content() {
                 fi
                 add_finding "P1" "$platdir/$suffix" \
                     "Platform kernel patch dir '$locdir' (EXTERNAL_KERNEL_PATCH_LOC) is copied into the kernel build and applied when INCLUDE_EXTERNAL_PATCHES=y (src/sonic-linux-kernel/Makefile), but the linux-kernel cache key folds only the INCLUDE_EXTERNAL_PATCHES *flag* in _DEP_FLAGS -- never the tracked patch content ($(echo "$tracked" | tr '\n' ' ')). Editing the patch while the flag stays 'y' reuses a stale cached kernel" \
-                    "Add the tracked EXTERNAL_KERNEL_PATCH_LOC files to \$(LINUX_HEADERS_COMMON)_DEP_FILES, e.g. DEP_FILES += \$(shell git ls-files $locdir)"
+                    "Add the tracked EXTERNAL_KERNEL_PATCH_LOC files to \$(LINUX_HEADERS_COMMON)_DEP_FILES, e.g. DEP_FILES += \$(shell git ls-files $locdir)" \
+                    "$locdir"
                 ((found++))
             done < "$mkf"
         done < <(grep -rlE 'EXTERNAL_KERNEL_PATCH_LOC[[:space:]]*:?=' $(all_rule_mk_files) 2>/dev/null)
@@ -2332,7 +2326,8 @@ check_inline_recipe_env_vars() {
         fi
         add_finding "P1" "$v" \
             "Passed INLINE (non-export, '$v=\$($v)') to the cache-backed ./build_debian.sh rootfs recipe (SONIC_RFS_TARGETS) and read by build_debian.sh, but the RFS cache key folds only SONIC_COMMON_FLAGS_LIST — so the value is in neither the key nor any _DEP_FLAGS. Because it is not exported, Check 10 cannot see it: changing the value bakes new content into the rootfs while the same stale cached squashfs is restored" \
-            "Add \$($v) to the RFS target DEP_FLAGS (SONIC_COMMON_FLAGS_LIST in Makefile.cache) so the value is folded into the rootfs cache key; if it provably cannot affect rootfs content, record it (with a reason) in scripts/cache_key_export_waivers.tsv"
+            "Add \$($v) to the RFS target DEP_FLAGS (SONIC_COMMON_FLAGS_LIST in Makefile.cache) so the value is folded into the rootfs cache key; if it provably cannot affect rootfs content, record it (with a reason) in scripts/cache_key_export_waivers.tsv" \
+            "slave.mk build_debian.sh"
         ((found++))
         $VERBOSE && echo -e "  ${RED}P1${NC} \$$v (inline, consumed by build_debian.sh, unkeyed)"
     done
@@ -2491,7 +2486,8 @@ check_recipe_body_drift() {
     if [[ -n "$COMMON_FLAGS_LIST_CACHE" ]] && ! echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx 'SONIC_CACHE_RECIPE_VER'; then
         add_finding "P1" "Makefile.cache" \
             "SONIC_CACHE_RECIPE_VER is not part of SONIC_COMMON_FLAGS_LIST, so the manual slave.mk recipe-body version stamp is folded into NO package cache key — every recipe-body change in slave.mk is invisible to the cache" \
-            "Add \$(SONIC_CACHE_RECIPE_VER) to SONIC_COMMON_FLAGS_LIST in Makefile.cache"
+            "Add \$(SONIC_CACHE_RECIPE_VER) to SONIC_COMMON_FLAGS_LIST in Makefile.cache" \
+            "Makefile.cache"
         ((found++))
     fi
 
@@ -2503,7 +2499,8 @@ check_recipe_body_drift() {
     if [[ -n "$baseline" && -n "$cur" && "$baseline" != "$cur" ]]; then
         add_finding "P1" "slave.mk" \
             "slave.mk (git-object $cur) has drifted from SONIC_CACHE_RECIPE_VER_BASELINE ($baseline) — if the change alters any package build recipe and SONIC_CACHE_RECIPE_VER was not bumped, cached packages built with the old recipe are served stale" \
-            "Review the slave.mk change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE=$cur; otherwise just update the baseline to $cur"
+            "Review the slave.mk change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE=$cur; otherwise just update the baseline to $cur" \
+            "slave.mk"
         ((found++))
     fi
 
@@ -2612,7 +2609,8 @@ check_recipe_invoked_scripts() {
         fi
         add_finding "P2" "$script" \
             "'$script' is invoked by a slave.mk build recipe and shapes produced artifacts (buildinfo/version/debug injection) but is not in SONIC_COMMON_FILES_LIST nor any _DEP_FILES — editing it changes outputs without invalidating any cache key" \
-            "Add '$script' (and the helper library it sources) to SONIC_COMMON_FILES_LIST so recipe-invoked build scripts are hashed into every key"
+            "Add '$script' (and the helper library it sources) to SONIC_COMMON_FILES_LIST so recipe-invoked build scripts are hashed into every key" \
+            "$script"
         ((found++))
     done <<< "$scripts_used"
     [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — recipe-invoked build scripts are hashed${NC}" \
@@ -2650,7 +2648,8 @@ check_embedded_sibling_deb() {
             echo "$deplines" | grep -iq "$name" && continue
             add_finding "P2" "$base" \
                 "$base's debian/rules extracts sibling artifact '$name' (dpkg -x of target/debs/.../${name}_*.deb) and copies content into the package, but declares no _DEPENDS edge on '$name' — rebuilding '$name' does not invalidate $base's cache key, serving a stale embed" \
-                "Add the '$name' package variable to $base's _DEPENDS so the embedded sibling participates in the cache key"
+                "Add the '$name' package variable to $base's _DEPENDS so the embedded sibling participates in the cache key" \
+                "$rulesfile"
             ((found++))
         done
     done <<< "$candidates"
@@ -2745,7 +2744,7 @@ main() {
     # Precompute the global flag list once for the data-driven classifiers.
     compute_common_flags_list
     compute_diff_vars
-    compute_base_finding_keys
+    compute_changed_files
 
     # Run all checks
     check_missing_dep_files

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -146,6 +146,31 @@
 #           (e.g. BRCM_DNX_SAI reuses the XGS-derived SAI_FLAGS). Data-driven:
 #           parses the spidered URL set and the consuming targets from the recipe.
 #
+# ── Check 20 closes the "in-repo patch content applied before the build but not
+#    folded into the artifact's cache key" class (two mechanisms). ──
+#
+# Check 20A (quilt patch series): slave.mk applies $(pkg)_SRC_PATH).patch/series
+#           to a source-built package via 'QUILT_PATCHES=... quilt push -a' right
+#           before dpkg-buildpackage / make / wheel builds. When the source root
+#           is a submodule, the sibling <root>.patch/ dir lives in the PARENT
+#           repo, so _SMDEP_FILES (which runs 'git ls-files' INSIDE the submodule)
+#           can never see it, and no _DEP_FILES enumerates it — editing a patch
+#           reuses a stale cached deb (e.g. src/sonic-swss.patch, ptf, scapy,
+#           supervisor, redis-dump-load, sonic-dash-ha, ptf-py3). Coverage is
+#           decided empirically per patch dir: a series is covered iff some
+#           resolved source root T satisfies 'git -C T ls-files <rel>' (which,
+#           for a submodule root, excludes a parent-repo sibling) — so nested
+#           patch dirs under a normal (non-submodule) root (p4lang/*, thrift_0_14_1)
+#           are correctly NOT flagged. Evidence-gated on the slave.mk quilt recipe.
+#
+# Check 20B (external kernel patches): a platform overrides EXTERNAL_KERNEL_PATCH_LOC
+#           (e.g. platform/mellanox/non-upstream-patches/); src/sonic-linux-kernel/
+#           Makefile copies + applies that dir's *.patch when INCLUDE_EXTERNAL_PATCHES=y,
+#           but the linux-kernel cache key folds only the INCLUDE_EXTERNAL_PATCHES
+#           *flag* in _DEP_FLAGS — never the tracked patch content — so editing the
+#           patch while the flag stays 'y' reuses a stale cached kernel. Evidence-
+#           gated on the linux-kernel recipe consuming EXTERNAL_KERNEL_PATCH_LOC.
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1764,6 +1789,113 @@ check_misscoped_remote_fingerprint() {
         || echo -e "  ${YELLOW}$found target(s) reuse a fingerprint that omits their own URL${NC}"
 }
 
+check_unhashed_patch_content() {
+    echo -e "\n${CYAN}=== Check 20: In-repo patch content applied before build but absent from the cache key ===${NC}"
+    local found=0
+    local line var val
+
+    # ---- Phase A: quilt patch-series dirs -- $(pkg)_SRC_PATH).patch/ ----
+    # Evidence gate: slave.mk must still apply patches via 'QUILT_PATCHES=... quilt push'.
+    if grep -qE 'QUILT_PATCHES=.*quilt[[:space:]]+push' "$REPO_ROOT/slave.mk"; then
+        # Global auto-silence: a repo-wide fold of a *.patch path into any DEP/SMDEP list.
+        local patch_folded=0
+        if { all_dep_files; echo "$MAKEFILE_CACHE"; } \
+             | xargs grep -hE '(DEP_FILES|SMDEP_FILES)[[:space:]]*[:+]?=.*\.patch' 2>/dev/null | grep -q .; then
+            patch_folded=1
+        fi
+        if [[ $patch_folded -eq 0 ]]; then
+            # Resolve every cache-key source root ($(X)_SRC_PATH), $(SRC_PATH)->src, with one
+            # level of $($(Y)_SRC_PATH) indirection. A patch series is COVERED iff some resolved
+            # root T satisfies 'git -C T ls-files <rel>' -- which, for a submodule root, can never
+            # list a parent-repo sibling <root>.patch, but for a normal dir root lists nested files.
+            local -A VARSRC=()
+            local -A RESOLVED=()
+            local -A SRCROOT=()
+            local f
+            while IFS= read -r f; do
+                [[ -f "$f" ]] || continue
+                while IFS= read -r line; do
+                    [[ "$line" =~ ^[[:space:]]*\$\(([A-Za-z0-9_]+)\)_SRC_PATH[[:space:]]*[:+]?=[[:space:]]*(.*)$ ]] || continue
+                    var="${BASH_REMATCH[1]}"; val="${BASH_REMATCH[2]}"
+                    val="${val%%#*}"; val="${val%"${val##*[![:space:]]}"}"
+                    VARSRC["$var"]="$val"
+                done < "$f"
+            done < <(all_rule_mk_files)
+            local changed=1 pass=0 rv other
+            while [[ $changed -eq 1 && $pass -lt 6 ]]; do
+                changed=0; ((pass++))
+                for var in "${!VARSRC[@]}"; do
+                    rv="${VARSRC[$var]}"
+                    rv="${rv//\$(SRC_PATH)/src}"
+                    if [[ "$rv" =~ \$\(\$\(([A-Za-z0-9_]+)\)_SRC_PATH\) ]]; then
+                        other="${BASH_REMATCH[1]}"
+                        [[ -n "${RESOLVED[$other]:-}" ]] && rv="${rv//\$(\$($other)_SRC_PATH)/${RESOLVED[$other]}}"
+                    fi
+                    if [[ "$rv" != *'$('* && -n "$rv" ]]; then
+                        [[ "${RESOLVED[$var]:-}" != "$rv" ]] && { RESOLVED["$var"]="$rv"; changed=1; }
+                    fi
+                done
+            done
+            for var in "${!RESOLVED[@]}"; do SRCROOT["${RESOLVED[$var]}"]=1; done
+
+            local series D base coveredby T rel
+            while IFS= read -r series; do
+                [[ -z "$series" ]] && continue
+                D="${series%/series}"          # repo-rel patch dir, e.g. src/sonic-swss.patch
+                base="${D%.patch}"             # source root it patches, e.g. src/sonic-swss
+                # Only a sibling/nested patch of a real built source root is applied by slave.mk.
+                [[ -n "${SRCROOT[$base]:-}" ]] || continue
+                coveredby=""
+                for T in "${!SRCROOT[@]}"; do
+                    [[ "$D/" == "$T/"* ]] || continue         # T must be an ancestor dir of D
+                    rel="${series#"$T"/}"
+                    if git -C "$REPO_ROOT/$T" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
+                        coveredby="$T"; break
+                    fi
+                done
+                [[ -n "$coveredby" ]] && continue
+                add_finding "P1" "$(basename "$base")" \
+                    "quilt patch series '$D' is applied to \$(...)_SRC_PATH='$base' by slave.mk before the build (QUILT_PATCHES=... quilt push -a), but '$base' is a submodule root so the sibling '$D' lives in the parent repo: _SMDEP_FILES runs 'git ls-files' INSIDE '$base' and cannot see it, and no _DEP_FILES enumerates it -- editing/adding/removing a patch reuses a stale cached artifact" \
+                    "Fold the patch dir into the package cache key, e.g. DEP_FILES += \$(shell git ls-files $D) in the package .dep (or \$(wildcard \$(<pkg>_SRC_PATH).patch/*) globally in Makefile.cache)"
+                ((found++))
+            done < <(git -C "$REPO_ROOT" ls-files '*.patch/series')
+        fi
+    fi
+
+    # ---- Phase B: platform EXTERNAL_KERNEL_PATCH_LOC dirs ----
+    # Evidence gate: the linux-kernel recipe must consume EXTERNAL_KERNEL_PATCH_LOC.
+    local lk_mk="$REPO_ROOT/src/sonic-linux-kernel/Makefile"
+    if [[ -f "$lk_mk" ]] && grep -qE 'EXTERNAL_KERNEL_PATCH_LOC' "$lk_mk"; then
+        local mkf rhs suffix platdir locdir tracked
+        while IFS= read -r mkf; do
+            [[ -f "$mkf" ]] || continue
+            while IFS= read -r line; do
+                [[ "$line" =~ EXTERNAL_KERNEL_PATCH_LOC[[:space:]]*:?=[[:space:]]*(.*)$ ]] || continue
+                rhs="${BASH_REMATCH[1]}"
+                [[ "$rhs" == *'$(PLATFORM_PATH)/'* ]] || continue     # need a repo-relative loc
+                suffix="${rhs#*\$(PLATFORM_PATH)/}"
+                suffix="${suffix%%#*}"; suffix="${suffix%"${suffix##*[![:space:]]}"}"; suffix="${suffix%/}"
+                platdir="$(dirname "${mkf#"$REPO_ROOT"/}")"           # e.g. platform/mellanox
+                locdir="$platdir/$suffix"
+                tracked=$(git -C "$REPO_ROOT" ls-files "$locdir" 2>/dev/null | grep -vEi '(^|/)README(\.md)?$')
+                [[ -z "$tracked" ]] && continue
+                # Coverage: does the linux-kernel key fold this path / loc content?
+                if { echo "$REPO_ROOT/rules/linux-kernel.dep"; echo "$MAKEFILE_CACHE"; } \
+                     | xargs grep -hE "(DEP_FILES|SMDEP_FILES)[[:space:]]*[:+]?=.*($suffix|EXTERNAL_KERNEL_PATCH_LOC|non-upstream)" 2>/dev/null | grep -q .; then
+                    continue
+                fi
+                add_finding "P1" "$platdir/$suffix" \
+                    "Platform kernel patch dir '$locdir' (EXTERNAL_KERNEL_PATCH_LOC) is copied into the kernel build and applied when INCLUDE_EXTERNAL_PATCHES=y (src/sonic-linux-kernel/Makefile), but the linux-kernel cache key folds only the INCLUDE_EXTERNAL_PATCHES *flag* in _DEP_FLAGS -- never the tracked patch content ($(echo "$tracked" | tr '\n' ' ')). Editing the patch while the flag stays 'y' reuses a stale cached kernel" \
+                    "Add the tracked EXTERNAL_KERNEL_PATCH_LOC files to \$(LINUX_HEADERS_COMMON)_DEP_FILES, e.g. DEP_FILES += \$(shell git ls-files $locdir)"
+                ((found++))
+            done < "$mkf"
+        done < <(grep -rlE 'EXTERNAL_KERNEL_PATCH_LOC[[:space:]]*:?=' $(all_rule_mk_files) 2>/dev/null)
+    fi
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — in-repo patch content applied before build is folded into the cache key${NC}" \
+        || echo -e "  ${YELLOW}$found patch source(s) applied before build but absent from the cache key${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -1872,6 +2004,7 @@ main() {
     check_docker_buildinfo_tracking
     check_docker_install_pkgs_unhashed
     check_misscoped_remote_fingerprint
+    check_unhashed_patch_content
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -193,6 +193,28 @@
 #           waivers in scripts/cache_key_export_waivers.tsv; everything else is
 #           default-deny (P1).
 #
+# ── Checks 25–26 close the two remaining "build-environment identity not in the
+#    key" classes: the slave.mk recipe body, and the slave/toolchain image. ──
+#
+# Check 25: slave.mk is intentionally NOT hashed into any DEP_FILES list; instead a
+#           MANUAL version stamp, SONIC_CACHE_RECIPE_VER, is folded into every key via
+#           SONIC_COMMON_FLAGS_LIST, and a git-object baseline (SONIC_CACHE_RECIPE_VER_
+#           BASELINE) records the slave.mk content it was last reviewed against. Two
+#           ways this silently fails: (a) the stamp is removed from SONIC_COMMON_FLAGS_
+#           LIST — then no key tracks the recipe body at all; (b) slave.mk drifts from
+#           the baseline without the stamp being bumped — packages built with the old
+#           recipe are served stale. Data-driven: parse the stamp membership and
+#           compare git hash-object slave.mk to the recorded baseline.
+#
+# Check 26: package keys capture the slave build environment only through the
+#           sonic-slave-<distro> Dockerfile SOURCE (SONIC_COMMON_BASE_FILES_LIST).
+#           The identity of the BUILT slave image (SLAVE_TAG / the resolved base-image
+#           digest / the apt package versions installed into it) is in NO package key,
+#           so a toolchain change that does not edit the Dockerfile source — a moving
+#           base tag, an upstream apt update — reuses stale cached packages. Reports
+#           the structural omission (no slave-image identity token in the common key)
+#           and, as evidence, each sonic-slave base image pinned by a moving tag.
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2149,6 +2171,89 @@ check_included_mk_unhashed() {
         || echo -e "  ${YELLOW}$found include'd recipe fragment(s) not in the target key${NC}"
 }
 
+# --- Check 25: slave.mk recipe-body version stamp integrity + drift ---
+check_recipe_body_drift() {
+    echo -e "\n${CYAN}=== Check 25: slave.mk recipe-body drift vs SONIC_CACHE_RECIPE_VER stamp ===${NC}"
+    local found=0
+
+    # (a) The recipe body of slave.mk is folded into every package key ONLY through the
+    #     manual SONIC_CACHE_RECIPE_VER stamp (slave.mk itself is intentionally not in
+    #     any DEP_FILES). If the stamp is not in SONIC_COMMON_FLAGS_LIST the whole guard
+    #     is silently defeated and no key tracks the recipe body.
+    if [[ -n "$COMMON_FLAGS_LIST_CACHE" ]] && ! echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx 'SONIC_CACHE_RECIPE_VER'; then
+        add_finding "P1" "Makefile.cache" \
+            "SONIC_CACHE_RECIPE_VER is not part of SONIC_COMMON_FLAGS_LIST, so the manual slave.mk recipe-body version stamp is folded into NO package cache key — every recipe-body change in slave.mk is invisible to the cache" \
+            "Add \$(SONIC_CACHE_RECIPE_VER) to SONIC_COMMON_FLAGS_LIST in Makefile.cache"
+        ((found++))
+    fi
+
+    # (b) slave.mk drifted from the reviewed baseline; if the stamp was not bumped,
+    #     packages built with the old recipe are served stale.
+    local baseline cur
+    baseline=$(grep -oP '^\s*SONIC_CACHE_RECIPE_VER_BASELINE\s*:?=\s*\K[0-9a-f]+' "$MAKEFILE_CACHE" 2>/dev/null | head -1)
+    cur=$(git -C "$REPO_ROOT" hash-object slave.mk 2>/dev/null)
+    if [[ -n "$baseline" && -n "$cur" && "$baseline" != "$cur" ]]; then
+        add_finding "P1" "slave.mk" \
+            "slave.mk (git-object $cur) has drifted from SONIC_CACHE_RECIPE_VER_BASELINE ($baseline) — if the change alters any package build recipe and SONIC_CACHE_RECIPE_VER was not bumped, cached packages built with the old recipe are served stale" \
+            "Review the slave.mk change: if it affects package output, bump SONIC_CACHE_RECIPE_VER and set SONIC_CACHE_RECIPE_VER_BASELINE=$cur; otherwise just update the baseline to $cur"
+        ((found++))
+    fi
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — slave.mk recipe body is stamped and in sync with the baseline${NC}" \
+        || echo -e "  ${YELLOW}$found recipe-body stamp/drift issue(s)${NC}"
+}
+
+# --- Check 26: slave/toolchain image identity not folded into any package key ---
+check_slave_toolchain_identity() {
+    echo -e "\n${CYAN}=== Check 26: slave/toolchain image identity not in any package key ===${NC}"
+    local found=0
+
+    # (a) Package keys capture the slave build environment only through the
+    #     sonic-slave-<distro> Dockerfile SOURCE (SONIC_COMMON_BASE_FILES_LIST). The
+    #     identity of the BUILT slave image (SLAVE_TAG / resolved base-image digest /
+    #     installed apt versions) is in NO package key.
+    if [[ -n "$COMMON_FLAGS_LIST_CACHE" ]] && ! echo "$COMMON_FLAGS_LIST_CACHE" | grep -qiE 'SLAVE_TAG|SLAVE_HASH|SLAVE_BASE'; then
+        add_finding "P2" "Makefile.cache" \
+            "No slave build-image identity (SLAVE_TAG / built-image digest) is in SONIC_COMMON_FLAGS_LIST — package keys track only the sonic-slave Dockerfile SOURCE, not the resolved toolchain. A moving base image or an upstream apt update changes the toolchain without moving any package cache key" \
+            "Fold a slave-image identity token (e.g. SLAVE_TAG, which already hashes the slave Dockerfile + build args) into SONIC_COMMON_FLAGS_LIST"
+        ((found++))
+    fi
+
+    # (b) Evidence: sonic-slave-<distro> distro base images pinned by a moving tag.
+    local d name fromline img seen
+    for d in "$REPO_ROOT"/sonic-slave-*; do
+        [[ -d "$d" && -f "$d/Dockerfile.j2" ]] || continue
+        name=$(basename "$d")
+        seen=""
+        while IFS= read -r fromline; do
+            # Strip: FROM keyword, --platform flags, jinja {{ registry prefix }},
+            # and a trailing "as <stage>" alias — leaving the bare image ref.
+            img=$(echo "$fromline" \
+                | sed -E 's/^[[:space:]]*FROM[[:space:]]+//I' \
+                | sed -E 's/--platform=[^[:space:]]+[[:space:]]*//g' \
+                | sed -E 's/\{\{[^}]*\}\}//g' \
+                | sed -E 's/[[:space:]]+as[[:space:]]+.*$//I' \
+                | awk '{print $1}')
+            [[ -n "$img" ]] || continue
+            [[ "$img" == *'{{'* || "$img" == *'$'* ]] && continue    # unresolved template
+            [[ "$img" == *@sha256:* ]] && continue                    # digest-pinned, ok
+            case "$img" in
+                *debian*:*|*ubuntu*:*) ;;                              # a distro base image
+                *) continue ;;
+            esac
+            [[ " $seen " == *" $img "* ]] && continue                 # dedupe per slave dir
+            seen="$seen $img"
+            add_finding "P3" "$name" \
+                "$name/Dockerfile.j2 base image '$img' is pinned by a MOVING tag (no @sha256 digest); the slave toolchain can change under an unchanged Dockerfile source, and no package key tracks the resolved image" \
+                "Pin the base image by @sha256 digest, or fold SLAVE_TAG into the package key so a rebuilt slave invalidates caches"
+            ((found++))
+        done < <(grep -iE '^[[:space:]]*FROM[[:space:]]' "$d/Dockerfile.j2")
+    done
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — slave toolchain identity is captured in the key${NC}" \
+        || echo -e "  ${YELLOW}$found toolchain-identity gap(s)${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -2261,6 +2366,8 @@ main() {
     check_inline_recipe_env_vars
     check_docker_flag_not_keyed
     check_included_mk_unhashed
+    check_recipe_body_drift
+    check_slave_toolchain_identity
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -577,7 +577,51 @@ compute_diff_vars() {
     DIFF_VARS_CACHE=$(git -C "$REPO_ROOT" diff --unified=0 "$range" -- \
             slave.mk 'rules/*.mk' Makefile.cache 'platform/*.mk' 2>/dev/null \
         | grep -E '^[-+]' | grep -vE '^[-+]{3} ' \
-        | grep -oP '(?:export\s+|\$\()\K[A-Za-z_][A-Za-z0-9_]*' \
+        | python3 -c '
+import sys, re
+# Mirror cache_key_scan.py:exported_vars so multi-var `export A B C`, shell
+# `export A=1 B=2`, and no-space operator forms (`export A+=v`) all register as
+# touched, while dynamic `export $(fn ...)` is skipped (its tokens are not
+# literal names) and quoted/`$(...)` values do not leak bare words. Also capture
+# $(VAR)/${VAR} dereferences the diff adds/removes.
+OP = r"(?:::=|:=|\?=|\+=|!=|=)"
+MOP = r"(?:::=|:=|\?=|\+=|!=)"   # make-only ops: value is rest of line => single var
+DQ = chr(34); SQ = chr(39)  # " and " built via chr() so no literal quote appears
+VAL = (r"(?:" + DQ + r"[^" + DQ + r"]*" + DQ + r"|" + SQ + r"[^" + SQ + r"]*" + SQ
+       + r"|\$\([^)]*\)|\$\{[^}]*\}|\\.|\S)*")
+HEAD = re.compile(r"^[A-Za-z_]\w*[ \t]*" + OP)
+SINGLE = re.compile(r"^([A-Za-z_]\w*)(?:[ \t]*" + MOP + r"|[ \t]+=)")
+STEP = re.compile(r"[ \t]*([A-Za-z_]\w*)=" + VAL)
+out = set()
+for line in sys.stdin:
+    line = line[1:] if line[:1] in "+-" else line
+    for m in re.finditer(r"\$[({]\s*([A-Za-z_]\w*)", line):
+        out.add(m.group(1))
+    me = re.match(r"\s*export\s+(.+)", line)
+    if not me:
+        continue
+    tail = me.group(1).strip()
+    if tail.startswith("$"):
+        continue
+    if HEAD.match(tail):
+        m0 = SINGLE.match(tail)
+        if m0:
+            out.add(m0.group(1))
+        else:
+            pos = 0
+            while pos < len(tail):
+                mm = STEP.match(tail, pos)
+                if not mm:
+                    break
+                out.add(mm.group(1))
+                pos = mm.end()
+    else:
+        for t in tail.split():
+            if re.fullmatch(r"[A-Za-z_]\w*", t):
+                out.add(t)
+for v in sorted(out):
+    print(v)
+' \
         | sort -u)
     log_verbose "diff-mode variables touched since $DIFF_BASE: $(echo "$DIFF_VARS_CACHE" | tr '\n' ' ')"
 }
@@ -627,6 +671,20 @@ compute_base_finding_keys() {
         return 0
     fi
 
+    # Initialize submodules in the base worktree to mirror CI's HEAD checkout
+    # (submodules: recursive). Without this the base audit cannot see submodule
+    # source trees (src/*/debian/rules, etc.), so submodule-owned findings are
+    # ABSENT from the baseline and every one is wrongly escalated to a blocking
+    # P0. Objects are already local from HEAD's recursive checkout, so this only
+    # populates working trees. If it fails, DISABLE escalation (fall back to
+    # Check 10 var-touch gating) rather than arm an incomplete baseline that
+    # would spuriously escalate submodule-owned findings to P0.
+    if ! git -C "$wt" submodule update --init --recursive --quiet 2>/dev/null; then
+        log_warn "PR-introduced escalation disabled: base-worktree submodule init failed — an incomplete baseline would falsely escalate submodule-owned findings to P0; only Check 10 var-touch gating remains active"
+        git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+        return 0
+    fi
+
     # Run HEAD's tooling against base content (base may predate this toolkit).
     mkdir -p "$wt/scripts"
     cp -f "$SCRIPT_DIR/audit_dep_completeness.sh"    "$wt/scripts/" 2>/dev/null || true
@@ -643,6 +701,19 @@ compute_base_finding_keys() {
     fi
 
     if [[ -n "$base_json" ]]; then
+        # Guard: only arm escalation if the base audit produced *valid* findings
+        # JSON. A non-empty but malformed/partial base_json (e.g. an interrupted
+        # base run) would otherwise extract zero keys yet still arm
+        # BASE_KEYS_READY, making every live finding look new and escalating the
+        # whole pre-existing backlog to spurious P0s. A genuinely empty list `[]`
+        # (clean base) is valid and DOES arm (all live findings are then
+        # correctly new). Parse-failure disables escalation instead.
+        if ! printf '%s' "$base_json" \
+             | python3 -c 'import json,sys; sys.exit(0 if isinstance(json.load(sys.stdin), list) else 1)' 2>/dev/null; then
+            log_warn "PR-introduced escalation disabled: base audit output is not valid findings JSON (partial/interrupted base run?) — only Check 10 var-touch gating remains active"
+            git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+            return 0
+        fi
         local k
         while IFS= read -r -d '' k; do
             # Strip the base worktree root so keys are comparable to the live
@@ -666,6 +737,11 @@ for f in data:
         log_warn "PR-introduced escalation disabled: base audit produced no findings JSON"
     fi
 
+    # Remove the base worktree. Do NOT `git submodule deinit` here: a linked
+    # worktree shares the main checkout's .git/config, so deinit would strip the
+    # MAIN worktree's submodule.* entries and silently stop `git ls-files
+    # --recurse-submodules` from recursing in the live checks that follow.
+    # `worktree remove --force` cleans populated submodule trees on its own.
     git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
 }
 

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -575,7 +575,7 @@ compute_diff_vars() {
         [[ -n "$mb" ]] && range="$mb"
     fi
     DIFF_VARS_CACHE=$(git -C "$REPO_ROOT" diff --unified=0 "$range" -- \
-            slave.mk 'rules/*.mk' Makefile.cache 2>/dev/null \
+            slave.mk 'rules/*.mk' Makefile.cache 'platform/*.mk' 2>/dev/null \
         | grep -E '^[-+]' | grep -vE '^[-+]{3} ' \
         | grep -oP '(?:export\s+|\$\()\K[A-Za-z_][A-Za-z0-9_]*' \
         | sort -u)
@@ -644,7 +644,7 @@ compute_base_finding_keys() {
 
     if [[ -n "$base_json" ]]; then
         local k
-        while IFS= read -r k; do
+        while IFS= read -r -d '' k; do
             # Strip the base worktree root so keys are comparable to the live
             # run's root-stripped keys (see add_finding).
             k="${k//"$wt"/}"
@@ -657,7 +657,8 @@ try:
 except Exception:
     sys.exit(0)
 for f in data:
-    sys.stdout.write(f.get('package','') + fs + f.get('issue','') + '\n')
+    # NUL-terminate records so a newline inside an issue string cannot split a key.
+    sys.stdout.write(f.get('package','') + fs + f.get('issue','') + '\0')
 " 2>/dev/null )
         BASE_KEYS_READY=true
         log_verbose "PR-introduced escalation armed: ${#BASE_FINDING_KEYS[@]} pre-existing finding key(s) at base $base_commit"

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -1,0 +1,1090 @@
+#!/bin/bash
+#
+# audit_dep_completeness.sh — Per-Package .dep File Completeness Audit
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# PURPOSE
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# In SONiC's DPKG caching system (Makefile.cache), each package has a .dep file
+# (rules/<pkg>.dep) that declares what inputs affect its cache key. If a .dep file
+# is incomplete — missing a build flag, a source file pattern, or a dependency —
+# the cache key won't change when it should, and stale artifacts will be served.
+#
+# This script performs static analysis across ALL rules/*.dep files to identify
+# gaps where build inputs exist in .mk files but are not reflected in cache key
+# computation. It cross-references:
+#   - rules/*.mk  (what flags/deps/sources actually affect each package)
+#   - rules/*.dep (what the cache system tracks)
+#   - Makefile.cache (global lists and hash computation logic)
+#   - Source directories (whether packages have source code at all)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# WHAT IT CHECKS (9 checks)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Check 1: Packages registered in build categories without a .dep file
+#           These packages have NO cache key computation at all — they'll always
+#           get a cache hit on first write, regardless of source changes.
+#
+# Check 2: .dep files that don't include their own .mk file in DEP_FILES
+#           The .mk file defines dependencies and build flags — if it changes
+#           (e.g., new _DEPENDS added), the cache key must reflect that.
+#
+# Check 3: Build flags (ifeq/ifneq conditionals) in .mk not tracked in .dep
+#           Analyzes WHAT each conditional does to distinguish:
+#           - Build-affecting: changes _DEPENDS, _RDEPENDS, build commands → REAL gap
+#           - Assembly-only: changes SONIC_INSTALL_DOCKER_IMAGES → safe to ignore
+#
+# Check 4: _DEPENDS declared in .mk but not reflected in .dep DEP_FILES
+#           If package A depends on package B, A's cache key should include B.
+#
+# Check 5: Source directory patterns — .dep declares _SRC_PATH or git ls-files
+#           but the pattern may miss files (e.g., generated sources, submodules).
+#
+# Check 6: CACHE_MODE consistency — GIT_COMMIT_SHA vs GIT_CONTENT_SHA
+#           GIT_COMMIT_SHA mode uses the git commit hash (fast but coarse).
+#           GIT_CONTENT_SHA hashes actual file content (precise but slower).
+#
+# Check 7: Cross-package dependency completeness — are transitive deps covered?
+#           If A depends on B depends on C, does A's cache key transitively
+#           include C's changes? (Makefile.cache handles this via DEP_MOD_SHA
+#           recursion, but only if B is declared as a dep of A.)
+#
+# Check 8: slave.mk flags used in package build rules but not tracked
+#           Scans for flags like SONIC_BUILD_JOBS, ENABLE_SYNCD_RPC that are
+#           used in conditionals but not in SONIC_COMMON_FLAGS_LIST or DEP_FLAGS.
+#
+# Check 9: Nested derived packages not covered by cache save/restore
+#           add_derived_package(X, Y) only adds Y to X's first-level
+#           _DERIVED_DEBS, and the cache save does not recurse. If X is itself a
+#           derived deb, Y is dropped from the top-level package's cache tarball.
+#           Confirmed by negative control NC-6 (libnl3 nested derived debs).
+#
+# Check 10: Exported build-env flags not tracked in any cache key
+#           Flags passed via `export FLAG` (not an ifeq($(FLAG)) conditional) are
+#           consumed inside debian/rules or sub-Makefiles, so the ifeq-based
+#           Checks 3 and 8 cannot see them. Closes the "export-only" blind spot
+#           (e.g. ENABLE_FRR_TCMALLOC on frr, whose _DEP_FLAGS is common-only).
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# USAGE
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+#   ./scripts/audit_dep_completeness.sh [OPTIONS]
+#
+# Options:
+#   --verbose        Show detailed explanations for each finding
+#   --json           Output findings in JSON format (for downstream tooling)
+#   --package NAME   Audit only the specified package (e.g., --package swss)
+#
+# Examples:
+#   # Full audit of all ~165 .dep files
+#   ./scripts/audit_dep_completeness.sh
+#
+#   # Audit a specific package with details
+#   ./scripts/audit_dep_completeness.sh --verbose --package docker-orchagent
+#
+#   # Machine-readable output for CI integration
+#   ./scripts/audit_dep_completeness.sh --json > findings.json
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# INTERPRETING RESULTS
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Findings are classified by severity:
+#
+#   P0 = Confirmed stale cache risk
+#        The gap WILL cause incorrect cache hits under normal usage.
+#        Example: A package has no .dep file at all.
+#
+#   P1 = Likely stale cache risk (needs verification)
+#        Strong evidence of a gap, but needs Phase 2 PoC to confirm binary diff.
+#        Example: ENABLE_SYNCD_RPC changes build profile but isn't in syncd.dep.
+#
+#   P2 = Potential risk / cosmetic concern
+#        May or may not cause issues depending on usage patterns.
+#        Example: A .dep doesn't include its own .mk file (redundant if .mk
+#        rarely changes build output independently of source).
+#
+#   P3 = Informational / design observation
+#        Not a bug, but worth knowing for completeness.
+#        Example: Deprecated flag still tracked in some .dep files.
+#
+# The summary table at the end shows counts by severity. Focus on P0/P1 first.
+#
+# Exit codes:
+#   0 = No P0 findings (P1 warnings may exist but are not blocking)
+#   1 = P0 findings present (confirmed stale cache risk)
+#   2 = Script error (e.g., not run from repo root, missing Makefile.cache)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# FALSE POSITIVE FILTERING
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# The script includes filters to reduce noise from known non-issues:
+#
+# - Assembly-only flags: INCLUDE_* flags that only control whether a Docker image
+#   is INSTALLED into the final NOS image (SONIC_INSTALL_DOCKER_IMAGES) — they
+#   don't change what's INSIDE the image during build.
+#
+# - Block-content analysis (data-driven, no hand-maintained flag lists): the script
+#   inspects WHAT a conditional block DOES rather than matching flag names. A block is
+#   "build-affecting" only if it touches a stable SONiC build variable (see
+#   BUILD_SIGNAL_RE: *_DEPENDS/_RDEPENDS/_DBG_PACKAGES/_EXTRA_DEBS/_DERIVED_DEBS/
+#   _SRC_PATH/_BUILD_ENV/_MAKE_ENV/_CFLAGS/_MAKE_TARGET, add_derived_package /
+#   add_extra_package, dpkg-buildpackage, DEB_BUILD_OPTIONS). Blocks that only select/assemble packages (SONIC_MAKE_DEBS,
+#   SONIC_INSTALL_DOCKER_IMAGES, SONIC_PACKAGES_LOCAL, DEFAULT_FEATURE_STATE/OWNER)
+#   carry no build signal and are classified assembly-only (not a gap). These naming
+#   conventions are fixed by Makefile.cache/slave.mk, so the audit needs no upkeep as
+#   new feature flags are added.
+#
+# - Deprecated flags: detected generically — any flag pinned to 'n' for the modern
+#   build envs (an if(n)eq filter on $(BLDENV) naming bookworm/trixie that sets the
+#   flag = n in slave.mk) is reported as P3 informational only.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONTEXT
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This script is part of the DPKG Cache Validation toolkit:
+#   - audit_dep_completeness.sh  → per-package .dep file audit (this script)
+#   - check_common_files.sh      → global cache input audit (5 checks)
+#
+# Together they form Phase 1 (Static Analysis) of the DPKG Cache Equivalence
+# verification plan. Their output feeds into Phase 2 (PoC builds) to confirm
+# whether identified gaps cause actual binary differences.
+#
+
+set -uo pipefail
+
+# --- Configuration ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RULES_DIR="$REPO_ROOT/rules"
+PLATFORM_DIR="$REPO_ROOT/platform/${CONFIGURED_PLATFORM:-vs}"
+MAKEFILE_CACHE="$REPO_ROOT/Makefile.cache"
+EXPORT_REGISTRY="$SCRIPT_DIR/cache_key_export_registry.tsv"   # informational snapshot only
+EXPORT_SCANNER="$SCRIPT_DIR/cache_key_scan.py"
+EXPORT_WAIVERS="$SCRIPT_DIR/cache_key_export_waivers.tsv"     # human-justified safe exports
+
+# Colors for terminal output
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Internal field separator for FINDINGS records. Uses ASCII Unit Separator
+# (0x1f) instead of '|' because finding text (e.g. grep -Ev "a|b" exclusion
+# patterns) can legitimately contain '|', which would corrupt the split.
+readonly FINDING_FS=$'\037'
+
+# Counters
+TOTAL_DEP_FILES=0
+FINDINGS_P0=0
+FINDINGS_P1=0
+FINDINGS_P2=0
+FINDINGS_P3=0
+
+# Options
+VERBOSE=false
+JSON_OUTPUT=false
+FILTER_PACKAGE=""
+FINDINGS=()
+DIFF_MODE=false
+DIFF_BASE=""
+DIFF_VARS_CACHE=""
+EXPORT_SCAN_CACHE=""
+
+# --- Argument Parsing ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose|-v)
+            VERBOSE=true
+            shift
+            ;;
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        --package|-p)
+            FILTER_PACKAGE="$2"
+            shift 2
+            ;;
+        --base|-b)
+            DIFF_MODE=true
+            DIFF_BASE="$2"
+            shift 2
+            ;;
+        --refresh-registry)
+            # Regenerate the comprehensive export registry from a whole-tree scan.
+            if [[ ! -f "$EXPORT_SCANNER" ]]; then
+                echo "Scanner not found: $EXPORT_SCANNER" >&2
+                exit 1
+            fi
+            exec python3 "$EXPORT_SCANNER"
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--verbose] [--json] [--package PKGNAME] [--base REF] [--refresh-registry]"
+            echo ""
+            echo "Options:"
+            echo "  --verbose, -v      Show detailed analysis for each .dep file"
+            echo "  --json             Output findings as JSON (for programmatic consumption)"
+            echo "  --package, -p      Only audit a specific package (e.g., 'swss')"
+            echo "  --base, -b REF     PR/diff mode: only judge packages and exported build"
+            echo "                     variables changed since git REF (e.g. origin/master)."
+            echo "                     Any not-provably-safe export the PR touches -> P0."
+            echo "  --refresh-registry Write an informational snapshot of the live export"
+            echo "                     classification to scripts/cache_key_export_registry.tsv"
+            echo "                     (scripts/cache_key_scan.py) and exit. The gate itself"
+            echo "                     classifies LIVE and does not depend on this snapshot."
+            echo "  --help, -h         Show this help"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# --- Helper Functions ---
+
+log_verbose() {
+    if $VERBOSE; then
+        echo -e "  ${CYAN}[VERBOSE]${NC} $1"
+    fi
+}
+
+add_finding() {
+    local severity="$1"
+    local package="$2"
+    local issue="$3"
+    local suggestion="$4"
+
+    FINDINGS+=("${severity}${FINDING_FS}${package}${FINDING_FS}${issue}${FINDING_FS}${suggestion}")
+
+    case $severity in
+        P0) ((FINDINGS_P0++)) ;;
+        P1) ((FINDINGS_P1++)) ;;
+        P2) ((FINDINGS_P2++)) ;;
+        P3) ((FINDINGS_P3++)) ;;
+    esac
+}
+
+# Run the comprehensive whole-tree scanner ONCE (live) and cache its output. The
+# gate classifies on every run from live code — there is no committed trust-store
+# to drift out of date. Output rows: variable<TAB>disposition<TAB>evidence.
+compute_export_scan() {
+    [[ -n "$EXPORT_SCAN_CACHE" ]] && return 0
+    [[ -f "$EXPORT_SCANNER" ]] || return 1
+    EXPORT_SCAN_CACHE=$(python3 "$EXPORT_SCANNER" --stdout 2>/dev/null)
+    [[ -n "$EXPORT_SCAN_CACHE" ]]
+}
+
+# Echo the human-recorded justification if $1 is waived in cache_key_export_waivers.tsv
+# (variable<TAB>reason, '#' comments ignored), else nothing. A waiver is the ONLY
+# way a not-provably-safe export is cleared, and it must carry a reason.
+waiver_reason() {
+    [[ -f "$EXPORT_WAIVERS" ]] || return 0
+    awk -F'\t' -v v="$1" '!/^[[:space:]]*#/ && $1==v {print $2; exit}' "$EXPORT_WAIVERS"
+}
+
+# Populate DIFF_VARS_CACHE with the set of build-env variables the diff touches:
+# any variable whose `export`/assignment/use lines were added or removed between
+# DIFF_BASE and the working tree in slave.mk / rules/*.mk / Makefile.cache. Used
+# by --base (PR) mode to scope Check 10 to what the PR actually changes.
+compute_diff_vars() {
+    $DIFF_MODE || return 0
+    local range="$DIFF_BASE"
+    # Resolve a merge-base when given a branch ref, so we only see PR-local changes.
+    if git -C "$REPO_ROOT" rev-parse --verify -q "$DIFF_BASE" >/dev/null 2>&1; then
+        local mb; mb=$(git -C "$REPO_ROOT" merge-base "$DIFF_BASE" HEAD 2>/dev/null)
+        [[ -n "$mb" ]] && range="$mb"
+    fi
+    DIFF_VARS_CACHE=$(git -C "$REPO_ROOT" diff --unified=0 "$range" -- \
+            slave.mk 'rules/*.mk' Makefile.cache 2>/dev/null \
+        | grep -E '^[-+]' | grep -vE '^[-+]{3} ' \
+        | grep -oP '(?:export\s+|\$\()\K[A-Za-z_][A-Za-z0-9_]*' \
+        | sort -u)
+    log_verbose "diff-mode variables touched since $DIFF_BASE: $(echo "$DIFF_VARS_CACHE" | tr '\n' ' ')"
+}
+
+# True (0) if $1 is one of the variables the diff touched (see compute_diff_vars).
+diff_touches_var() {
+    grep -qx "$1" <<< "$DIFF_VARS_CACHE"
+}
+
+# Escape a string for safe embedding inside a JSON double-quoted value.
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"   # backslash first
+    s="${s//\"/\\\"}"   # then double quotes
+    s="${s//	/\\t}"    # literal tab -> \t
+    printf '%s' "$s"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data-driven flag classifiers (no hand-maintained allow-lists)
+# ─────────────────────────────────────────────────────────────────────────────
+# Whether a build flag affects cached package output is decided by INSPECTING
+# what its ifeq/ifneq blocks actually DO, using the SONiC Make build-variable
+# naming convention as the signal. That convention (e.g. *_DEPENDS, *_DBG_PACKAGES)
+# is fixed by Makefile.cache/slave.mk and effectively never changes, whereas the
+# set of feature flags grows constantly — so this needs no manual upkeep.
+
+# A conditional block is "build-affecting" if it assigns to a package build
+# input: dependency lists, derived/extra/dbg debs, source paths, build env/flags,
+# or runs a build recipe. It is ALSO build-affecting if it registers a derived or
+# extra package via the add_derived_package / add_extra_package helpers (which
+# expand to *_DERIVED_DEBS / *_EXTRA_DEBS and change a package's cached payload) —
+# matched explicitly because the helper call site does not contain the literal
+# *_DERIVED_DEBS/*_EXTRA_DEBS token. Blocks that only touch image-assembly /
+# installer / feature-inclusion variables (e.g. SONIC_INSTALL_DOCKER_IMAGES,
+# *_DOCKERS, SONIC_PACKAGES*, DEFAULT_FEATURE_*) do NOT match and are cosmetic.
+readonly BUILD_SIGNAL_RE='_(DEPENDS|RDEPENDS|DBG_DEPENDS|DBG_PACKAGES|EXTRA_DEBS|DERIVED_DEBS|SRC_PATH|BUILD_ENV|MAKE_ENV|CFLAGS|MAKE_TARGET)[[:space:]+:=]|add_(derived|extra)_package|dpkg-buildpackage|DEB_BUILD_OPTIONS'
+
+# Print the ifeq/ifneq($(flag)...) ... endif block(s) that reference $flag in $file.
+# Captures ALL such blocks (not just the first) and tolerates nested conditionals
+# via depth tracking, so build signals in later blocks are not missed.
+flag_blocks_in_file() {
+    local flag="$1" file="$2"
+    [[ -f "$file" ]] || return 0
+    awk -v flag="$flag" '
+        function isif(l){ return (l ~ /^[[:space:]]*if(eq|neq|def|ndef)([[:space:]]|\()/) }
+        depth==0 && $0 ~ ("if(eq|neq).*\\$\\(" flag "\\)") { depth=1; print; next }
+        depth>0 {
+            print
+            if (isif($0)) depth++
+            else if ($0 ~ /^[[:space:]]*endif([[:space:]]|$)/) depth--
+        }
+    ' "$file" 2>/dev/null || true
+}
+
+# True (0) if any block content carries a build signal (i.e. affects build output).
+block_is_build_affecting() {
+    echo "$1" | grep -qE "$BUILD_SIGNAL_RE"
+}
+
+# True (0) if $flag gates a package BUILD input anywhere in rules/*.mk or slave.mk.
+flag_affects_build() {
+    local flag="$1" f
+    for f in "$RULES_DIR"/*.mk "$REPO_ROOT/slave.mk"; do
+        if block_is_build_affecting "$(flag_blocks_in_file "$flag" "$f")"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# True (0) if $flag is tracked in some cache key: SONIC_COMMON_FLAGS_LIST or any
+# per-package *_DEP_FLAGS in rules/*.dep.
+flag_tracked_anywhere() {
+    local flag="$1"
+    if echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx "$flag"; then
+        return 0
+    fi
+    grep -lE "_DEP_FLAGS" "$RULES_DIR"/*.dep 2>/dev/null \
+        | xargs -r grep -lE "\\\$\\(${flag}\\)" 2>/dev/null | grep -q . && return 0
+    return 1
+}
+
+# True (0) if slave.mk pins $flag to 'n' for all modern build envs
+# (bookworm/trixie), making it effectively deprecated/dead (e.g. ENABLE_PY2_MODULES).
+flag_forced_off_for_modern_bldenv() {
+    local flag="$1"
+    awk -v flag="$flag" '
+        /if(eq|neq).*filter.*\$\(BLDENV\)/ { inblk = (/bookworm/ && /trixie/) ? 1 : 0; next }
+        inblk && $0 ~ ("^[[:space:]]*" flag "[[:space:]]*=[[:space:]]*n([[:space:]]|$)") { found=1 }
+        /^endif/ { inblk=0 }
+        END { exit(found?0:1) }
+    ' "$REPO_ROOT/slave.mk" 2>/dev/null
+}
+
+# SONIC_COMMON_FLAGS_LIST contents, computed once (used by classifiers above).
+compute_common_flags_list() {
+    COMMON_FLAGS_LIST_CACHE=$(sed -n '/^SONIC_COMMON_FLAGS_LIST/,/[^\\]$/p' "$MAKEFILE_CACHE" \
+        | grep -oP '\$\(\w+\)' | tr -d '$()' | sort -u)
+}
+COMMON_FLAGS_LIST_CACHE=""
+
+# --- Check 1: Missing .dep files ---
+# Packages with .mk files but no .dep file are NEVER cached.
+check_missing_dep_files() {
+    echo -e "\n${CYAN}=== Check 1: Packages without .dep files (never cached) ===${NC}"
+
+    local count=0
+    for mk_file in "$RULES_DIR"/*.mk; do
+        local base
+        base=$(basename "$mk_file" .mk)
+        local dep_file="$RULES_DIR/$base.dep"
+
+        # Skip non-package mk files (config, functions, etc.)
+        if [[ "$base" == "config" ]] || [[ "$base" == "functions" ]]; then
+            continue
+        fi
+
+        # Check if .mk defines any SONIC_* target category
+        if ! grep -qE "SONIC_(DPKG_DEBS|MAKE_DEBS|ONLINE_DEBS|COPY_DEBS|PYTHON_STDEB_DEBS|PYTHON_WHEELS|DOCKER_IMAGES|MAKE_FILES)" "$mk_file"; then
+            continue
+        fi
+
+        if [[ ! -f "$dep_file" ]]; then
+            ((count++))
+            # Check if any cached package depends on this uncached package.
+            # If yes → P1 (downstream stale risk). If no → P2 (performance only).
+            # Strategy: extract variable names assigned in this .mk file, then check
+            # if other .mk files reference them in DEPENDS lines.
+            local has_dependents=false
+            local defined_vars
+            # Match both "$(VAR)_DEPENDS" style and "VAR = value" style assignments
+            defined_vars=$(grep -oP '^\s*\$\(\K[A-Z][A-Z0-9_]+' "$mk_file" 2>/dev/null | sort -u)
+            if [[ -z "$defined_vars" ]]; then
+                # Try bare variable assignments (VAR = value)
+                defined_vars=$(grep -oP '^\s*\K[A-Z][A-Z0-9_]+(?=\s*[:+?]?=)' "$mk_file" 2>/dev/null | sort -u)
+            fi
+            for var in $defined_vars; do
+                # Skip common non-package variables
+                [[ "$var" =~ ^(SONIC_|BLDENV|CONFIGURED|PATH|SRC_PATH|VERSION) ]] && continue
+                if grep -rl "DEPENDS.*\$($var)" "$RULES_DIR"/*.mk "$PLATFORM_DIR"/*.mk 2>/dev/null | grep -qv "$mk_file"; then
+                    has_dependents=true
+                    break
+                fi
+            done
+
+            if $has_dependents; then
+                add_finding "P1" "$base" "No .dep file — package is never cached (other cached packages depend on it)" "Create $dep_file to enable caching"
+            else
+                add_finding "P2" "$base" "No .dep file — package is never cached (performance only, no downstream dependents)" "Create $dep_file to enable caching"
+            fi
+            if $VERBOSE; then
+                echo -e "  ${YELLOW}MISSING${NC}: $base.dep (targets defined in $base.mk)"
+            fi
+        fi
+    done
+
+    echo "  Found $count packages without .dep files"
+}
+
+# --- Check 2: SONIC_COMMON_BASE_FILES_LIST completeness ---
+# Verify all sonic-slave-* directories are tracked
+check_common_base_files() {
+    echo -e "\n${CYAN}=== Check 2: SONIC_COMMON_BASE_FILES_LIST completeness ===${NC}"
+
+    # Extract currently tracked slave containers from Makefile.cache
+    local tracked_slaves
+    tracked_slaves=$(grep -oP 'sonic-slave-\w+' "$MAKEFILE_CACHE" | sort -u)
+
+    # Find all sonic-slave-* directories that exist
+    local existing_slaves
+    existing_slaves=$(find "$REPO_ROOT" -maxdepth 1 -type d -name "sonic-slave-*" -exec basename {} \; | sort)
+
+    echo "  Tracked in SONIC_COMMON_BASE_FILES_LIST:"
+    echo "$tracked_slaves" | sed 's/^/    /'
+
+    echo "  Existing sonic-slave-* directories:"
+    echo "$existing_slaves" | sed 's/^/    /'
+
+    # Find gaps
+    while IFS= read -r slave_dir; do
+        if ! echo "$tracked_slaves" | grep -q "^${slave_dir}$"; then
+            add_finding "P1" "$slave_dir" "Missing from SONIC_COMMON_BASE_FILES_LIST in Makefile.cache" \
+                "Add ${slave_dir}/Dockerfile.j2 and ${slave_dir}/Dockerfile.user.j2 to the list"
+            echo -e "  ${RED}GAP${NC}: $slave_dir exists but is NOT tracked!"
+        fi
+    done <<< "$existing_slaves"
+}
+
+# --- Check 3: DEP_FLAGS vs actual build-affecting flags ---
+# For each .dep, check if the .mk uses conditional flags not declared in DEP_FLAGS
+check_dep_flags_coverage() {
+    echo -e "\n${CYAN}=== Check 3: DEP_FLAGS coverage vs conditional build flags ===${NC}"
+
+    # Extract SONIC_COMMON_FLAGS_LIST once for lookups
+    local common_flags_list
+    common_flags_list=$(sed -n '/^SONIC_COMMON_FLAGS_LIST/,/[^\\]$/p' "$MAKEFILE_CACHE" | \
+        grep -oP '\$\(\w+\)' | tr -d '$()' | sort -u)
+
+    for dep_file in "$RULES_DIR"/*.dep; do
+        local base
+        base=$(basename "$dep_file" .dep)
+        local mk_file="$RULES_DIR/$base.mk"
+
+        # Skip if no corresponding .mk
+        [[ ! -f "$mk_file" ]] && continue
+
+        # Filter if specific package requested
+        if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        # Extract flags declared in .dep
+        local dep_flags
+        dep_flags=$(grep "_DEP_FLAGS" "$dep_file" 2>/dev/null | grep -oP '\$\(\w+\)' | tr -d '$()')
+
+        # Extract conditional flags used in .mk (ifeq/ifneq patterns)
+        local mk_flags
+        mk_flags=$(grep -oP '(?<=ifeq \(\$\()[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
+        mk_flags+=$'\n'
+        mk_flags+=$(grep -oP '(?<=ifneq \(\$\()[\w]+(?=\))' "$mk_file" 2>/dev/null || true)
+
+        # Filter to build-affecting flags. INSTALL_ is included so that
+        # INSTALL_DEBUG_TOOLS (which adds debug packages to docker image content,
+        # e.g. docker-base _DBG_PACKAGES) is evaluated; the install_only filter
+        # below still suppresses cases where it merely selects an image to ship.
+        local build_flags
+        build_flags=$(echo "$mk_flags" | grep -E "^(ENABLE_|INCLUDE_|INSTALL_|SONIC_)" | sort -u)
+
+        if [[ -z "$build_flags" ]]; then
+            log_verbose "$base: No conditional build flags in .mk"
+            continue
+        fi
+
+        # Check each build flag is covered
+        while IFS= read -r flag; do
+            [[ -z "$flag" ]] && continue
+
+            # --- FALSE POSITIVE FILTERING (data-driven, no flag allow-lists) ---
+
+            # Pattern 0: Effectively deprecated flags — pinned off for all modern
+            # build envs (bookworm/trixie) in slave.mk, so their conditional is
+            # dead code. Detected from slave.mk rather than a hardcoded name list.
+            if flag_forced_off_for_modern_bldenv "$flag"; then
+                log_verbose "$base: \$$flag is pinned off for modern BLDENV — downgrading to P3"
+                add_finding "P3" "$base" \
+                    "Flag \$$flag used but effectively deprecated (pinned to 'n' for bookworm/trixie in slave.mk)" \
+                    "Low priority — only matters for legacy build envs where the flag can be 'y'"
+                continue
+            fi
+
+            # Pattern 1: Flag's conditional in this .mk only controls image
+            # assembly / installer inclusion (e.g. SONIC_INSTALL_DOCKER_IMAGES,
+            # SONIC_PACKAGES_LOCAL) and does NOT touch any package build input.
+            # Classified by build-signal inspection, not a hardcoded variable list.
+            local block_content
+            block_content=$(flag_blocks_in_file "$flag" "$mk_file")
+            if [[ -n "$block_content" ]] && ! block_is_build_affecting "$block_content"; then
+                log_verbose "$base: \$$flag only controls assembly/inclusion (no build signal) — skipping"
+                continue
+            fi
+
+            # Check if flag is in DEP_FLAGS (directly or via SONIC_COMMON_FLAGS_LIST)
+            if ! echo "$dep_flags" | grep -q "$flag"; then
+                # Check if it's already in SONIC_COMMON_FLAGS_LIST (also check SONIC_ prefix variant)
+                local flag_in_common=false
+                if echo "$common_flags_list" | grep -q "^${flag}$"; then
+                    flag_in_common=true
+                elif echo "$common_flags_list" | grep -q "^SONIC_${flag}$"; then
+                    flag_in_common=true
+                fi
+
+                if $flag_in_common; then
+                    log_verbose "$base: $flag is in SONIC_COMMON_FLAGS_LIST (OK)"
+                elif echo "$dep_flags" | grep -q "SONIC_COMMON_FLAGS_LIST"; then
+                    # The dep uses SONIC_COMMON_FLAGS_LIST — check if the flag is there
+                    if echo "$common_flags_list" | grep -q "^${flag}$" || \
+                       echo "$common_flags_list" | grep -q "^SONIC_${flag}$"; then
+                        log_verbose "$base: $flag covered via SONIC_COMMON_FLAGS_LIST"
+                    else
+                        add_finding "P1" "$base" \
+                            "Flag \$$flag used in .mk conditional but not in DEP_FLAGS or SONIC_COMMON_FLAGS_LIST" \
+                            "Add \$($flag) to ${base}_DEP_FLAGS in $base.dep, or add to SONIC_COMMON_FLAGS_LIST"
+                        if $VERBOSE; then
+                            echo -e "  ${YELLOW}GAP${NC}: $base uses \$$flag but doesn't track it"
+                        fi
+                    fi
+                else
+                    add_finding "P1" "$base" \
+                        "Flag \$$flag used in .mk conditional but not tracked in DEP_FLAGS" \
+                        "Add \$($flag) to DEP_FLAGS in $base.dep"
+                fi
+            fi
+        done <<< "$build_flags"
+    done
+}
+
+# --- Check 4: _DEPENDS declared in .mk vs what .dep tracks ---
+# The .dep tracks file-level inputs. But _DEPENDS in .mk declares package-level deps.
+# Those package deps are handled separately by Makefile.cache (via DEP_MOD_SHA).
+# This check verifies that all _DEPENDS packages themselves have .dep files.
+check_dependency_chain_coverage() {
+    echo -e "\n${CYAN}=== Check 4: Dependency chain — do all dependencies have .dep files? ===${NC}"
+
+    local missing_dep_count=0
+
+    for mk_file in "$RULES_DIR"/*.mk; do
+        local base
+        base=$(basename "$mk_file" .mk)
+
+        [[ "$base" == "config" ]] || [[ "$base" == "functions" ]] && continue
+        if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        # Extract _DEPENDS targets (the variable names, not filenames)
+        local depends
+        depends=$(grep -oP '\$\((\w+)\)_DEPENDS' "$mk_file" 2>/dev/null | head -1 | grep -oP '(?<=\$\()\w+(?=\))' || true)
+
+        if [[ -z "$depends" ]]; then
+            continue
+        fi
+
+        # Get the dependency list (right side of _DEPENDS assignment)
+        local dep_packages
+        dep_packages=$(grep "_DEPENDS" "$mk_file" | grep -oP '\$\(\w+\)' | grep -v "_DEPENDS\|_RDEPENDS\|_UNINSTALLS" | tr -d '$()')
+
+        for dep_pkg_var in $dep_packages; do
+            # Find which .mk defines this variable
+            local defining_mk
+            defining_mk=$(grep -l "^${dep_pkg_var}\s*=" "$RULES_DIR"/*.mk 2>/dev/null | head -1 || true)
+
+            if [[ -n "$defining_mk" ]]; then
+                local dep_base
+                dep_base=$(basename "$defining_mk" .mk)
+                if [[ ! -f "$RULES_DIR/$dep_base.dep" ]]; then
+                    ((missing_dep_count++))
+                    add_finding "P2" "$base" \
+                        "Depends on \$($dep_pkg_var) (from $dep_base.mk) which has no .dep file" \
+                        "Cache key for $base may not reflect changes in $dep_base"
+                    log_verbose "$base depends on $dep_pkg_var → $dep_base has no .dep"
+                fi
+            fi
+        done
+    done
+
+    echo "  Found $missing_dep_count dependency chain gaps"
+}
+
+# --- Check 5: Source path exclusion patterns ---
+# Some .dep files use grep -Ev to exclude files. Flag these for review.
+# Filter out benign patterns like `grep -v " "` (filename sanitization).
+check_exclusion_patterns() {
+    echo -e "\n${CYAN}=== Check 5: Source file exclusion patterns in .dep files ===${NC}"
+
+    for dep_file in "$RULES_DIR"/*.dep; do
+        local base
+        base=$(basename "$dep_file" .dep)
+
+        if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        # Look for grep -Ev or grep -v (exclusion patterns)
+        local exclusions
+        exclusions=$(grep -oP 'grep\s+-[Ev]+\s+"[^"]*"' "$dep_file" 2>/dev/null || true)
+
+        if [[ -n "$exclusions" ]]; then
+            # Filter out benign patterns:
+            # - `grep -v " "` just removes filenames with spaces (sanitization)
+            local is_benign=false
+            if echo "$exclusions" | grep -qP 'grep\s+-v\s+" "'; then
+                is_benign=true
+                log_verbose "$base: Exclusion is just space-filtering (benign)"
+            fi
+
+            if ! $is_benign; then
+                add_finding "P2" "$base" \
+                    "Uses exclusion pattern: $exclusions" \
+                    "Verify excluded files don't affect build output"
+                if $VERBOSE; then
+                    echo -e "  ${YELLOW}EXCLUSION${NC}: $base — $exclusions"
+                fi
+            fi
+        fi
+    done
+}
+
+# --- Check 6: CACHE_MODE analysis ---
+# GIT_CONTENT_SHA vs GIT_COMMIT_SHA — the latter is stricter but causes more cache misses
+check_cache_modes() {
+    echo -e "\n${CYAN}=== Check 6: Cache mode analysis ===${NC}"
+
+    local content_sha_count=0
+    local commit_sha_count=0
+    local no_mode_count=0
+
+    for dep_file in "$RULES_DIR"/*.dep; do
+        local base
+        base=$(basename "$dep_file" .dep)
+
+        if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        if grep -q "GIT_CONTENT_SHA" "$dep_file"; then
+            ((content_sha_count++))
+        elif grep -q "GIT_COMMIT_SHA" "$dep_file"; then
+            ((commit_sha_count++))
+            add_finding "P3" "$base" \
+                "Uses GIT_COMMIT_SHA mode — any commit (even non-functional) invalidates cache" \
+                "Consider GIT_CONTENT_SHA if commit metadata doesn't affect output"
+        else
+            ((no_mode_count++))
+            add_finding "P3" "$base" \
+                "No explicit CACHE_MODE set (defaults may apply)" \
+                "Consider explicitly setting CACHE_MODE for clarity"
+        fi
+    done
+
+    echo "  GIT_CONTENT_SHA: $content_sha_count packages"
+    echo "  GIT_COMMIT_SHA:  $commit_sha_count packages"
+    echo "  No explicit mode: $no_mode_count packages"
+}
+
+# --- Check 7: Docker images — verify Dockerfile.j2 directory is fully tracked ---
+check_docker_dep_tracking() {
+    echo -e "\n${CYAN}=== Check 7: Docker image .dep file completeness ===${NC}"
+
+    for dep_file in "$RULES_DIR"/docker-*.dep; do
+        [[ ! -f "$dep_file" ]] && continue
+        local base
+        base=$(basename "$dep_file" .dep)
+
+        if [[ -n "$FILTER_PACKAGE" ]] && [[ "$base" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        # Check if dep tracks the Docker directory via git ls-files
+        if ! grep -q "git ls-files" "$dep_file" && ! grep -q "shell.*ls" "$dep_file"; then
+            # Check if it at least references the DPATH
+            if ! grep -q "DPATH\|_PATH" "$dep_file"; then
+                add_finding "P1" "$base" \
+                    "Docker .dep doesn't appear to track Dockerfile directory contents" \
+                    "Add: DEP_FILES += \$(shell git ls-files \$(DPATH))"
+            fi
+        fi
+
+        # Check for SMDEP_FILES (docker images usually don't have them — they use DEP_FILES)
+        # This is expected behavior, not a gap
+        log_verbose "$base: Docker dep structure OK"
+    done
+}
+
+# --- Check 8: Validate SONIC_COMMON_FLAGS_LIST against slave.mk usage ---
+check_common_flags_completeness() {
+    echo -e "\n${CYAN}=== Check 8: SONIC_COMMON_FLAGS_LIST vs actual build-affecting variables ===${NC}"
+
+    local common_flags="$COMMON_FLAGS_LIST_CACHE"
+
+    echo "  Current SONIC_COMMON_FLAGS_LIST:"
+    echo "$common_flags" | sed 's/^/    /'
+
+    # Look for ENABLE_*/INCLUDE_*/INSTALL_*/SONIC_* vars used in slave.mk conditionals
+    local slave_flags
+    slave_flags=$(grep -oP '(?<=ifeq \(\$\()(ENABLE_\w+|INCLUDE_\w+|INSTALL_\w+|SONIC_\w+)(?=\))' \
+        "$REPO_ROOT/slave.mk" 2>/dev/null | sort -u)
+
+    echo ""
+    echo "  Flags used in slave.mk conditionals but NOT tracked in any cache key:"
+
+    # A slave.mk flag is only a real gap if it (a) actually affects package build
+    # output AND (b) is not tracked anywhere (global list or per-package DEP_FLAGS).
+    # Both tests are data-driven, so no assembly-only / per-package allow-lists are
+    # maintained: flags that merely drive image assembly are filtered by
+    # flag_affects_build, and flags tracked per-package are filtered by
+    # flag_tracked_anywhere.
+    local gap_count=0
+    while IFS= read -r flag; do
+        [[ -z "$flag" ]] && continue
+
+        if ! flag_affects_build "$flag"; then
+            log_verbose "  $flag — no build signal (assembly/inclusion/orchestration only)"
+            continue
+        fi
+        if flag_tracked_anywhere "$flag"; then
+            log_verbose "  $flag — tracked globally or per-package (OK)"
+            continue
+        fi
+
+        ((gap_count++))
+        echo -e "    ${YELLOW}$flag${NC}"
+        add_finding "P2" "Makefile.cache" \
+            "slave.mk uses \$$flag in a build-affecting conditional but it's tracked in neither SONIC_COMMON_FLAGS_LIST nor any package DEP_FLAGS" \
+            "Add \$($flag) to SONIC_COMMON_FLAGS_LIST, or to the DEP_FLAGS of each affected package"
+    done <<< "$slave_flags"
+
+    if [[ $gap_count -eq 0 ]]; then
+        echo -e "    ${GREEN}None — all covered (or tracked per-package / assembly-only)${NC}"
+    fi
+}
+
+# --- Check 9: Nested derived packages (cache save/restore completeness) ---
+# add_derived_package(X, Y) only appends Y to X's first-level _DERIVED_DEBS.
+# The cache save logic (Makefile.cache) tars the MAIN package plus its
+# _DERIVED_DEBS only — it does NOT recurse. If X is itself a derived package
+# (i.e. X appeared as the child/2nd arg of another add_derived_package call),
+# then Y lives under X's _DERIVED_DEBS, not the top-level main package's, so Y
+# is silently dropped from the cache tarball. A cache HIT then restores the
+# main deb and its first-level derived debs but MISSES the nested ones.
+# This is the exact class of bug confirmed by negative control NC-6 (libnl3).
+check_nested_derived_packages() {
+    echo -e "\n${CYAN}=== Check 9: Nested derived packages (cache completeness) ===${NC}"
+
+    local found=0
+    local mk
+    for mk in "$RULES_DIR"/*.mk; do
+        [[ -f "$mk" ]] || continue
+        grep -q 'add_derived_package' "$mk" || continue
+        if [[ -n "$FILTER_PACKAGE" && "$(basename "$mk" .mk)" != "$FILTER_PACKAGE" ]]; then
+            continue
+        fi
+
+        # Build PARENT,CHILD pairs from each add_derived_package(parent, child) call
+        local pairs
+        pairs=$(grep -oE 'add_derived_package,[^,]+,[^)]+\)' "$mk" \
+            | sed -E 's/add_derived_package,//' | tr -d ' $()')
+        [[ -z "$pairs" ]] && continue
+
+        local parents children
+        parents=$(echo "$pairs" | cut -d, -f1 | sort -u)
+        children=$(echo "$pairs" | cut -d, -f2 | sort -u)
+
+        local p
+        for p in $parents; do
+            [[ -z "$p" ]] && continue
+            # A parent that is also a child = nested derivation
+            if echo "$children" | grep -qxF "$p"; then
+                local grandchildren
+                grandchildren=$(echo "$pairs" | awk -F, -v par="$p" '$1==par {print $2}' \
+                    | sort -u | tr '\n' ' ')
+                add_finding "P1" "$(basename "$mk" .mk)" \
+                    "Nested add_derived_package: \$$p is itself a derived deb; its derived debs ($grandchildren) are absent from the top-level package _DERIVED_DEBS and may be dropped from cache save/restore" \
+                    "Register nested derived debs against the top-level main package, or confirm coverage with negative control NC-6"
+                echo -e "  ${RED}GAP${NC}: $(basename "$mk"): nested parent \$$p -> derived debs: $grandchildren"
+                ((found++))
+            fi
+        done
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo -e "  ${GREEN}None — no nested add_derived_package chains found${NC}"
+    fi
+}
+
+# --- Check 10: Exported build-env variables vs the cache key (live whole-tree scan) ---
+# Some build inputs never appear in an ifeq($(FLAG)) conditional; they are simply
+# `export`ed from slave.mk / a rules/*.mk and consumed inside a package's
+# debian/rules, source Makefile, or Dockerfile.j2 — or read straight from the
+# environment by an external tool (docker, cargo, dpkg). Checks 3/8 only inspect
+# ifeq/ifneq blocks, so such an export-only input that changes build output but is
+# absent from SONIC_COMMON_FLAGS_LIST and every per-package *_DEP_FLAGS is invisible
+# to them — flipping it silently reuses a stale cached artifact (the
+# DOCKER_DEFAULT_PLATFORM class of bug).
+#
+# DESIGN: NO name heuristics, NO reliance on the Tier-2 rebuild, NO committed
+# trust-store that can drift. scripts/cache_key_scan.py enumerates EVERY exported
+# variable from live git-tracked source and classifies each by concrete evidence:
+#   in-key    -> literally in SONIC_COMMON_FLAGS_LIST / a *_DEP_FLAGS. PROVABLY safe.
+#   filename  -> value flows into a cached target's *.deb/*.whl/*.gz name. PROVABLY safe.
+#   gap       -> referenced by a cached build recipe but untracked. REPORTED (P1).
+#   assembly  -> referenced in the make/assembly layer, no cached-recipe consumer.
+#                NOT provably safe (can still reach a cached `docker build`). REPORTED (P2).
+#   external-env -> exported, NO in-repo consumer (read from the env by an external
+#                tool). Cannot be proven safe by static analysis. REPORTED (P2).
+# Only in-key/filename auto-clear (both recomputed live). Everything else is a
+# finding (default-deny). A human clears a specific variable by recording it — WITH
+# A REASON — in scripts/cache_key_export_waivers.tsv.
+#
+# PR/diff mode (--base REF): any not-provably-safe, un-waived export the PR TOUCHES
+# is escalated to P0 (a hard gate) — this is exactly how DOCKER_DEFAULT_PLATFORM
+# would be caught on the PR that introduces it. A full run (no --base) reports the
+# whole standing problem set: gap=P1, assembly/external-env=P2.
+check_exported_flags() {
+    echo -e "\n${CYAN}=== Check 10: Exported build-env variables vs cache key (live scan) ===${NC}"
+
+    if ! compute_export_scan; then
+        add_finding "P1" "cache_key_scan.py" \
+            "Export scanner $EXPORT_SCANNER did not run — cannot verify exported build-env variables against the cache key" \
+            "Ensure python3 and scripts/cache_key_scan.py are present; run: $0 --refresh-registry to test it"
+        echo -e "  ${YELLOW}Scanner unavailable${NC}"
+        return
+    fi
+
+    local gap_count=0 unproven_count=0 p0_count=0 waived_count=0
+    while IFS=$'\t' read -r flag disp ev; do
+        [[ -z "$flag" ]] && continue
+        # In diff mode, only judge variables the PR actually touches.
+        if $DIFF_MODE && ! diff_touches_var "$flag"; then
+            continue
+        fi
+
+        # Provably cache-safe — no finding.
+        case "$disp" in
+            in-key|filename)
+                log_verbose "  $flag — $disp (provably cache-safe)"
+                continue
+                ;;
+        esac
+        # Belt-and-suspenders: honor a live cache-key membership too.
+        if flag_tracked_anywhere "$flag"; then
+            log_verbose "  $flag — tracked in a cache key (OK)"
+            continue
+        fi
+
+        # Human-justified waiver — the only way a not-provable export is cleared.
+        local reason
+        reason=$(waiver_reason "$flag")
+        if [[ -n "$reason" ]]; then
+            ((waived_count++))
+            log_verbose "  $flag — waived: $reason"
+            add_finding "P3" "$flag" \
+                "Exported build-env variable waived from cache-key tracking (human-justified): $reason" \
+                "Re-verify the waiver reason still holds if this variable's build usage changes"
+            continue
+        fi
+
+        # A real finding. Standing severity by evidence strength; PR-touched -> P0.
+        local sev msg
+        if $DIFF_MODE; then
+            sev="P0"; ((p0_count++))
+        elif [[ "$disp" == "gap" ]]; then
+            sev="P1"; ((gap_count++))
+        else
+            sev="P2"; ((unproven_count++))
+        fi
+        case "$disp" in
+            gap)
+                msg="Exported and consumed by a cached build recipe (${ev:-recipe}) but tracked in neither SONIC_COMMON_FLAGS_LIST nor any package DEP_FLAGS — changing it alters the built artifact without flipping the cache key (stale-cache risk)"
+                ;;
+            assembly)
+                msg="Exported into the build environment (referenced in the make/assembly layer) but not tracked in any cache key and not provably cache-safe — an assembly-layer variable can still reach a 'docker build' whose image is cached (the DOCKER_DEFAULT_PLATFORM class)"
+                ;;
+            *)
+                msg="Exported into the build environment with NO in-repo consumer — it is read straight from the environment by an external build tool (docker/cargo/dpkg/...), which static analysis cannot see inside, so it cannot be proven cache-safe (the DOCKER_DEFAULT_PLATFORM class)"
+                ;;
+        esac
+        add_finding "$sev" "$flag" "$msg" \
+            "If it can affect any cached artifact, add \$($flag) to SONIC_COMMON_FLAGS_LIST or the relevant package DEP_FLAGS. If it provably cannot, record it (with a reason) in scripts/cache_key_export_waivers.tsv."
+        $VERBOSE && echo -e "  ${RED}$sev${NC} \$$flag ($disp${ev:+: $ev})"
+    done <<< "$EXPORT_SCAN_CACHE"
+
+    if [[ $((gap_count + unproven_count + p0_count)) -eq 0 ]]; then
+        echo -e "  ${GREEN}None — every exported build variable is provably cache-safe or waived${NC}"
+    else
+        [[ $p0_count -gt 0 ]] && echo -e "  ${RED}$p0_count PR-introduced untracked export(s) (P0)${NC}"
+        [[ $gap_count -gt 0 ]] && echo -e "  ${YELLOW}$gap_count exported var(s) consumed by a cached recipe but untracked (P1)${NC}"
+        [[ $unproven_count -gt 0 ]] && echo "  $unproven_count exported var(s) not provably cache-safe — review or waive (P2)"
+    fi
+    [[ $waived_count -gt 0 ]] && log_verbose "$waived_count exported var(s) cleared by recorded waivers"
+}
+
+# --- Output Results ---
+print_summary() {
+    echo -e "\n${CYAN}============================================${NC}"
+    echo -e "${CYAN}=== AUDIT SUMMARY ===${NC}"
+    echo -e "${CYAN}============================================${NC}"
+    echo ""
+    echo "  Total .dep files analyzed: $TOTAL_DEP_FILES"
+    echo ""
+    echo -e "  ${RED}P0 (Confirmed stale cache risk):${NC}  $FINDINGS_P0"
+    echo -e "  ${YELLOW}P1 (Likely stale cache risk):${NC}     $FINDINGS_P1"
+    echo -e "  P2 (Potential risk / verify):        $FINDINGS_P2"
+    echo -e "  P3 (Informational):                  $FINDINGS_P3"
+    echo ""
+
+    if [[ ${#FINDINGS[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}No findings! All .dep files appear complete.${NC}"
+        return
+    fi
+
+    # Print findings table
+    echo -e "  ${CYAN}--- Findings Detail ---${NC}"
+    printf "  %-4s | %-30s | %-60s | %s\n" "SEV" "PACKAGE" "ISSUE" "SUGGESTION"
+    printf "  %-4s-+-%-30s-+-%-60s-+-%s\n" "----" "------------------------------" "------------------------------------------------------------" "----------"
+
+    # Sort by severity
+    IFS=$'\n' sorted=($(sort <<< "${FINDINGS[*]}")); unset IFS
+
+    for finding in "${sorted[@]}"; do
+        IFS=$FINDING_FS read -r sev pkg issue suggestion <<< "$finding"
+        local color="$NC"
+        case $sev in
+            P0) color="$RED" ;;
+            P1) color="$YELLOW" ;;
+        esac
+        printf "  ${color}%-4s${NC} | %-30s | %-60s | %s\n" "$sev" "$pkg" "$issue" "$suggestion"
+    done
+}
+
+print_json() {
+    echo "["
+    local first=true
+    for finding in "${FINDINGS[@]}"; do
+        IFS=$FINDING_FS read -r sev pkg issue suggestion <<< "$finding"
+        if $first; then
+            first=false
+        else
+            echo ","
+        fi
+        printf '  {"severity": "%s", "package": "%s", "issue": "%s", "suggestion": "%s"}' \
+            "$(json_escape "$sev")" "$(json_escape "$pkg")" \
+            "$(json_escape "$issue")" "$(json_escape "$suggestion")"
+    done
+    echo ""
+    echo "]"
+}
+
+# --- Main ---
+main() {
+    # In JSON mode, route all human-readable progress to stderr so that stdout
+    # carries only the JSON payload (emitted by print_json after restoring fd 1).
+    if $JSON_OUTPUT; then
+        exec 3>&1 1>&2
+    fi
+
+    echo -e "${CYAN}╔══════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║  SONiC DPKG Cache — Dependency Tracking Completeness Audit  ║${NC}"
+    echo -e "${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo "  Repository: $REPO_ROOT"
+    echo "  Date: $(date -u '+%Y-%m-%d %H:%M UTC')"
+
+    # Validate we're in the right directory
+    if [[ ! -f "$MAKEFILE_CACHE" ]]; then
+        echo -e "${RED}ERROR: Makefile.cache not found. Run from sonic-buildimage root.${NC}"
+        exit 2
+    fi
+
+    TOTAL_DEP_FILES=$(find "$RULES_DIR" -name "*.dep" | wc -l)
+    echo "  Total .dep files found: $TOTAL_DEP_FILES"
+
+    if [[ -n "$FILTER_PACKAGE" ]]; then
+        echo -e "  ${CYAN}Filtering to package: $FILTER_PACKAGE${NC}"
+    fi
+
+    # Precompute the global flag list once for the data-driven classifiers.
+    compute_common_flags_list
+    compute_diff_vars
+
+    # Run all checks
+    check_missing_dep_files
+    check_common_base_files
+    check_dep_flags_coverage
+    check_dependency_chain_coverage
+    check_exclusion_patterns
+    check_cache_modes
+    check_docker_dep_tracking
+    check_common_flags_completeness
+    check_nested_derived_packages
+    check_exported_flags
+
+    # Output
+    if $JSON_OUTPUT; then
+        exec 1>&3 3>&-   # restore stdout for the JSON payload
+        print_json
+    else
+        print_summary
+    fi
+
+    # Exit code based on findings
+    if [[ $FINDINGS_P0 -gt 0 ]]; then
+        exit 1
+    elif [[ $FINDINGS_P1 -gt 0 ]]; then
+        exit 0  # Warnings but not blocking
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -941,10 +941,53 @@ check_dep_flags_coverage() {
 # The .dep tracks file-level inputs. But _DEPENDS in .mk declares package-level deps.
 # Those package deps are handled separately by Makefile.cache (via DEP_MOD_SHA).
 # This check verifies that all _DEPENDS packages themselves have .dep files.
+#
+# Two classes of dependency are deliberately NOT flagged (they were previously
+# reported but are false positives, confirmed by cache-mechanism review):
+#   1. Docker-image dependencies. SONIC_DOCKER_IMAGES/*_DOCKERS targets are
+#      content-keyed by their own mechanism (SHA_DEP_RULES folds
+#      files/build/versions/** and _FILES into their DEP_FILES, and DEP_MOD_SHA
+#      recursively folds their DEPENDS' hashes). They intentionally carry no
+#      rules/*.dep, so "no .dep file" does not imply a stale cache key.
+#   2. Dependencies whose defining .mk is already listed in the CONSUMER's own
+#      .dep DEP_FILES. Editing that .mk (including a pinned vendor version bump)
+#      already changes the consumer's cache key, so the dependency's missing
+#      .dep is not a staleness gap for this consumer.
+# The genuine gaps are from-source / version-pinned online libs (e.g. grpc,
+# libsaithrift-dev, saiserver) with no .dep, embedded in a cacheable consumer
+# that does not otherwise track them.
+
+# Memoised set of every package variable registered into any SONiC docker-image
+# list (SONIC_DOCKER_IMAGES, SONIC_DOCKER_DBG_IMAGES, SONIC_<DEB>_DOCKERS, ...).
+DOCKER_TARGET_SET_CACHE=""
+docker_target_set() {
+    if [[ -z "$DOCKER_TARGET_SET_CACHE" ]]; then
+        DOCKER_TARGET_SET_CACHE=$(all_rule_mk_files | tr '\n' '\0' | xargs -0 grep -rhoP \
+            'SONIC_[A-Z_]*DOCKER[A-Z_]*\s*\+=\s*\$\(\K\w+(?=\))' 2>/dev/null | sort -u)
+    fi
+    printf '%s\n' "$DOCKER_TARGET_SET_CACHE"
+}
+is_docker_target() {
+    [[ -n "$1" ]] && docker_target_set | grep -qx "$1"
+}
+
+# True when the consumer's .dep already tracks the dependency's defining .mk in
+# its DEP_FILES (by repo-relative path or basename).
+consumer_dep_covers_mk() {
+    local consumer_dep="$1" dep_mk="$2"
+    [[ -f "$consumer_dep" ]] || return 1
+    local dep_mk_rel dep_mk_base
+    dep_mk_rel="${dep_mk#"$REPO_ROOT"/}"
+    dep_mk_base=$(basename "$dep_mk")
+    grep -qF -e "$dep_mk_rel" -e "$dep_mk_base" "$consumer_dep"
+}
+
 check_dependency_chain_coverage() {
     echo -e "\n${CYAN}=== Check 4: Dependency chain — do all dependencies have .dep files? ===${NC}"
 
     local missing_dep_count=0
+    local suppressed_docker=0
+    local suppressed_covered=0
 
     while IFS= read -r mk_file; do
         [[ -n "$mk_file" ]] || continue
@@ -979,6 +1022,23 @@ check_dependency_chain_coverage() {
                 dep_base=$(basename "$defining_mk" .mk)
                 dep_rel="${defining_mk#"$REPO_ROOT"/}"
                 if [[ ! -f "${defining_mk%.mk}.dep" ]]; then
+                    # Suppression 1: docker-image dependencies are keyed by their
+                    # own mechanism (SHA_DEP_RULES versions/ injection + recursive
+                    # DEP_MOD_SHA), not rules/*.dep — a missing .dep is an FP.
+                    if is_docker_target "$dep_pkg_var"; then
+                        ((suppressed_docker++))
+                        log_verbose "$base → \$$dep_pkg_var is a docker target; keyed separately (suppressed)"
+                        continue
+                    fi
+                    # Suppression 2: the consumer's own .dep already lists the
+                    # dependency's defining .mk in DEP_FILES, so edits to it
+                    # (incl. a pinned version bump) already invalidate the
+                    # consumer's cache key — not a gap for this consumer.
+                    if consumer_dep_covers_mk "${mk_file%.mk}.dep" "$defining_mk"; then
+                        ((suppressed_covered++))
+                        log_verbose "$base → $dep_base has no .dep, but $base.dep already tracks $dep_rel (suppressed)"
+                        continue
+                    fi
                     ((missing_dep_count++))
                     add_finding "P2" "$(pkg_label "$mk_file")" \
                         "Depends on \$($dep_pkg_var) (from $dep_rel) which has no .dep file" \
@@ -989,7 +1049,7 @@ check_dependency_chain_coverage() {
         done
     done < <(all_rule_mk_files)
 
-    echo "  Found $missing_dep_count dependency chain gaps"
+    echo "  Found $missing_dep_count dependency chain gaps (suppressed $suppressed_docker docker-target, $suppressed_covered consumer-covered)"
 }
 
 # --- Check 5: Source path exclusion patterns ---

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -215,6 +215,22 @@
 #           the structural omission (no slave-image identity token in the common key)
 #           and, as evidence, each sonic-slave base image pinned by a moving tag.
 #
+# Check 27: output-affecting GLOBAL build-mode selectors that are not encoded in the
+#           output filename and not one of CONFIGURED_PLATFORM/CONFIGURED_ARCH/BLDENV
+#           (which ARE in SONIC_COMMON_FLAGS_LIST). CROSS_BUILD_ENVIRON gates the
+#           CROSS_COMPILE_FLAGS in the dpkg-buildpackage recipe, so a native vs cross
+#           build of the SAME arch produces different binaries under the same key. If
+#           such a selector is used by a build recipe but is absent from SONIC_COMMON_
+#           FLAGS_LIST, the two builds collide on one cache entry. This is the residual
+#           of the variant/mode-collision class NOT already covered by CONFIGURED_*.
+#
+# Check 28: helper scripts invoked by slave.mk build recipes (scripts/*, src/sonic-
+#           build-hooks/*) that shape the CONTENT of produced artifacts — buildinfo /
+#           version-pin / debug-file injection into images — but are not in SONIC_
+#           COMMON_FILES_LIST nor any _DEP_FILES. Editing such a script changes every
+#           affected output without moving any cache key. Data-driven: enumerate the
+#           scripts referenced in recipes and verify each is hashed by a file list.
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -2254,6 +2270,63 @@ check_slave_toolchain_identity() {
         || echo -e "  ${YELLOW}$found toolchain-identity gap(s)${NC}"
 }
 
+check_build_mode_selectors() {
+    echo -e "\n${CYAN}=== Check 27: output-affecting global build-mode selectors not in the key ===${NC}"
+    local found=0
+    # Global toggles that change the CONTENT of a produced artifact but are neither
+    # encoded in the output filename nor selected by CONFIGURED_PLATFORM/CONFIGURED_
+    # ARCH/BLDENV (all three ARE in SONIC_COMMON_FLAGS_LIST). Platform-specific
+    # _BUILD_ENV (e.g. libsaithrift-dev's platform=vs vs platform=vpp) is therefore
+    # already keyed via CONFIGURED_PLATFORM and is intentionally NOT flagged here.
+    # The residual is a selector that varies WITHIN one platform/arch.
+    local sel used_in_recipe
+    for sel in CROSS_BUILD_ENVIRON; do
+        # Only matters if a build recipe actually consumes it.
+        used_in_recipe=$(grep -cE "\b$sel\b" "$REPO_ROOT/slave.mk" 2>/dev/null)
+        [[ "${used_in_recipe:-0}" -gt 0 ]] || continue
+        if [[ -z "$COMMON_FLAGS_LIST_CACHE" ]] || ! echo "$COMMON_FLAGS_LIST_CACHE" | grep -qw "$sel"; then
+            add_finding "P2" "Makefile.cache" \
+                "Global build-mode selector '$sel' alters produced artifacts (consumed by the slave.mk build recipe) but is absent from SONIC_COMMON_FLAGS_LIST and not encoded in output filenames — a build toggled only by '$sel' (native vs cross for the SAME arch) reuses a stale cache key" \
+                "Fold \$($sel) into SONIC_COMMON_FLAGS_LIST so the selector participates in every package key"
+            ((found++))
+        fi
+    done
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — build-mode selectors are keyed${NC}" \
+        || echo -e "  ${YELLOW}$found build-mode-selector gap(s)${NC}"
+}
+
+check_recipe_invoked_scripts() {
+    echo -e "\n${CYAN}=== Check 28: recipe-invoked build scripts not hashed into any key ===${NC}"
+    local found=0
+    # slave.mk recipes invoke helper scripts that shape the CONTENT of produced
+    # artifacts (buildinfo / version-pin / debug-file injection). Only .platform,
+    # rules/functions and Makefile.cache are in SONIC_COMMON_FILES_LIST, so edits to
+    # these scripts change every affected output without moving any cache key.
+    local script scripts_used
+    # Pure control-flow helpers with no effect on artifact content.
+    local denylist=" scripts/wait_for_docker.sh "
+    scripts_used=$(grep -hoE '(scripts|src/sonic-build-hooks)/[A-Za-z0-9_./-]+\.(sh|py)' \
+        "$REPO_ROOT/slave.mk" 2>/dev/null | sort -u)
+    while IFS= read -r script; do
+        [[ -n "$script" ]] || continue
+        [[ "$denylist" == *" $script "* ]] && continue
+        [[ -f "$REPO_ROOT/$script" ]] || continue
+        # "Hashed" == referenced by a file list in Makefile.cache or any .dep. The
+        # slave.mk invocation line itself is recipe usage, NOT tracking, so it is not
+        # consulted here.
+        if grep -qF "$script" "$MAKEFILE_CACHE" 2>/dev/null || \
+           grep -rqF --include='*.dep' "$script" "$REPO_ROOT/rules" "$REPO_ROOT/platform" 2>/dev/null; then
+            continue
+        fi
+        add_finding "P2" "$script" \
+            "'$script' is invoked by a slave.mk build recipe and shapes produced artifacts (buildinfo/version/debug injection) but is not in SONIC_COMMON_FILES_LIST nor any _DEP_FILES — editing it changes outputs without invalidating any cache key" \
+            "Add '$script' (and the helper library it sources) to SONIC_COMMON_FILES_LIST so recipe-invoked build scripts are hashed into every key"
+        ((found++))
+    done <<< "$scripts_used"
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — recipe-invoked build scripts are hashed${NC}" \
+        || echo -e "  ${YELLOW}$found untracked build-script(s)${NC}"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -2368,6 +2441,8 @@ main() {
     check_included_mk_unhashed
     check_recipe_body_drift
     check_slave_toolchain_identity
+    check_build_mode_selectors
+    check_recipe_invoked_scripts
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -171,6 +171,28 @@
 #           patch while the flag stays 'y' reuses a stale cached kernel. Evidence-
 #           gated on the linux-kernel recipe consuming EXTERNAL_KERNEL_PATCH_LOC.
 #
+# ── Check 21 closes the "inline (non-export) env VALUE consumed by a cached recipe
+#    but absent from the key" class that Check 10 (exported-only) is blind to. ──
+#
+# Check 21: slave.mk's rootfs (RFS) recipe invokes ./build_debian.sh with a long
+#           prefix of INLINE, per-command environment assignments
+#           (VAR=$(VAR) ./build_debian.sh) instead of `export`ed variables.
+#           build_debian.sh reads those VALUES and bakes them into the rootfs that
+#           the recipe then SAVE_CACHEs, yet the RFS target's cache key folds only
+#           SONIC_COMMON_FLAGS_LIST. Because Check 10 scans EXPORTED variables only,
+#           these inline values are a structural blind spot — e.g. the default admin
+#           USERNAME/PASSWORD, CHANGE_DEFAULT_PASSWORD, the BMC account credentials,
+#           MASTER_KUBERNETES_VERSION and MASTER_CRI_DOCKERD, IMAGE_TYPE, DBGOPT:
+#           changing any of them bakes new content into the rootfs while the same
+#           stale cached squashfs is restored. Data-driven: parse the inline env
+#           prefix of every SAVE_CACHE-backed ./build_debian.sh recipe, keep only the
+#           vars build_debian.sh actually reads, then drop those already in the key,
+#           those exported (deferred to Check 10), and those human-waived. Identity /
+#           plumbing values ($* target-stem name, its derived TARGET_MACHINE, the
+#           TARGET_PATH output dir, SONIC_VERSION_CACHE) are cleared via reasoned
+#           waivers in scripts/cache_key_export_waivers.tsv; everything else is
+#           default-deny (P1).
+#
 # ═══════════════════════════════════════════════════════════════════════════════
 # USAGE
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -1896,6 +1918,100 @@ check_unhashed_patch_content() {
         || echo -e "  ${YELLOW}$found patch source(s) applied before build but absent from the cache key${NC}"
 }
 
+# --- Check 21: Inline (non-export) env VALUES passed to a cached build recipe ---
+# The rootfs (RFS) recipe in slave.mk invokes ./build_debian.sh with a prefix of
+# INLINE, per-command environment assignments (VAR=$(VAR) ./build_debian.sh) rather
+# than `export`ed variables. build_debian.sh reads those values and bakes them into
+# the rootfs the recipe SAVE_CACHEs, yet the RFS target key folds only
+# SONIC_COMMON_FLAGS_LIST. Check 10 scans EXPORTED variables only, so these inline
+# values are a structural blind spot. Data-driven: parse the inline env prefix of
+# every SAVE_CACHE-backed ./build_debian.sh recipe, keep only vars the consumed
+# script actually references, and default-deny those that are not in the key, not
+# exported (Check 10), and not human-waived.
+check_inline_recipe_env_vars() {
+    echo -e "\n${CYAN}=== Check 21: Inline (non-export) recipe env values vs cache key ===${NC}"
+    local sm="$REPO_ROOT/slave.mk"
+    local consumer="$REPO_ROOT/build_debian.sh"
+    local found=0 waived=0
+
+    # Evidence gate: the cache-backed rootfs recipe and its consumed script must exist.
+    if [[ ! -f "$sm" || ! -f "$consumer" ]]; then
+        echo -e "  ${GREEN}None — no cache-backed build_debian.sh recipe present${NC}"
+        return
+    fi
+
+    local -a SM_LINES=()
+    mapfile -t SM_LINES < "$sm"
+    local nlines=${#SM_LINES[@]}
+
+    # Collect inline env var names from every SAVE_CACHE-backed ./build_debian.sh
+    # recipe: for each invocation confirm a SAVE_CACHE within the next few lines
+    # (only cached targets matter), then walk backward over the contiguous
+    # 'VAR=... \' continuation block that forms the inline env prefix.
+    local -A CAND=()
+    local ln
+    while IFS= read -r ln; do
+        [[ -n "$ln" ]] || continue
+        local cached=0 j peek
+        for ((j=ln; j<ln+6 && j<nlines; j++)); do
+            peek="${SM_LINES[$j]}"
+            [[ "$peek" == *SAVE_CACHE* ]] && { cached=1; break; }
+        done
+        [[ $cached -eq 1 ]] || continue
+        local k=$((ln-2)) body           # ln is 1-based build_debian.sh line; SM_LINES 0-based
+        while ((k>=0)); do
+            body="${SM_LINES[$k]}"
+            if [[ "$body" =~ ^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*\\[[:space:]]*$ ]]; then
+                CAND["${BASH_REMATCH[1]}"]=1
+                ((k--))
+            else
+                break
+            fi
+        done
+    done < <(grep -nE '\./build_debian\.sh' "$sm" | cut -d: -f1)
+
+    if [[ ${#CAND[@]} -eq 0 ]]; then
+        echo -e "  ${GREEN}None — no cache-backed build_debian.sh recipe present${NC}"
+        return
+    fi
+
+    local v reason
+    for v in $(printf '%s\n' "${!CAND[@]}" | sort); do
+        # Covered: folded into the RFS target's key (its DEP_FLAGS := SONIC_COMMON_FLAGS_LIST).
+        if echo "$COMMON_FLAGS_LIST_CACHE" | grep -qx "$v"; then
+            log_verbose "  $v — in SONIC_COMMON_FLAGS_LIST (OK)"; continue
+        fi
+        # Exported elsewhere -> Check 10 already models it; don't double-report.
+        if flag_is_exported "$v"; then
+            log_verbose "  $v — exported (Check 10 covers it)"; continue
+        fi
+        # Consumed? Data-driven: the value must actually be read by build_debian.sh.
+        # A var that is passed but never referenced is not a content input -> skip.
+        if ! grep -qE "(\\\$\{?${v}\b|[^A-Za-z0-9_]${v}=)" "$consumer" 2>/dev/null; then
+            log_verbose "  $v — passed but not read by build_debian.sh (not a content input)"; continue
+        fi
+        # Human-justified waiver — clears identity/plumbing values (target-stem name,
+        # output dir, version-cache path) that provably cannot alter rootfs content.
+        reason=$(waiver_reason "$v")
+        if [[ -n "$reason" ]]; then
+            ((waived++)); log_verbose "  $v — waived: $reason"
+            add_finding "P3" "$v" \
+                "Inline recipe env value waived from cache-key tracking (human-justified): $reason" \
+                "Re-verify the waiver reason still holds if this variable's build usage changes"
+            continue
+        fi
+        add_finding "P1" "$v" \
+            "Passed INLINE (non-export, '$v=\$($v)') to the cache-backed ./build_debian.sh rootfs recipe (SONIC_RFS_TARGETS) and read by build_debian.sh, but the RFS cache key folds only SONIC_COMMON_FLAGS_LIST — so the value is in neither the key nor any _DEP_FLAGS. Because it is not exported, Check 10 cannot see it: changing the value bakes new content into the rootfs while the same stale cached squashfs is restored" \
+            "Add \$($v) to the RFS target DEP_FLAGS (SONIC_COMMON_FLAGS_LIST in Makefile.cache) so the value is folded into the rootfs cache key; if it provably cannot affect rootfs content, record it (with a reason) in scripts/cache_key_export_waivers.tsv"
+        ((found++))
+        $VERBOSE && echo -e "  ${RED}P1${NC} \$$v (inline, consumed by build_debian.sh, unkeyed)"
+    done
+
+    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — every inline recipe env value is keyed, exported (Check 10), or waived${NC}" \
+        || echo -e "  ${YELLOW}$found inline recipe env value(s) consumed by build_debian.sh but absent from the cache key${NC}"
+    [[ $waived -gt 0 ]] && log_verbose "$waived inline env value(s) cleared by recorded waivers"
+}
+
 # --- Output Results ---
 print_summary() {
     echo -e "\n${CYAN}============================================${NC}"
@@ -2005,6 +2121,7 @@ main() {
     check_docker_install_pkgs_unhashed
     check_misscoped_remote_fingerprint
     check_unhashed_patch_content
+    check_inline_recipe_env_vars
 
     # Output
     if $JSON_OUTPUT; then

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -2012,7 +2012,7 @@ check_inline_recipe_env_vars() {
     [[ $waived -gt 0 ]] && log_verbose "$waived inline env value(s) cleared by recorded waivers"
 }
 
-# --- Shared resolvers for the docker cache-key checks (22-24) ---------------
+# --- Shared resolvers for the docker cache-key checks (23-24) ---------------
 # Repo-relative Dockerfile-context directory ($(DPATH)) for a docker .mk/.dep.
 # The docker recipe dir is named after the file stem: rules/docker-X.mk builds
 # dockers/docker-X, while a platform docker (platform/<vendor>/docker-X.mk) builds
@@ -2023,25 +2023,6 @@ docker_dir_for_stem() {
         rules/*) echo "dockers/$stem" ;;
         *)       echo "$(dirname "$rel")/$stem" ;;
     esac
-}
-
-# Map every file-key variable used in a docker $(PKG)_FILES list to its source
-# filename ($(VAR) value) and source dir ($(VAR)_PATH). Both live in rules/*.mk
-# (e.g. rules/scripts.mk): 'ARP_UPDATE_SCRIPT = arp_update' +
-# '$(ARP_UPDATE_SCRIPT)_PATH = files/scripts' -> files/scripts/arp_update. Built
-# once from the whole-tree .mk corpus; no evaluation of make.
-build_filekey_maps() {
-    [[ "${FILEKEYS_BUILT:-0}" == "1" ]] && return
-    declare -gA FILEKEY_VAL FILEKEY_DIR
-    FILEKEYS_BUILT=1
-    local line
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^[[:space:]]*\$\(([A-Za-z0-9_]+)\)_PATH[[:space:]]*[:+]?=[[:space:]]*([^[:space:]#]+) ]]; then
-            FILEKEY_DIR["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
-        elif [[ "$line" =~ ^[[:space:]]*([A-Za-z0-9_]+)[[:space:]]*=[[:space:]]*([^[:space:]#]+)[[:space:]]*$ ]]; then
-            FILEKEY_VAL["${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
-        fi
-    done < <(all_rule_mk_files | tr '\n' '\0' | xargs -0 cat 2>/dev/null)
 }
 
 # Set of build-flag identifiers that at least one docker .dep folds into its own
@@ -2068,77 +2049,29 @@ build_docker_keyed_flags() {
     done < <(all_dep_files)
 }
 
-# --- Check 22: Docker $(PKG)_FILES sources not folded into the docker key ---
-# slave.mk stages every file named in $(IMG)_FILES into the image build context
-# (COPY'd by the Dockerfile), but those sources live OUTSIDE the image's $(DPATH)
-# (typically files/scripts, files/build_templates, files/image_config, scripts/).
-# A docker key is SONIC_COMMON_FILES_LIST + rules/<img>.{mk,dep} + base list +
-# git ls-files $(DPATH) — so a _FILES source is in NO docker key: editing e.g.
-# files/scripts/arp_update reuses a stale image. Data-driven: resolve each _FILES
-# token to its $(VAR)/$(VAR)_PATH source, require it be git-tracked, outside
-# $(DPATH), not listed in the .dep, and actually referenced by the Dockerfile.
-# Distinct from Check 18 (_INSTALL_DEBS/_WHEELS) and Check 17 (buildinfo generators).
-check_docker_files_unhashed() {
-    echo -e "\n${CYAN}=== Check 22: Docker \$(IMG)_FILES sources not folded into the docker key ===${NC}"
-    local found=0
-    build_filekey_maps
-    local mk mk_rel stem ddir dep j2
-    while IFS= read -r mk; do
-        [[ -f "$mk" ]] || continue
-        grep -qE '\)_FILES[[:space:]]*[:+]?=' "$mk" || continue
-        mk_rel="${mk#"$REPO_ROOT"/}"
-        stem=$(basename "$mk_rel" .mk)
-        [[ -n "$FILTER_PACKAGE" && "$stem" != "$FILTER_PACKAGE" ]] && continue
-        ddir=$(docker_dir_for_stem "$mk_rel" "$stem")
-        j2="$REPO_ROOT/$ddir/Dockerfile.j2"
-        [[ -f "$j2" ]] || continue                       # gate: a real docker image target
-        dep="${mk%.mk}.dep"
-        [[ -f "$dep" ]] || continue
-        grep -qE "_CACHE_MODE[[:space:]]*:?=[[:space:]]*none" "$dep" && continue
-
-        local -a toks=()
-        mapfile -t toks < <(
-            awk '
-                !inf && /\)_FILES[[:space:]]*[:+]?=/ { sub(/^.*\)_FILES[[:space:]]*[:+]?=/,""); inf=1; print; if ($0 !~ /\\[[:space:]]*$/) inf=0; next }
-                inf { print; if ($0 !~ /\\[[:space:]]*$/) inf=0 }
-            ' "$mk" | grep -oE '\$\([A-Za-z0-9_]+\)' | sed -E 's/^\$\(//; s/\)$//' | sort -u
-        )
-        [[ ${#toks[@]} -gt 0 ]] || continue
-
-        local -a unhashed=()
-        local t val dir src bn
-        for t in "${toks[@]}"; do
-            val="${FILEKEY_VAL[$t]:-}"; dir="${FILEKEY_DIR[$t]:-}"
-            [[ -n "$val" && -n "$dir" ]] || continue
-            [[ "$dir" == *'$('* ]] && continue           # unresolved make var
-            src="$dir/$val"
-            [[ -n "$(git -C "$REPO_ROOT" ls-files -- "$src" 2>/dev/null | head -1)" ]] || continue
-            [[ "$src" == "$ddir/"* ]] && continue         # under $(DPATH) -> already hashed
-            grep -qF "$src" "$dep" && continue            # listed explicitly in the key
-            bn=$(basename "$src")
-            grep -qF "$bn" "$j2" || continue              # consumed evidence in the Dockerfile
-            unhashed+=("$src")
-        done
-        [[ ${#unhashed[@]} -gt 0 ]] || continue
-        local list; list=$(printf '%s, ' "${unhashed[@]}"); list="${list%, }"
-        add_finding "P1" "$(pkg_label "$dep")" \
-            "Stages in-repo file(s) into the image build context via its _FILES list: ${list} — these live outside \$(DPATH) ($ddir) and are absent from the docker cache key (SONIC_COMMON_FILES_LIST + ${stem}.{mk,dep} + git ls-files \$(DPATH)); editing any of them restores a stale image" \
-            "Add the resolved _FILES source paths to ${stem}_DEP_FILES in ${stem}.dep, or fold \$(IMG)_FILES source paths into the docker dep SHA in Makefile.cache"
-        ((found++))
-    done < <(all_rule_mk_files)
-    [[ $found -eq 0 ]] && echo -e "  ${GREEN}None — docker _FILES sources are hashed (or under \$(DPATH))${NC}" \
-        || echo -e "  ${YELLOW}$found docker(s) stage unhashed _FILES source(s) into the image${NC}"
-}
+# NOTE: A former "Check 22" flagged docker $(IMG)_FILES sources as absent from the
+# cache key. It was WITHDRAWN as a false positive: Makefile.cache SHA_DEP_RULES
+# (lines ~638-645) already appends every $(IMG)_FILES source — resolved via its
+# $(VAR)_PATH, else $(FILES_PATH) — into $(IMG)_DEP_FILES, which is git-hashed into
+# the docker dep SHA (upstream fix #15473). Verified empirically: the generated
+# target/docker-*.gz.dep lists those sources (e.g. files/build_templates/swss_vars.j2,
+# src/sonic-ctrmgrd/*). Editing such a file therefore DOES move the key. Numbering
+# below is preserved for continuity with recorded findings.
 
 # --- Check 23: Docker build-arg flag consumed by Dockerfile but not in its key --
 # A docker image's rendered Dockerfile.j2 can branch on a build flag ({% if FLAG %}
 # / {{FLAG}}). When sibling docker images DO fold that flag into their _DEP_FLAGS
 # (proving it is a real keyed build input — e.g. ENABLE_ASAN in docker-orchagent /
-# docker-syncd-mlnx) but THIS image omits it, the flag's two renderings collide on
-# one key. A class-level "is ENABLE_* known?" allow-list cannot catch a per-target
-# omission. Data-driven: the keyed-flag set is parsed from real docker _DEP_FLAGS.
+# docker-syncd-mlnx) but THIS image omits it, the image's own _MOD_HASH does not
+# separate the two flag renderings. NOTE (P3, hygiene): a full collision usually
+# does NOT occur, because the docker cache filename also folds the flags/SHAs of
+# every _DEPENDS package via GET_MOD_DEP_SHA — if any dependency keys the flag
+# (e.g. docker-sonic-vs depends on SYSMGR, whose rules/sysmgr.dep carries
+# $(ENABLE_ASAN)), the transitive hash already separates the keys. This check is
+# therefore defense-in-depth: fix the direct omission so correctness does not rely
+# on an incidental dependency. Data-driven: keyed-flag set parsed from real _DEP_FLAGS.
 check_docker_flag_not_keyed() {
-    echo -e "\n${CYAN}=== Check 23: Docker Dockerfile build flag not in that image's _DEP_FLAGS ===${NC}"
+    echo -e "\n${CYAN}=== Check 23: Docker Dockerfile build flag not in that image's _DEP_FLAGS (hygiene) ===${NC}"
     local found=0
     build_docker_keyed_flags
     local dep dep_rel stem ddir j2 F
@@ -2155,8 +2088,8 @@ check_docker_flag_not_keyed() {
         for F in "${!DOCKER_KEYED_FLAGS[@]}"; do
             grep -qE "\{[%{][^}]*\b${F}\b" "$j2" || continue          # consumed in a Jinja directive
             grep -qE "_DEP_FLAGS[[:space:]]*[:+]?=.*\\\$\\(${F}\\)" "$dep" && continue  # keyed here
-            add_finding "P2" "$(pkg_label "$dep")" \
-                "Dockerfile.j2 branches on build flag \$($F) (which sibling docker images fold into their cache key) but ${stem}.dep _DEP_FLAGS omits it — a $F=y vs $F=n build renders a different image with an identical key (variant collision, silent stale reuse across the two)" \
+            add_finding "P3" "$(pkg_label "$dep")" \
+                "Dockerfile.j2 branches on build flag \$($F) (which sibling docker images fold into their cache key) but ${stem}.dep _DEP_FLAGS omits it. A direct collision is usually blocked because a _DEPENDS package that keys \$($F) already separates the key via GET_MOD_DEP_SHA — but this is incidental; add the flag directly as defense-in-depth" \
                 "Append \$($F) to \$(IMG)_DEP_FLAGS in ${stem}.dep (as the sibling docker .dep files already do)"
             ((found++))
         done
@@ -2168,13 +2101,17 @@ check_docker_flag_not_keyed() {
 # --- Check 24: include'd recipe .mk fragment not tracked in the target's key ---
 # A rule/platform .mk can 'include' a shared recipe fragment (e.g. platform docker
 # targets include platform/template/docker-syncd-*.mk, which supplies _LOAD_DOCKERS/
-# _CONTAINER_NAME/_RUN_OPT that shape the built image). If that fragment is not in
-# the target's DEP_FILES (it lives outside $(DPATH)), editing it changes the build
-# without invalidating the cache key. Data-driven: resolve each include (expanding
-# $(PLATFORM_PATH)/$(DOCKERS_PATH)), require a git-tracked .mk, and flag those the
-# paired .dep does not list. Overlaps Check 15 (recipe body) but is file-scoped.
+# _CONTAINER_NAME/_RUN_OPT). The fragment lives outside $(DPATH) and is not in the
+# target's DEP_FILES, so editing it is not directly hashed. NOTE (P3, narrow): most
+# of the fragment's content is already covered or harmless — _LOAD_DOCKERS (base
+# image) is keyed via MOD_DEP_PKGS/GET_MOD_DEP_SHA, and _RUN_OPT is runtime-only
+# (does not affect the built .gz). The only build-affecting, un-keyed variable is
+# _CONTAINER_NAME (passed as --build-arg docker_container_name), and only images
+# whose Dockerfile actually consumes that ARG bake it in. Blast radius is therefore
+# small. Data-driven: resolve each include (expanding $(PLATFORM_PATH)/$(DOCKERS_PATH)),
+# require a git-tracked .mk, and flag those the paired .dep does not list.
 check_included_mk_unhashed() {
-    echo -e "\n${CYAN}=== Check 24: include'd recipe .mk fragment not in the target's cache key ===${NC}"
+    echo -e "\n${CYAN}=== Check 24: include'd recipe .mk fragment not in the target's cache key (narrow) ===${NC}"
     local found=0
     local mk mk_rel dep stem plat inc resolved rel bn
     while IFS= read -r mk; do
@@ -2202,8 +2139,8 @@ check_included_mk_unhashed() {
             grep -qF "$rel" "$dep" && continue             # tracked by full path
             bn=$(basename "$rel")
             grep -qF "$bn" "$dep" && continue              # tracked by basename
-            add_finding "P2" "$(pkg_label "$dep")" \
-                "${stem}.mk 'include's recipe fragment $rel (supplies build vars such as _LOAD_DOCKERS/_CONTAINER_NAME/_RUN_OPT) but ${stem}.dep does not track it (it lives outside \$(DPATH)) — editing the fragment changes the target's build output without invalidating its cache key" \
+            add_finding "P3" "$(pkg_label "$dep")" \
+                "${stem}.mk 'include's recipe fragment $rel but ${stem}.dep does not track it (it lives outside \$(DPATH)). Most of the fragment is already covered — _LOAD_DOCKERS is keyed via MOD_DEP_PKGS and _RUN_OPT is runtime-only; the only un-keyed build-affecting var is _CONTAINER_NAME (--build-arg docker_container_name), baked in only where the Dockerfile consumes that ARG" \
                 "Add $rel to ${stem}_DEP_FILES in ${stem}.dep (or hash every include'd .mk into the target key)"
             ((found++))
         done < <(grep -oP '^[[:space:]]*include[[:space:]]+\K\S+' "$mk")
@@ -2322,7 +2259,6 @@ main() {
     check_misscoped_remote_fingerprint
     check_unhashed_patch_content
     check_inline_recipe_env_vars
-    check_docker_files_unhashed
     check_docker_flag_not_keyed
     check_included_mk_unhashed
 

--- a/scripts/audit_dep_completeness.sh
+++ b/scripts/audit_dep_completeness.sh
@@ -588,8 +588,11 @@ waiver_reason() {
 
 # Populate DIFF_VARS_CACHE with the set of build-env variables the diff touches:
 # any variable whose `export`/assignment/use lines were added or removed between
-# DIFF_BASE and the working tree in slave.mk / rules/*.mk / Makefile.cache. Used
-# by --base (PR) mode to scope Check 10 to what the PR actually changes.
+# DIFF_BASE and the working tree in slave.mk / Makefile / Makefile.work /
+# rules/*.mk / Makefile.cache / platform/*.mk. This producer set mirrors the
+# make-orchestration layer scanned by cache_key_scan.py (slave.mk, Makefile,
+# Makefile.work, and every tracked *.mk). Used by --base (PR) mode to scope
+# Check 10 to what the PR actually changes.
 compute_diff_vars() {
     $DIFF_MODE || return 0
     local range="$DIFF_BASE"
@@ -599,7 +602,7 @@ compute_diff_vars() {
         [[ -n "$mb" ]] && range="$mb"
     fi
     DIFF_VARS_CACHE=$(git -C "$REPO_ROOT" diff --unified=0 "$range" -- \
-            slave.mk 'rules/*.mk' Makefile.cache 'platform/*.mk' 2>/dev/null \
+            slave.mk Makefile Makefile.work 'rules/*.mk' Makefile.cache 'platform/*.mk' 2>/dev/null \
         | grep -E '^[-+]' | grep -vE '^[-+]{3} ' \
         | python3 -c '
 import sys, re

--- a/scripts/cache_key_export_waivers.tsv
+++ b/scripts/cache_key_export_waivers.tsv
@@ -1,0 +1,61 @@
+# cache_key_export_waivers.tsv
+#
+# Human-justified waivers for Check 10 of scripts/audit_dep_completeness.sh.
+#
+# The audit classifies every exported build-environment variable LIVE on each run
+# (scripts/cache_key_scan.py). Only `in-key` and `filename` dispositions are
+# machine-provably cache-safe and auto-clear. Every other exported variable is a
+# finding (default-deny) because static analysis cannot prove it is harmless to
+# the build cache — an assembly-layer or environment-only variable can still reach
+# a `docker build` (whose image is cached) or a package build recipe.
+#
+# This file is the ONLY way to clear such a variable without adding it to the
+# cache key. Each entry asserts, under human review, that changing the variable
+# cannot alter any cached artifact's content. A waiver MUST carry a concrete
+# reason; unreasoned waivers are meaningless and will be rejected in review.
+#
+# Format (TAB-separated):
+#   variable<TAB>reason
+#
+# Guidance:
+#   - Prefer FIXING the gap (add $(VAR) to SONIC_COMMON_FLAGS_LIST or a package
+#     *_DEP_FLAGS) over waiving it. Waive only when the variable provably cannot
+#     change build output.
+#   - A waived variable still surfaces as an informational P3 finding so the
+#     waiver stays visible and auditable.
+#   - Re-verify a waiver if the variable's build usage changes.
+#
+#
+# variable	reason
+module_out_put_dir	cp *.ko destination directory only; changing it relocates output, not module content
+common_out_put_dir	cp binary destination directory only; relocation, not content
+sysfs_out_put_dir	cp *.ko destination directory only; relocation, not content
+BUILD_OUTPUT_DIR	mv *.ko destination directory only; relocation, not content
+BUILD_WORKDIR	base path used to locate the sign-file tool; relocation only, signed output unchanged
+PROJECT_ROOT	base path to source/scripts; relocation only, no content effect
+debs_path	points at the location of already-built debs, each independently keyed; not a content input
+GOPATH	Go build workspace path (/tmp/go); binary output is content-identical regardless of workspace location
+SDK	in-tree SDK source path (override SDK:=$(CURDIR)); SDK content is hashed via its submodule, path is relocation only
+SONIC_CONFIG_MAKE_JOBS	dpkg-buildpackage -j parallelism; affects build speed only, not output
+Q	make command-echo verbosity prefix ($(Q)=@ or empty); no content effect
+PIP_HTTP_TIMEOUT	pip network timeout written to buildinfo; no effect on resolved package content
+vs_build_prepare_mem	KVM build VM memory sizing; build resource only, no content
+BUILD_TIMESTAMP	volatile per-build timestamp; intentionally excluded from the key (keying it would defeat caching)
+DEFAULT_CONTAINER_REGISTRY	registry prefix stripped from an image tag; registry location, not image content
+DOCKER_USERNAME	strips a username suffix from an image name; image naming only, not content
+SONIC_VERSION_CACHE	controls the version-cache mechanism itself; not an input to any cached artifact
+ENABLE_FIPS	consumed only by build_image.sh (SONIC_INSTALLERS stage), which is not in the cache framework and is always rebuilt
+BUILD_MULTIASIC_KVM	consumed only by build_image.sh (non-cached installer stage); no cached artifact depends on it
+onie_recovery_image	consumed only by build_image.sh; selects a recovery ISO for the always-rebuilt installer, not a cached target
+onie_recovery_kvm_4asic_image	consumed only by build_image.sh; installer-stage recovery ISO, not a cached target
+onie_recovery_kvm_6asic_image	consumed only by build_image.sh; installer-stage recovery ISO, not a cached target
+kversion	shell alias exporting $(KVERSION) verbatim (slave.mk:1437); the content signal is KVERSION, which is tracked in SONIC_COMMON_FLAGS_LIST
+sonic_asic_platform	derived from $(CONFIGURED_PLATFORM)/$(CONFIGURED_ARCH) (slave.mk:1440), both already in the cache key; alias carries no independent signal
+enable_organization_extensions	shell alias exporting $(ENABLE_ORGANIZATION_EXTENSIONS) verbatim (slave.mk:1551); the content signal is that make var, tracked in SONIC_COMMON_FLAGS_LIST
+sonic_su_prod_signing_tool	basename of $(SECURE_UPGRADE_PROD_SIGNING_TOOL) (slave.mk:1559); the content signal is that make var, tracked in SONIC_COMMON_FLAGS_LIST
+RFS_SPLIT_FIRST_STAGE	literal y/n recipe constant (slave.mk:1441/1704) selecting the RFS split stage; value can only change if slave.mk changes, which is itself hashed
+RFS_SPLIT_LAST_STAGE	literal y/n recipe constant (slave.mk:1442/1705) selecting the RFS split stage; value can only change if slave.mk changes, which is itself hashed
+PATH	prepends a cross-Python venv bin dir to the existing ${PATH} (slave.mk:1051) and extends the container PATH (docker-bmp-watchdog/Dockerfile.j2:15); embeds the host/container PATH which varies per environment - keying it changes no artifact content and would defeat cross-machine cache reuse
+docker_container_name	docker build-arg set to $($*.gz_CONTAINER_NAME) (slave.mk:1125/1295/1363); a fixed per-image name, constant for a given cached docker target, so it cannot change independently and cause a stale hit
+sonic_version	set from $(SONIC_GET_VERSION) (platform/alpinevs/sonic-version.mk:3) and written into the volatile sonic_version.yml build-stamp metadata alongside commit_id/build_date/build_number; same class as BUILD_TIMESTAMP - keying it would defeat caching
+KERNEL_SRC	filesystem path to the kernel build tree, default /lib/modules/$(KVERSION)/build (platform/aspeed/sonic-platform-modules-arista/Makefile:11); kernel identity is KVERSION (tracked in the cache key) and the path itself is relocation-only

--- a/scripts/cache_key_export_waivers.tsv
+++ b/scripts/cache_key_export_waivers.tsv
@@ -1,13 +1,16 @@
 # cache_key_export_waivers.tsv
 #
-# Human-justified waivers for Check 10 of scripts/audit_dep_completeness.sh.
+# Human-justified waivers for Check 10 and Check 21 of
+# scripts/audit_dep_completeness.sh.
 #
-# The audit classifies every exported build-environment variable LIVE on each run
-# (scripts/cache_key_scan.py). Only `in-key` and `filename` dispositions are
-# machine-provably cache-safe and auto-clear. Every other exported variable is a
-# finding (default-deny) because static analysis cannot prove it is harmless to
-# the build cache — an assembly-layer or environment-only variable can still reach
-# a `docker build` (whose image is cached) or a package build recipe.
+# Check 10 classifies every exported build-environment variable LIVE on each run
+# (scripts/cache_key_scan.py). Check 21 classifies the INLINE (non-export) env
+# values passed to the cache-backed ./build_debian.sh rootfs recipe. For both,
+# only `in-key` (folded into a cache key) is machine-provably cache-safe and
+# auto-clears. Every other variable is a finding (default-deny) because static
+# analysis cannot prove it is harmless to the build cache — an assembly-layer or
+# environment-only variable can still reach a `docker build` (whose image is
+# cached) or a package/rootfs build recipe.
 #
 # This file is the ONLY way to clear such a variable without adding it to the
 # cache key. Each entry asserts, under human review, that changing the variable
@@ -59,3 +62,6 @@ PATH	prepends a cross-Python venv bin dir to the existing ${PATH} (slave.mk:1051
 docker_container_name	docker build-arg set to $($*.gz_CONTAINER_NAME) (slave.mk:1125/1295/1363); a fixed per-image name, constant for a given cached docker target, so it cannot change independently and cause a stale hit
 sonic_version	set from $(SONIC_GET_VERSION) (platform/alpinevs/sonic-version.mk:3) and written into the volatile sonic_version.yml build-stamp metadata alongside commit_id/build_date/build_number; same class as BUILD_TIMESTAMP - keying it would defeat caching
 KERNEL_SRC	filesystem path to the kernel build tree, default /lib/modules/$(KVERSION)/build (platform/aspeed/sonic-platform-modules-arista/Makefile:11); kernel identity is KVERSION (tracked in the cache key) and the path itself is relocation-only
+RFS_SQUASHFS_NAME	equals $* (the RFS target stem <installer>__<machine>__rfs.squashfs); it IS the cached artifact's own squashfs filename, so it cannot cause a stale cross-key reuse (Check 21)
+TARGET_MACHINE	equals $($*_MACHINE), a deterministic function of the RFS target stem $* which already encodes the machine in the artifact filename identity; not an independent content input (Check 21)
+TARGET_PATH	output directory path (target/) where build_debian.sh writes results; relocation only, does not alter rootfs content (Check 21)

--- a/scripts/cache_key_scan.py
+++ b/scripts/cache_key_scan.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+cache_key_scan.py - comprehensive, evidence-based classifier for build-environment
+variables versus the SONiC dpkg build-cache key.
+
+This is the "source of truth" behind Check 10 of audit_dep_completeness.sh. It is a
+WHOLE-TREE scan of GIT-TRACKED source (no build artifacts, no name heuristics, no
+shortcuts) that assigns every exported build-environment variable to exactly one
+disposition, justified by concrete code evidence.
+
+PRODUCERS (where a build-env variable is set for child processes/recipes):
+  the entire superproject make-orchestration layer - slave.mk, Makefile,
+  Makefile.work, and every tracked *.mk (rules/*, platform/**). Both `export VAR`
+  and inline `VAR=val ... $(MAKE)` environment passing are collected. Submodule-
+  internal Makefiles are NOT producers: their own exports are part of that
+  package's recipe content, already hashed into its cache key.
+
+CONSUMERS (where a variable is dereferenced during a cached build):
+  every build recipe across the whole tree INCLUDING submodules - each package's
+  debian/rules, its build Makefile(s), Dockerfile*.j2 templates, and build shell
+  scripts (*.sh). A "consumer" must actually dereference the variable ($(VAR),
+  ${VAR} or $VAR); a bare textual mention in a comment does not count (comments
+  are stripped before matching).
+
+DISPOSITIONS:
+  in-key    Variable is literally part of a cache key: in SONIC_COMMON_FLAGS_LIST
+            or some package's *_DEP_FLAGS. A change flips the key. PROVABLY SAFE.
+  filename  Variable's value flows (transitively) into a cached target's file NAME
+            (*.deb/*.whl/*.gz). The name is part of the key. PROVABLY SAFE. Only
+            the filename token itself is inspected - not prerequisites or recipe
+            bodies on the same line - so this cannot false-clear.
+  gap       Dereferenced by a cached build recipe but neither in-key nor filename.
+            Changing it alters the artifact without flipping the key. REPORTED.
+  assembly  Dereferenced only in the make/assembly layer, not in a cached recipe.
+            NOT provably safe (an assembly-layer var can still reach a cached
+            `docker build`). REPORTED.
+  external-env  Exported but never dereferenced in-repo: read straight from the
+            environment by an external tool (docker/cargo/dpkg). Static analysis
+            cannot see inside those tools. REPORTED.
+
+Only in-key and filename are machine-provably cache-safe and auto-clear. Every
+other exported variable is a finding (default-deny). A human clears a specific
+variable by recording it - WITH A REASON - in cache_key_export_waivers.tsv.
+
+Usage:
+  cache_key_scan.py            Write scripts/cache_key_export_registry.tsv snapshot
+                               and print a distribution summary.
+  cache_key_scan.py --stdout   Emit "variable<TAB>disposition<TAB>evidence" rows to
+                               stdout (consumed live by the audit gate). No file I/O.
+
+Enumeration is driven by `git ls-files`, so the scan sees committed source only and
+runs in a few seconds regardless of how dirty the working tree is.
+"""
+import os
+import re
+import sys
+import collections
+import subprocess
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+REGISTRY = os.path.join(os.path.dirname(__file__), "cache_key_export_registry.tsv")
+
+# A dereference of a make/shell/docker variable: $(VAR), ${VAR} or $VAR.
+REF_RE = re.compile(r"\$\((\w+)\)|\$\{(\w+)\}|\$(\w+)")
+# A cached-target filename token: a contiguous run ending in .deb/.whl/.gz that may
+# embed $(VAR)/${VAR} references. It stops at whitespace and rule/recipe separators
+# (: ; = | & < > quotes) so it captures ONLY the artifact name - never a
+# prerequisite or a recipe command on the same line - while still spanning the
+# parentheses of an embedded $(VAR).
+FN_TOKEN_RE = re.compile(r"[^\s:;=|&<>'\"]*\.(?:deb|whl|gz)\b")
+# A make variable reference in EITHER syntax: $(VAR) or ${VAR}. Package .mk files
+# freely mix both (e.g. `foo_${VER}_${ARCH}.deb`), so var-ref extraction must not
+# be paren-only or it silently misses curly-brace refs and reports false gaps.
+VARREF_RE = re.compile(r"\$[({]\s*(\w+)\s*[})]")
+EXPORT_RE = re.compile(r"^\s*export\s+([A-Za-z_]\w*)", re.M)
+ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*[:?+]?=\s*(.*)$", re.M)
+# Unconditional (re)assignment of a variable inside a recipe: `VAR = x` / `VAR := x`
+# (make), `export VAR=x` / `override VAR := x` (make), or `VAR=x` (shell). Such a
+# variable is SHADOWED - the recipe forces its own value (a plain make assignment
+# overrides the inherited environment), so the recipe is not a consumer of the
+# export. `?=` (use-env-if-set) and `+=` (append to the inherited value) still
+# consume, so they are excluded from this pattern.
+OVERRIDE_RE = re.compile(r"^\s*(?:export\s+|override\s+)*([A-Za-z_]\w*)\s*:?=", re.M)
+
+
+def read(path):
+    try:
+        with open(os.path.join(REPO_ROOT, path), encoding="utf-8", errors="ignore") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def git_files(recurse=False):
+    cmd = ["git", "ls-files"] + (["--recurse-submodules"] if recurse else [])
+    try:
+        out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
+                             text=True, check=True).stdout
+    except (OSError, subprocess.CalledProcessError):
+        return []
+    return out.splitlines()
+
+
+def strip_comments(text):
+    """Remove '#' comments (Makefile/shell/Dockerfile) and Jinja {# #} so that a
+    variable mentioned only in a comment is never counted as a real reference.
+    Errs toward removal; over-stripping can only downgrade a finding's severity,
+    never falsely clear one."""
+    text = re.sub(r"\{#.*?#\}", " ", text, flags=re.S)   # jinja comments
+    out = []
+    for line in text.splitlines():
+        h = line.find("#")
+        out.append(line if h < 0 else line[:h])
+    return "\n".join(out)
+
+
+def refs_in(text):
+    """Set of variable names dereferenced ($(V)/${V}/$V) in text."""
+    return {m.group(1) or m.group(2) or m.group(3) for m in REF_RE.finditer(text)}
+
+
+def logical_lines(text):
+    """Yield make 'logical lines' with backslash-continuations joined, so a
+    multi-line assignment (e.g. SONIC_COMMON_FLAGS_LIST or a _DEP_FLAGS spanning
+    several `\\`-continued lines) is treated as one line. Without this, vars on
+    continuation lines are missed and falsely reported as gaps."""
+    buf = ""
+    for line in text.splitlines():
+        if line.endswith("\\"):
+            buf += line[:-1] + " "
+        else:
+            yield buf + line
+            buf = ""
+    if buf:
+        yield buf
+
+
+# ---- producers -------------------------------------------------------------
+def _src_root_patterns(candidates):
+    """Regexes matching every cached package's SOURCE root, derived from the
+    `$(PKG)_SRC_PATH = ...` declarations in the make-layer. Files under a source
+    root are package content (hashed by GIT_CONTENT_SHA); a variable whose
+    producer AND consumer both live inside the same source tree is intra-package
+    flow, NOT a build-env injection, so such files must be excluded from the
+    producer set. Cross-boundary injections (a superproject .mk exporting into a
+    package build) are unaffected because the superproject .mk is not under a
+    source root. Roots shallower than a concrete package subdirectory (e.g. a
+    bare $(PLATFORM_PATH)) are skipped so sibling build-rule .mk are not excluded."""
+    SENT = "\x01"   # placeholder for an unresolved make-var path segment
+    pats = []
+    for f in candidates:
+        for m in re.finditer(r"_SRC_PATH\s*[:+]?=\s*(\S+)", read(f)):
+            val = m.group(1)
+            val = val.replace("$(SRC_PATH)", "src")
+            val = re.sub(r"\$\(PLATFORM(?:_PDDF|_COMMON)?_PATH\)", "platform/" + SENT, val)
+            prev = None
+            while prev != val:                      # collapse remaining (possibly nested) make vars
+                prev = val
+                val = re.sub(r"\$\([^()]*\)", SENT, val)
+            segs = [s for s in val.split("/") if s]
+            if len(segs) < 2 or SENT in segs[-1]:   # need a concrete package subdir at the leaf
+                continue
+            rx = re.escape(val).replace(re.escape(SENT), "[^/]+")
+            pats.append(re.compile("^" + rx + "/"))
+    return pats
+
+
+def producer_candidates():
+    """All make-layer files (root orchestration + every tracked .mk/Makefile),
+    BEFORE narrowing out package sources. Used for filename capture: an artifact
+    file NAME may be composed in a package-internal Makefile, and a variable whose
+    value flows into a cached *.deb/*.whl/*.gz name is cache-safe wherever that
+    name is defined."""
+    out = []
+    for f in git_files(recurse=False):
+        base = os.path.basename(f)
+        if f.endswith(".mk") or base in ("slave.mk", "Makefile", "Makefile.work"):
+            out.append(f)
+    return out
+
+
+def producer_files():
+    candidates = producer_candidates()
+    src_roots = _src_root_patterns(candidates)
+    return [f for f in candidates if not any(p.match(f) for p in src_roots)]
+
+
+def exported_vars(text):
+    """Every exported build-env variable: `export VAR` plus inline `VAR=val $(MAKE)`
+    command-line environment passed to sub-makes."""
+    names = set(EXPORT_RE.findall(text))
+    for line in text.splitlines():
+        if "$(MAKE)" in line:
+            head = line.split("$(MAKE)", 1)[0]
+            names |= set(re.findall(r"\b([A-Z_][A-Z0-9_]*)=", head))
+    return sorted(names)
+
+
+# ---- in-key ----------------------------------------------------------------
+def tracked_vars():
+    mk = read("Makefile.cache")
+    flags = set()
+    for line in logical_lines(mk):
+        if "SONIC_COMMON_FLAGS_LIST" in line:
+            flags |= set(VARREF_RE.findall(line))
+    for dep in git_files(recurse=False):
+        if dep.endswith(".dep"):
+            for line in logical_lines(read(dep)):
+                if re.search(r"DEP_FLAGS\s*[:+?]?=", line):
+                    flags |= set(VARREF_RE.findall(line))
+    return flags
+
+
+# ---- filename (token-scoped, transitive) -----------------------------------
+def filename_captured(producer_text_values):
+    """Vars whose value is (part of) a cached target's file NAME - so a change flips
+    the cache key. Seeds are:
+      (a) $(VAR) refs that appear INSIDE a *.deb/*.whl/*.gz token, and
+      (b) a variable A whose assignment RHS *is* an artifact filename, e.g.
+          A = foo-dbgsym_$(VER)_$(ARCH).deb  ->  A's value is a target name.
+    Then it propagates through assignments: if a captured var A is defined as
+    `A = ... $(V) ...`, V is a component of A's value and is captured too. A
+    dangerous plain env var is never assigned a .deb/.whl/.gz name, so this cannot
+    false-clear the DOCKER_DEFAULT_PLATFORM class."""
+    seed = set()
+    contributes = collections.defaultdict(set)  # A -> vars referenced in A's RHS
+    for t in producer_text_values:
+        for line in t.splitlines():
+            for tok in FN_TOKEN_RE.findall(line):
+                seed |= set(VARREF_RE.findall(tok))
+        for m in ASSIGN_RE.finditer(t):
+            lhs, rhs = m.group(1), m.group(2)
+            contributes[lhs] |= set(VARREF_RE.findall(rhs))
+            if FN_TOKEN_RE.search(rhs):     # RHS is itself an artifact filename
+                seed.add(lhs)
+    captured = set(seed)
+    stack = list(seed)
+    while stack:
+        a = stack.pop()
+        for v in contributes.get(a, ()):
+            if v not in captured:
+                captured.add(v)
+                stack.append(v)
+    return captured
+
+
+# ---- consumers (recipes, whole tree incl. submodules) ----------------------
+def recipe_files():
+    files = []
+    for f in git_files(recurse=True):
+        base = os.path.basename(f)
+        if base == "rules" and "/debian/" in ("/" + f):
+            files.append(f)
+        elif base == "Makefile" and f != "Makefile":          # exclude top orchestration
+            files.append(f)
+        elif re.search(r"Dockerfile.*\.j2$", base):
+            files.append(f)
+        elif base.endswith(".sh"):
+            files.append(f)
+    return files
+
+
+def recipe_consumers(residual, recipes):
+    """{var: example_recipe_file} for residual vars actually DEREFERENCED by a cached
+    build recipe (comment-stripped; $(V)/${V}/$V only). A recipe that unconditionally
+    re-assigns the variable is SHADOWED and does not count - it uses its own value,
+    not the inherited export."""
+    resid = set(residual)
+    if not resid:
+        return {}
+    example = {}
+    for f in recipes:
+        t = strip_comments(read(f))
+        refs = refs_in(t) & resid
+        if not refs:
+            continue
+        overridden = set(OVERRIDE_RE.findall(t))
+        for v in refs - overridden:
+            example.setdefault(v, f)
+        if len(example) == len(resid):
+            break
+    return example
+
+
+# ---- classify --------------------------------------------------------------
+def classify():
+    prod = producer_files()
+    text = {f: strip_comments(read(f)) for f in prod}
+    values = list(text.values())
+    alltext = "\n".join(values)
+
+    exp = exported_vars(alltext)
+    tracked = tracked_vars()
+    captured = filename_captured([strip_comments(read(f)) for f in producer_candidates()])
+    make_refs = refs_in(alltext)
+
+    residual = [v for v in exp if v not in tracked and v not in captured]
+    examples = recipe_consumers(residual, recipe_files())
+
+    rows = []
+    for v in exp:
+        if v in tracked:
+            rows.append((v, "in-key", ""))
+        elif v in captured:
+            rows.append((v, "filename", "target-name"))
+        elif v in examples:
+            rows.append((v, "gap", examples[v]))
+        elif v in make_refs:
+            rows.append((v, "assembly", "make-layer only"))
+        else:
+            rows.append((v, "external-env", "no in-repo consumer"))
+    return rows
+
+
+def main():
+    rows = classify()
+    if "--stdout" in sys.argv[1:]:
+        for v, d, e in sorted(rows):
+            print(f"{v}\t{d}\t{e}")
+        return 0
+    counts = collections.Counter(d for _, d, _ in rows)
+    with open(REGISTRY, "w", encoding="utf-8") as out:
+        out.write("# cache_key_export_registry.tsv - SNAPSHOT generated by scripts/cache_key_scan.py\n")
+        out.write("# Informational audit snapshot only. The gate classifies LIVE on every run;\n")
+        out.write("# human waivers live in scripts/cache_key_export_waivers.tsv.\n")
+        out.write("# variable\tdisposition\tevidence\n")
+        for v, d, e in sorted(rows):
+            out.write(f"{v}\t{d}\t{e}\n")
+    print(f"wrote {REGISTRY} ({len(rows)} exports)")
+    for d, n in counts.most_common():
+        print(f"  {d:14}{n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cache_key_scan.py
+++ b/scripts/cache_key_scan.py
@@ -72,7 +72,31 @@ FN_TOKEN_RE = re.compile(r"[^\s:;=|&<>'\"]*\.(?:deb|whl|gz)\b")
 # freely mix both (e.g. `foo_${VER}_${ARCH}.deb`), so var-ref extraction must not
 # be paren-only or it silently misses curly-brace refs and reports false gaps.
 VARREF_RE = re.compile(r"\$[({]\s*(\w+)\s*[})]")
-EXPORT_RE = re.compile(r"^\s*export\s+([A-Za-z_]\w*)", re.M)
+# An `export` directive. Make supports two forms:
+#   list form       `export A B C`      -> exports EVERY listed name
+#   assignment form `export A := v`      -> exports the single assigned name
+# (shell `export A=v` inside a recipe is the assignment form too). Capture the
+# whole tail after `export`; exported_vars() splits list vs assignment. A single
+# capture group + findall previously kept only the FIRST name, silently dropping
+# the rest of a list like `export FRR FRR_DBG FRR_SNMP`.
+EXPORT_RE = re.compile(r"^[ \t]*export[ \t]+(.+)$", re.M)
+# Assignment operators. `_ASSIGN_OP` is any operator (used only to detect that a
+# tail is an assignment vs a bare `export A B C` list). `_MAKE_OP` are the
+# make-ONLY operators: for these GNU Make takes the ENTIRE rest of the line as the
+# value (`export A := v B=2` exports only A), so they are always single-var. Only
+# a plain `=` is ambiguous: `NAME = value` (space before `=`) is a make assignment
+# (single var, rest-of-line value), while `NAME=value` (no space) is shell and may
+# be a multi-assign (`export A=1 B=2`), so only that form is walked. A VALUE is one
+# shell word: quoted spans (`"..."`/`'...'`), `$(...)`/`${...}`, and backslash
+# escapes (`\ `) are consumed whole so their internal spaces do not end the word
+# and their internal text never leaks as a name; the walk resumes at the next
+# `NAME=` after unescaped/unquoted whitespace.
+_ASSIGN_OP = r"(?:::=|:=|\?=|\+=|!=|=)"
+_MAKE_OP = r"(?:::=|:=|\?=|\+=|!=)"
+_VALUE = r'(?:"[^"]*"|' + r"'[^']*'" + r"|\$\([^)]*\)|\$\{[^}]*\}|\\.|\S)*"
+ASSIGN_HEAD_RE = re.compile(r"^[A-Za-z_]\w*[ \t]*" + _ASSIGN_OP)
+ASSIGN_SINGLE_RE = re.compile(r"^([A-Za-z_]\w*)(?:[ \t]*" + _MAKE_OP + r"|[ \t]+=)")
+ASSIGN_STEP_RE = re.compile(r"[ \t]*([A-Za-z_]\w*)=" + _VALUE)
 ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*[:?+]?=\s*(.*)$", re.M)
 # Unconditional (re)assignment of a variable inside a recipe: `VAR = x` / `VAR := x`
 # (make), `export VAR=x` / `override VAR := x` (make), or `VAR=x` (shell). Such a
@@ -92,13 +116,32 @@ def read(path):
 
 
 def git_files(recurse=False):
-    cmd = ["git", "ls-files"] + (["--recurse-submodules"] if recurse else [])
+    """Git-tracked files. A git failure here silently yielding [] would let the
+    scan run on incomplete inputs and emit misleading classifications, so a
+    failure is surfaced instead of swallowed:
+      - base `git ls-files` failing is fatal (broken repo / not a work tree).
+      - `--recurse-submodules` failing (uninitialized submodules, older git)
+        falls back to the non-recursive listing with a warning, so the
+        superproject is still scanned rather than the whole tree vanishing."""
+    def _run(cmd):
+        return subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
+                              text=True, check=True).stdout.splitlines()
+    base = ["git", "ls-files"]
+    if not recurse:
+        try:
+            return _run(base)
+        except (OSError, subprocess.CalledProcessError) as e:
+            sys.stderr.write("cache_key_scan: FATAL: `git ls-files` failed "
+                             "(not a git work tree?): %s\n" % e)
+            raise
     try:
-        out = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
-                             text=True, check=True).stdout
-    except (OSError, subprocess.CalledProcessError):
-        return []
-    return out.splitlines()
+        return _run(base + ["--recurse-submodules"])
+    except (OSError, subprocess.CalledProcessError) as e:
+        sys.stderr.write("cache_key_scan: WARNING: `git ls-files "
+                         "--recurse-submodules` failed (%s); falling back to a "
+                         "non-recursive scan — submodule recipes will be "
+                         "MISSED, classifications may be incomplete.\n" % e)
+        return git_files(recurse=False)
 
 
 def strip_comments(text):
@@ -187,8 +230,50 @@ def producer_files():
 
 def exported_vars(text):
     """Every exported build-env variable: `export VAR` plus inline `VAR=val $(MAKE)`
-    command-line environment passed to sub-makes."""
-    names = set(EXPORT_RE.findall(text))
+    command-line environment passed to sub-makes. Handles:
+      list form        `export A B C`          -> all names
+      make assignment  `export A := v`         -> the single LHS name (any of the
+                       `=` `:=` `::=` `?=` `+=` `!=` operators, with or without
+                       surrounding spaces, e.g. `export A+=v`)
+      shell assignment `export A=1 B=2`        -> every LHS name
+    A dynamic expansion `export $(fn ...)` produces its name(s) at make time; the
+    literal names are not statically knowable and tokenizing the expansion body
+    yields garbage (function/flag tokens), so such lines are skipped.
+
+    Assignment values are NOT tokenized on whitespace: a naive split leaks bare
+    words out of quoted/`$(...)` values (`export FOO="a b"` -> phantom `b`;
+    `export FOO="$(shell basename ...)"` -> phantom `basename`) and misses the
+    LHS of no-space operator forms. Instead the leading `NAME<op>VALUE` run is
+    walked with a shell-word VALUE (quoted spans and `$(...)`/`${...}` consumed
+    whole), so only real LHS names are captured while a later assignment in a
+    shell multi-assign (`export A="a b" B=2`) is still reached."""
+    names = set()
+    for tail in EXPORT_RE.findall(text):
+        tail = tail.strip()
+        if tail.startswith("$"):
+            continue  # `export $(fn ...)` / `export ${VAR}` — dynamic, no literal names
+        if ASSIGN_HEAD_RE.match(tail):
+            m0 = ASSIGN_SINGLE_RE.match(tail)
+            if m0:
+                # make-only operator (value is the rest of the line) or `NAME = v`
+                # (space before plain `=`, a make assignment): a single LHS.
+                names.add(m0.group(1))
+            else:
+                # `NAME=value` with no space before a plain `=`: shell-style, may be
+                # a multi-assign (`A=1 B=2`). Walk each `NAME=VALUE`; VALUE consumes
+                # quoted/`$(...)`/escaped spans whole so a later assignment is still
+                # reached and no inner word leaks as a name.
+                pos = 0
+                while pos < len(tail):
+                    m = ASSIGN_STEP_RE.match(tail, pos)
+                    if not m:
+                        break
+                    names.add(m.group(1))
+                    pos = m.end()
+        else:
+            for t in tail.split():             # list form `export A B C`
+                if re.fullmatch(r"[A-Za-z_]\w*", t):
+                    names.add(t)
     for line in text.splitlines():
         if "$(MAKE)" in line:
             head = line.split("$(MAKE)", 1)[0]

--- a/scripts/verify_cache_equivalence.sh
+++ b/scripts/verify_cache_equivalence.sh
@@ -50,8 +50,8 @@
 # Optional:
 #   --level LEVELS       Comma-separated levels to compare: 1,2,3,5 (default: 1,2,3,5)
 #   --output-dir DIR     Report output directory (default: ./poc-results/comparison/)
-#   --diffoscope         Force diffoscope even for non-semantic diffs (auto-runs on semantic by default)
-#   --no-diffoscope      Disable automatic diffoscope on semantic diffs
+#   --diffoscope         Enable diffoscope deep analysis on semantic diffs (default: enabled)
+#   --no-diffoscope      Disable diffoscope deep analysis on semantic diffs
 #   --max-report-size N  diffoscope max report size in bytes (default: 50000000)
 #   --timeout N          Timeout per file comparison in seconds (default: 300)
 #   --json               Output results in JSON format
@@ -201,7 +201,7 @@ usage() {
     echo "Optional:"
     echo "  --level LEVELS       Levels to compare: 1,2,3,5 (default: 1,2,3,5)"
     echo "  --output-dir DIR     Report output (default: ./poc-results/comparison/)"
-    echo "  --diffoscope         Force diffoscope even for non-semantic diffs (auto-runs on semantic diffs)"
+    echo "  --diffoscope         Enable diffoscope deep analysis on semantic diffs (default: enabled)"
     echo "  --max-report-size N  diffoscope report limit in bytes (default: 50MB)"
     echo "  --timeout N          Per-file timeout in seconds (default: 300)"
     echo "  --json               JSON output format"
@@ -259,13 +259,13 @@ if [[ -n "$BASELINE_FILE" ]]; then
     while IFS= read -r artifact; do
         [[ -n "$artifact" ]] && BASELINE_SEMANTICS["$artifact"]=1
     done < <(python3 -c "
-import json
-with open('$BASELINE_FILE') as f:
+import json, sys
+with open(sys.argv[1]) as f:
     data = json.load(f)
 for r in data.get('results', []):
     if r.get('classification') == 'SEMANTIC':
         print(r.get('artifact', ''))
-" 2>/dev/null)
+" "$BASELINE_FILE" 2>/dev/null)
     echo -e "${CYAN}[INFO]${NC} Loaded baseline with ${#BASELINE_SEMANTICS[@]} known non-deterministic artifact(s)"
 fi
 
@@ -779,16 +779,18 @@ compare_debs() {
         ((total_debs++))
 
         if [[ -z "${map_a[$name]:-}" ]]; then
-            record_result "$(basename "$name")" "MISSING" "Only in dir-b ($name)"
+            record_result "$name" "MISSING" "Only in dir-b ($name)"
             continue
         fi
         if [[ -z "${map_b[$name]:-}" ]]; then
-            record_result "$(basename "$name")" "MISSING" "Only in dir-a ($name)"
+            record_result "$name" "MISSING" "Only in dir-a ($name)"
             continue
         fi
 
-        local display_name
-        display_name=$(basename "$name")
+        # Use the full relative-path key (e.g. bookworm/foo.deb) as the artifact
+        # identity so same-named packages in different distro dirs (bookworm/ vs
+        # trixie/) stay distinct in results and --baseline keying.
+        local display_name="$name"
 
         # Quick SHA256 check
         local hash_a hash_b
@@ -815,12 +817,24 @@ compare_debs() {
 }
 
 # Deep .deb comparison (extract and compare file-by-file)
+# Thin wrapper: own the temp dirs and clean them up exactly once, after the
+# worker returns. A `trap ... RETURN` inside the worker is unsafe — under
+# `set -T`/functrace it fires on every nested helper return (e.g.
+# is_cosmetic_diff / elf_code_sections_identical), deleting the dirs
+# mid-comparison, and it also leaks the trap to the caller.
 compare_deb_deep() {
-    local deb_a="$1" deb_b="$2" name="$3"
-    local tmp_a tmp_b
+    local tmp_a tmp_b rc
     tmp_a=$(mktemp -d)
     tmp_b=$(mktemp -d)
-    trap "rm -rf '$tmp_a' '$tmp_b'" RETURN
+    _compare_deb_deep_impl "$1" "$2" "$3" "$tmp_a" "$tmp_b"
+    rc=$?
+    rm -rf "$tmp_a" "$tmp_b"
+    return $rc
+}
+
+_compare_deb_deep_impl() {
+    local deb_a="$1" deb_b="$2" name="$3"
+    local tmp_a="$4" tmp_b="$5"
 
     # Extract .deb files using dpkg-deb (handles any compression format)
     local data_dir_a="$tmp_a/data" data_dir_b="$tmp_b/data"
@@ -1430,8 +1444,9 @@ compare_wheels() {
     while IFS= read -r rel_key; do
         [[ -z "$rel_key" ]] && continue
         ((total_whls++))
-        local name
-        name=$(basename "$rel_key")
+        # Use the full relative-path key as the artifact identity so same-named
+        # wheels in different distro dirs stay distinct in results / --baseline.
+        local name="$rel_key"
 
         if [[ -z "${whl_map_a[$rel_key]:-}" ]]; then
             record_result "$name" "MISSING" "Only in dir-b"
@@ -1465,18 +1480,28 @@ compare_wheels() {
     log_info "Level 2 summary: $total_whls wheels, $identical_whls identical by hash"
 }
 
+# Thin wrapper (see compare_deb_deep): own the temp dirs and clean up once,
+# after the worker returns — avoids an unsafe `trap ... RETURN` in the worker.
 compare_wheel_deep() {
-    local whl_a="$1" whl_b="$2" name="$3"
+    local name="$3"
 
     if ! has_tool unzip; then
         record_result "$name" "ERROR" "unzip not available for .whl extraction"
         return
     fi
 
-    local tmp_a tmp_b
+    local tmp_a tmp_b rc
     tmp_a=$(mktemp -d)
     tmp_b=$(mktemp -d)
-    trap "rm -rf '$tmp_a' '$tmp_b'" RETURN
+    _compare_wheel_deep_impl "$1" "$2" "$3" "$tmp_a" "$tmp_b"
+    rc=$?
+    rm -rf "$tmp_a" "$tmp_b"
+    return $rc
+}
+
+_compare_wheel_deep_impl() {
+    local whl_a="$1" whl_b="$2" name="$3"
+    local tmp_a="$4" tmp_b="$5"
 
     unzip -q "$whl_a" -d "$tmp_a" 2>/dev/null || {
         record_result "$name" "ERROR" "Failed to unzip whl_a"
@@ -2562,6 +2587,23 @@ main() {
     # Exit code: fail on SEMANTIC, MISSING, ERROR, or zero artifacts compared.
     # (baseline-matched SEMANTIC and dbgsym EXPECTED_MISSING were already
     # downgraded in record_result, so they do not count toward failure.)
+    if $GENERATE_BASELINE; then
+        # Baseline generation is fresh-vs-fresh: SEMANTIC/MISSING diffs are the
+        # inherent build non-determinism we are recording, not failures. Only a
+        # broken run (extraction errors or nothing compared) is fatal — so under
+        # the pipeline's `set -e` the report is emitted and the subsequent
+        # A-vs-C comparison step still runs.
+        if [[ $COUNT_ERROR -gt 0 ]]; then
+            log_warn "Exiting with code 2: $COUNT_ERROR artifacts had extraction/comparison errors"
+            exit 2
+        elif [[ $TOTAL_ARTIFACTS -eq 0 ]]; then
+            log_warn "Exiting with code 2: No artifacts were compared (check --dir-a/--dir-b paths)"
+            exit 2
+        fi
+        echo ""
+        echo -e "${GREEN}Baseline generated: recorded $COUNT_SEMANTIC semantic diff(s) as known non-determinism${NC}"
+        exit 0
+    fi
     if [[ $COUNT_SEMANTIC -gt 0 || $COUNT_MISSING -gt 0 ]]; then
         if [[ -n "$BASELINE_FILE" ]]; then
             echo ""

--- a/scripts/verify_cache_equivalence.sh
+++ b/scripts/verify_cache_equivalence.sh
@@ -1,0 +1,2589 @@
+#!/bin/bash
+#
+# verify_cache_equivalence.sh — Deep Comparison of Cached vs Fresh Build Artifacts
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# PURPOSE
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Takes two build output directories (typically Build B and Build C from
+# run_poc_builds.sh) and produces a comprehensive equivalence report.
+# Classifies every difference as cosmetic (known-benign) or semantic (real drift).
+#
+# If ALL differences are cosmetic → cache is safe to use.
+# If ANY semantic differences exist → cache has bugs that need fixing.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# WHAT IT COMPARES (4 implemented levels)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Level 1: .deb packages (target/debs/)
+#   - SHA256 raw comparison (expected to differ due to timestamps)
+#   - Extract and compare file-by-file (dpkg-deb -x/-e for data and control)
+#   - ELF binaries: strip debug info then compare
+#   - Online/copy debs: must match exactly (no compilation involved)
+#
+# Level 2: Python wheels (target/python-wheels/)
+#   - SHA256 raw comparison (may differ due to ZIP metadata)
+#   - Unzip and compare .py source files
+#   - Compare METADATA and RECORD manifests
+#   - Ignore .pyc timestamp differences
+#
+# Level 3: Docker images (target/*.gz)
+#   - Primary: tar-based comparison (no Docker daemon required)
+#     Extract .gz → compare manifest.json, config JSON (minus timestamps), layer.tar SHA256s
+#   - Fallback: docker load + container-diff or docker inspect (if tar extraction fails)
+#
+# Level 5: Installer image (target/sonic-*.img.gz)
+#   - Extract and compare partition contents
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# USAGE
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+#   ./scripts/verify_cache_equivalence.sh --dir-a DIR_A --dir-b DIR_B [OPTIONS]
+#
+# Required:
+#   --dir-a DIR    First build directory (e.g., poc-results/build-B)
+#   --dir-b DIR    Second build directory (e.g., poc-results/build-C)
+#
+# Optional:
+#   --level LEVELS       Comma-separated levels to compare: 1,2,3,5 (default: 1,2,3,5)
+#   --output-dir DIR     Report output directory (default: ./poc-results/comparison/)
+#   --diffoscope         Force diffoscope even for non-semantic diffs (auto-runs on semantic by default)
+#   --no-diffoscope      Disable automatic diffoscope on semantic diffs
+#   --max-report-size N  diffoscope max report size in bytes (default: 50000000)
+#   --timeout N          Timeout per file comparison in seconds (default: 300)
+#   --json               Output results in JSON format
+#   --verbose            Show detailed per-file comparison output
+#   --quick              Skip deep analysis; only do SHA256 + file listing comparison
+#   --baseline FILE      JSON baseline from a fresh-vs-fresh run; SEMANTIC diffs whose
+#                        artifact appears in the baseline are downgraded to
+#                        BASELINE_NONDETERMINISM (inherent build non-determinism, not a
+#                        cache bug) and do not trigger FAIL
+#   --generate-baseline  Run as a baseline generator (fresh-vs-fresh); records the
+#                        inherent non-determinism set. Implies --json.
+#
+# Examples:
+#   # Standard comparison of Build B vs Build C
+#   ./scripts/verify_cache_equivalence.sh \
+#       --dir-a ./poc-results/build-B \
+#       --dir-b ./poc-results/build-C
+#
+#   # Debs only with diffoscope deep analysis
+#   ./scripts/verify_cache_equivalence.sh \
+#       --dir-a ./poc-results/build-B \
+#       --dir-b ./poc-results/build-C \
+#       --level 1 --diffoscope
+#
+#   # Quick hash-only check
+#   ./scripts/verify_cache_equivalence.sh \
+#       --dir-a ./poc-results/build-B \
+#       --dir-b ./poc-results/build-C --quick
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# INTERPRETING RESULTS
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Each artifact gets a classification:
+#
+#   IDENTICAL   = SHA256 matches exactly (no further analysis needed)
+#   COSMETIC    = Differences exist but are all known-benign patterns:
+#                 timestamps, gzip headers, ar metadata, .pyc magic, etc.
+#   SEMANTIC    = Real content difference — build output actually differs
+#   MISSING     = Artifact present in one build but not the other
+#   ERROR       = Comparison failed (tool error, timeout, etc.)
+#
+# Summary exit codes:
+#   0 = All artifacts IDENTICAL or COSMETIC (cache is safe)
+#   1 = SEMANTIC differences found (cache has correctness issues)
+#   2 = Script/environment error
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# KNOWN COSMETIC PATTERNS (auto-whitelisted)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# These differences are expected and do NOT indicate cache bugs:
+#   - ar archive header timestamps (every .deb has these)
+#   - tar entry mtime in data.tar.* and control.tar.*
+#   - gzip/pigz header timestamp bytes (decompressed content compared)
+#   - Docker image "Created" timestamp in manifest.json
+#   - Docker "Tag" and build-specific labels in config JSON
+#   - Docker rootfs.diff_ids (content-addressed layer hashes change with timestamps)
+#   - .pyc file header (4-byte timestamp + source size)
+#   - Build path strings in ELF .comment section
+#   - Go binary non-determinism (.note.go.buildid, .go.buildinfo, .text variance)
+#   - File ordering in tar archives (non-deterministic in some tools)
+#   - stdeb-generated debian/changelog date lines
+#   - ZIP extra field timestamps in .whl files
+#   - Embedded .whl in platform .debs (ZIP timestamps; .py source compared)
+#   - Date-only differences in man pages and info files (.gz content)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# PREREQUISITES
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Required tools:
+#   - dpkg-deb, sha256sum, tar, gzip (standard — always available)
+#   - diff, find, sort (standard)
+#
+# Optional tools (enable deeper analysis):
+#   - diffoscope: detailed recursive .deb comparison (apt install diffoscope)
+#   - container-diff: Docker image comparison (go install github.com/GoogleContainerTools/container-diff)
+#   - objcopy: ELF debug stripping (from binutils — usually available)
+#   - unzip: .whl extraction (usually available)
+#   - docker: Docker image loading and inspection
+#   - unsquashfs: installer/root filesystem extraction (squashfs-tools)
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONTEXT
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# This script is part of the DPKG Cache Validation toolkit (Phase 3):
+#   - Phase 1: audit_dep_completeness.sh, check_common_files.sh
+#   - Phase 2: run_poc_builds.sh, run_negative_controls.sh
+#   - Phase 3: verify_cache_equivalence.sh (this script), classify_diff.sh, dump_cache_keys.sh
+#
+# Exit codes:
+#   0 = All differences cosmetic (cache is safe)
+#   1 = Semantic differences found (cache has bugs)
+#   2 = Script error or missing prerequisites
+#
+
+set -uo pipefail
+
+# --- Configuration ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Defaults
+DIR_A=""
+DIR_B=""
+LEVELS="1,2,3,5"
+OUTPUT_DIR="./poc-results/comparison"
+USE_DIFFOSCOPE=true
+MAX_REPORT_SIZE=50000000
+TIMEOUT=300
+JSON_OUTPUT=false
+VERBOSE=false
+QUICK_MODE=false
+BASELINE_FILE=""
+GENERATE_BASELINE=false
+
+# Counters
+TOTAL_ARTIFACTS=0
+COUNT_IDENTICAL=0
+COUNT_COSMETIC=0
+COUNT_SEMANTIC=0
+COUNT_MISSING=0
+COUNT_ERROR=0
+COUNT_BASELINE_NONDETERMINISM=0
+COUNT_EXPECTED_MISSING=0
+
+# Results array for JSON/report output
+declare -a RESULTS=()
+
+# --- Argument Parsing ---
+usage() {
+    echo "Usage: $0 --dir-a DIR --dir-b DIR [OPTIONS]"
+    echo ""
+    echo "Required:"
+    echo "  --dir-a DIR          First build directory (e.g., poc-results/build-B)"
+    echo "  --dir-b DIR          Second build directory (e.g., poc-results/build-C)"
+    echo ""
+    echo "Optional:"
+    echo "  --level LEVELS       Levels to compare: 1,2,3,5 (default: 1,2,3,5)"
+    echo "  --output-dir DIR     Report output (default: ./poc-results/comparison/)"
+    echo "  --diffoscope         Force diffoscope even for non-semantic diffs (auto-runs on semantic diffs)"
+    echo "  --max-report-size N  diffoscope report limit in bytes (default: 50MB)"
+    echo "  --timeout N          Per-file timeout in seconds (default: 300)"
+    echo "  --json               JSON output format"
+    echo "  --verbose            Detailed per-file output"
+    echo "  --quick              SHA256 + file-list only (skip deep analysis)"
+    echo "  --baseline FILE      JSON baseline (fresh-vs-fresh); matching SEMANTIC diffs are"
+    echo "                       downgraded to BASELINE_NONDETERMINISM and won't trigger FAIL"
+    echo "  --generate-baseline  Generate a baseline file from a fresh-vs-fresh run (implies --json)"
+    echo "  --help               Show this help"
+    exit "${1:-1}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dir-a) DIR_A="$2"; shift 2 ;;
+        --dir-b) DIR_B="$2"; shift 2 ;;
+        --level) LEVELS="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --diffoscope) USE_DIFFOSCOPE=true; shift ;;
+        --no-diffoscope) USE_DIFFOSCOPE=false; shift ;;
+        --max-report-size) MAX_REPORT_SIZE="$2"; shift 2 ;;
+        --timeout) TIMEOUT="$2"; shift 2 ;;
+        --json) JSON_OUTPUT=true; shift ;;
+        --verbose) VERBOSE=true; shift ;;
+        --quick) QUICK_MODE=true; shift ;;
+        --baseline) BASELINE_FILE="$2"; shift 2 ;;
+        --generate-baseline) GENERATE_BASELINE=true; JSON_OUTPUT=true; shift ;;
+        --help|-h) usage 0 ;;
+        *) echo -e "${RED}Unknown option: $1${NC}"; exit 1 ;;
+    esac
+done
+
+if [[ -z "$DIR_A" || -z "$DIR_B" ]]; then
+    echo -e "${RED}ERROR: --dir-a and --dir-b are required${NC}"
+    usage
+fi
+
+if [[ ! -d "$DIR_A" ]]; then
+    echo -e "${RED}ERROR: Directory not found: $DIR_A${NC}"; exit 2
+fi
+if [[ ! -d "$DIR_B" ]]; then
+    echo -e "${RED}ERROR: Directory not found: $DIR_B${NC}"; exit 2
+fi
+
+if [[ -n "$BASELINE_FILE" && ! -f "$BASELINE_FILE" ]]; then
+    echo -e "${RED}ERROR: Baseline file not found: $BASELINE_FILE${NC}"; exit 2
+fi
+
+# Load baseline SEMANTIC artifacts into an associative array for O(1) lookup.
+# A baseline is produced from a fresh-vs-fresh (non-cached) run: any SEMANTIC
+# diff there reflects inherent build non-determinism, not a cache bug. When a
+# baseline is supplied, those same artifacts are downgraded (see record_result).
+declare -A BASELINE_SEMANTICS=()
+if [[ -n "$BASELINE_FILE" ]]; then
+    while IFS= read -r artifact; do
+        [[ -n "$artifact" ]] && BASELINE_SEMANTICS["$artifact"]=1
+    done < <(python3 -c "
+import json
+with open('$BASELINE_FILE') as f:
+    data = json.load(f)
+for r in data.get('results', []):
+    if r.get('classification') == 'SEMANTIC':
+        print(r.get('artifact', ''))
+" 2>/dev/null)
+    echo -e "${CYAN}[INFO]${NC} Loaded baseline with ${#BASELINE_SEMANTICS[@]} known non-deterministic artifact(s)"
+fi
+
+# --- Helper Functions ---
+log_info() { echo -e "${CYAN}[INFO]${NC} $*"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
+
+# Scratch directory for generated helper scripts; cleaned up on exit.
+HELPER_DIR=$(mktemp -d)
+trap 'rm -rf "$HELPER_DIR"' EXIT
+
+# Python helper: read a tar archive from stdin and print, one per line,
+# "<path>\t<xattr-name>=<hex-value>" for every security.* extended attribute
+# (e.g. security.capability set via setcap). Used to detect capability drift in
+# .deb payloads without requiring privileged extraction.
+CAPS_FROM_TAR_PY="$HELPER_DIR/caps_from_tar.py"
+cat > "$CAPS_FROM_TAR_PY" <<'PY'
+import sys, tarfile, binascii
+
+out = []
+try:
+    tf = tarfile.open(fileobj=sys.stdin.buffer, mode='r|*')
+    for m in tf:
+        xattrs = {}
+        for k, v in (m.pax_headers or {}).items():
+            if k.startswith('SCHILY.xattr.security.'):
+                name = k[len('SCHILY.xattr.'):]
+                raw = v.encode('latin-1') if isinstance(v, str) else v
+                xattrs[name] = binascii.hexlify(raw).decode()
+        for name in sorted(xattrs):
+            out.append(f"{m.name}\t{name}={xattrs[name]}")
+except Exception:
+    pass
+print("\n".join(sorted(out)))
+PY
+
+# Python helper: flatten a docker-archive image into its FINAL filesystem.
+#   argv: <extracted_image_dir> <dest_rootfs_dir> <metadata_manifest_out>
+# Layers are applied in manifest order (honouring whiteouts and opaque dirs), so
+# the merged tree reflects true "latest-layer-wins" precedence. The merged files
+# are materialised under dest for content comparison, and a sidecar manifest
+# records type/mode/uid/gid/linkname per path (ownership is read from tar headers
+# so it survives unprivileged extraction).
+FLATTEN_DOCKER_PY="$HELPER_DIR/flatten_docker.py"
+cat > "$FLATTEN_DOCKER_PY" <<'PY'
+import json, os, posixpath, shutil, stat, sys, tarfile
+
+img_dir, dest, manifest_out = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(os.path.join(img_dir, 'manifest.json')) as fh:
+    layers = json.load(fh)[0]['Layers']
+
+meta = {}  # rel-path -> (type, mode, uid, gid, linkname)
+
+def safe(rel):
+    rel = rel.lstrip('/')
+    parts = []
+    for p in rel.split('/'):
+        if p in ('', '.'):
+            continue
+        if p == '..':
+            return None
+        parts.append(p)
+    return '/'.join(parts)
+
+def remove(rel):
+    full = os.path.join(dest, rel)
+    meta.pop(rel, None)
+    for k in list(meta):
+        if k.startswith(rel + '/'):
+            meta.pop(k, None)
+    if os.path.islink(full) or os.path.isfile(full):
+        try: os.remove(full)
+        except OSError: pass
+    elif os.path.isdir(full):
+        shutil.rmtree(full, ignore_errors=True)
+
+for layer in layers:
+    with tarfile.open(os.path.join(img_dir, layer)) as tf:
+        for m in tf:
+            rel = safe(m.name)
+            if rel is None:
+                continue
+            base = posixpath.basename(rel)
+            parent = posixpath.dirname(rel)
+            if base == '.wh..wh..opq':              # opaque dir: drop lower contents
+                prefix = (parent + '/') if parent else ''
+                for k in list(meta):
+                    if prefix == '' or k.startswith(prefix):
+                        if k != parent:
+                            remove(k)
+                continue
+            if base.startswith('.wh.'):             # whiteout: delete target
+                target = posixpath.join(parent, base[4:]) if parent else base[4:]
+                remove(target)
+                continue
+            full = os.path.join(dest, rel)
+            if (os.path.islink(full) or os.path.isfile(full)) and not m.isdir():
+                try: os.remove(full)
+                except OSError: pass
+            os.makedirs(os.path.dirname(full) or dest, exist_ok=True)
+            if m.isdir():
+                os.makedirs(full, exist_ok=True)
+                meta[rel] = ('d', stat.S_IMODE(m.mode), m.uid, m.gid, '')
+            elif m.issym():
+                if os.path.lexists(full):
+                    try: os.remove(full)
+                    except OSError: pass
+                try: os.symlink(m.linkname, full)
+                except OSError: pass
+                meta[rel] = ('l', 0, m.uid, m.gid, m.linkname)
+            elif m.islnk():                          # hardlink -> copy resolved content
+                src = os.path.join(dest, safe(m.linkname) or '')
+                try: shutil.copyfile(src, full)
+                except OSError: pass
+                meta[rel] = ('f', stat.S_IMODE(m.mode), m.uid, m.gid, '')
+            elif m.isfile():
+                try:
+                    with tf.extractfile(m) as srcf, open(full, 'wb') as dst:
+                        shutil.copyfileobj(srcf, dst)
+                except Exception:
+                    pass
+                meta[rel] = ('f', stat.S_IMODE(m.mode), m.uid, m.gid, '')
+            else:
+                meta[rel] = ('o', stat.S_IMODE(m.mode), m.uid, m.gid, '')
+
+with open(manifest_out, 'w') as out:
+    for rel in sorted(meta):
+        t, mode, uid, gid, link = meta[rel]
+        out.write(f"{rel}\t{t}\t{mode:04o}\t{uid}\t{gid}\t{link}\n")
+PY
+
+
+
+# Record a comparison result
+record_result() {
+    local artifact="$1"
+    local classification="$2"  # IDENTICAL, COSMETIC, SEMANTIC, MISSING, ERROR
+    local detail="$3"
+
+    # Downgrade SEMANTIC to BASELINE_NONDETERMINISM when this artifact was already
+    # SEMANTIC in a fresh-vs-fresh baseline (inherent build non-determinism, not a
+    # cache correctness issue). Keyed by artifact name.
+    if [[ "$classification" == "SEMANTIC" && -n "$BASELINE_FILE" && -n "${BASELINE_SEMANTICS[$artifact]:-}" ]]; then
+        classification="BASELINE_NONDETERMINISM"
+        detail="[baseline-matched] $detail"
+    fi
+
+    # Downgrade MISSING to EXPECTED_MISSING for auto-generated debug-symbol
+    # companion packages. read-cache restores only cache-registered derived .deb
+    # targets; it does NOT re-emit the auto-generated *-dbgsym companions, so they
+    # are legitimately absent and never part of the runtime image (non-fatal).
+    # Deliberately narrow — vendor/runtime packages still FAIL on MISSING.
+    if [[ "$classification" == "MISSING" && "$artifact" == *-dbgsym_*.deb ]]; then
+        classification="EXPECTED_MISSING"
+        detail="[dbgsym companion not restored by cache — non-fatal] $detail"
+    fi
+
+    RESULTS+=("$classification|$artifact|$detail")
+    ((TOTAL_ARTIFACTS++))
+
+    case "$classification" in
+        IDENTICAL) ((COUNT_IDENTICAL++)) ;;
+        COSMETIC)  ((COUNT_COSMETIC++)) ;;
+        SEMANTIC)  ((COUNT_SEMANTIC++)) ;;
+        MISSING)   ((COUNT_MISSING++)) ;;
+        ERROR)     ((COUNT_ERROR++)) ;;
+        BASELINE_NONDETERMINISM) ((COUNT_BASELINE_NONDETERMINISM++)) ;;
+        EXPECTED_MISSING) ((COUNT_EXPECTED_MISSING++)) ;;
+    esac
+
+    if $VERBOSE; then
+        local color="$NC"
+        case "$classification" in
+            IDENTICAL) color="$GREEN" ;;
+            COSMETIC)  color="$YELLOW" ;;
+            SEMANTIC)  color="$RED" ;;
+            MISSING)   color="$RED" ;;
+            ERROR)     color="$RED" ;;
+            BASELINE_NONDETERMINISM) color="$YELLOW" ;;
+            EXPECTED_MISSING) color="$YELLOW" ;;
+        esac
+        printf "  ${color}%-10s${NC} %s\n" "$classification" "$artifact"
+        if [[ -n "$detail" && "$classification" != "IDENTICAL" ]]; then
+            echo "             $detail"
+        fi
+    fi
+}
+
+# Check if a tool is available
+has_tool() {
+    command -v "$1" &>/dev/null
+}
+
+# Normalize away date/time strings and check whether two text files differ
+# only because of build timestamps embedded in generated docs/changelogs.
+content_diff_is_date_only() {
+    local file_a="$1" file_b="$2"
+
+    has_tool python3 || return 1
+
+    python3 - "$file_a" "$file_b" <<'PY' 2>/dev/null
+import pathlib
+import re
+import sys
+
+text_a = pathlib.Path(sys.argv[1]).read_text(errors='replace')
+text_b = pathlib.Path(sys.argv[2]).read_text(errors='replace')
+
+month_names = (
+    r'Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|'
+    r'Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|'
+    r'Nov(?:ember)?|Dec(?:ember)?'
+)
+weekday_names = r'Mon|Tue|Wed|Thu|Fri|Sat|Sun'
+
+patterns = [
+    (re.compile(rf'\b(?:{weekday_names}),\s+\d{{1,2}}\s+(?:{month_names})\s+\d{{4}}\s+\d{{2}}:\d{{2}}:\d{{2}}\s+[+-]\d{{4}}\b', re.I), '<RFC2822_DATE>'),
+    (re.compile(rf'\b\d{{1,2}}\s+(?:{month_names})\s+\d{{4}}\b', re.I), '<DATE>'),
+    (re.compile(rf'\b(?:{month_names})\s+\d{{1,2}},\s+\d{{4}}\b', re.I), '<DATE>'),
+    (re.compile(r'\b\d{4}-\d{2}-\d{2}\b'), '<DATE>'),
+    (re.compile(r'\b\d{2}:\d{2}:\d{2}\b'), '<TIME>'),
+]
+
+def normalize(text: str) -> str:
+    for pattern, replacement in patterns:
+        text = pattern.sub(replacement, text)
+    return text
+
+sys.exit(0 if normalize(text_a) == normalize(text_b) else 1)
+PY
+}
+
+# Return 0 only when two text files contain the SAME set of lines (i.e. the
+# difference is purely line/block reordering, as produced by some code
+# generators with non-deterministic import/field ordering). Added/removed or
+# modified lines make the files genuinely different and return non-zero.
+content_diff_is_reorder_only() {
+    local file_a="$1" file_b="$2"
+    # Both must be text
+    grep -Iq . "$file_a" 2>/dev/null || return 1
+    grep -Iq . "$file_b" 2>/dev/null || return 1
+    diff <(sort "$file_a") <(sort "$file_b") >/dev/null 2>&1
+}
+
+# Documentation/changelog payloads from some SONiC package generators differ
+# only by (a) an embedded build-date trailer and/or (b) non-deterministic
+# ordering of otherwise identical entries (e.g. frr's auto-generated
+# debian/changelog regroups the same patch set under [ Author ] blocks in a
+# different order on each build). Normalize dates, then require both files to
+# contain the EXACT SAME multiset of non-blank lines (reordering only). Any
+# added, removed or modified content line still makes them genuinely different
+# and returns non-zero, so a stale/changed changelog is still caught.
+content_diff_is_date_or_reorder() {
+    local file_a="$1" file_b="$2"
+
+    has_tool python3 || return 1
+
+    python3 - "$file_a" "$file_b" <<'PY' 2>/dev/null
+import pathlib
+import re
+import sys
+
+month_names = (
+    r'Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|'
+    r'Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|'
+    r'Nov(?:ember)?|Dec(?:ember)?'
+)
+weekday_names = r'Mon|Tue|Wed|Thu|Fri|Sat|Sun'
+
+patterns = [
+    (re.compile(rf'\b(?:{weekday_names}),\s+\d{{1,2}}\s+(?:{month_names})\s+\d{{4}}\s+\d{{2}}:\d{{2}}:\d{{2}}\s+[+-]\d{{4}}\b', re.I), '<RFC2822_DATE>'),
+    (re.compile(rf'\b\d{{1,2}}\s+(?:{month_names})\s+\d{{4}}\b', re.I), '<DATE>'),
+    (re.compile(rf'\b(?:{month_names})\s+\d{{1,2}},\s+\d{{4}}\b', re.I), '<DATE>'),
+    (re.compile(r'\b\d{4}-\d{2}-\d{2}\b'), '<DATE>'),
+    (re.compile(r'\b\d{2}:\d{2}:\d{2}\b'), '<TIME>'),
+]
+
+def normalize(path: str):
+    text = pathlib.Path(path).read_text(errors='replace')
+    for pattern, replacement in patterns:
+        text = pattern.sub(replacement, text)
+    # Compare the multiset of non-blank, right-stripped lines so pure reordering
+    # (and blank-line churn around moved blocks) is ignored, but added/removed
+    # or modified content lines are not. Debian changelog author-attribution
+    # headers ("  [ Some Name ]") are dropped because the same patch set is
+    # non-deterministically regrouped under a varying number of these headers.
+    author_header = re.compile(r'^\s*\[ .+ \]\s*$')
+    return sorted(
+        l.rstrip() for l in text.splitlines()
+        if l.strip() and not author_header.match(l)
+    )
+
+sys.exit(0 if normalize(sys.argv[1]) == normalize(sys.argv[2]) else 1)
+PY
+}
+
+# /etc/shadow & /etc/gshadow (and their .bak counterparts) embed a per-account
+# "last password change" value (field 3, sp_lstchg: days since epoch) that build
+# tooling sets to the current build date when an account is created. Two builds
+# on different calendar days therefore differ ONLY in that field while the hash,
+# uid/gid and aging policy are identical. Treat a difference confined to that
+# single field as cosmetic; any other field change (hash, policy, added/removed
+# account) is genuine and returns non-zero.
+shadow_diff_is_lastchange_only() {
+    local file_a="$1" file_b="$2"
+
+    has_tool python3 || return 1
+
+    python3 - "$file_a" "$file_b" <<'PY' 2>/dev/null
+import pathlib
+import sys
+
+def normalize(path: str):
+    out = []
+    for line in pathlib.Path(path).read_text(errors='replace').splitlines():
+        fields = line.split(':')
+        if len(fields) >= 3:
+            fields[2] = '<LASTCHG>'   # blank only sp_lstchg (last change date)
+        out.append(':'.join(fields))
+    return out
+
+sys.exit(0 if normalize(sys.argv[1]) == normalize(sys.argv[2]) else 1)
+PY
+}
+
+# Return 0 when two binaries differ in at most $max_bytes individual byte
+# positions (used for kernel/EFI images that embed a build timestamp but are
+# otherwise identical). A larger byte delta indicates a real payload change.
+binaries_differ_by_at_most() {
+    local file_a="$1" file_b="$2" max_bytes="$3"
+    # Different size => more than a localized timestamp changed.
+    local sa sb
+    sa=$(stat -c%s "$file_a" 2>/dev/null || echo 0)
+    sb=$(stat -c%s "$file_b" 2>/dev/null || echo 0)
+    [[ "$sa" == "$sb" ]] || return 1
+    local nbytes
+    nbytes=$(cmp -l "$file_a" "$file_b" 2>/dev/null | wc -l)
+    [[ "${nbytes:-0}" -le "$max_bytes" ]]
+}
+
+# Extract an ELF section in a way that still works for foreign-architecture
+# artifacts (e.g. ARM .ko / ELF files on an x86_64 host).
+extract_elf_section_for_compare() {
+    local file="$1" section="$2" out="$3"
+
+    : > "$out"
+
+    if has_tool objcopy; then
+        if objcopy -O binary -j "$section" "$file" "$out" >/dev/null 2>&1 && [[ -s "$out" ]]; then
+            return 0
+        fi
+        : > "$out"
+        if objcopy --only-section="$section" -O binary "$file" "$out" >/dev/null 2>&1 && [[ -s "$out" ]]; then
+            return 0
+        fi
+    fi
+
+    if has_tool objdump; then
+        objdump -s -j "$section" "$file" 2>/dev/null | tail -n +4 > "$out"
+        [[ -s "$out" ]] && return 0
+    fi
+
+    return 1
+}
+
+# Compare executable code sections after metadata/debug normalization.
+elf_code_sections_identical() {
+    local file_a="$1" file_b="$2"
+    local tmp_a tmp_b
+    local found_section=false
+
+    tmp_a=$(mktemp)
+    tmp_b=$(mktemp)
+
+    # Include initialized-data sections (.data/.data.rel.ro) in addition to code
+    # and read-only data, so that a data-only payload change is NOT masked as
+    # cosmetic. .bss is NOBITS (no file content) and is covered by the overall
+    # strip-debug cmp performed by callers.
+    for section in .text .init.text .rodata .data .data.rel.ro; do
+        local have_a=false have_b=false
+        if extract_elf_section_for_compare "$file_a" "$section" "$tmp_a"; then
+            have_a=true
+        fi
+        if extract_elf_section_for_compare "$file_b" "$section" "$tmp_b"; then
+            have_b=true
+        fi
+
+        if $have_a || $have_b; then
+            if ! $have_a || ! $have_b; then
+                rm -f "$tmp_a" "$tmp_b"
+                return 1
+            fi
+            found_section=true
+            if ! cmp -s "$tmp_a" "$tmp_b"; then
+                rm -f "$tmp_a" "$tmp_b"
+                return 1
+            fi
+        fi
+    done
+
+    rm -f "$tmp_a" "$tmp_b"
+    $found_section
+}
+
+# Recursively compare an embedded .deb/.udeb payload.
+embedded_deb_is_cosmetic() {
+    local deb_a="$1" deb_b="$2"
+    local tmp_a tmp_b
+    local data_dir_a data_dir_b ctrl_dir_a ctrl_dir_b
+
+    has_tool dpkg-deb || return 1
+
+    tmp_a=$(mktemp -d)
+    tmp_b=$(mktemp -d)
+    data_dir_a="$tmp_a/data"
+    data_dir_b="$tmp_b/data"
+    ctrl_dir_a="$tmp_a/control"
+    ctrl_dir_b="$tmp_b/control"
+    mkdir -p "$data_dir_a" "$data_dir_b" "$ctrl_dir_a" "$ctrl_dir_b"
+
+    dpkg-deb -x "$deb_a" "$data_dir_a" 2>/dev/null || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+    dpkg-deb -x "$deb_b" "$data_dir_b" 2>/dev/null || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+    dpkg-deb -e "$deb_a" "$ctrl_dir_a" 2>/dev/null || true
+    dpkg-deb -e "$deb_b" "$ctrl_dir_b" 2>/dev/null || true
+
+    local files_a files_b
+    files_a=$(cd "$data_dir_a" && find . -type f | sort)
+    files_b=$(cd "$data_dir_b" && find . -type f | sort)
+    [[ "$files_a" == "$files_b" ]] || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+
+    while IFS= read -r rel; do
+        [[ -z "$rel" ]] && continue
+        local fa="$data_dir_a/$rel" fb="$data_dir_b/$rel"
+        if ! cmp -s "$fa" "$fb"; then
+            if ! is_cosmetic_diff "$fa" "$fb" "$rel"; then
+                rm -rf "$tmp_a" "$tmp_b"
+                return 1
+            fi
+        fi
+    done <<< "$files_a"
+
+    local ctrl_files_a ctrl_files_b
+    ctrl_files_a=$(cd "$ctrl_dir_a" 2>/dev/null && find . -type f | sort || true)
+    ctrl_files_b=$(cd "$ctrl_dir_b" 2>/dev/null && find . -type f | sort || true)
+    [[ "$ctrl_files_a" == "$ctrl_files_b" ]] || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+
+    while IFS= read -r rel; do
+        [[ -z "$rel" ]] && continue
+        local cfa="$ctrl_dir_a/$rel" cfb="$ctrl_dir_b/$rel"
+        if ! cmp -s "$cfa" "$cfb"; then
+            if [[ "$rel" == "./control" ]]; then
+                local ctrl_non_cosmetic
+                ctrl_non_cosmetic=$(diff "$cfa" "$cfb" 2>/dev/null | grep "^[<>]" | grep -cvE "Build-Ids:|Installed-Size:" 2>/dev/null || true)
+                if [[ "${ctrl_non_cosmetic:-0}" != "0" ]]; then
+                    rm -rf "$tmp_a" "$tmp_b"
+                    return 1
+                fi
+            elif ! is_cosmetic_diff "$cfa" "$cfb" "$rel"; then
+                rm -rf "$tmp_a" "$tmp_b"
+                return 1
+            fi
+        fi
+    done <<< "$ctrl_files_a"
+
+    rm -rf "$tmp_a" "$tmp_b"
+    return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEVEL 1: .deb Package Comparison
+# ═══════════════════════════════════════════════════════════════════════════════
+compare_debs() {
+    echo ""
+    echo -e "${BOLD}━━━ Level 1: .deb Package Comparison ━━━${NC}"
+    echo ""
+
+    # Find all .deb files in both directories
+    local debs_a debs_b
+    debs_a=$(find "$DIR_A" \( -name "*.deb" -o -name "*.udeb" \) -type f 2>/dev/null | sort)
+    debs_b=$(find "$DIR_B" \( -name "*.deb" -o -name "*.udeb" \) -type f 2>/dev/null | sort)
+
+    if [[ -z "$debs_a" && -z "$debs_b" ]]; then
+        log_warn "No .deb files found in either directory"
+        return
+    fi
+
+    # Build relative-path maps (use path relative to DIR_A/DIR_B as key to handle
+    # same-named packages in different subdirs like bookworm/ vs trixie/)
+    declare -A map_a=() map_b=()
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        local rel_key="${path#$DIR_A/}"
+        map_a["$rel_key"]="$path"
+    done <<< "$debs_a"
+
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        local rel_key="${path#$DIR_B/}"
+        map_b["$rel_key"]="$path"
+    done <<< "$debs_b"
+
+    # Compare matching files (match by relative path)
+    local total_debs=0 identical_debs=0
+    local all_keys
+    all_keys=$(printf '%s\n' "${!map_a[@]}" "${!map_b[@]}" | sort -u)
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((total_debs++))
+
+        if [[ -z "${map_a[$name]:-}" ]]; then
+            record_result "$(basename "$name")" "MISSING" "Only in dir-b ($name)"
+            continue
+        fi
+        if [[ -z "${map_b[$name]:-}" ]]; then
+            record_result "$(basename "$name")" "MISSING" "Only in dir-a ($name)"
+            continue
+        fi
+
+        local display_name
+        display_name=$(basename "$name")
+
+        # Quick SHA256 check
+        local hash_a hash_b
+        hash_a=$(sha256sum "${map_a[$name]}" | awk '{print $1}')
+        hash_b=$(sha256sum "${map_b[$name]}" | awk '{print $1}')
+
+        if [[ "$hash_a" == "$hash_b" ]]; then
+            record_result "$display_name" "IDENTICAL" ""
+            ((identical_debs++))
+            continue
+        fi
+
+        # Hashes differ — need deeper analysis
+        if $QUICK_MODE; then
+            record_result "$display_name" "SEMANTIC" "SHA256 mismatch (quick mode — no deep analysis)"
+            continue
+        fi
+
+        # Deep comparison: extract and compare contents
+        compare_deb_deep "${map_a[$name]}" "${map_b[$name]}" "$display_name"
+    done <<< "$all_keys"
+
+    log_info "Level 1 summary: $total_debs debs, $identical_debs identical by hash"
+}
+
+# Deep .deb comparison (extract and compare file-by-file)
+compare_deb_deep() {
+    local deb_a="$1" deb_b="$2" name="$3"
+    local tmp_a tmp_b
+    tmp_a=$(mktemp -d)
+    tmp_b=$(mktemp -d)
+    trap "rm -rf '$tmp_a' '$tmp_b'" RETURN
+
+    # Extract .deb files using dpkg-deb (handles any compression format)
+    local data_dir_a="$tmp_a/data" data_dir_b="$tmp_b/data"
+    local ctrl_dir_a="$tmp_a/control" ctrl_dir_b="$tmp_b/control"
+    mkdir -p "$data_dir_a" "$data_dir_b" "$ctrl_dir_a" "$ctrl_dir_b"
+
+    dpkg-deb -x "$deb_a" "$data_dir_a" 2>/dev/null || {
+        record_result "$name" "ERROR" "Failed to extract deb_a data"
+        return
+    }
+    dpkg-deb -x "$deb_b" "$data_dir_b" 2>/dev/null || {
+        record_result "$name" "ERROR" "Failed to extract deb_b data"
+        return
+    }
+    dpkg-deb -e "$deb_a" "$ctrl_dir_a" 2>/dev/null || true
+    dpkg-deb -e "$deb_b" "$ctrl_dir_b" 2>/dev/null || true
+
+    # Compare all files by content (ignoring timestamps/permissions)
+    local semantic_diff=false
+    local control_semantic=false
+    local diff_details=""
+    local diff_count=0
+
+    # Get file lists
+    local files_a files_b
+    files_a=$(cd "$data_dir_a" && find . -type f | sort)
+    files_b=$(cd "$data_dir_b" && find . -type f | sort)
+
+    # Check for file list differences
+    local list_diff
+    list_diff=$(diff <(echo "$files_a") <(echo "$files_b") 2>/dev/null || true)
+    if [[ -n "$list_diff" ]]; then
+        # .build-id/ SYMLINK path differences are cosmetic (the path encodes the
+        # binary's build-id hash, which legitimately changes per build). But a
+        # one-sided .build-id/ REGULAR file is real content drift, and any
+        # non-.build-id path difference is always semantic.
+        local non_buildid_diffs
+        non_buildid_diffs=$(echo "$list_diff" | grep "^[<>]" | grep -cv "\.build-id/" 2>/dev/null || true)
+        non_buildid_diffs=${non_buildid_diffs:-0}
+        local buildid_regular=0
+        while IFS= read -r dl; do
+            [[ "$dl" =~ ^([<>])\ (.*\.build-id/.*)$ ]] || continue
+            local side="${BASH_REMATCH[1]}" rel="${BASH_REMATCH[2]}"
+            local base="$data_dir_a"; [[ "$side" == ">" ]] && base="$data_dir_b"
+            [[ -f "$base/$rel" && ! -L "$base/$rel" ]] && ((buildid_regular++))
+        done < <(echo "$list_diff" | grep "^[<>]")
+        if [[ $non_buildid_diffs -gt 0 || $buildid_regular -gt 0 ]]; then
+            semantic_diff=true
+            diff_details="File list differs"
+            diff_count=$((diff_count + 1))
+        fi
+    fi
+
+    # Compare file metadata: full mode (setuid/setgid/sticky included),
+    # ownership (user/group), and symlink targets for every path. dpkg-deb -c
+    # reports these from the package's tar headers (so ownership is accurate even
+    # though extraction runs unprivileged). The size/date/time columns are
+    # content-derived and stripped. .build-id/ entries are excluded (their names
+    # and link targets encode the per-build build-id hash).
+    if ! $semantic_diff; then
+        local meta_a meta_b meta_diff
+        meta_a=$(dpkg-deb -c "$deb_a" 2>/dev/null | grep -v '\.build-id/' \
+            | awk '{out=$1" "$2; for(i=6;i<=NF;i++) out=out" "$i; print out}' | sort)
+        meta_b=$(dpkg-deb -c "$deb_b" 2>/dev/null | grep -v '\.build-id/' \
+            | awk '{out=$1" "$2; for(i=6;i<=NF;i++) out=out" "$i; print out}' | sort)
+        meta_diff=$(diff <(echo "$meta_a") <(echo "$meta_b") 2>/dev/null || true)
+        if [[ -n "$meta_diff" ]]; then
+            local meta_diff_count
+            meta_diff_count=$(echo "$meta_diff" | grep -c "^[<>]" || true)
+            semantic_diff=true
+            diff_details="${diff_details:+$diff_details; }File mode/ownership/symlink metadata differs (${meta_diff_count:-0} entries)"
+            diff_count=$((diff_count + 1))
+        fi
+    fi
+
+    # Compare file capabilities (security.capability xattr, e.g. from setcap).
+    # Read directly from the data tar headers via python so unprivileged
+    # extraction does not hide capability drift (a security-relevant change).
+    if ! $semantic_diff && has_tool python3; then
+        local caps_a caps_b
+        caps_a=$(dpkg-deb --fsys-tarfile "$deb_a" 2>/dev/null | python3 "$CAPS_FROM_TAR_PY" 2>/dev/null || true)
+        caps_b=$(dpkg-deb --fsys-tarfile "$deb_b" 2>/dev/null | python3 "$CAPS_FROM_TAR_PY" 2>/dev/null || true)
+        if [[ "$caps_a" != "$caps_b" ]]; then
+            semantic_diff=true
+            diff_details="${diff_details:+$diff_details; }File capabilities (setcap/xattr) differ"
+            diff_count=$((diff_count + 1))
+        fi
+    fi
+
+    # Compare file contents (collect multiple diffs, not just the first — Gap 2 fix)
+    # Limit to 10 semantic diffs to avoid excessive runtime on large packages
+    local all_diff_files=""
+    local max_semantic_diffs=10
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        [[ $diff_count -ge $max_semantic_diffs ]] && break
+        local fa="$data_dir_a/$file" fb="$data_dir_b/$file"
+        if [[ -f "$fa" && -f "$fb" ]]; then
+            if ! cmp -s "$fa" "$fb"; then
+                # Check if it's an ELF binary — strip debug and compare
+                if file "$fa" | grep -q "ELF"; then
+                    if has_tool objcopy; then
+                        local stripped_a stripped_b
+                        stripped_a=$(mktemp)
+                        stripped_b=$(mktemp)
+                        # Detect Go binaries and apply Go-specific normalization (Gap 3/8 fix)
+                        if readelf -S "$fa" 2>/dev/null | grep -q "\.note\.go\.buildid\|\.go\.buildinfo"; then
+                            # Go binary: remove Go-specific non-deterministic sections
+                            objcopy --strip-debug \
+                                --remove-section=.note.go.buildid \
+                                --remove-section=.go.buildinfo \
+                                --remove-section=.note.gnu.build-id \
+                                "$fa" "$stripped_a" 2>/dev/null || cp "$fa" "$stripped_a"
+                            objcopy --strip-debug \
+                                --remove-section=.note.go.buildid \
+                                --remove-section=.go.buildinfo \
+                                --remove-section=.note.gnu.build-id \
+                                "$fb" "$stripped_b" 2>/dev/null || cp "$fb" "$stripped_b"
+                            if ! cmp -s "$stripped_a" "$stripped_b"; then
+                                # Go binary differs after stripping metadata sections.
+                                # Check if .text+.rodata are identical (compiler non-determinism)
+                                # vs genuine code change.
+                                if elf_code_sections_identical "$fa" "$fb"; then
+                                    all_diff_files="$all_diff_files  [GO-NONDETERMINISTIC] $file\n"
+                                else
+                                    # Code sections differ — this is a real change, flag SEMANTIC
+                                    semantic_diff=true
+                                    diff_count=$((diff_count + 1))
+                                    all_diff_files="$all_diff_files  [GO-SEMANTIC] $file\n"
+                                    if [[ -z "$diff_details" || "$diff_details" == "File list differs" ]]; then
+                                        diff_details="Go binary code sections differ: $file"
+                                    fi
+                                fi
+                            fi
+                        else
+                            # C/C++ binary: standard strip-debug + remove build-id
+                            local strip_ok_a=false strip_ok_b=false
+                            objcopy --strip-debug \
+                                --remove-section=.note.gnu.build-id \
+                                "$fa" "$stripped_a" 2>/dev/null && strip_ok_a=true || cp "$fa" "$stripped_a"
+                            objcopy --strip-debug \
+                                --remove-section=.note.gnu.build-id \
+                                "$fb" "$stripped_b" 2>/dev/null && strip_ok_b=true || cp "$fb" "$stripped_b"
+                            if ! { $strip_ok_a && $strip_ok_b && cmp -s "$stripped_a" "$stripped_b"; }; then
+                                if elf_code_sections_identical "$fa" "$fb"; then
+                                    # Code sections (.text, .init.text, .rodata) are identical —
+                                    # remaining drift is in symbol tables, comments, or debug metadata.
+                                    all_diff_files="$all_diff_files  [CODE-SECTIONS-IDENTICAL] $file\n"
+                                else
+                                    semantic_diff=true
+                                    diff_count=$((diff_count + 1))
+                                    all_diff_files="$all_diff_files  $file\n"
+                                    if [[ -z "$diff_details" || "$diff_details" == "File list differs" ]]; then
+                                        diff_details="ELF binary differs after stripping debug: $file"
+                                    fi
+                                fi
+                            fi
+                        fi
+                        rm -f "$stripped_a" "$stripped_b"
+                    else
+                        semantic_diff=true
+                        diff_count=$((diff_count + 1))
+                        all_diff_files="$all_diff_files  $file\n"
+                        if [[ -z "$diff_details" ]]; then
+                            diff_details="Binary differs (no objcopy for strip): $file"
+                        fi
+                    fi
+                else
+                    # Non-ELF file differs — check known cosmetic patterns
+                    if is_cosmetic_diff "$fa" "$fb" "$file"; then
+                        : # cosmetic, skip
+                    elif [[ "$file" == *.deb || "$file" == *.udeb ]] && embedded_deb_is_cosmetic "$fa" "$fb"; then
+                        : # embedded package differs only in archive/compression metadata
+                    # Recursively compare embedded wheels: ALL files in BOTH
+                    # directions, compiled extensions via ELF sections, and
+                    # RECORD integrity (handled by wheel_dirs_cosmetic).
+                    elif [[ "$file" == *.whl ]] && has_tool unzip; then
+                        local emb_a emb_b
+                        emb_a=$(mktemp -d)
+                        emb_b=$(mktemp -d)
+                        unzip -q "$fa" -d "$emb_a" 2>/dev/null || true
+                        unzip -q "$fb" -d "$emb_b" 2>/dev/null || true
+                        if ! wheel_dirs_cosmetic "$emb_a" "$emb_b"; then
+                            semantic_diff=true
+                            diff_count=$((diff_count + 1))
+                            all_diff_files="$all_diff_files  $file (embedded wheel payload differs)\n"
+                            if [[ -z "$diff_details" ]]; then
+                                diff_details="Embedded wheel payload differs: $file"
+                            fi
+                        fi
+                        rm -rf "$emb_a" "$emb_b"
+                    # Gap 15 fix: strip debug from static .a libraries
+                    elif [[ "$file" == *.a ]] && has_tool objcopy; then
+                        local sa sb
+                        sa=$(mktemp)
+                        sb=$(mktemp)
+                        objcopy --strip-debug "$fa" "$sa" 2>/dev/null || cp "$fa" "$sa"
+                        objcopy --strip-debug "$fb" "$sb" 2>/dev/null || cp "$fb" "$sb"
+                        if ! cmp -s "$sa" "$sb"; then
+                            semantic_diff=true
+                            diff_count=$((diff_count + 1))
+                            all_diff_files="$all_diff_files  $file\n"
+                            if [[ -z "$diff_details" ]]; then
+                                diff_details="Static library differs after stripping debug: $file"
+                            fi
+                        fi
+                        rm -f "$sa" "$sb"
+                    else
+                        semantic_diff=true
+                        diff_count=$((diff_count + 1))
+                        all_diff_files="$all_diff_files  $file\n"
+                        if [[ -z "$diff_details" ]]; then
+                            diff_details="File content differs: $file"
+                        fi
+                    fi
+                fi
+            fi
+        fi
+    done <<< "$files_a"
+
+    # Append count if multiple diffs found
+    if [[ $diff_count -gt 1 ]]; then
+        diff_details="$diff_details (+$((diff_count - 1)) more)"
+    fi
+
+    if $semantic_diff; then
+        record_result "$name" "SEMANTIC" "$diff_details"
+    else
+        # Data contents are identical — check control for semantic differences
+        # (dependency fields, maintainer scripts are NOT cosmetic)
+        local control_details=""
+
+        if [[ -d "$ctrl_dir_a" && -d "$ctrl_dir_b" ]]; then
+
+            # Check ALL control files (not just a fixed list) for semantic differences
+            # This catches shlibs, symbols, md5sums, and any other DEBIAN/ metadata
+            local all_ctrl_files
+            all_ctrl_files=$(cd "$ctrl_dir_a" && find . -type f | sort; cd "$ctrl_dir_b" && find . -type f | sort)
+            all_ctrl_files=$(echo "$all_ctrl_files" | sort -u)
+
+            while IFS= read -r cf_rel; do
+                [[ -z "$cf_rel" ]] && continue
+                local cfa="$ctrl_dir_a/$cf_rel" cfb="$ctrl_dir_b/$cf_rel"
+                # File exists in one but not the other
+                if [[ -f "$cfa" && ! -f "$cfb" ]] || [[ ! -f "$cfa" && -f "$cfb" ]]; then
+                    control_semantic=true
+                    control_details="Control file '$cf_rel' present in one build but not the other"
+                    break
+                fi
+                # Both exist but differ
+                if [[ -f "$cfa" && -f "$cfb" ]] && ! cmp -s "$cfa" "$cfb"; then
+                    # For 'control' file: check if only cosmetic fields differ
+                    if [[ "$cf_rel" == "./control" ]]; then
+                        local ctrl_non_cosmetic
+                        # Build-Ids (ELF hashes) and Installed-Size (computed from content) are cosmetic
+                        ctrl_non_cosmetic=$(diff "$cfa" "$cfb" 2>/dev/null | grep "^[<>]" | grep -cvE "Build-Ids:|Installed-Size:" 2>/dev/null || true)
+                        if [[ "${ctrl_non_cosmetic:-0}" == "0" ]]; then
+                            continue  # Only cosmetic control fields differ
+                        fi
+                    fi
+                    # md5sums changes are cosmetic if data content comparison already passed
+                    if [[ "$cf_rel" == "./md5sums" ]]; then
+                        continue  # md5sums reflect content hashes we already compared
+                    fi
+                    control_semantic=true
+                    control_details="Control file '$cf_rel' differs between builds"
+                    break
+                fi
+            done <<< "$all_ctrl_files"
+        fi
+
+        if $control_semantic; then
+            record_result "$name" "SEMANTIC" "$control_details"
+        else
+            record_result "$name" "COSMETIC" "ar/tar timestamp differences only"
+        fi
+    fi
+
+    # Auto-run diffoscope on semantic diffs (if available) for detailed root-cause analysis
+    if { $semantic_diff || $control_semantic; } && $USE_DIFFOSCOPE && has_tool diffoscope; then
+        local diffoscope_report="$OUTPUT_DIR/diffoscope/${name}.html"
+        mkdir -p "$(dirname "$diffoscope_report")"
+        timeout "$TIMEOUT" diffoscope \
+            --max-report-size "$MAX_REPORT_SIZE" \
+            --html "$diffoscope_report" \
+            "$deb_a" "$deb_b" 2>/dev/null || true
+        if [[ -f "$diffoscope_report" ]]; then
+            log_info "  diffoscope report: $diffoscope_report"
+        fi
+    fi
+}
+
+# Check if a file difference is known-cosmetic
+# Compare two NESTED .deb/.udeb archives (e.g. a build-hooks deb embedded inside
+# a docker rootfs or another package) at the payload level. The .deb container
+# wraps its data in an ar archive + gzip/xz stream whose headers carry build
+# timestamps, so byte-identical payloads routinely produce different container
+# bytes. This decides cosmetic-vs-semantic on the REAL payload: file set, full
+# mode/ownership/symlink metadata, capability xattrs, and (ELF-aware) content.
+# Returns 0 when only container/timestamp noise differs.
+nested_deb_cosmetic() {
+    local deb_a="$1" deb_b="$2"
+    has_tool dpkg-deb || return 1
+    local da db rc=0
+    da=$(mktemp -d); db=$(mktemp -d)
+    if ! dpkg-deb -x "$deb_a" "$da" 2>/dev/null || ! dpkg-deb -x "$deb_b" "$db" 2>/dev/null; then
+        rm -rf "$da" "$db"; return 1
+    fi
+
+    # File set (excluding per-build .build-id/ paths) must match.
+    local files_a files_b
+    files_a=$(cd "$da" && find . -type f | grep -v '\.build-id/' | sort)
+    files_b=$(cd "$db" && find . -type f | grep -v '\.build-id/' | sort)
+    if [[ "$files_a" != "$files_b" ]]; then
+        rm -rf "$da" "$db"; return 1
+    fi
+
+    # Full mode / ownership / symlink metadata (size+date columns stripped).
+    local meta_a meta_b
+    meta_a=$(dpkg-deb -c "$deb_a" 2>/dev/null | grep -v '\.build-id/' \
+        | awk '{out=$1" "$2; for(i=6;i<=NF;i++) out=out" "$i; print out}' | sort)
+    meta_b=$(dpkg-deb -c "$deb_b" 2>/dev/null | grep -v '\.build-id/' \
+        | awk '{out=$1" "$2; for(i=6;i<=NF;i++) out=out" "$i; print out}' | sort)
+    if [[ "$meta_a" != "$meta_b" ]]; then
+        rm -rf "$da" "$db"; return 1
+    fi
+
+    # Capability xattrs (setcap) — security-relevant, read from tar headers.
+    if has_tool python3; then
+        local caps_a caps_b
+        caps_a=$(dpkg-deb --fsys-tarfile "$deb_a" 2>/dev/null | python3 "$CAPS_FROM_TAR_PY" 2>/dev/null || true)
+        caps_b=$(dpkg-deb --fsys-tarfile "$deb_b" 2>/dev/null | python3 "$CAPS_FROM_TAR_PY" 2>/dev/null || true)
+        if [[ "$caps_a" != "$caps_b" ]]; then
+            rm -rf "$da" "$db"; return 1
+        fi
+    fi
+
+    # Per-file content (ELF-aware so build-id-only drift stays cosmetic).
+    local f
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        local fa="$da/$f" fb="$db/$f"
+        cmp -s "$fa" "$fb" && continue
+        if ! regular_files_cosmetic "$fa" "$fb" "${f#./}"; then
+            rc=1; break
+        fi
+    done <<< "$files_a"
+
+    rm -rf "$da" "$db"
+    return $rc
+}
+
+is_cosmetic_diff() {
+    local file_a="$1" file_b="$2" rel_path="$3"
+
+    # Nested Debian packages (e.g. build-hooks debs embedded in docker rootfs):
+    # decide on the payload, ignoring ar/gzip container timestamp noise.
+    if [[ "$rel_path" == *.deb || "$rel_path" == *.udeb || "$rel_path" == *.ddeb ]]; then
+        if nested_deb_cosmetic "$file_a" "$file_b"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    # .pyc files — timestamp in header
+    if [[ "$rel_path" == *.pyc ]]; then
+        return 0  # cosmetic
+    fi
+
+    # /etc/shadow & /etc/gshadow: only the last-password-change date field drifts
+    # between builds on different days; everything else (hash/policy) must match.
+    case "$rel_path" in
+        */etc/shadow|*/etc/shadow-|etc/shadow|etc/shadow-|\
+        */etc/gshadow|*/etc/gshadow-|etc/gshadow|etc/gshadow-)
+            if shadow_diff_is_lastchange_only "$file_a" "$file_b"; then
+                return 0  # only the last-change date field differs
+            fi
+            return 1
+            ;;
+    esac
+
+    # changelog files with date stamps (and non-deterministic entry ordering)
+    if [[ "$rel_path" == *changelog* || "$rel_path" == *CHANGELOG* ]]; then
+        if content_diff_is_date_or_reorder "$file_a" "$file_b"; then
+            return 0  # only date and/or entry ordering differ
+        fi
+    fi
+
+    # Build-id or build-path in text files
+    if [[ "$rel_path" == *.buildinfo || "$rel_path" == *.changes ]]; then
+        return 0  # cosmetic
+    fi
+
+    # .gz files — decompress and compare content; gzip headers contain timestamps
+    if [[ "$rel_path" == *.gz ]] && has_tool gzip; then
+        local ungz_a ungz_b
+        ungz_a=$(mktemp)
+        ungz_b=$(mktemp)
+        if gzip -dc "$file_a" > "$ungz_a" 2>/dev/null && gzip -dc "$file_b" > "$ungz_b" 2>/dev/null; then
+            if cmp -s "$ungz_a" "$ungz_b"; then
+                rm -f "$ungz_a" "$ungz_b"
+                return 0  # gunzipped content identical — gzip header timestamp only
+            fi
+            # Content differs. Only treat date/time drift as cosmetic for KNOWN
+            # documentation payloads (man pages, info docs, changelogs). For any
+            # other compressed payload (e.g. configuration, rules, data files) a
+            # changed timestamp may be semantically meaningful, so do NOT mask it.
+            case "$rel_path" in
+                *changelog*|*CHANGELOG*)
+                    # Changelogs additionally tolerate non-deterministic entry
+                    # ordering (same patch set, reshuffled author blocks).
+                    if content_diff_is_date_or_reorder "$ungz_a" "$ungz_b"; then
+                        rm -f "$ungz_a" "$ungz_b"
+                        return 0
+                    fi
+                    ;;
+                */man/*|*.1.gz|*.2.gz|*.3.gz|*.4.gz|*.5.gz|*.6.gz|*.7.gz|*.8.gz|*.9.gz|\
+                *.info.gz|*.info-[0-9]*.gz|*/doc/*|*NEWS.gz)
+                    if content_diff_is_date_only "$ungz_a" "$ungz_b"; then
+                        rm -f "$ungz_a" "$ungz_b"
+                        return 0
+                    fi
+                    ;;
+            esac
+        fi
+        rm -f "$ungz_a" "$ungz_b"
+    fi
+
+    # Kernel-related files with embedded build timestamps
+    if [[ "$rel_path" == *utsversion.h || "$rel_path" == *utsrelease.h ]]; then
+        # These are single-line header files with build timestamp — verify only that differs
+        if content_diff_is_date_only "$file_a" "$file_b"; then
+            return 0
+        fi
+        return 1  # Non-date content change in kernel header
+    fi
+    if [[ "$rel_path" == */boot/vmlinuz-* ]]; then
+        # Kernel binary: an embedded build timestamp changes only a handful of
+        # bytes. Same size alone is NOT sufficient proof (a same-size payload
+        # change would slip through), so require the byte-level delta to be tiny.
+        if binaries_differ_by_at_most "$file_a" "$file_b" 64; then
+            return 0  # localized timestamp/build-id bytes only
+        fi
+        return 1  # real kernel change
+    fi
+
+    # GRUB EFI binaries with embedded build timestamps
+    if [[ "$rel_path" == */monolithic/gcd*.efi || "$rel_path" == */monolithic/grub*.efi ]]; then
+        if binaries_differ_by_at_most "$file_a" "$file_b" 64; then
+            return 0  # localized build timestamp bytes only
+        fi
+        return 1  # real content change
+    fi
+
+    # Doxygen/auto-generated documentation (timestamps in HTML/info)
+    if [[ "$rel_path" == */html/*.html || "$rel_path" == *_tree.html || "$rel_path" == *grub-dev.info* ]]; then
+        return 0  # generated docs contain generation timestamps or non-deterministic ordering
+    fi
+
+    # Non-deterministic file ordering in generated outputs (YANG trees).
+    # Cosmetic ONLY if the two files contain the same set of lines reordered;
+    # added/removed/changed lines are semantic.
+    if [[ "$rel_path" == *allyangs.tree || "$rel_path" == *allyangs.txt ]]; then
+        if content_diff_is_reorder_only "$file_a" "$file_b"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    # Generated Go code from protobuf/YANG. Generator output ordering is
+    # non-deterministic, but real content changes must still be flagged: only
+    # treat as cosmetic when the difference is pure line reordering.
+    if [[ "$rel_path" == *ocbinds*.go || "$rel_path" == *_generated.go || "$rel_path" == *.pb.go ]]; then
+        if content_diff_is_reorder_only "$file_a" "$file_b"; then
+            return 0
+        fi
+        return 1
+    fi
+
+    # JSON files with non-deterministic key ordering
+    if [[ "$rel_path" == *.json ]] && has_tool python3; then
+        if python3 -c 'import json,sys;a=json.load(open(sys.argv[1]));b=json.load(open(sys.argv[2]));sys.exit(0 if json.dumps(a,sort_keys=True)==json.dumps(b,sort_keys=True) else 1)' "$file_a" "$file_b" 2>/dev/null; then
+            return 0  # JSON semantically identical, only key ordering differs
+        fi
+    fi
+
+    return 1  # NOT cosmetic — treat as semantic
+}
+
+# Validate the integrity of a wheel's RECORD file: every regular file listed in
+# RECORD must exist with a matching sha256. A RECORD that disagrees with the
+# on-disk payload (hash/size drift, missing/extra entries) indicates a
+# corrupted or tampered wheel and is reported as non-cosmetic.
+# Returns 0 when RECORD is consistent (or absent), 1 when inconsistent.
+wheel_record_consistent() {
+    local root="$1"
+    has_tool python3 || return 0
+    python3 - "$root" <<'PY' 2>/dev/null
+import base64, csv, hashlib, pathlib, sys
+
+root = pathlib.Path(sys.argv[1])
+records = list(root.glob('*.dist-info/RECORD'))
+if not records:
+    sys.exit(0)  # nothing to validate
+for record in records:
+    base = record.parent.parent
+    with record.open(newline='') as fh:
+        for row in csv.reader(fh):
+            if not row:
+                continue
+            rel = row[0]
+            digest = row[1] if len(row) > 1 else ''
+            target = (base / rel)
+            # RECORD lists itself with empty hash/size — skip integrity check.
+            if not digest:
+                continue
+            if not digest.startswith('sha256='):
+                continue
+            try:
+                data = target.read_bytes()
+            except OSError:
+                sys.exit(1)  # listed file missing
+            want = digest.split('=', 1)[1]
+            got = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b'=').decode()
+            if got != want:
+                sys.exit(1)  # hash mismatch — payload diverges from RECORD
+sys.exit(0)
+PY
+}
+
+# Boolean comparison of two already-extracted wheel directories. Returns 0 when
+# the difference is purely cosmetic (zip/pyc timestamps, RECORD self-hash) and 1
+# when a semantic difference exists. Checks ALL files in BOTH directions, uses
+# ELF section comparison for compiled extensions, and validates RECORD integrity
+# on each side.
+wheel_dirs_cosmetic() {
+    local dir_a="$1" dir_b="$2"
+
+    # RECORD must be internally consistent on each side.
+    wheel_record_consistent "$dir_a" || return 1
+    wheel_record_consistent "$dir_b" || return 1
+
+    # Files present in A: compare content with B.
+    local file_a rel_path fb
+    while IFS= read -r file_a; do
+        [[ -z "$file_a" ]] && continue
+        rel_path="${file_a#$dir_a/}"
+        [[ "$rel_path" == *.pyc ]] && continue
+        [[ "$rel_path" == */RECORD ]] && continue
+        fb="$dir_b/$rel_path"
+        [[ -f "$fb" ]] || return 1  # file missing in B
+        if ! cmp -s "$file_a" "$fb"; then
+            if [[ "$rel_path" == *.so || "$rel_path" == *.so.* ]]; then
+                elf_code_sections_identical "$file_a" "$fb" || return 1
+            elif ! is_cosmetic_diff "$file_a" "$fb" "$rel_path"; then
+                return 1
+            fi
+        fi
+    done < <(find "$dir_a" -type f)
+
+    # Files present only in B.
+    local file_b fa
+    while IFS= read -r file_b; do
+        [[ -z "$file_b" ]] && continue
+        rel_path="${file_b#$dir_b/}"
+        [[ "$rel_path" == *.pyc ]] && continue
+        [[ "$rel_path" == */RECORD ]] && continue
+        fa="$dir_a/$rel_path"
+        [[ -f "$fa" ]] || return 1  # file missing in A
+    done < <(find "$dir_b" -type f)
+
+    return 0
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEVEL 2: Python Wheel Comparison
+# ═══════════════════════════════════════════════════════════════════════════════
+compare_wheels() {
+    echo ""
+    echo -e "${BOLD}━━━ Level 2: Python Wheel Comparison ━━━${NC}"
+    echo ""
+
+    local wheels_a wheels_b
+    wheels_a=$(find "$DIR_A" -name "*.whl" -type f 2>/dev/null | sort)
+    wheels_b=$(find "$DIR_B" -name "*.whl" -type f 2>/dev/null | sort)
+
+    if [[ -z "$wheels_a" && -z "$wheels_b" ]]; then
+        log_warn "No .whl files found in either directory"
+        return
+    fi
+
+    # Build relative-path maps
+    declare -A whl_map_a=() whl_map_b=()
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        whl_map_a["${path#$DIR_A/}"]="$path"
+    done <<< "$wheels_a"
+
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        whl_map_b["${path#$DIR_B/}"]="$path"
+    done <<< "$wheels_b"
+
+    local total_whls=0 identical_whls=0
+    local all_whl_keys
+    all_whl_keys=$(printf '%s\n' "${!whl_map_a[@]}" "${!whl_map_b[@]}" | sort -u)
+    while IFS= read -r rel_key; do
+        [[ -z "$rel_key" ]] && continue
+        ((total_whls++))
+        local name
+        name=$(basename "$rel_key")
+
+        if [[ -z "${whl_map_a[$rel_key]:-}" ]]; then
+            record_result "$name" "MISSING" "Only in dir-b"
+            continue
+        fi
+        if [[ -z "${whl_map_b[$rel_key]:-}" ]]; then
+            record_result "$name" "MISSING" "Only in dir-a"
+            continue
+        fi
+
+        # Quick SHA256
+        local hash_a hash_b
+        hash_a=$(sha256sum "${whl_map_a[$rel_key]}" | awk '{print $1}')
+        hash_b=$(sha256sum "${whl_map_b[$rel_key]}" | awk '{print $1}')
+
+        if [[ "$hash_a" == "$hash_b" ]]; then
+            record_result "$name" "IDENTICAL" ""
+            ((identical_whls++))
+            continue
+        fi
+
+        if $QUICK_MODE; then
+            record_result "$name" "SEMANTIC" "SHA256 mismatch (quick mode)"
+            continue
+        fi
+
+        # Deep comparison: unzip and compare
+        compare_wheel_deep "${whl_map_a[$rel_key]}" "${whl_map_b[$rel_key]}" "$name"
+    done <<< "$all_whl_keys"
+
+    log_info "Level 2 summary: $total_whls wheels, $identical_whls identical by hash"
+}
+
+compare_wheel_deep() {
+    local whl_a="$1" whl_b="$2" name="$3"
+
+    if ! has_tool unzip; then
+        record_result "$name" "ERROR" "unzip not available for .whl extraction"
+        return
+    fi
+
+    local tmp_a tmp_b
+    tmp_a=$(mktemp -d)
+    tmp_b=$(mktemp -d)
+    trap "rm -rf '$tmp_a' '$tmp_b'" RETURN
+
+    unzip -q "$whl_a" -d "$tmp_a" 2>/dev/null || {
+        record_result "$name" "ERROR" "Failed to unzip whl_a"
+        return
+    }
+    unzip -q "$whl_b" -d "$tmp_b" 2>/dev/null || {
+        record_result "$name" "ERROR" "Failed to unzip whl_b"
+        return
+    }
+
+    # Compare .py source files (ignoring .pyc)
+    local semantic_diff=false
+    local diff_details=""
+
+    # Compare METADATA
+    local meta_a meta_b
+    meta_a=$(find "$tmp_a" -name "METADATA" | head -1)
+    meta_b=$(find "$tmp_b" -name "METADATA" | head -1)
+
+    if [[ -n "$meta_a" && -n "$meta_b" ]]; then
+        if ! cmp -s "$meta_a" "$meta_b"; then
+            # Normalize only date fields in METADATA (Version IS semantic)
+            local meta_norm_a meta_norm_b
+            meta_norm_a=$(grep -vE "^(Date|Build-Date|Created):" "$meta_a" 2>/dev/null || cat "$meta_a")
+            meta_norm_b=$(grep -vE "^(Date|Build-Date|Created):" "$meta_b" 2>/dev/null || cat "$meta_b")
+            if [[ "$meta_norm_a" != "$meta_norm_b" ]]; then
+                semantic_diff=true
+                diff_details="METADATA differs (non-date fields)"
+            fi
+        fi
+    elif [[ -n "$meta_a" || -n "$meta_b" ]]; then
+        # METADATA exists on one side only — broken/incomplete wheel
+        semantic_diff=true
+        diff_details="METADATA present in only one wheel"
+    fi
+
+    # Compare ALL files in the wheel (both directions)
+    # This catches .py, .so, .yaml, .json, .cfg, .pth, templates, data files, etc.
+    if ! $semantic_diff; then
+        while IFS= read -r file_a; do
+            [[ -z "$file_a" ]] && continue
+            local rel_path="${file_a#$tmp_a/}"
+            local fb="$tmp_b/$rel_path"
+
+            # Skip .pyc files and RECORD (installer metadata with hashes)
+            [[ "$rel_path" == *.pyc ]] && continue
+            [[ "$rel_path" == */RECORD ]] && continue
+
+            if [[ ! -f "$fb" ]]; then
+                semantic_diff=true
+                diff_details="File missing in B: $rel_path"
+                break
+            fi
+            if ! cmp -s "$file_a" "$fb"; then
+                # For .so files, use ELF section comparison
+                if [[ "$rel_path" == *.so ]] || [[ "$rel_path" == *.so.* ]]; then
+                    if ! elf_code_sections_identical "$file_a" "$fb"; then
+                        semantic_diff=true
+                        diff_details="Compiled extension differs: $rel_path"
+                        break
+                    fi
+                else
+                    semantic_diff=true
+                    diff_details="File content differs: $rel_path"
+                    break
+                fi
+            fi
+        done < <(find "$tmp_a" -type f)
+    fi
+
+    # Validate RECORD integrity on each side (hash/size drift, missing entries).
+    if ! $semantic_diff; then
+        if ! wheel_record_consistent "$tmp_a"; then
+            semantic_diff=true
+            diff_details="RECORD inconsistent with payload in wheel A"
+        elif ! wheel_record_consistent "$tmp_b"; then
+            semantic_diff=true
+            diff_details="RECORD inconsistent with payload in wheel B"
+        fi
+    fi
+
+    # Check for files in B that don't exist in A
+    if ! $semantic_diff; then
+        while IFS= read -r file_b; do
+            [[ -z "$file_b" ]] && continue
+            local rel_path="${file_b#$tmp_b/}"
+            [[ "$rel_path" == *.pyc ]] && continue
+            [[ "$rel_path" == */RECORD ]] && continue
+            local fa="$tmp_a/$rel_path"
+            if [[ ! -f "$fa" ]]; then
+                semantic_diff=true
+                diff_details="File missing in A: $rel_path"
+                break
+            fi
+        done < <(find "$tmp_b" -type f)
+    fi
+
+    if $semantic_diff; then
+        record_result "$name" "SEMANTIC" "$diff_details"
+    else
+        record_result "$name" "COSMETIC" "ZIP metadata/pyc timestamp differences only"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEVEL 3: Docker Image Comparison
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Return 0 when two regular files differ only cosmetically. ELF objects are
+# compared after stripping debug/build-id (and, for the remaining drift, by
+# code+data section equality); other files fall back to is_cosmetic_diff.
+regular_files_cosmetic() {
+    local fa="$1" fb="$2" rel="$3"
+    cmp -s "$fa" "$fb" && return 0
+    if file "$fa" 2>/dev/null | grep -q "ELF"; then
+        if has_tool objcopy; then
+            local sa sb rc=1
+            sa=$(mktemp); sb=$(mktemp)
+            if readelf -S "$fa" 2>/dev/null | grep -q "\.note\.go\.buildid\|\.go\.buildinfo"; then
+                objcopy --strip-debug --remove-section=.note.go.buildid \
+                    --remove-section=.go.buildinfo --remove-section=.note.gnu.build-id \
+                    "$fa" "$sa" 2>/dev/null || cp "$fa" "$sa"
+                objcopy --strip-debug --remove-section=.note.go.buildid \
+                    --remove-section=.go.buildinfo --remove-section=.note.gnu.build-id \
+                    "$fb" "$sb" 2>/dev/null || cp "$fb" "$sb"
+            else
+                objcopy --strip-debug --remove-section=.note.gnu.build-id "$fa" "$sa" 2>/dev/null || cp "$fa" "$sa"
+                objcopy --strip-debug --remove-section=.note.gnu.build-id "$fb" "$sb" 2>/dev/null || cp "$fb" "$sb"
+            fi
+            if cmp -s "$sa" "$sb"; then
+                rc=0
+            elif elf_code_sections_identical "$fa" "$fb"; then
+                rc=0
+            fi
+            rm -f "$sa" "$sb"
+            return $rc
+        fi
+        return 1  # ELF differs and cannot normalize
+    fi
+    is_cosmetic_diff "$fa" "$fb" "$rel"
+}
+
+# Return 0 when a docker rootfs path holds inherently non-deterministic build
+# state (logs, caches, package-manager bookkeeping, byte-compiled python), whose
+# drift is cosmetic. Everything else (binaries, configs, scripts) is significant.
+docker_path_is_noise() {
+    local rel="$1"
+    case "/$rel" in
+        *.pyc|*/__pycache__/*) return 0 ;;
+        */.wh.*|*cache.tgz) return 0 ;;
+        */var/log/*|*/var/cache/*|*/var/tmp/*|*/tmp/*) return 0 ;;
+        */var/lib/apt/*|*/var/lib/dpkg/*) return 0 ;;
+        */etc/machine-id|*/var/lib/dbus/machine-id) return 0 ;;
+        */ld.so.cache|*aux-cache) return 0 ;;
+        */var/lib/systemd/*|*/var/lib/sonic-*) return 0 ;;
+    esac
+    return 1
+}
+
+# Flatten a docker-archive (already extracted to $1) into a merged rootfs under
+# $2, writing a metadata manifest to $3. Returns non-zero on failure.
+flatten_docker_image() {
+    local img_dir="$1" dest="$2" manifest_out="$3"
+    has_tool python3 || return 1
+    mkdir -p "$dest"
+    python3 "$FLATTEN_DOCKER_PY" "$img_dir" "$dest" "$manifest_out" 2>/dev/null
+}
+
+
+compare_dockers() {
+    echo ""
+    echo -e "${BOLD}━━━ Level 3: Docker Image Comparison ━━━${NC}"
+    echo ""
+
+    local images_a images_b
+    images_a=$(find "$DIR_A" -name "*.gz" -path "*/docker*" -type f 2>/dev/null | sort)
+    images_b=$(find "$DIR_B" -name "*.gz" -path "*/docker*" -type f 2>/dev/null | sort)
+
+    # Also check top-level .gz files that are docker images
+    if [[ -z "$images_a" ]]; then
+        images_a=$(find "$DIR_A" -maxdepth 2 -name "docker-*.gz" -type f 2>/dev/null | sort)
+    fi
+    if [[ -z "$images_b" ]]; then
+        images_b=$(find "$DIR_B" -maxdepth 2 -name "docker-*.gz" -type f 2>/dev/null | sort)
+    fi
+
+    if [[ -z "$images_a" && -z "$images_b" ]]; then
+        log_warn "No Docker images found in either directory"
+        return
+    fi
+
+    # Build filename maps
+    declare -A img_map_a=() img_map_b=()
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        img_map_a["$(basename "$path")"]="$path"
+    done <<< "$images_a"
+
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        img_map_b["$(basename "$path")"]="$path"
+    done <<< "$images_b"
+
+    local total_imgs=0 identical_imgs=0
+    local all_img_keys
+    all_img_keys=$(printf '%s\n' "${!img_map_a[@]}" "${!img_map_b[@]}" | sort -u)
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        ((total_imgs++))
+
+        if [[ -z "${img_map_a[$name]:-}" ]]; then
+            record_result "$name" "MISSING" "Only in dir-b"
+            continue
+        fi
+        if [[ -z "${img_map_b[$name]:-}" ]]; then
+            record_result "$name" "MISSING" "Only in dir-a"
+            continue
+        fi
+
+        # Quick SHA256 (Docker images almost always differ due to layer timestamps)
+        local hash_a hash_b
+        hash_a=$(sha256sum "${img_map_a[$name]}" | awk '{print $1}')
+        hash_b=$(sha256sum "${img_map_b[$name]}" | awk '{print $1}')
+
+        if [[ "$hash_a" == "$hash_b" ]]; then
+            record_result "$name" "IDENTICAL" ""
+            ((identical_imgs++))
+            continue
+        fi
+
+        if $QUICK_MODE; then
+            # Quick mode cannot prove equivalence for Docker images — flag conservatively
+            record_result "$name" "SEMANTIC" "SHA256 differs (quick mode — deep analysis required to verify)"
+            continue
+        fi
+
+        # Deep Docker comparison
+        compare_docker_deep "${img_map_a[$name]}" "${img_map_b[$name]}" "$name"
+    done <<< "$all_img_keys"
+
+    log_info "Level 3 summary: $total_imgs images, $identical_imgs identical by hash"
+}
+
+compare_docker_deep() {
+    local img_a="$1" img_b="$2" name="$3"
+
+    # Try tar-based comparison first (no Docker dependency)
+    if compare_docker_tar "$img_a" "$img_b" "$name"; then
+        return
+    fi
+
+    # Fallback: use Docker if available
+    if ! has_tool docker; then
+        record_result "$name" "ERROR" "Tar-based comparison failed and Docker not available"
+        return
+    fi
+
+    compare_docker_with_daemon "$img_a" "$img_b" "$name"
+}
+
+# Tar-based Docker image comparison (no Docker daemon required).
+# Docker images (.gz) are gzipped tar archives containing:
+#   - manifest.json (layer references and config pointer)
+#   - <sha256>.json (image config: env, cmd, labels, timestamps)
+#   - <layer-id>/layer.tar (filesystem layers)
+compare_docker_tar() {
+    local img_a="$1" img_b="$2" name="$3"
+    local tmp_a tmp_b
+
+    tmp_a=$(mktemp -d -p "${TMPDIR:-${OUTPUT_DIR:-/tmp}}" 2>/dev/null || mktemp -d) || return 1
+    tmp_b=$(mktemp -d -p "${TMPDIR:-${OUTPUT_DIR:-/tmp}}" 2>/dev/null || mktemp -d) || { rm -rf "$tmp_a"; return 1; }
+
+    # Extract both images
+    if ! tar xzf "$img_a" -C "$tmp_a" 2>/dev/null; then
+        rm -rf "$tmp_a" "$tmp_b"
+        return 1
+    fi
+    if ! tar xzf "$img_b" -C "$tmp_b" 2>/dev/null; then
+        rm -rf "$tmp_a" "$tmp_b"
+        return 1
+    fi
+
+    # Compare manifest.json (layer ordering and references)
+    local manifest_a manifest_b
+    manifest_a=$(cat "$tmp_a/manifest.json" 2>/dev/null) || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+    manifest_b=$(cat "$tmp_b/manifest.json" 2>/dev/null) || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+
+    # Compare config JSON (normalize: remove timestamps)
+    local config_a config_b
+    config_a=$(python3 -c "
+import json, sys, glob, os, re
+mf = json.load(open('$tmp_a/manifest.json'))
+cfg_file = os.path.join('$tmp_a', mf[0]['Config'])
+cfg = json.load(open(cfg_file))
+# Remove fields that are expected to differ (timestamps, image IDs)
+for key in ['created', 'container', 'docker_version']:
+    cfg.pop(key, None)
+import re
+if 'history' in cfg:
+    for entry in cfg['history']:
+        entry.pop('created', None)
+        if 'created_by' in entry:
+            entry['created_by'] = re.sub(r'(?i)image_version=[^\s]+', 'IMAGE_VERSION=NORMALIZED', entry['created_by'])
+# Normalize labels: remove pipeline-specific labels (Gap 11 fix)
+labels = cfg.get('config', {}).get('Labels', {})
+for label_key in list(labels.keys()):
+    # Remove build-specific labels that differ between pipeline runs
+    if label_key in ('Tag', 'build_date', 'build_number', 'build_id'):
+        del labels[label_key]
+# Normalize Env: remove IMAGE_VERSION (contains pipeline ID and branch)
+env_list = cfg.get('config', {}).get('Env', [])
+cfg.get('config', {})['Env'] = [e for e in env_list if not e.startswith('IMAGE_VERSION=')]
+# Normalize rootfs diff_ids — these are content-addressed layer hashes
+# that will differ when layers contain different timestamps/logs (expected)
+cfg.pop('rootfs', None)
+print(json.dumps(cfg, sort_keys=True))
+" 2>/dev/null) || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+
+    config_b=$(python3 -c "
+import json, sys, glob, os, re
+mf = json.load(open('$tmp_b/manifest.json'))
+cfg_file = os.path.join('$tmp_b', mf[0]['Config'])
+cfg = json.load(open(cfg_file))
+for key in ['created', 'container', 'docker_version']:
+    cfg.pop(key, None)
+if 'history' in cfg:
+    for entry in cfg['history']:
+        entry.pop('created', None)
+        if 'created_by' in entry:
+            entry['created_by'] = re.sub(r'(?i)image_version=[^\s]+', 'IMAGE_VERSION=NORMALIZED', entry['created_by'])
+labels = cfg.get('config', {}).get('Labels', {})
+for label_key in list(labels.keys()):
+    if label_key in ('Tag', 'build_date', 'build_number', 'build_id'):
+        del labels[label_key]
+env_list = cfg.get('config', {}).get('Env', [])
+cfg.get('config', {})['Env'] = [e for e in env_list if not e.startswith('IMAGE_VERSION=')]
+cfg.pop('rootfs', None)
+print(json.dumps(cfg, sort_keys=True))
+" 2>/dev/null) || { rm -rf "$tmp_a" "$tmp_b"; return 1; }
+
+    # Ordered list of layers as referenced by the manifest (detects same layer
+    # SET applied in a different ORDER, which yields a different final fs).
+    local layer_order_a layer_order_b
+    layer_order_a=$(python3 -c "import json,hashlib,os;m=json.load(open('$tmp_a/manifest.json'))[0]['Layers'];print('\n'.join(hashlib.sha256(open(os.path.join('$tmp_a',l),'rb').read()).hexdigest() for l in m))" 2>/dev/null || echo "ERR_A")
+    layer_order_b=$(python3 -c "import json,hashlib,os;m=json.load(open('$tmp_b/manifest.json'))[0]['Layers'];print('\n'.join(hashlib.sha256(open(os.path.join('$tmp_b',l),'rb').read()).hexdigest() for l in m))" 2>/dev/null || echo "ERR_B")
+
+    local has_semantic_diff=false
+    local diff_details=""
+
+    # When the ordered layer hashes match exactly, the final filesystems are
+    # byte-identical and only metadata (config/manifest) can differ — skip the
+    # expensive flatten. Otherwise, flatten BOTH images to their final rootfs
+    # (manifest order + whiteouts) and compare full content + metadata.
+    if [[ "$layer_order_a" != "$layer_order_b" || "$layer_order_a" == ERR_A ]]; then
+        local root_a="$tmp_a/_merged" root_b="$tmp_b/_merged"
+        local meta_a="$tmp_a/_meta.tsv" meta_b="$tmp_b/_meta.tsv"
+
+        if ! flatten_docker_image "$tmp_a" "$root_a" "$meta_a" \
+            || ! flatten_docker_image "$tmp_b" "$root_b" "$meta_b"; then
+            # Flatten unavailable (no python3) — cannot prove equivalence here.
+            rm -rf "$tmp_a" "$tmp_b"
+            return 1   # let the caller fall back to the docker-daemon path
+        fi
+
+        # 1) Metadata comparison: path presence, type, mode, owner, symlink
+        #    target. Ignore inherently non-deterministic build-state paths.
+        local meta_diff
+        meta_diff=$(diff "$meta_a" "$meta_b" 2>/dev/null | grep "^[<>]" || true)
+        if [[ -n "$meta_diff" ]]; then
+            local meta_sig=0
+            while IFS= read -r line; do
+                [[ -z "$line" ]] && continue
+                local rel="${line#? }"; rel="${rel%%$'\t'*}"
+                docker_path_is_noise "$rel" || ((meta_sig++))
+            done <<< "$meta_diff"
+            if [[ $meta_sig -gt 0 ]]; then
+                has_semantic_diff=true
+                diff_details="Filesystem metadata differs ($meta_sig path/mode/owner/symlink entries)"
+            fi
+        fi
+
+        # 2) Content comparison over the merged rootfs for files present on
+        #    both sides; ELF-/cosmetic-aware. Bidirectional presence is already
+        #    covered by the metadata diff above.
+        if ! $has_semantic_diff; then
+            local content_sig=0 first_sig=""
+            while IFS= read -r fa; do
+                [[ -z "$fa" ]] && continue
+                local rel="${fa#$root_a/}"
+                docker_path_is_noise "$rel" && continue
+                local fb="$root_b/$rel"
+                [[ -f "$fb" ]] || continue          # presence handled by metadata diff
+                cmp -s "$fa" "$fb" && continue
+                if ! regular_files_cosmetic "$fa" "$fb" "$rel"; then
+                    ((content_sig++))
+                    [[ -z "$first_sig" ]] && first_sig="$rel"
+                    [[ $content_sig -ge 10 ]] && break
+                fi
+            done < <(find "$root_a" -type f)
+            if [[ $content_sig -gt 0 ]]; then
+                has_semantic_diff=true
+                diff_details="Filesystem content differs ($content_sig files, e.g. $first_sig)"
+            fi
+        fi
+    fi
+
+    # Check config (env, cmd, entrypoint, labels — excluding timestamps)
+    if [[ "$config_a" != "$config_b" ]]; then
+        has_semantic_diff=true
+        diff_details="${diff_details:+$diff_details; }Config differs (Env/Cmd/Labels/Entrypoint)"
+    fi
+
+    # Determine result
+    if [[ "$has_semantic_diff" == "true" ]]; then
+        record_result "$name" "SEMANTIC" "$diff_details"
+    elif [[ "$layer_order_a" != "$layer_order_b" || "$manifest_a" != "$manifest_b" ]]; then
+        # Final filesystem + config are equivalent; only timestamps/metadata in
+        # the archive differ.
+        record_result "$name" "COSMETIC" "Layer/manifest timestamps only; merged filesystem equivalent (tar-based)"
+    else
+        record_result "$name" "IDENTICAL" "All layers and config match (tar-based)"
+    fi
+
+    rm -rf "$tmp_a" "$tmp_b"
+    return 0
+}
+
+# Docker daemon-based comparison (original approach, used as fallback)
+compare_docker_with_daemon() {
+    local img_a="$1" img_b="$2" name="$3"
+
+    local tag_a="verify-cache-a/${name%.gz}:test"
+    local tag_b="verify-cache-b/${name%.gz}:test"
+
+    docker load -i "$img_a" 2>/dev/null | grep -oP "Loaded image: \K.*" > /dev/null || {
+        local loaded_id
+        loaded_id=$(docker load -i "$img_a" 2>/dev/null | grep -oP "Loaded image ID: sha256:\K[a-f0-9]+" | head -1)
+        if [[ -n "$loaded_id" ]]; then
+            docker tag "$loaded_id" "$tag_a" 2>/dev/null || true
+        else
+            record_result "$name" "ERROR" "Failed to load Docker image A"
+            return
+        fi
+    }
+
+    docker load -i "$img_b" 2>/dev/null | grep -oP "Loaded image: \K.*" > /dev/null || {
+        local loaded_id
+        loaded_id=$(docker load -i "$img_b" 2>/dev/null | grep -oP "Loaded image ID: sha256:\K[a-f0-9]+" | head -1)
+        if [[ -n "$loaded_id" ]]; then
+            docker tag "$loaded_id" "$tag_b" 2>/dev/null || true
+        else
+            record_result "$name" "ERROR" "Failed to load Docker image B"
+            return
+        fi
+    }
+
+    # Compare using container-diff if available
+    if has_tool container-diff; then
+        local diff_output="$OUTPUT_DIR/container-diff/${name}.txt"
+        mkdir -p "$(dirname "$diff_output")"
+        timeout "$TIMEOUT" container-diff diff \
+            "daemon://$tag_a" "daemon://$tag_b" \
+            --type=file --type=apt 2>/dev/null > "$diff_output" || true
+
+        if [[ -s "$diff_output" ]]; then
+            local pkg_diffs
+            pkg_diffs=$(grep -c "^-\|^+" "$diff_output" 2>/dev/null || echo "0")
+            if [[ $pkg_diffs -gt 0 ]]; then
+                record_result "$name" "SEMANTIC" "container-diff found $pkg_diffs differences (see $diff_output)"
+            else
+                record_result "$name" "COSMETIC" "Docker layer timestamps only"
+            fi
+        else
+            record_result "$name" "COSMETIC" "No filesystem/package differences detected"
+        fi
+    else
+        # Fallback: compare docker inspect (normalized)
+        local inspect_a inspect_b
+        inspect_a=$(docker inspect "$tag_a" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)[0]['Config']
+for key in ['Hostname', 'Image']:
+    data.pop(key, None)
+print(json.dumps(data, sort_keys=True, indent=2))
+" 2>/dev/null || echo "ERROR")
+
+        inspect_b=$(docker inspect "$tag_b" 2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)[0]['Config']
+for key in ['Hostname', 'Image']:
+    data.pop(key, None)
+print(json.dumps(data, sort_keys=True, indent=2))
+" 2>/dev/null || echo "ERROR")
+
+        if [[ "$inspect_a" == "$inspect_b" ]]; then
+            record_result "$name" "COSMETIC" "docker inspect configs match (timestamp diffs only)"
+        elif [[ "$inspect_a" == "ERROR" || "$inspect_b" == "ERROR" ]]; then
+            record_result "$name" "ERROR" "Failed to inspect Docker images"
+        else
+            record_result "$name" "SEMANTIC" "Docker config differs (Env/Cmd/Labels/etc.)"
+        fi
+    fi
+
+    # Cleanup loaded images
+    docker rmi "$tag_a" "$tag_b" 2>/dev/null || true
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEVEL 5: INSTALLER IMAGE COMPARISON
+# ═══════════════════════════════════════════════════════════════════════════════
+compare_installers() {
+    echo ""
+    echo -e "${BOLD}━━━ Level 5: Installer Image Comparison ━━━${NC}"
+    echo ""
+
+    local images_a images_b
+    images_a=$(find "$DIR_A" -maxdepth 2 \( -name "sonic-*.img.gz" -o -name "sonic-*.bin" \) -type f 2>/dev/null | sort)
+    images_b=$(find "$DIR_B" -maxdepth 2 \( -name "sonic-*.img.gz" -o -name "sonic-*.bin" \) -type f 2>/dev/null | sort)
+
+    if [[ -z "$images_a" && -z "$images_b" ]]; then
+        log_warn "No installer images found in either directory"
+        return
+    fi
+
+    # Match by filename
+    local names_a names_b
+    names_a=$(echo "$images_a" | xargs -I{} basename {} | sort)
+    names_b=$(echo "$images_b" | xargs -I{} basename {} | sort)
+
+    local common_names
+    common_names=$(comm -12 <(echo "$names_a") <(echo "$names_b"))
+
+    # Report missing
+    local only_a only_b
+    only_a=$(comm -23 <(echo "$names_a") <(echo "$names_b"))
+    only_b=$(comm -13 <(echo "$names_a") <(echo "$names_b"))
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        record_result "$name" "MISSING" "Only in A"
+    done <<< "$only_a"
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        record_result "$name" "MISSING" "Only in B"
+    done <<< "$only_b"
+
+    # Compare common images
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        local file_a file_b
+        file_a=$(find "$DIR_A" -maxdepth 2 -name "$name" -type f | head -1)
+        file_b=$(find "$DIR_B" -maxdepth 2 -name "$name" -type f | head -1)
+
+        echo -n "  Comparing $name ... "
+
+        # Quick SHA check
+        local sha_a sha_b
+        sha_a=$(sha256sum "$file_a" | cut -d' ' -f1)
+        sha_b=$(sha256sum "$file_b" | cut -d' ' -f1)
+
+        if [[ "$sha_a" == "$sha_b" ]]; then
+            echo "IDENTICAL"
+            record_result "$name" "IDENTICAL" "SHA256 match"
+            continue
+        fi
+
+        # Deep comparison: extract and compare squashfs contents
+        compare_installer_deep "$name" "$file_a" "$file_b"
+    done <<< "$common_names"
+}
+
+compare_installer_deep() {
+    local name="$1" file_a="$2" file_b="$3"
+    local tmp_a tmp_b
+    # Use OUTPUT_DIR parent for temp (in case /tmp is full)
+    local tmpbase="${TMPDIR:-${OUTPUT_DIR:-/tmp}}"
+    mkdir -p "$tmpbase" 2>/dev/null || tmpbase="/tmp"
+    tmp_a=$(mktemp -d -p "$tmpbase")
+    tmp_b=$(mktemp -d -p "$tmpbase")
+
+    local is_img_gz=false
+    [[ "$name" == *.img.gz ]] && is_img_gz=true
+
+    local has_semantic=false
+    local diff_details=""
+
+    if $is_img_gz; then
+        # .img.gz: decompress, find squashfs, extract file/package lists.
+        # Decompression MUST succeed — a failed/partial gunzip would otherwise
+        # let two corrupt images look "equal" (e.g. both empty) and PASS.
+        if ! gunzip -c "$file_a" > "$tmp_a/image.img" 2>/dev/null; then
+            echo "ERROR (gunzip A failed)"
+            record_result "$name" "ERROR" "Failed to decompress installer image A (corrupt .img.gz?)"
+            rm -rf "$tmp_a" "$tmp_b"
+            return
+        fi
+        if ! gunzip -c "$file_b" > "$tmp_b/image.img" 2>/dev/null; then
+            echo "ERROR (gunzip B failed)"
+            record_result "$name" "ERROR" "Failed to decompress installer image B (corrupt .img.gz?)"
+            rm -rf "$tmp_a" "$tmp_b"
+            return
+        fi
+        if [[ ! -s "$tmp_a/image.img" || ! -s "$tmp_b/image.img" ]]; then
+            echo "ERROR (empty decompressed image)"
+            record_result "$name" "ERROR" "Decompressed installer image is empty (corrupt .img.gz?)"
+            rm -rf "$tmp_a" "$tmp_b"
+            return
+        fi
+
+        # Extract squashfs from raw image (offset varies; use unsquashfs -s to find it)
+        # The squashfs is typically at a known offset or we can scan for the magic bytes
+        local sqfs_a sqfs_b
+        sqfs_a=$(extract_installer_squashfs "$tmp_a/image.img" "$tmp_a")
+        sqfs_b=$(extract_installer_squashfs "$tmp_b/image.img" "$tmp_b")
+
+        if [[ -z "$sqfs_a" || -z "$sqfs_b" ]]; then
+            # Fallback: compare decompressed image sizes
+            local size_a size_b
+            size_a=$(stat -c%s "$tmp_a/image.img" 2>/dev/null || echo "0")
+            size_b=$(stat -c%s "$tmp_b/image.img" 2>/dev/null || echo "0")
+            if [[ "$size_a" == "$size_b" ]]; then
+                # Same size — check if identical
+                if cmp -s "$tmp_a/image.img" "$tmp_b/image.img"; then
+                    echo "COSMETIC (gzip header only)"
+                    record_result "$name" "COSMETIC" "Decompressed content identical; gzip header differs"
+                else
+                    # Same size but different content and we can't extract — flag as SEMANTIC
+                    # (we have no way to prove it's cosmetic without payload inspection)
+                    echo "SEMANTIC (content differs, extraction unavailable)"
+                    record_result "$name" "SEMANTIC" "Decompressed content differs ($size_a bytes); squashfs extraction unavailable for deeper analysis"
+                fi
+            else
+                # Different decompressed image size with no way to extract the
+                # squashfs payload. The raw installer image size is deterministic,
+                # so ANY size delta is evidence of a real content change — we
+                # cannot prove it cosmetic without payload inspection. Flag
+                # SEMANTIC rather than masking small deltas as "alignment".
+                local size_diff pct_diff
+                size_diff=$((size_a > size_b ? size_a - size_b : size_b - size_a))
+                local larger=$((size_a > size_b ? size_a : size_b))
+                pct_diff=$(python3 -c "print(f'{100*$size_diff/$larger:.2f}')" 2>/dev/null || echo "0")
+                echo "SEMANTIC (size diff: $size_diff bytes / ${pct_diff}%, extraction unavailable)"
+                record_result "$name" "SEMANTIC" "Decompressed size differs by $size_diff bytes (${pct_diff}%); squashfs extraction unavailable to prove equivalence"
+                has_semantic=true
+            fi
+            rm -rf "$tmp_a" "$tmp_b"
+            return
+        fi
+
+        # Compare squashfs file listings
+        local files_a files_b
+        files_a=$(find "$sqfs_a" -type f | sed "s|$sqfs_a||" | sort)
+        files_b=$(find "$sqfs_b" -type f | sed "s|$sqfs_b||" | sort)
+
+        local file_diff
+        file_diff=$(diff <(echo "$files_a") <(echo "$files_b") 2>/dev/null || true)
+
+        if [[ -n "$file_diff" ]]; then
+            local diff_count
+            diff_count=$(echo "$file_diff" | grep -c "^[<>]" || true)
+            has_semantic=true
+            diff_details="File list differs by $diff_count entries"
+        fi
+
+        # Content hash comparison: hash key configs/scripts in the squashfs
+        # For binaries, strip debug info before hashing to avoid build-id noise
+        if ! $has_semantic; then
+            local hash_list_a hash_list_b
+            hash_list_a=$(mktemp)
+            hash_list_b=$(mktemp)
+
+            # Hash config/script files directly (text — no normalization needed)
+            find "$sqfs_a" \( -path "*/etc/sonic/*" -o -path "*/etc/supervisor/*" \) \
+                -type f -exec sha256sum {} \; 2>/dev/null | \
+                sed "s|$sqfs_a||" | sort -k2 > "$hash_list_a"
+            find "$sqfs_b" \( -path "*/etc/sonic/*" -o -path "*/etc/supervisor/*" \) \
+                -type f -exec sha256sum {} \; 2>/dev/null | \
+                sed "s|$sqfs_b||" | sort -k2 > "$hash_list_b"
+
+            # For binaries, strip debug/build-id then hash (avoids build-id false positives)
+            if has_tool objcopy; then
+                local bin_tmp
+                bin_tmp=$(mktemp -d -p "${TMPDIR:-${OUTPUT_DIR:-/tmp}}" 2>/dev/null || mktemp -d)
+                for dir_pair in "$sqfs_a:a" "$sqfs_b:b"; do
+                    local sqfs_dir="${dir_pair%%:*}" side="${dir_pair##*:}"
+                    local target_file="$hash_list_a"
+                    [[ "$side" == "b" ]] && target_file="$hash_list_b"
+                    find "$sqfs_dir" \( -path "*/usr/bin/*" -o -path "*/usr/sbin/*" \) \
+                        -type f | while read -r bin_file; do
+                        local stripped="$bin_tmp/stripped_$$"
+                        if file "$bin_file" 2>/dev/null | grep -q "ELF"; then
+                            objcopy --strip-debug --remove-section=.note.gnu.build-id \
+                                "$bin_file" "$stripped" 2>/dev/null || cp "$bin_file" "$stripped"
+                        else
+                            cp "$bin_file" "$stripped"
+                        fi
+                        local h
+                        h=$(sha256sum "$stripped" | cut -d' ' -f1)
+                        echo "$h  ${bin_file#$sqfs_dir}" >> "$target_file"
+                        rm -f "$stripped"
+                    done
+                done
+                rm -rf "$bin_tmp"
+            else
+                # No objcopy — hash raw binaries (may produce false positives from build-ids)
+                find "$sqfs_a" \( -path "*/usr/bin/*" -o -path "*/usr/sbin/*" \) \
+                    -type f -exec sha256sum {} \; 2>/dev/null | \
+                    sed "s|$sqfs_a||" >> "$hash_list_a"
+                find "$sqfs_b" \( -path "*/usr/bin/*" -o -path "*/usr/sbin/*" \) \
+                    -type f -exec sha256sum {} \; 2>/dev/null | \
+                    sed "s|$sqfs_b||" >> "$hash_list_b"
+            fi
+
+            # Sort and compare
+            local content_diff
+            content_diff=$(diff <(sort -k2 "$hash_list_a") <(sort -k2 "$hash_list_b") 2>/dev/null || true)
+            if [[ -n "$content_diff" ]]; then
+                local content_diff_count
+                content_diff_count=$(echo "$content_diff" | grep -c "^[<>]" || true)
+                content_diff_count=${content_diff_count:-0}
+                if [[ $content_diff_count -gt 0 ]]; then
+                    has_semantic=true
+                    diff_details="${diff_details:+$diff_details; }Content hash differs in $((content_diff_count / 2)) files"
+                fi
+            fi
+            rm -f "$hash_list_a" "$hash_list_b"
+        fi
+
+        # Compare installed package lists with versions (dpkg status)
+        local pkgs_a pkgs_b
+        pkgs_a=$(find "$sqfs_a" -path "*/var/lib/dpkg/status" -exec grep -E "^(Package|Version):" {} \; 2>/dev/null | \
+            paste -d' ' - - | sort)
+        pkgs_b=$(find "$sqfs_b" -path "*/var/lib/dpkg/status" -exec grep -E "^(Package|Version):" {} \; 2>/dev/null | \
+            paste -d' ' - - | sort)
+
+        if [[ -n "$pkgs_a" && -n "$pkgs_b" ]]; then
+            local pkg_diff
+            pkg_diff=$(diff <(echo "$pkgs_a") <(echo "$pkgs_b") 2>/dev/null || true)
+            if [[ -n "$pkg_diff" ]]; then
+                local pkg_diff_count
+                pkg_diff_count=$(echo "$pkg_diff" | grep -c "^[<>]" || true)
+                has_semantic=true
+                diff_details="${diff_details:+$diff_details; }Package list differs by $pkg_diff_count entries"
+            fi
+        fi
+    else
+        # .bin files: ONIE installer script + payload
+        # Compare decompressed content
+        local size_a size_b
+        size_a=$(stat -c%s "$file_a")
+        size_b=$(stat -c%s "$file_b")
+
+        if [[ "$size_a" == "$size_b" ]]; then
+            # Same size, check if content identical after skipping ONIE shell script header
+            # ONIE .bin installers have a variable-length shell script header (typically 4KB-50KB)
+            # terminated by a binary payload marker.
+            local sha_payload_a sha_payload_b
+            local skip_bytes_a skip_bytes_b
+            # Find payload offset independently for each file
+            skip_bytes_a=$(python3 -c "
+import sys
+data = open('$file_a', 'rb').read(65536)
+for i in range(512, len(data) - 2):
+    if data[i:i+2] == b'\x1f\x8b' or data[i:i+6] == b'\xfd7zXZ\x00':
+        print(i); sys.exit(0)
+print(512)
+" 2>/dev/null || echo "512")
+            skip_bytes_b=$(python3 -c "
+import sys
+data = open('$file_b', 'rb').read(65536)
+for i in range(512, len(data) - 2):
+    if data[i:i+2] == b'\x1f\x8b' or data[i:i+6] == b'\xfd7zXZ\x00':
+        print(i); sys.exit(0)
+print(512)
+" 2>/dev/null || echo "512")
+            sha_payload_a=$(tail -c "+$((skip_bytes_a + 1))" "$file_a" | sha256sum | cut -d' ' -f1)
+            sha_payload_b=$(tail -c "+$((skip_bytes_b + 1))" "$file_b" | sha256sum | cut -d' ' -f1)
+            if [[ "$sha_payload_a" == "$sha_payload_b" ]]; then
+                echo "COSMETIC (header differs, payload identical)"
+                record_result "$name" "COSMETIC" "Payload identical; header/script differs (skip_a=$skip_bytes_a, skip_b=$skip_bytes_b)"
+                rm -rf "$tmp_a" "$tmp_b"
+                return
+            fi
+            # Payload differs — this is SEMANTIC (don't fall through to header-only check)
+            has_semantic=true
+            diff_details="Binary payload differs after header (skip_a=$skip_bytes_a, skip_b=$skip_bytes_b)"
+        fi
+
+        # Different size — always SEMANTIC for .bin
+        if ! $has_semantic; then
+            has_semantic=true
+            diff_details="Binary content differs (size A: $size_a, B: $size_b)"
+        fi
+    fi
+
+    if $has_semantic; then
+        echo "SEMANTIC — $diff_details"
+        record_result "$name" "SEMANTIC" "$diff_details"
+    else
+        echo "COSMETIC"
+        record_result "$name" "COSMETIC" "Squashfs content identical; metadata/compression differs"
+    fi
+
+    rm -rf "$tmp_a" "$tmp_b"
+}
+
+# Extract squashfs from a raw disk image
+# Returns path to extracted squashfs root, or empty string on failure
+extract_squashfs() {
+    local image="$1" dest="$2"
+    local sqfs_dir="$dest/squashfs-root"
+
+    # Method 1: Find squashfs magic (hsqs) using grep -boa (fast, no Python memory load)
+    local offset
+    offset=$(grep -boa 'hsqs' "$image" 2>/dev/null | head -1 | cut -d: -f1)
+
+    if [[ -n "$offset" ]]; then
+        # Extract squashfs starting at offset
+        dd if="$image" bs=1 skip="$offset" 2>/dev/null | unsquashfs -d "$sqfs_dir" -f /dev/stdin >/dev/null 2>&1
+        if [[ -d "$sqfs_dir" && $(find "$sqfs_dir" -type f | wc -l) -gt 100 ]]; then
+            echo "$sqfs_dir"
+            return
+        fi
+    fi
+
+    # Method 2: Try unsquashfs directly (works if image IS a squashfs)
+    unsquashfs -d "$sqfs_dir" -f "$image" >/dev/null 2>&1
+    if [[ -d "$sqfs_dir" && $(find "$sqfs_dir" -type f | wc -l) -gt 100 ]]; then
+        echo "$sqfs_dir"
+        return
+    fi
+
+    echo ""
+}
+
+# Extract the installer's embedded rootfs squashfs from either:
+#   - a raw/squashfs image, or
+#   - a qcow2/raw disk image containing /image-*/fs.squashfs in the rootfs partition.
+extract_installer_squashfs() {
+    local image="$1" dest="$2"
+    local sqfs_dir
+
+    sqfs_dir=$(extract_squashfs "$image" "$dest")
+    if [[ -n "$sqfs_dir" ]]; then
+        echo "$sqfs_dir"
+        return
+    fi
+
+    if has_tool qemu-img && has_tool fdisk && has_tool debugfs; then
+        local inspect_image="$image"
+        local raw_image="$dest/image.raw"
+
+        if qemu-img info "$image" 2>/dev/null | grep -q "file format: qcow2"; then
+            qemu-img convert -O raw "$image" "$raw_image" >/dev/null 2>&1 || {
+                echo ""
+                return
+            }
+            inspect_image="$raw_image"
+        fi
+
+        local part_info part_start part_sectors
+        part_info=$(fdisk -l "$inspect_image" 2>/dev/null | awk '/ Linux filesystem$/ {print $2, $4; exit}')
+        if [[ -n "$part_info" ]]; then
+            read -r part_start part_sectors <<< "$part_info"
+
+            local part_image="$dest/rootfs-partition.ext4"
+            dd if="$inspect_image" of="$part_image" bs=512 skip="$part_start" count="$part_sectors" conv=sparse status=none 2>/dev/null || {
+                echo ""
+                return
+            }
+
+            local image_dir
+            image_dir=$(printf 'ls -p /\nquit\n' | debugfs -f - "$part_image" 2>/dev/null | \
+                awk -F/ '/image-.*\/\/$/ {print $5; exit}')
+
+            if [[ -n "$image_dir" ]]; then
+                local embedded_sqfs="$dest/fs.squashfs"
+                debugfs -R "dump /$image_dir/fs.squashfs $embedded_sqfs" "$part_image" >/dev/null 2>&1 || true
+                if [[ -s "$embedded_sqfs" ]]; then
+                    sqfs_dir="$dest/squashfs-root"
+                    unsquashfs -d "$sqfs_dir" -f "$embedded_sqfs" >/dev/null 2>&1 || true
+                    if [[ -d "$sqfs_dir" && $(find "$sqfs_dir" -type f | wc -l) -gt 100 ]]; then
+                        echo "$sqfs_dir"
+                        return
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    echo ""
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# REPORT GENERATION
+# ═══════════════════════════════════════════════════════════════════════════════
+generate_report() {
+    echo ""
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}  EQUIVALENCE REPORT${NC}"
+    echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "  Directory A: $DIR_A"
+    echo "  Directory B: $DIR_B"
+    echo "  Levels compared: $LEVELS"
+    echo ""
+    echo -e "  ${GREEN}IDENTICAL:${NC}  $COUNT_IDENTICAL"
+    echo -e "  ${YELLOW}COSMETIC:${NC}   $COUNT_COSMETIC  (timestamp/metadata diffs — safe)"
+    echo -e "  ${RED}SEMANTIC:${NC}   $COUNT_SEMANTIC  (real content differences — cache bug)"
+    if [[ $COUNT_BASELINE_NONDETERMINISM -gt 0 ]]; then
+        echo -e "  ${YELLOW}BASELINE:${NC}   $COUNT_BASELINE_NONDETERMINISM  (known non-determinism — not cache-related)"
+    fi
+    echo -e "  ${RED}MISSING:${NC}    $COUNT_MISSING  (artifact in one build only)"
+    if [[ $COUNT_EXPECTED_MISSING -gt 0 ]]; then
+        echo -e "  ${YELLOW}EXPECTED_MISSING:${NC} $COUNT_EXPECTED_MISSING  (dbgsym companions not restored by cache — non-fatal)"
+    fi
+    echo -e "  ERROR:      $COUNT_ERROR"
+    echo -e "  ─────────────────"
+    echo -e "  TOTAL:      $TOTAL_ARTIFACTS"
+    echo ""
+
+    if [[ $COUNT_SEMANTIC -eq 0 && $COUNT_MISSING -eq 0 && $COUNT_ERROR -eq 0 ]]; then
+        echo -e "  ${GREEN}${BOLD}VERDICT: PASS — Cache produces equivalent artifacts${NC}"
+        if [[ $COUNT_BASELINE_NONDETERMINISM -gt 0 ]]; then
+            echo "  $COUNT_BASELINE_NONDETERMINISM diff(s) matched baseline (build non-determinism, not cache-related)"
+        else
+            echo "  All differences are known-cosmetic (timestamps, gzip headers, etc.)"
+        fi
+        if [[ $COUNT_EXPECTED_MISSING -gt 0 ]]; then
+            echo "  $COUNT_EXPECTED_MISSING dbgsym companion(s) not restored by cache (non-fatal; not in runtime image)"
+        fi
+    elif [[ $COUNT_ERROR -gt 0 && $COUNT_SEMANTIC -eq 0 && $COUNT_MISSING -eq 0 ]]; then
+        echo -e "  ${YELLOW}${BOLD}VERDICT: INCONCLUSIVE — $COUNT_ERROR artifacts had errors${NC}"
+        echo ""
+        echo "  Errors (could not compare — fix tool availability or inputs):"
+        for result in "${RESULTS[@]}"; do
+            IFS='|' read -r class artifact detail <<< "$result"
+            [[ "$class" == "ERROR" ]] && echo "    • $artifact: $detail"
+        done
+    else
+        echo -e "  ${RED}${BOLD}VERDICT: FAIL — Cache has correctness issues${NC}"
+        echo ""
+        echo "  Semantic differences found in:"
+        for result in "${RESULTS[@]}"; do
+            IFS='|' read -r class artifact detail <<< "$result"
+            if [[ "$class" == "SEMANTIC" || "$class" == "MISSING" ]]; then
+                echo -e "    ${RED}•${NC} $artifact: $detail"
+            fi
+        done
+    fi
+    echo ""
+
+    # Save detailed report
+    mkdir -p "$OUTPUT_DIR"
+    local report_file="$OUTPUT_DIR/equivalence-report.txt"
+    {
+        echo "═══════════════════════════════════════════════════════════════"
+        echo "  DPKG Cache Equivalence Report"
+        echo "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+        echo "═══════════════════════════════════════════════════════════════"
+        echo ""
+        echo "Dir A: $DIR_A"
+        echo "Dir B: $DIR_B"
+        echo ""
+        echo "Summary: $COUNT_IDENTICAL identical, $COUNT_COSMETIC cosmetic, $COUNT_SEMANTIC semantic, $COUNT_BASELINE_NONDETERMINISM baseline, $COUNT_MISSING missing, $COUNT_EXPECTED_MISSING expected-missing(dbgsym), $COUNT_ERROR errors"
+        echo ""
+        printf "%-12s %-50s %s\n" "STATUS" "ARTIFACT" "DETAIL"
+        printf "%-12s %-50s %s\n" "────────────" "──────────────────────────────────────────────────" "──────"
+        for result in "${RESULTS[@]}"; do
+            IFS='|' read -r class artifact detail <<< "$result"
+            printf "%-12s %-50s %s\n" "$class" "$artifact" "$detail"
+            # Link to diffoscope report if one was generated
+            if [[ "$class" == "SEMANTIC" && -f "$OUTPUT_DIR/diffoscope/${artifact}.html" ]]; then
+                printf "%-12s %-50s %s\n" "" "" "→ diffoscope: diffoscope/${artifact}.html"
+            fi
+        done
+        # Note diffoscope reports if any were generated
+        if [[ -d "$OUTPUT_DIR/diffoscope" ]] && ls "$OUTPUT_DIR/diffoscope"/*.html &>/dev/null; then
+            echo ""
+            echo "Detailed diffoscope reports: $OUTPUT_DIR/diffoscope/"
+            ls "$OUTPUT_DIR/diffoscope/"*.html 2>/dev/null | while read -r f; do
+                echo "  • $(basename "$f")"
+            done
+        fi
+    } > "$report_file"
+
+    log_info "Full report saved to: $report_file"
+
+    # JSON output if requested
+    if $JSON_OUTPUT; then
+        local json_file="$OUTPUT_DIR/equivalence-report.json"
+        # Generate JSON via stdin to avoid injection from paths/details containing quotes
+        _JSON_DIR_A="$DIR_A" _JSON_DIR_B="$DIR_B" _JSON_LEVELS="$LEVELS" \
+        _JSON_TOTAL="$TOTAL_ARTIFACTS" _JSON_IDENTICAL="$COUNT_IDENTICAL" \
+        _JSON_COSMETIC="$COUNT_COSMETIC" _JSON_SEMANTIC="$COUNT_SEMANTIC" \
+        _JSON_MISSING="$COUNT_MISSING" _JSON_ERROR="$COUNT_ERROR" \
+        _JSON_BASELINE_ND="$COUNT_BASELINE_NONDETERMINISM" \
+        _JSON_EXPECTED_MISSING="$COUNT_EXPECTED_MISSING" \
+        _JSON_BASELINE_FILE="$BASELINE_FILE" \
+        _JSON_IS_BASELINE="$( $GENERATE_BASELINE && echo true || echo false )" \
+        python3 -c "
+import json, sys, os
+lines = sys.stdin.read().strip().split('\n')
+results = []
+for line in lines:
+    parts = line.split('|', 2)
+    if len(parts) == 3:
+        results.append({'classification': parts[0], 'artifact': parts[1], 'detail': parts[2]})
+semantic = int(os.environ['_JSON_SEMANTIC'])
+missing = int(os.environ['_JSON_MISSING'])
+error = int(os.environ['_JSON_ERROR'])
+if semantic == 0 and missing == 0 and error == 0:
+    verdict = 'PASS'
+elif error > 0 and semantic == 0 and missing == 0:
+    verdict = 'INCONCLUSIVE'
+else:
+    verdict = 'FAIL'
+baseline_file = os.environ.get('_JSON_BASELINE_FILE') or None
+report = {
+    'dir_a': os.environ['_JSON_DIR_A'],
+    'dir_b': os.environ['_JSON_DIR_B'],
+    'levels': os.environ['_JSON_LEVELS'],
+    'summary': {
+        'total': int(os.environ['_JSON_TOTAL']),
+        'identical': int(os.environ['_JSON_IDENTICAL']),
+        'cosmetic': int(os.environ['_JSON_COSMETIC']),
+        'semantic': semantic,
+        'baseline_nondeterminism': int(os.environ['_JSON_BASELINE_ND']),
+        'missing': missing,
+        'expected_missing': int(os.environ['_JSON_EXPECTED_MISSING']),
+        'error': error
+    },
+    'baseline_file': baseline_file,
+    'is_baseline': os.environ['_JSON_IS_BASELINE'] == 'true',
+    'verdict': verdict,
+    'results': results
+}
+print(json.dumps(report, indent=2))
+" > "$json_file" < <(printf '%s\n' "${RESULTS[@]}") || log_warn "Failed to generate JSON report"
+        log_info "JSON report saved to: $json_file"
+    fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# MAIN
+# ═══════════════════════════════════════════════════════════════════════════════
+main() {
+    echo -e "${CYAN}╔════════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║  SONiC DPKG Cache — Artifact Equivalence Verification         ║${NC}"
+    echo -e "${CYAN}╚════════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo "  Dir A: $DIR_A"
+    echo "  Dir B: $DIR_B"
+    echo "  Levels: $LEVELS"
+    echo "  Mode: $( $QUICK_MODE && echo "quick (hash only)" || echo "deep analysis" )"
+    echo "  diffoscope: $( $USE_DIFFOSCOPE && echo "enabled" || echo "disabled" )"
+    if [[ -n "$BASELINE_FILE" ]]; then
+        echo "  Baseline: $BASELINE_FILE (${#BASELINE_SEMANTICS[@]} known non-deterministic)"
+    fi
+    if $GENERATE_BASELINE; then
+        echo "  Mode: GENERATING BASELINE (fresh-vs-fresh — record inherent non-determinism)"
+    fi
+
+    mkdir -p "$OUTPUT_DIR"
+
+    # Run requested levels (use comma-boundary matching to avoid greedy patterns)
+    local level_csv=",$LEVELS,"
+    if [[ "$level_csv" == *",1,"* ]]; then
+        compare_debs
+    fi
+    if [[ "$level_csv" == *",2,"* ]]; then
+        compare_wheels
+    fi
+    if [[ "$level_csv" == *",3,"* ]]; then
+        compare_dockers
+    fi
+    if [[ "$level_csv" == *",5,"* ]]; then
+        compare_installers
+    fi
+
+    # Generate report
+    generate_report
+
+    # Exit code: fail on SEMANTIC, MISSING, ERROR, or zero artifacts compared.
+    # (baseline-matched SEMANTIC and dbgsym EXPECTED_MISSING were already
+    # downgraded in record_result, so they do not count toward failure.)
+    if [[ $COUNT_SEMANTIC -gt 0 || $COUNT_MISSING -gt 0 ]]; then
+        if [[ -n "$BASELINE_FILE" ]]; then
+            echo ""
+            echo -e "${RED}FAIL: $COUNT_SEMANTIC new semantic difference(s) not in baseline${NC}"
+            if [[ $COUNT_BASELINE_NONDETERMINISM -gt 0 ]]; then
+                echo -e "${YELLOW}      ($COUNT_BASELINE_NONDETERMINISM additional diffs matched baseline — expected non-determinism)${NC}"
+            fi
+        fi
+        exit 1
+    elif [[ $COUNT_ERROR -gt 0 ]]; then
+        log_warn "Exiting with code 2: $COUNT_ERROR artifacts had extraction/comparison errors"
+        exit 2
+    elif [[ $TOTAL_ARTIFACTS -eq 0 ]]; then
+        log_warn "Exiting with code 2: No artifacts were compared (check --dir-a/--dir-b paths)"
+        exit 2
+    else
+        if [[ $COUNT_BASELINE_NONDETERMINISM -gt 0 ]]; then
+            echo ""
+            echo -e "${GREEN}PASS: All $COUNT_BASELINE_NONDETERMINISM semantic diff(s) matched the baseline (known non-determinism)${NC}"
+        fi
+        exit 0
+    fi
+}
+
+main "$@"

--- a/scripts/verify_cache_equivalence.sh
+++ b/scripts/verify_cache_equivalence.sh
@@ -266,11 +266,11 @@ if [[ -n "$BASELINE_FILE" ]]; then
         [[ -z "$artifact" ]] && continue
         BASELINE_SEMANTICS["$artifact"]=1
         if [[ -n "$sig" ]]; then
-            local_oldIFS="$IFS"; IFS=','
-            for tok in $sig; do
+            tokarr=()
+            IFS=',' read -ra tokarr <<< "$sig"
+            for tok in "${tokarr[@]}"; do
                 [[ -n "$tok" ]] && BASELINE_SIG_TOKENS["$artifact"$'\t'"$tok"]=1
             done
-            IFS="$local_oldIFS"
         fi
     done < <(python3 -c "
 import json, sys
@@ -446,15 +446,14 @@ _diff_signature() {
 _sig_subset_of_baseline() {
     local artifact="$1" sig="$2"
     [[ -z "$sig" ]] && return 1
-    local tok oldIFS="$IFS"
-    IFS=','
-    for tok in $sig; do
+    local tok tokarr=()
+    IFS=',' read -ra tokarr <<< "$sig"
+    for tok in "${tokarr[@]}"; do
         [[ -z "$tok" ]] && continue
         if [[ -z "${BASELINE_SIG_TOKENS["$artifact"$'\t'"$tok"]:-}" ]]; then
-            IFS="$oldIFS"; return 1
+            return 1
         fi
     done
-    IFS="$oldIFS"
     return 0
 }
 

--- a/scripts/verify_cache_equivalence.sh
+++ b/scripts/verify_cache_equivalence.sh
@@ -57,10 +57,11 @@
 #   --json               Output results in JSON format
 #   --verbose            Show detailed per-file comparison output
 #   --quick              Skip deep analysis; only do SHA256 + file listing comparison
-#   --baseline FILE      JSON baseline from a fresh-vs-fresh run; SEMANTIC diffs whose
-#                        artifact appears in the baseline are downgraded to
-#                        BASELINE_NONDETERMINISM (inherent build non-determinism, not a
-#                        cache bug) and do not trigger FAIL
+#   --baseline FILE      JSON baseline from a fresh-vs-fresh run; a SEMANTIC diff is
+#                        downgraded to BASELINE_NONDETERMINISM only when its differing-member
+#                        signature is a SUBSET of the baseline's for that artifact (inherent
+#                        build non-determinism, not a cache bug) and so does not trigger FAIL.
+#                        A NEW differing member (e.g. a stale executable) is never masked.
 #   --generate-baseline  Run as a baseline generator (fresh-vs-fresh); records the
 #                        inherent non-determinism set. Implies --json.
 #
@@ -207,8 +208,9 @@ usage() {
     echo "  --json               JSON output format"
     echo "  --verbose            Detailed per-file output"
     echo "  --quick              SHA256 + file-list only (skip deep analysis)"
-    echo "  --baseline FILE      JSON baseline (fresh-vs-fresh); matching SEMANTIC diffs are"
-    echo "                       downgraded to BASELINE_NONDETERMINISM and won't trigger FAIL"
+    echo "  --baseline FILE      JSON baseline (fresh-vs-fresh); a SEMANTIC diff is downgraded to"
+    echo "                       BASELINE_NONDETERMINISM only if its differing-member set is a subset"
+    echo "                       of the baseline's for that artifact (a new member is never masked)"
     echo "  --generate-baseline  Generate a baseline file from a fresh-vs-fresh run (implies --json)"
     echo "  --help               Show this help"
     exit "${1:-1}"
@@ -250,21 +252,33 @@ if [[ -n "$BASELINE_FILE" && ! -f "$BASELINE_FILE" ]]; then
     echo -e "${RED}ERROR: Baseline file not found: $BASELINE_FILE${NC}"; exit 2
 fi
 
-# Load baseline SEMANTIC artifacts into an associative array for O(1) lookup.
+# Load baseline SEMANTIC artifacts into associative arrays for O(1) lookup.
 # A baseline is produced from a fresh-vs-fresh (non-cached) run: any SEMANTIC
 # diff there reflects inherent build non-determinism, not a cache bug. When a
-# baseline is supplied, those same artifacts are downgraded (see record_result).
+# baseline is supplied, a SEMANTIC diff is downgraded only if its differing-member
+# signature is a subset of the baseline's for that artifact (see record_result).
+#   BASELINE_SEMANTICS[artifact]          -> artifact was SEMANTIC in baseline
+#   BASELINE_SIG_TOKENS[artifact<TAB>tok] -> member token was non-deterministic in baseline
 declare -A BASELINE_SEMANTICS=()
+declare -A BASELINE_SIG_TOKENS=()
 if [[ -n "$BASELINE_FILE" ]]; then
-    while IFS= read -r artifact; do
-        [[ -n "$artifact" ]] && BASELINE_SEMANTICS["$artifact"]=1
+    while IFS=$'\t' read -r artifact sig; do
+        [[ -z "$artifact" ]] && continue
+        BASELINE_SEMANTICS["$artifact"]=1
+        if [[ -n "$sig" ]]; then
+            local_oldIFS="$IFS"; IFS=','
+            for tok in $sig; do
+                [[ -n "$tok" ]] && BASELINE_SIG_TOKENS["$artifact"$'\t'"$tok"]=1
+            done
+            IFS="$local_oldIFS"
+        fi
     done < <(python3 -c "
 import json, sys
 with open(sys.argv[1]) as f:
     data = json.load(f)
 for r in data.get('results', []):
     if r.get('classification') == 'SEMANTIC':
-        print(r.get('artifact', ''))
+        print(r.get('artifact', '') + '\t' + r.get('signature', ''))
 " "$BASELINE_FILE" 2>/dev/null)
     echo -e "${CYAN}[INFO]${NC} Loaded baseline with ${#BASELINE_SEMANTICS[@]} known non-deterministic artifact(s)"
 fi
@@ -403,17 +417,67 @@ PY
 
 
 # Record a comparison result
+# Build a normalized signature of *what* differs, so baseline matching can key on the
+# actual difference rather than only the artifact name. For member-level comparisons
+# (e.g. .deb payloads) the caller passes the accumulated differing-member list; we reduce
+# it to a sorted, de-duplicated, comma-joined token set with volatile annotations/counts
+# stripped. When no member set is available (quick-mode SHA mismatch, docker/whl summaries)
+# we fall back to the normalized detail string as a single stable token.
+_diff_signature() {
+    local diffset="$1" detail="$2"
+    if [[ -n "$diffset" ]]; then
+        printf '%s' "$diffset" \
+            | sed 's/\\n/\n/g' \
+            | sed -E 's/\([^)]*\)//g; s/^[[:space:]]+//; s/[[:space:]]+$//' \
+            | grep -v '^$' \
+            | sort -u | paste -sd, -
+    else
+        printf '%s' "$detail" \
+            | sed -E 's/ \(\+[0-9]+ more\)//; s/[0-9]+ files/N files/; s/e\.g\.[^);]*//' \
+            | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+    fi
+}
+
+# True when every differing member in the current signature was ALSO known-nondeterministic
+# for this artifact in the fresh-vs-fresh baseline (i.e. the current diff is a subset of the
+# baseline diff). A NEW differing member (e.g. a stale executable restored from cache) makes
+# this false, so it is never downgraded/masked. An empty signature is treated as NOT a subset
+# (fail-safe: keep it SEMANTIC).
+_sig_subset_of_baseline() {
+    local artifact="$1" sig="$2"
+    [[ -z "$sig" ]] && return 1
+    local tok oldIFS="$IFS"
+    IFS=','
+    for tok in $sig; do
+        [[ -z "$tok" ]] && continue
+        if [[ -z "${BASELINE_SIG_TOKENS["$artifact"$'\t'"$tok"]:-}" ]]; then
+            IFS="$oldIFS"; return 1
+        fi
+    done
+    IFS="$oldIFS"
+    return 0
+}
+
 record_result() {
     local artifact="$1"
     local classification="$2"  # IDENTICAL, COSMETIC, SEMANTIC, MISSING, ERROR
     local detail="$3"
+    local diffset="${4:-}"     # optional: raw accumulated differing-member list
 
-    # Downgrade SEMANTIC to BASELINE_NONDETERMINISM when this artifact was already
-    # SEMANTIC in a fresh-vs-fresh baseline (inherent build non-determinism, not a
-    # cache correctness issue). Keyed by artifact name.
+    # Normalized signature of the actual difference (see _diff_signature).
+    local sig
+    sig=$(_diff_signature "$diffset" "$detail")
+
+    # Downgrade SEMANTIC to BASELINE_NONDETERMINISM only when this artifact was SEMANTIC in
+    # a fresh-vs-fresh baseline AND the current differing-member set is a SUBSET of the
+    # baseline's known-nondeterministic members (keyed by artifact + normalized difference).
+    # This prevents an unrelated baseline non-determinism (e.g. a doc timestamp) from masking
+    # a real cache defect (e.g. a stale executable or config) in the same artifact.
     if [[ "$classification" == "SEMANTIC" && -n "$BASELINE_FILE" && -n "${BASELINE_SEMANTICS[$artifact]:-}" ]]; then
-        classification="BASELINE_NONDETERMINISM"
-        detail="[baseline-matched] $detail"
+        if _sig_subset_of_baseline "$artifact" "$sig"; then
+            classification="BASELINE_NONDETERMINISM"
+            detail="[baseline-matched] $detail"
+        fi
     fi
 
     # Downgrade MISSING to EXPECTED_MISSING for auto-generated debug-symbol
@@ -426,7 +490,7 @@ record_result() {
         detail="[dbgsym companion not restored by cache — non-fatal] $detail"
     fi
 
-    RESULTS+=("$classification|$artifact|$detail")
+    RESULTS+=("$classification|$artifact|$detail@@SIG@@$sig")
     ((TOTAL_ARTIFACTS++))
 
     case "$classification" in
@@ -1061,7 +1125,7 @@ _compare_deb_deep_impl() {
     fi
 
     if $semantic_diff; then
-        record_result "$name" "SEMANTIC" "$diff_details"
+        record_result "$name" "SEMANTIC" "$diff_details" "$all_diff_files"
     else
         # Data contents are identical — check control for semantic differences
         # (dependency fields, maintainer scripts are NOT cosmetic)
@@ -2438,6 +2502,7 @@ generate_report() {
         echo "  Errors (could not compare — fix tool availability or inputs):"
         for result in "${RESULTS[@]}"; do
             IFS='|' read -r class artifact detail <<< "$result"
+            detail="${detail%%@@SIG@@*}"
             [[ "$class" == "ERROR" ]] && echo "    • $artifact: $detail"
         done
     else
@@ -2446,6 +2511,7 @@ generate_report() {
         echo "  Semantic differences found in:"
         for result in "${RESULTS[@]}"; do
             IFS='|' read -r class artifact detail <<< "$result"
+            detail="${detail%%@@SIG@@*}"
             if [[ "$class" == "SEMANTIC" || "$class" == "MISSING" ]]; then
                 echo -e "    ${RED}•${NC} $artifact: $detail"
             fi
@@ -2471,6 +2537,7 @@ generate_report() {
         printf "%-12s %-50s %s\n" "────────────" "──────────────────────────────────────────────────" "──────"
         for result in "${RESULTS[@]}"; do
             IFS='|' read -r class artifact detail <<< "$result"
+            detail="${detail%%@@SIG@@*}"
             printf "%-12s %-50s %s\n" "$class" "$artifact" "$detail"
             # Link to diffoscope report if one was generated
             if [[ "$class" == "SEMANTIC" && -f "$OUTPUT_DIR/diffoscope/${artifact}.html" ]]; then
@@ -2508,7 +2575,11 @@ results = []
 for line in lines:
     parts = line.split('|', 2)
     if len(parts) == 3:
-        results.append({'classification': parts[0], 'artifact': parts[1], 'detail': parts[2]})
+        detail = parts[2]
+        signature = ''
+        if '@@SIG@@' in detail:
+            detail, signature = detail.split('@@SIG@@', 1)
+        results.append({'classification': parts[0], 'artifact': parts[1], 'detail': detail, 'signature': signature})
 semantic = int(os.environ['_JSON_SEMANTIC'])
 missing = int(os.environ['_JSON_MISSING'])
 error = int(os.environ['_JSON_ERROR'])


### PR DESCRIPTION
#### Why I did it
The dpkg/image build cache serves a cached artifact whenever a target's cache key is unchanged. If a build-affecting input (feature flag, exported build-env variable, derived package, source file) is **not** reflected in that key, a cache hit can serve a **stale** artifact. This tooling detects that class of bug as a **first-gate PR check** — a comprehensive, no-heuristic producer/consumer static scan of the entire codebase (up to submodule consumers).

The companion PRs #28763, #28765, #28766, #28767 fix the real cache-key gaps this scanner surfaced.

#### How I did it
Added the analysis tooling and its pipelines:

- **`scripts/cache_key_scan.py`** — enumerates every exported build-env variable and classifies each as `in-key`, `filename` (its value flows into a cached artifact's file name), `waived`, or an untracked **gap**, by scanning make producers and recipe / Dockerfile / submodule consumers. No heuristics.
- **`scripts/audit_dep_completeness.sh`** — Tier-1 gate; Check 10 live-runs the scanner and exits non-zero on a P0 gap. Also includes **Checks 11–24**, additional data-driven, no-heuristic checks that close cache-staleness gaps the earlier checks missed:
  - **Check 11** — build flags (`ENABLE_*`/`INCLUDE_*`) consumed only inside a package's source recipe (`debian/rules`, `Makefile`, `setup.py`) but untracked in any cache key (e.g. `ENABLE_GCOV`/`ENABLE_ASAN`).
  - **Check 12** — in-repo Jinja2 templates a `Dockerfile.j2` imports (e.g. `dockers/dockerfile-macros.j2`) that aren't hashed in the docker `.dep`.
  - **Check 13** — a source-built cached package whose `.dep` hashes no source at all.
  - **Check 14** — moving-ref / non-deterministic fetches (`raw/master`, `:latest`, unpinned `go get`) behind a stable key, gated on the fetch actually being cached.
  - **Check 15** — structural `DEP_FILES` bugs (SRC_PATH aliasing, make-expansion typos, reassignment that drops accumulated files).
  - **Check 16** — host root-filesystem files consumed by `build_debian.sh` (transitively over the `*.sh` it invokes) but absent from `RFS_DEP_FILES` / `SONIC_COMMON_BASE_FILES_LIST`, so the rootfs/squashfs cache key ignores them (e.g. `files/build_templates/*.j2`, `scripts/versions_manager.py`, secure-boot signing scripts). Coverage parsing expands `$(addprefix DIR/, ...)` and `$(shell git ls-files DIR)` forms; path tokens are anchored to path boundaries to avoid substring false positives.
  - **Check 17** — docker build-context generators run by `scripts/prepare_docker_buildinfo.sh` (and its transitive script/`src` build-context inputs) that live in no docker image cache key.
  - **Check 18** — docker packages installed into the image via `$(D)_INSTALL_PYTHON_WHEELS` / `$(D)_INSTALL_DEBS` that are not folded into the module dependency SHA (`GET_MOD_DEP_SHA` in `Makefile.cache`), so image content can change without invalidating the docker cache key. Tokens also present in a folded role are excluded.
  - **Check 19** — build targets that fold a remote-content fingerprint variable (computed via `wget --spider`) whose own `$(T)_URL` is never spidered, so upstream artifact changes at that URL do not invalidate the target's cache key (e.g. `BRCM_DNX_SAI` reusing XGS-derived `SAI_FLAGS`).
  - **Check 20** — in-repo *patch content* applied to a package's source immediately before build but absent from the artifact's cache key: (a) `slave.mk` quilt series `$(pkg)_SRC_PATH).patch/` on a **submodule** source root, whose sibling `<root>.patch/` is invisible to `_SMDEP_FILES` (`git ls-files` runs inside the submodule) and unlisted in `_DEP_FILES` (e.g. `src/sonic-swss.patch`, ptf, ptf-py3, scapy, supervisor, redis-dump-load, sonic-dash-ha); and (b) a platform `EXTERNAL_KERNEL_PATCH_LOC` (`platform/mellanox/non-upstream-patches/`) applied to the kernel build when `INCLUDE_EXTERNAL_PATCHES=y` while the linux-kernel key folds only the flag. Coverage is decided empirically per patch dir via `git -C <root> ls-files`, so patch dirs nested under a non-submodule root (`p4lang/*`, `thrift_0_14_1`) are correctly not flagged.
  - **Check 21** — inline (non-`export`) env *values* passed to the cache-backed `./build_debian.sh` rootfs recipe (`VAR=$(VAR) ./build_debian.sh`) and read by `build_debian.sh`, but absent from the RFS cache key (which folds only `SONIC_COMMON_FLAGS_LIST`). Because Check 10 scans exported variables only, these inline values are a structural blind spot (e.g. the default admin `USERNAME`/`PASSWORD`, `CHANGE_DEFAULT_PASSWORD`, the BMC credentials, `MASTER_KUBERNETES_VERSION`/`MASTER_CRI_DOCKERD`, `IMAGE_TYPE`, `DBGOPT`). Data-driven: parses the inline env prefix of every `SAVE_CACHE`-backed recipe, keeps only vars the script actually reads, and defers exported ones to Check 10; identity/plumbing values (`RFS_SQUASHFS_NAME=$*`, its derived `TARGET_MACHINE`, the `TARGET_PATH` output dir) are cleared via reasoned waivers.
  - **Check 22** — *(withdrawn)* originally flagged docker `$(IMG)_FILES` sources as absent from the cache key. Empirical inspection of a generated `target/docker-*.gz.dep` showed this is a **false positive**: `Makefile.cache` `SHA_DEP_RULES` (~lines 638–645) already appends every `$(IMG)_FILES` source (resolved via its `$(VAR)_PATH`, else `$(FILES_PATH)`) into `$(IMG)_DEP_FILES`, which is git-hashed into the docker dep SHA (upstream fix #15473). The check and its helper were removed.
  - **Check 23** *(P3, hygiene)* — a `Dockerfile.j2` build flag consumed in a `{% if %}`/`{{ }}` directive but omitted from that image's `_DEP_FLAGS` while sibling images fold it into their key (e.g. `ENABLE_ASAN` in `docker-sonic-vs`). Review found a full collision is normally blocked because a `_DEPENDS` package that keys the flag (e.g. `docker-sonic-vs` → `SYSMGR`, whose `rules/sysmgr.dep` carries `$(ENABLE_ASAN)`) already separates the key via `GET_MOD_DEP_SHA`; kept as defense-in-depth at P3.
  - **Check 24** *(P3, narrow)* — a recipe `.mk` fragment `include`'d by a rule/platform `.mk` (e.g. `platform/template/docker-syncd-*.mk`) not tracked in the target's `DEP_FILES`. Review found the blast radius is small: `_LOAD_DOCKERS` is already keyed via `MOD_DEP_PKGS`/`GET_MOD_DEP_SHA` and `_RUN_OPT` is runtime-only; only `_CONTAINER_NAME` (`--build-arg docker_container_name`) reaches the built image. Kept at P3.
  All new checks are evidence-gated and manually false-positive-validated; the existing checks 1–10 baseline is unchanged (0 regressions).
- **`scripts/cache_key_export_waivers.tsv`** — human-justified, **code-cited** waivers for exports that provably cannot change any cached artifact's content (paths, image names, volatile stamps, non-cached installer-stage inputs).
- **`scripts/verify_cache_equivalence.sh`** — Tier-2 driver comparing read-cache vs write-cache builds for artifact equivalence.
- **`.azure-pipelines/cache-key-lint.yml`** — standalone Tier-1 static-lint pipeline (fast, per-PR).
- **`.azure-pipelines/azure-pipelines-cache-equivalence.yml`** — Tier-2 build/verify pipeline.

#### How to verify it
- `python3 scripts/cache_key_scan.py --stdout` lists each exported variable and its disposition.
- `./scripts/audit_dep_completeness.sh --verbose` runs the full audit; Check 10 fails on a P0 cache-key gap.
- Both pipeline YAMLs parse and are intended to run as a stage in the PR pipeline.

#### Which release branch to backport (provide reason below if selected)
<!-- - [ ] 202xxx -->

#### Description for the changelog
Add static dpkg/image build-cache-key completeness analysis (PR gate) and its CI pipeline definitions.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>







---
> **Note:** This PR supersedes #28768, which GitHub auto-closed (and would not let me reopen) after an accidental force-push replaced its head with an unrelated commit. Same branch, same tooling. It additionally folds in two fixes to the pipeline integration:
> 1. **Tier 2** `SONIC_DPKG_CACHE_SOURCE` is now platform-namespaced (`/nfs/dpkg_cache/${{ parameters.platform }}`) to match the official build templates + `Makefile.work` mount, so the cached (tree C) build actually hits the cache and the A-vs-C equivalence comparison is meaningful.
> 2. **Tier 1** header/displayName corrected: the audit's P0 (its only exit-1 severity) is emitted only in `--base` diff mode, so the standalone whole-tree run is documented as a *report* (exits 0), and the production PR stage must pass `--base` to arm the gate.



---
> **Review feedback addressed** (commit `fd68d6d`): multi-variable `export` parsing so Check 10 sees every exported var (not just the first); ~~base merge-base worktree now initializes submodules so pre-existing submodule findings aren't falsely escalated to P0 (and escalation is disabled rather than armed on a partial baseline)~~ *(superseded by commit `7b823416a` below — the base-worktree escalation mechanism was removed in favor of deterministic changed-file provenance scoping)*; Tier‑2 artifacts are keyed by full distro-qualified relative path instead of basename; safer tmp-dir cleanup (wrapper/`_impl` split instead of a `RETURN` trap); baseline path passed to Python as argv; `--generate-baseline` exits 0 so the scheduled A‑vs‑C step runs; `git_files()` fails/falls back instead of silently scanning an empty tree; `--diffoscope` help text corrected; and `BuildVS` given `dependsOn: []`.


> **Review feedback (follow-up, commit `c8ddcc8c4`):** the scheduled cache-equivalence pipeline now covers **every platform that has a populated dpkg cache** (the official allow-list in `azure-pipelines-image-template.yml`), grouped into one job per arch since Azure picks the pool per job: amd64 (vs, broadcom, mellanox, vpp, alpinevs), arm64 (marvell-prestera-arm64, nvidia-bluefield), armhf (marvell-prestera-armhf). Each leg runs the full A/B/C build + compare with cache-namespace-suffixed artifacts (shared steps in `cache-equivalence-steps.yml`). Non-cached platforms are excluded because their "cached" build is just another fresh build.




> **Review feedback (follow-up, commit `7b823416a`):** made the `--base` PR gate **deterministic**. It previously materialized the merge-base in a second `git worktree`, re-ran the whole audit there, and escalated any finding whose `package+issue` text was absent from that base set to a blocking P0. In CI (`checkout: self`, `submodules: recursive`) the base worktree's submodule content can differ from HEAD's for reasons unrelated to the PR (partial local fetch, pin resolution, list ordering), so a pre-existing submodule-owned finding could look "new" and escalate to a **spurious P0 on one run while passing on the next** — flagging P0 items the PR never touched (thanks @yijingyan2). This supersedes the base-worktree/submodule-init mechanism described in the `fd68d6d` note above. The gate now computes the PR's changed-file set **once**, HEAD-side, from `git diff <merge-base> HEAD` (submodule gitlink bumps expanded to their inner changed files), and `add_finding` escalates a finding to P0 **only when its provenance — the build input the finding is about — is among the files the PR changes**. Same commit + same diff ⇒ same result on every run and machine. The pre-existing whole-tree backlog stays non-blocking, advisory/perf-only findings never gate, and Check 10's export var-touch gating (already deterministic) is unchanged.

