### PR TITLE
[nvidia-bmc] add init_cfg.json to configure the features and services

### DIFF
--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/init_cfg.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/init_cfg.json
@@ -1,0 +1,44 @@
+{
+    "FEATURE": {
+        "bgp": {
+            "state": "disabled"
+        },
+        "dhcp_relay": {
+            "state": "disabled"
+        },
+        "macsec": {
+            "state": "disabled"
+        },
+        "mgmt-framework": {
+            "state": "disabled"
+        },
+        "nat": {
+            "state": "disabled"
+        },
+        "sflow": {
+            "state": "disabled"
+        },
+        "swss": {
+            "state": "disabled"
+        },
+        "syncd": {
+            "state": "disabled"
+        },
+        "teamd": {
+            "state": "disabled"
+        },
+        "gnmi": {
+            "state": "enabled",
+            "delayed": "False"
+        },
+        "database": {
+            "delayed": "False"
+        },
+        "lldp": {
+            "delayed": "False"
+        },
+        "pmon": {
+            "delayed": "False"
+        }
+    }
+}

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/control
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.6
 
 Package: sonic-platform-aspeed-nvidia-ast2700-bmc
 Architecture: arm64
-Depends: ${misc:Depends}, ${python3:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, jq
 Description: SONiC platform support for NVIDIA Aspeed AST2700 BMC
  This package provides platform-specific implementation for NVIDIA's
  BMC card based on Aspeed AST2700.

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.postinst
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.postinst
@@ -15,6 +15,29 @@ case "$1" in
             # Force reinstall to ensure this platform's wheel is installed
             pip3 install --force-reinstall --no-deps "${DEVICE_DIR}"/*.whl
         fi
+
+        # Merge the platform's FEATURE overrides into init_cfg.json.
+        INIT_CFG="/etc/sonic/init_cfg.json"
+        DEVICE_INIT_CFG="${DEVICE_DIR}/init_cfg.json"
+        if [ -f "$INIT_CFG" ] && [ -f "$DEVICE_INIT_CFG" ]; then
+            if ! command -v jq >/dev/null 2>&1; then
+                echo "Error: jq not found, cannot merge $DEVICE_INIT_CFG into $INIT_CFG" >&2
+                exit 1
+            fi
+            # Run jq directly; under `set -e` any failure aborts package
+            # configuration so AST2700 FEATURE overrides are always applied.
+            merged=$(jq -s '.[0] * .[1]' "$INIT_CFG" "$DEVICE_INIT_CFG")
+            if [ -z "$merged" ]; then
+                echo "Error: failed to merge $DEVICE_INIT_CFG into $INIT_CFG" >&2
+                exit 1
+            fi
+            tmp=$(mktemp -p /etc/sonic init_cfg.XXXXXX)
+            printf '%s\n' "$merged" > "$tmp"
+            # Preserve the original file's permissions on the replacement.
+            chmod "$(stat -c %a "$INIT_CFG")" "$tmp"
+            mv "$tmp" "$INIT_CFG"
+            echo "Merged BMC FEATURE defaults from $DEVICE_INIT_CFG into $INIT_CFG"
+        fi
         ;;
 esac
 


### PR DESCRIPTION
#### Why I did it
Add platform-specific feature configuration for the NVIDIA AST2700 BMC, disabling unnecessary SONiC services and enabling required BMC services.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added init_cfg.json for the NVIDIA AST2700 BMC platform.

#### How to verify it
Manual tests.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
