### PR TITLE
slave.mk: abort build loudly if quilt patch application fails

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -811,7 +811,11 @@ $(addprefix $(FILES_PATH)/, $(SONIC_MAKE_FILES)) : $(FILES_PATH)/% : .platform $
 		# Remove target to force rebuild
 		rm -f $(addprefix $(FILES_PATH)/, $*)
 		# Apply series of patches if exist
-		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi $(LOG)
+		if [ -f $($*_SRC_PATH).patch/series ]; then \
+		  pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+		  QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; \
+		  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*_SRC_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+		  popd; fi $(LOG)
 		# Build project and take package
 		make DEST=$(shell pwd)/$(FILES_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(FILES_PATH)/$* $(LOG)
 		# Archive patched source for static analysis (patches still applied)
@@ -932,7 +936,11 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_MAKE_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		# Remove target to force rebuild
 		rm -f $(addprefix $(DEBS_PATH)/, $* $($*_DERIVED_DEBS) $($*_EXTRA_DEBS))
 		# Apply series of patches if exist
-		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi $(LOG)
+		if [ -f $($*_SRC_PATH).patch/series ]; then \
+		  pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+		  QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; \
+		  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*_SRC_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+		  popd; fi $(LOG)
 		# Build project and take package
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
 		$(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) make -j$(SONIC_CONFIG_MAKE_JOBS) DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
@@ -980,7 +988,11 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		# Remove old build logs if they exist
 		rm -f $($*_SRC_PATH)/debian/*.debhelper.log
 		# Apply series of patches if exist
-		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi $(LOG)
+		if [ -f $($*_SRC_PATH).patch/series ]; then \
+		  pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+		  QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; \
+		  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*_SRC_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+		  popd; fi $(LOG)
 		# Build project
 		pushd $($*_SRC_PATH) $(LOG_SIMPLE)
 		if [ -f ./autogen.sh ]; then ./autogen.sh $(LOG); fi
@@ -1103,7 +1115,11 @@ $(addprefix $(PYTHON_DEBS_PATH)/, $(SONIC_PYTHON_STDEB_DEBS)) : $(PYTHON_DEBS_PA
 	if [ -z '$($*_CACHE_LOADED)' ] ; then
 
 		# Apply series of patches if exist
-		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi $(LOG)
+		if [ -f $($*_SRC_PATH).patch/series ]; then \
+		  pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+		  QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; \
+		  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*_SRC_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+		  popd; fi $(LOG)
 		# Build project
 		pushd $($*_SRC_PATH) $(LOG_SIMPLE)
 		rm -rf deb_dist/* $(LOG)
@@ -1148,7 +1164,10 @@ $(addprefix $(PYTHON_WHEELS_PATH)/, $(SONIC_PYTHON_WHEELS)) : $(PYTHON_WHEELS_PA
 
 		pushd $($*_SRC_PATH) $(LOG_SIMPLE)
 		# apply series of patches if exist
-		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; fi $(LOG)
+		if [ -f ../$(notdir $($*_SRC_PATH)).patch/series ]; then \
+		  ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+		  QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; \
+		  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $(notdir $($*_SRC_PATH)).patch/series" >&2; exit $$QUILT_RC; fi; fi $(LOG)
 ifneq ($(CROSS_BUILD_ENVIRON),y)
 		# Use pip instead of later setup.py to install dependencies into user home, but uninstall self
 		{ pip$($*_PYTHON_VERSION) install . &&
@@ -1244,7 +1263,11 @@ docker-start :
 $(addprefix $(TARGET_PATH)/, $(SONIC_SIMPLE_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform docker-start $$(addsuffix -load,$$(addprefix $(TARGET_PATH)/,$$($$*.gz_LOAD_DOCKERS)))
 	$(HEADER)
 	# Apply series of patches if exist
-	if [ -f $($*.gz_PATH).patch/series ]; then pushd $($*.gz_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*.gz_PATH)).patch quilt push -a; popd; fi $(LOG)
+	if [ -f $($*.gz_PATH).patch/series ]; then \
+	  pushd $($*.gz_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+	  QUILT_PATCHES=../$(notdir $($*.gz_PATH)).patch quilt push -a; \
+	  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*.gz_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+	  popd; fi $(LOG)
 	# Prepare docker build info
 	SONIC_ENFORCE_VERSIONS=$(SONIC_ENFORCE_VERSIONS) \
 	TRUSTED_GPG_URLS=$(TRUSTED_GPG_URLS) \
@@ -1389,7 +1412,11 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 	if [ -z '$($*.gz_CACHE_LOADED)' ] ; then
 
 		# Apply series of patches if exist
-		if [ -f $($*.gz_PATH).patch/series ]; then pushd $($*.gz_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*.gz_PATH)).patch quilt push -a; popd; fi $(LOG)
+		if [ -f $($*.gz_PATH).patch/series ]; then \
+	  pushd $($*.gz_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ); \
+	  QUILT_PATCHES=../$(notdir $($*.gz_PATH)).patch quilt push -a; \
+	  QUILT_RC=$$?; if [ $$QUILT_RC -ne 0 ]; then echo "ERROR: quilt push -a failed (rc=$$QUILT_RC) for $($*.gz_PATH).patch/series" >&2; exit $$QUILT_RC; fi; \
+	  popd; fi $(LOG)
 		mkdir -p $($*.gz_PATH)/debs $(LOG)
 		mkdir -p $($*.gz_PATH)/files $(LOG)
 		mkdir -p $($*.gz_PATH)/python-debs $(LOG)


### PR DESCRIPTION
Under `-e`, a `quilt push -a` failure was silently ignored because it is the non-final command in a `&&` chain — per POSIX, `-e` does not apply to commands that are not the last in a `&&` or `||` list. The build continued with patches unapplied, producing a binary that compiled clean but was missing intended changes.

Capture quilt's exit code explicitly with `set +e` / `QUILT_RC` and fail with a clear error message if it is non-zero (treating rc=2 as success, since quilt exits 2 when all patches are already applied). Fixes all 7 call sites in slave.mk.