### PR TITLE
[docker-fpm-frr]: Fix prefix_list script skipping on SmartSwitch

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source "$(dirname "$0")/platform_utils" > /dev/null 2>&1
+
 # Function to display help message
 display_help() {
     echo "Usage: sudo prefix-list <command> <PREFIX_TYPE> <NETWORK>"
@@ -68,7 +70,7 @@ validate_device_for_type() {
 
 # Function to skip operation on chassis supervisor
 skip_chassis_supervisor() {
-    if [ -f /etc/sonic/chassisdb.conf ]; then
+    if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ]; then
         echo "Skipping Operation on chassis supervisor"
         exit 0
     fi

--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source "$(dirname "$0")/platform_utils" > /dev/null 2>&1
-
 # Function to display help message
 display_help() {
     echo "Usage: sudo prefix-list <command> <PREFIX_TYPE> <NETWORK>"
@@ -70,7 +68,12 @@ validate_device_for_type() {
 
 # Function to skip operation on chassis supervisor
 skip_chassis_supervisor() {
-    if [ -f /etc/sonic/chassisdb.conf ] && [ "$SMARTSWITCH" = false ]; then
+    local PLATFORM supervisor
+    PLATFORM="$(sonic-cfggen -d -v DEVICE_METADATA.localhost.platform)"
+    [ -f "/usr/share/sonic/device/$PLATFORM/platform_env.conf" ] && \
+        . "/usr/share/sonic/device/$PLATFORM/platform_env.conf"
+
+    if [ "$supervisor" = "1" ]; then
         echo "Skipping Operation on chassis supervisor"
         exit 0
     fi


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

##### Work item tracking
- Microsoft ADO **39059738**:

##### Why I did it
The prefix_list CLI script incorrectly skips execution on SmartSwitch NPUs (e.g., MSN4280). The original skip_chassis_supervisor() function checks only for the existence of /etc/sonic/chassisdb.conf, but on SmartSwitch this file is present for DPU midplane management — not because the device is a chassis supervisor. This causes all prefix_list add/remove/status commands to no-op with exit 0, resulting in test failures in test_prefix_list_suppress.py on SmartSwitch platforms.

##### How I did it
Replaced the chassisdb.conf-existence check in skip_chassis_supervisor() with a direct supervisor=1 check from platform_env.conf. Only the two real chassis supervisors (arista_7800_sup, nokia_ixr7250e_sup-r0) define supervisor=1; all other platforms that ship chassisdb.conf (SmartSwitch, disaggregated linecards) either lack platform_env.conf entirely or don't set it, so they correctly proceed with prefix_list operations.

##### How to verify it
- Deploy the updated image on a SmartSwitch platform (e.g., MSN4280).
- Run sudo prefix_list add SUPPRESS_PREFIX 192.168.100.0/24 — should succeed and write to CONFIG_DB.
- Run sudo prefix_list status — should display the added entry.
- Run sudo prefix_list remove SUPPRESS_PREFIX 192.168.100.0/24 — should remove the entry.
- Verify on a chassis supervisor that the script still correctly skips with "Skipping Operation on chassis supervisor".

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
```
=================================================================================================================== short test summary info ====================================================================================================================
SKIPPED [1] bgp/test_prefix_list_suppress.py:503: No UpstreamLC / UpperSpineRouter duthost in this testbed
SKIPPED [1] bgp/test_prefix_list_suppress.py:629: No UpstreamLC / UpperSpineRouter duthost in this testbed
SKIPPED [1] bgp/test_prefix_list_suppress.py:1264: Testbed has no chassis supervisor
=================================================================================================== 15 passed, 3 skipped, 375 warnings in 600.71s (0:10:00) ====================================================================================================
```
#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)