### PR TITLE
[sonic-py-common] Add shared PmonDaemonConfig resolver for pmon daemon tunables

### DIFF
--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -135,28 +135,16 @@ dependent_startup_wait_for=rsyslogd:running
 {% if not skip_xcvrd %}
 [program:xcvrd]
 {% set base_command = "python3 /usr/local/bin/xcvrd" %}
-{% set options = "" -%}
 
-{% if skip_xcvrd_cmis_mgr %}
-    {%- set options = options + " --skip_cmis_mgr" %}
-{% endif -%}
-
-{% if enable_xcvrd_sff_mgr %}
-    {%- set options = options + " --enable_sff_mgr" %}
-{% endif -%}
-
-{% if xcvrd and xcvrd.dom_temperature_poll_interval %}
-    {%- set options = options + " --dom_temperature_poll_interval " + xcvrd.dom_temperature_poll_interval|string %}
-{% endif -%}
-
-{% if xcvrd and xcvrd.dom_update_interval %}
-    {%- set options = options + " --dom_update_interval " + xcvrd.dom_update_interval|string %}
-{% endif -%}
-
+{# xcvrd no longer parses CLI flags: the manager toggles (skip_xcvrd_cmis_mgr,
+   enable_xcvrd_sff_mgr) and dom cadences (dom_temperature_poll_interval,
+   dom_update_interval) are read directly from pmon_daemon_control.json by
+   XcvrdConfig, which honors both the nested xcvrd section and the legacy flat/
+   top-level keys. See doc/pmon/pmon_daemon_config_hld.md. #}
 {% if delay_xcvrd %}
-    {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ options ~ "\"" %}
+    {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ "\"" %}
 {% else %}
-    {%- set command = base_command ~ options %}
+    {%- set command = base_command %}
 {% endif -%}
 command={{ command }}
 priority=6

--- a/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
+++ b/dockers/docker-platform-monitor/docker-pmon.supervisord.conf.j2
@@ -135,16 +135,28 @@ dependent_startup_wait_for=rsyslogd:running
 {% if not skip_xcvrd %}
 [program:xcvrd]
 {% set base_command = "python3 /usr/local/bin/xcvrd" %}
+{% set options = "" -%}
 
-{# xcvrd no longer parses CLI flags: the manager toggles (skip_xcvrd_cmis_mgr,
-   enable_xcvrd_sff_mgr) and dom cadences (dom_temperature_poll_interval,
-   dom_update_interval) are read directly from pmon_daemon_control.json by
-   XcvrdConfig, which honors both the nested xcvrd section and the legacy flat/
-   top-level keys. See doc/pmon/pmon_daemon_config_hld.md. #}
+{% if skip_xcvrd_cmis_mgr %}
+    {%- set options = options + " --skip_cmis_mgr" %}
+{% endif -%}
+
+{% if enable_xcvrd_sff_mgr %}
+    {%- set options = options + " --enable_sff_mgr" %}
+{% endif -%}
+
+{% if xcvrd and xcvrd.dom_temperature_poll_interval %}
+    {%- set options = options + " --dom_temperature_poll_interval " + xcvrd.dom_temperature_poll_interval|string %}
+{% endif -%}
+
+{% if xcvrd and xcvrd.dom_update_interval %}
+    {%- set options = options + " --dom_update_interval " + xcvrd.dom_update_interval|string %}
+{% endif -%}
+
 {% if delay_xcvrd %}
-    {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ "\"" %}
+    {%- set command = "bash -c \"sleep 30 && " ~ base_command ~ options ~ "\"" %}
 {% else %}
-    {%- set command = base_command %}
+    {%- set command = base_command ~ options %}
 {% endif -%}
 command={{ command }}
 priority=6

--- a/src/sonic-py-common/sonic_py_common/pmon_daemon_config.py
+++ b/src/sonic-py-common/sonic_py_common/pmon_daemon_config.py
@@ -1,0 +1,327 @@
+"""
+Shared resolver for pmon daemon runtime tunables.
+
+Historically every pmon tunable was plumbed end-to-end as a command-line flag:
+the platform set it in pmon_daemon_control.json, sonic-cfggen loaded that file
+when rendering docker-pmon.supervisord.conf.j2, the template flattened it into
+"--flag value", argparse re-parsed it, and the daemon constructor grew another
+parameter. Adding one knob meant editing four places, once per daemon.
+
+This module removes that round trip. A daemon declares a dataclass subclass of
+PmonDaemonConfig naming the section it owns and the fields it accepts; the base
+locates pmon_daemon_control.json, extracts that section, and layers it over the
+built-in defaults.
+
+Precedence, highest wins:
+  1. Per-platform / per-hwsku file - the daemon's section of pmon_daemon_control.json
+  2. Built-in defaults            - the subclass's dataclass field defaults
+
+The per-platform file is read from the same device directories (and with the
+same hwsku-over-platform precedence) that docker_init.j2 uses and that xcvrd's
+media_settings.json / optics_si_settings.json parsers already read.
+
+Adding a tunable is one field plus one FIELD_SPECS entry declaring its type
+coercion and valid range. Platform owners set it in the section they already
+maintain; no template, argparse, or constructor change.
+
+Example:
+
+    @dataclass
+    class XcvrdConfig(PmonDaemonConfig):
+        SECTION_NAME = 'xcvrd'
+        FIELD_SPECS = {
+            'dom_update_interval': FieldSpec(caster=int, minimum=0, maximum=86400),
+        }
+
+        dom_update_interval: Optional[int] = None
+
+    config = XcvrdConfig.resolve()
+
+Nothing here raises on bad input: an unreadable file, a malformed section, an
+uncoercible value, or an out-of-range value degrades to the built-in default
+with a syslog warning, so a bad tunable can never keep a pmon daemon down.
+"""
+
+import json
+import os
+
+from dataclasses import dataclass, fields
+from typing import Callable, ClassVar, Dict, Optional, Tuple, get_origin
+
+from . import device_info
+from .syslogger import SysLogger
+
+# Per-platform / per-hwsku file. Each daemon's tunables live under its own key,
+# alongside the top-level skip_<daemon> / delay_<daemon> capability keys.
+PMON_DAEMON_CONTROL_FILE = "pmon_daemon_control.json"
+
+# One SysLogger per identifier: a daemon's config schema module and the base
+# class both log under the same identifier and should share one instance.
+_LOGGERS = {}
+
+
+def get_config_logger(identifier):
+    """Return the SysLogger for identifier, creating it on first use."""
+    logger = _LOGGERS.get(identifier)
+    if logger is None:
+        logger = SysLogger(identifier, enable_runtime_config=True)
+        _LOGGERS[identifier] = logger
+    return logger
+
+
+def to_bool(value):
+    """Coerce a platform-file value to a bool.
+
+    Boolean tunables cannot use bool() as their caster: bool("false") is True,
+    so a platform writing the string "false" would silently enable the feature.
+    Accepts real booleans, 0/1, and the usual textual spellings; anything else
+    raises ValueError so the caller keeps the built-in default.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value in (0, 1):
+            return bool(value)
+        raise ValueError("cannot interpret {!r} as a boolean".format(value))
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in ('true', 'yes', 'on', '1'):
+            return True
+        if lowered in ('false', 'no', 'off', '0'):
+            return False
+    raise ValueError("cannot interpret {!r} as a boolean".format(value))
+
+
+def _is_class_var(annotation):
+    """True if an annotation declares class-level config rather than a tunable."""
+    if annotation is ClassVar or get_origin(annotation) is ClassVar:
+        return True
+    # PEP 563 string annotations never reach get_origin.
+    if isinstance(annotation, str):
+        return annotation.split('[')[0].split('.')[-1] == 'ClassVar'
+    return False
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Type coercion and validation policy for one tunable.
+
+    caster  - applied first, e.g. int / float / to_bool. A TypeError or
+              ValueError from it rejects the value.
+    minimum - inclusive lower bound, or None for unbounded below.
+    maximum - inclusive upper bound, or None for unbounded above.
+    choices - permitted values, or None if not an enumeration.
+
+    Coercion alone is not validation: a negative interval coerces to a perfectly
+    good int but is not a valid cadence, and downstream consumers differ in
+    whether they notice. Declaring the range here gives every tunable one
+    enforced, testable contract. A field that is genuinely unbounded declares
+    FieldSpec(caster=...) with no bounds, so "unbounded" stays an explicit
+    choice rather than an omission.
+    """
+
+    caster: Optional[Callable] = None
+    minimum: Optional[float] = None
+    maximum: Optional[float] = None
+    choices: Optional[Tuple] = None
+
+    def coerce(self, value):
+        """Apply caster. Raises TypeError/ValueError if the value is unusable."""
+        if self.caster is None:
+            return value
+        return self.caster(value)
+
+    def describe_range(self):
+        """Human-readable bounds, for log messages."""
+        if self.choices is not None:
+            return "one of {}".format(sorted(self.choices, key=repr))
+        low = "-inf" if self.minimum is None else self.minimum
+        high = "+inf" if self.maximum is None else self.maximum
+        return "[{}, {}]".format(low, high)
+
+    def rejection_reason(self, value):
+        """Return None if value is acceptable, else why it is not."""
+        if self.choices is not None and value not in self.choices:
+            return "expected {}".format(self.describe_range())
+        if self.minimum is None and self.maximum is None:
+            return None
+        try:
+            below = self.minimum is not None and value < self.minimum
+            above = self.maximum is not None and value > self.maximum
+        except TypeError:
+            # Not comparable to the bounds at all (e.g. a dict where an int was
+            # declared) - treat as out of range rather than raising.
+            return "expected a value in {}".format(self.describe_range())
+        if below or above:
+            return "expected a value in {}".format(self.describe_range())
+        return None
+
+
+@dataclass
+class PmonDaemonConfig:
+    """Base class for a pmon daemon's resolved configuration.
+
+    Subclasses are dataclasses that set SECTION_NAME, populate FIELD_SPECS, and
+    declare one field per tunable whose default is the built-in default. The
+    base carries no fields of its own, so subclass field ordering is unaffected.
+    """
+
+    # Key in pmon_daemon_control.json that holds this daemon's tunables.
+    SECTION_NAME: ClassVar[str] = ''
+    # field name -> FieldSpec. A field with no entry is stored as-is.
+    FIELD_SPECS: ClassVar[Dict[str, FieldSpec]] = {}
+    # Defaults to "<section>_config" when unset.
+    SYSLOG_IDENTIFIER: ClassVar[Optional[str]] = None
+
+    def __init_subclass__(cls, **kwargs):
+        """Reject a schema whose fields and FIELD_SPECS disagree.
+
+        FIELD_SPECS is keyed by field name, so a key matching no field is
+        silently ignored - and that field then gets neither coercion nor a range
+        check, which is precisely the failure the specs exist to prevent. A field
+        with no spec is likewise stored exactly as the platform wrote it.
+
+        Both are static errors in the schema, not bad input, so they raise here
+        and surface the first time the module is imported. Bad values in
+        pmon_daemon_control.json stay non-fatal; see _merge.
+
+        Runs before @dataclass processes the subclass, so fields are read from
+        annotations rather than dataclasses.fields().
+        """
+        super().__init_subclass__(**kwargs)
+        declared = cls._declared_tunables()
+        specced = set(cls.FIELD_SPECS)
+
+        unknown = sorted(specced - declared)
+        if unknown:
+            raise TypeError(
+                "{}.FIELD_SPECS has no matching field for: {}. A spec keyed by a "
+                "name no field declares is never applied, leaving that tunable "
+                "with no type coercion and no range check.".format(
+                    cls.__name__, ", ".join(unknown)))
+
+        unspecced = sorted(declared - specced)
+        if unspecced:
+            raise TypeError(
+                "{}.FIELD_SPECS is missing an entry for: {}. Every tunable "
+                "declares its coercion and bounds; a field that is genuinely "
+                "unbounded declares FieldSpec() so that stays an explicit "
+                "choice.".format(cls.__name__, ", ".join(unspecced)))
+
+    @classmethod
+    def _declared_tunables(cls):
+        """Field names across the MRO, excluding ClassVar class-level config."""
+        names = set()
+        for klass in reversed(cls.__mro__):
+            # vars() rather than cls.__annotations__: the latter falls through to
+            # a base class's annotations when a class declares none of its own.
+            for name, annotation in vars(klass).get('__annotations__', {}).items():
+                if _is_class_var(annotation):
+                    names.discard(name)
+                else:
+                    names.add(name)
+        return names
+
+    @classmethod
+    def _logger(cls):
+        identifier = cls.SYSLOG_IDENTIFIER or '{}_config'.format(
+            cls.SECTION_NAME or 'pmon_daemon')
+        return get_config_logger(identifier)
+
+    @classmethod
+    def _log_prefix(cls):
+        return '{} config'.format(cls.SECTION_NAME or 'pmon daemon')
+
+    @classmethod
+    def resolve(cls, platform_section=None):
+        """Build a config by layering the platform file over the built-in defaults.
+
+        platform_section is exposed for tests so the merge logic can be exercised
+        without touching the filesystem; in production it is read from disk.
+        """
+        cfg = cls()
+        if platform_section is None:
+            platform_section = cls._read_platform_section()
+        cfg._merge(platform_section)
+        cfg._post_merge()
+        return cfg
+
+    def _merge(self, overrides):
+        """Apply the platform section: unknown keys and unusable values are dropped."""
+        logger = self._logger()
+        prefix = self._log_prefix()
+        valid = {f.name for f in fields(self)}
+        for key, value in overrides.items():
+            if key not in valid:
+                logger.log_notice(
+                    "{}: ignoring unknown key '{}' in {}".format(
+                        prefix, key, PMON_DAEMON_CONTROL_FILE))
+                continue
+            if value is None:
+                # An absent override never clobbers the default.
+                continue
+            spec = self.FIELD_SPECS.get(key)
+            if spec is not None:
+                try:
+                    value = spec.coerce(value)
+                except (TypeError, ValueError):
+                    logger.log_warning(
+                        "{}: invalid value {!r} for '{}' in {}; keeping default".format(
+                            prefix, value, key, PMON_DAEMON_CONTROL_FILE))
+                    continue
+                reason = spec.rejection_reason(value)
+                if reason is not None:
+                    logger.log_warning(
+                        "{}: out-of-range value {!r} for '{}' in {}; {}; keeping "
+                        "default".format(prefix, value, key,
+                                         PMON_DAEMON_CONTROL_FILE, reason))
+                    continue
+            setattr(self, key, value)
+
+    def _post_merge(self):
+        """Hook for constraints that span more than one field.
+
+        FieldSpec validates each field in isolation; a subclass overrides this to
+        enforce (or clamp) relationships between fields once every override has
+        been applied. Default: nothing to do.
+        """
+        return
+
+    @classmethod
+    def _read_platform_section(cls):
+        """Return this daemon's dict from pmon_daemon_control.json, or {} if absent.
+
+        Mirrors docker_init.j2: the hwsku file takes precedence over the platform
+        file, and only the first existing file is consulted (no cross-file merge).
+        Any failure degrades to {} so the daemon starts on its built-in defaults.
+        """
+        logger = cls._logger()
+        prefix = cls._log_prefix()
+        try:
+            platform_path, hwsku_path = device_info.get_paths_to_platform_and_hwsku_dirs()
+        except Exception as exc:  # device_info can raise if platform is undetermined
+            logger.log_warning(
+                "{}: unable to determine platform/hwsku dirs: {}".format(prefix, exc))
+            return {}
+
+        for directory in (hwsku_path, platform_path):
+            if not directory:
+                continue
+            path = os.path.join(directory, PMON_DAEMON_CONTROL_FILE)
+            if not os.path.isfile(path):
+                continue
+            try:
+                with open(path) as control_file:
+                    data = json.load(control_file)
+            except (OSError, ValueError) as exc:
+                logger.log_warning(
+                    "{}: failed to read {}: {}".format(prefix, path, exc))
+                return {}
+            section = data.get(cls.SECTION_NAME, {})
+            if not isinstance(section, dict):
+                logger.log_warning(
+                    "{}: '{}' section in {} is not an object; ignoring".format(
+                        prefix, cls.SECTION_NAME, path))
+                return {}
+            return section
+        return {}

--- a/src/sonic-py-common/sonic_py_common/pmon_daemon_config.py
+++ b/src/sonic-py-common/sonic_py_common/pmon_daemon_config.py
@@ -1,52 +1,54 @@
 """
 Shared resolver for pmon daemon runtime tunables.
 
-Historically every pmon tunable was plumbed end-to-end as a command-line flag:
-the platform set it in pmon_daemon_control.json, sonic-cfggen loaded that file
-when rendering docker-pmon.supervisord.conf.j2, the template flattened it into
-"--flag value", argparse re-parsed it, and the daemon constructor grew another
-parameter. Adding one knob meant editing four places, once per daemon.
+A daemon declares a dataclass subclass of PmonDaemonConfig that names the
+section it owns in pmon_daemon_control.json and the fields it accepts. The base
+locates the file, extracts that section, and layers it over the built-in field
+defaults, coercing and range-checking each value.
 
-This module removes that round trip. A daemon declares a dataclass subclass of
-PmonDaemonConfig naming the section it owns and the fields it accepts; the base
-locates pmon_daemon_control.json, extracts that section, and layers it over the
-built-in defaults.
+Schema options on a subclass:
+  - FIELD_SPECS     per-field type coercion and valid range (see FieldSpec).
+  - SUBSECTIONS     group related fields one level deep, each a nested
+                    PmonDaemonConfig subclass with its own FIELD_SPECS.
+  - LEGACY_ALIASES  route a deprecated key to its new (possibly nested) target
+                    for a compatibility window; an explicit nested value wins.
 
-Precedence, highest wins:
-  1. Per-platform / per-hwsku file - the daemon's section of pmon_daemon_control.json
-  2. Built-in defaults            - the subclass's dataclass field defaults
+Precedence, highest first:
+  1. The daemon's section of pmon_daemon_control.json.
+  2. The subclass's built-in field defaults.
 
-The per-platform file is read from the same device directories (and with the
-same hwsku-over-platform precedence) that docker_init.j2 uses and that xcvrd's
-media_settings.json / optics_si_settings.json parsers already read.
-
-Adding a tunable is one field plus one FIELD_SPECS entry declaring its type
-coercion and valid range. Platform owners set it in the section they already
-maintain; no template, argparse, or constructor change.
-
-Example:
-
-    @dataclass
-    class XcvrdConfig(PmonDaemonConfig):
-        SECTION_NAME = 'xcvrd'
-        FIELD_SPECS = {
-            'dom_update_interval': FieldSpec(caster=int, minimum=0, maximum=86400),
-        }
-
-        dom_update_interval: Optional[int] = None
-
-    config = XcvrdConfig.resolve()
+The file is read from the same device directories, with the same
+hwsku-over-platform precedence, that docker_init.j2 uses.
 
 Nothing here raises on bad input: an unreadable file, a malformed section, an
 uncoercible value, or an out-of-range value degrades to the built-in default
 with a syslog warning, so a bad tunable can never keep a pmon daemon down.
+
+Example:
+
+    @dataclass
+    class DomConfig(PmonDaemonConfig):
+        SECTION_NAME = 'dom'
+        FIELD_SPECS = {
+            'update_interval': FieldSpec(caster=int, minimum=0, maximum=86400),
+        }
+        update_interval: Optional[int] = None
+
+    @dataclass
+    class XcvrdConfig(PmonDaemonConfig):
+        SECTION_NAME = 'xcvrd'
+        SUBSECTIONS = {'dom': DomConfig}
+        dom: DomConfig = field(default_factory=DomConfig)
+
+    config = XcvrdConfig.resolve()   # -> config.dom.update_interval
 """
 
+import copy
 import json
 import os
 
 from dataclasses import dataclass, fields
-from typing import Callable, ClassVar, Dict, Optional, Tuple, get_origin
+from typing import Callable, ClassVar, Dict, Optional, Tuple, Type, get_origin
 
 from . import device_info
 from .syslogger import SysLogger
@@ -157,6 +159,30 @@ class FieldSpec:
         return None
 
 
+@dataclass(frozen=True)
+class LegacyAlias:
+    """Maps a deprecated key to a field on the new (possibly nested) schema.
+
+    A schema keeps working for platform files that still use an old flat key or
+    an old top-level key after the tunable has moved under a subsection. The
+    alias is applied before the nested form is merged and never overwrites an
+    explicit nested value, so the nested key always wins when both are present.
+
+    target    - dotted path to the destination field, e.g. "cmis_mgr.enabled"
+                (at most one level: "<field>" or "<subsection>.<field>").
+    scope     - 'section' reads the deprecated key from the daemon's own section;
+                'file' reads it from the top level of pmon_daemon_control.json
+                (a sibling of the daemon section).
+    transform - optional rewrite of the raw value before it is routed to target,
+                e.g. inverting a legacy skip_* flag into an enabled toggle. A
+                TypeError/ValueError from it drops the value (default kept).
+    """
+
+    target: str
+    scope: str = 'section'
+    transform: Optional[Callable] = None
+
+
 @dataclass
 class PmonDaemonConfig:
     """Base class for a pmon daemon's resolved configuration.
@@ -172,6 +198,11 @@ class PmonDaemonConfig:
     FIELD_SPECS: ClassVar[Dict[str, FieldSpec]] = {}
     # Defaults to "<section>_config" when unset.
     SYSLOG_IDENTIFIER: ClassVar[Optional[str]] = None
+    # field name -> subsection schema (a PmonDaemonConfig subclass). Subsections
+    # are exactly one level deep: a subsection schema may not declare its own.
+    SUBSECTIONS: ClassVar[Dict[str, Type['PmonDaemonConfig']]] = {}
+    # deprecated key -> LegacyAlias describing where its value now lives.
+    LEGACY_ALIASES: ClassVar[Dict[str, 'LegacyAlias']] = {}
 
     def __init_subclass__(cls, **kwargs):
         """Reject a schema whose fields and FIELD_SPECS disagree.
@@ -191,6 +222,7 @@ class PmonDaemonConfig:
         super().__init_subclass__(**kwargs)
         declared = cls._declared_tunables()
         specced = set(cls.FIELD_SPECS)
+        subsectioned = set(cls.SUBSECTIONS)
 
         unknown = sorted(specced - declared)
         if unknown:
@@ -200,13 +232,40 @@ class PmonDaemonConfig:
                 "with no type coercion and no range check.".format(
                     cls.__name__, ", ".join(unknown)))
 
-        unspecced = sorted(declared - specced)
-        if unspecced:
+        unknown_subs = sorted(subsectioned - declared)
+        if unknown_subs:
+            raise TypeError(
+                "{}.SUBSECTIONS names field(s) that do not exist: {}.".format(
+                    cls.__name__, ", ".join(unknown_subs)))
+
+        both = sorted(specced & subsectioned)
+        if both:
+            raise TypeError(
+                "{}: field(s) {} appear in both FIELD_SPECS and SUBSECTIONS; a "
+                "field is either a scalar tunable or a nested group, not both.".format(
+                    cls.__name__, ", ".join(both)))
+
+        uncovered = sorted(declared - specced - subsectioned)
+        if uncovered:
             raise TypeError(
                 "{}.FIELD_SPECS is missing an entry for: {}. Every tunable "
-                "declares its coercion and bounds; a field that is genuinely "
-                "unbounded declares FieldSpec() so that stays an explicit "
-                "choice.".format(cls.__name__, ", ".join(unspecced)))
+                "declares its coercion and bounds (or is a SUBSECTIONS group); a "
+                "field that is genuinely unbounded declares FieldSpec() so that "
+                "stays an explicit choice.".format(
+                    cls.__name__, ", ".join(uncovered)))
+
+        for name, subcls in cls.SUBSECTIONS.items():
+            if not (isinstance(subcls, type) and issubclass(subcls, PmonDaemonConfig)):
+                raise TypeError(
+                    "{}.SUBSECTIONS['{}'] must be a PmonDaemonConfig subclass.".format(
+                        cls.__name__, name))
+            if subcls.SUBSECTIONS:
+                raise TypeError(
+                    "{}.SUBSECTIONS['{}'] ({}) declares its own SUBSECTIONS; "
+                    "subsections are exactly one level deep.".format(
+                        cls.__name__, name, subcls.__name__))
+
+        cls._validate_legacy_aliases(declared)
 
     @classmethod
     def _declared_tunables(cls):
@@ -223,6 +282,41 @@ class PmonDaemonConfig:
         return names
 
     @classmethod
+    def _validate_legacy_aliases(cls, declared):
+        """Reject a LEGACY_ALIASES target that names no real field.
+
+        Like the FIELD_SPECS guard, this is a static schema error caught at
+        import rather than a bad platform value.
+        """
+        for old_key, alias in cls.LEGACY_ALIASES.items():
+            if alias.scope not in ('section', 'file'):
+                raise TypeError(
+                    "{}.LEGACY_ALIASES['{}'] has invalid scope {!r}; expected "
+                    "'section' or 'file'.".format(cls.__name__, old_key, alias.scope))
+            parts = alias.target.split('.')
+            if len(parts) == 1:
+                if parts[0] not in declared:
+                    raise TypeError(
+                        "{}.LEGACY_ALIASES['{}'] target '{}' names no field.".format(
+                            cls.__name__, old_key, alias.target))
+            elif len(parts) == 2:
+                sub, field_name = parts
+                subcls = cls.SUBSECTIONS.get(sub)
+                if subcls is None:
+                    raise TypeError(
+                        "{}.LEGACY_ALIASES['{}'] target '{}' does not name a "
+                        "subsection.".format(cls.__name__, old_key, alias.target))
+                if field_name not in subcls._declared_tunables():
+                    raise TypeError(
+                        "{}.LEGACY_ALIASES['{}'] target '{}' names no field on "
+                        "subsection '{}'.".format(
+                            cls.__name__, old_key, alias.target, sub))
+            else:
+                raise TypeError(
+                    "{}.LEGACY_ALIASES['{}'] target '{}' is more than one level "
+                    "deep.".format(cls.__name__, old_key, alias.target))
+
+    @classmethod
     def _logger(cls):
         identifier = cls.SYSLOG_IDENTIFIER or '{}_config'.format(
             cls.SECTION_NAME or 'pmon_daemon')
@@ -233,16 +327,18 @@ class PmonDaemonConfig:
         return '{} config'.format(cls.SECTION_NAME or 'pmon daemon')
 
     @classmethod
-    def resolve(cls, platform_section=None):
+    def resolve(cls, platform_section=None, platform_file=None):
         """Build a config by layering the platform file over the built-in defaults.
 
-        platform_section is exposed for tests so the merge logic can be exercised
-        without touching the filesystem; in production it is read from disk.
+        platform_section (and, for scope='file' legacy aliases, platform_file)
+        are exposed for tests so the merge and alias logic can be exercised
+        without touching the filesystem; in production both are read from disk.
         """
         cfg = cls()
         if platform_section is None:
-            platform_section = cls._read_platform_section()
-        cfg._merge(platform_section)
+            platform_section, platform_file = cls._read_platform_control()
+        overrides = cfg._with_legacy_aliases(platform_section, platform_file)
+        cfg._merge(overrides)
         cfg._post_merge()
         return cfg
 
@@ -259,6 +355,9 @@ class PmonDaemonConfig:
                 continue
             if value is None:
                 # An absent override never clobbers the default.
+                continue
+            if key in self.SUBSECTIONS:
+                self._merge_subsection(key, value)
                 continue
             spec = self.FIELD_SPECS.get(key)
             if spec is not None:
@@ -287,13 +386,103 @@ class PmonDaemonConfig:
         """
         return
 
+    def _merge_subsection(self, key, value):
+        """Merge a nested dict into the subsection instance at self.<key>.
+
+        The subsection keeps the parent's built-in defaults for any field the
+        nested dict omits; a non-dict value is rejected and the subsection is
+        left untouched. Coercion and validation inside the subsection use its
+        own FIELD_SPECS, identical to the top level.
+        """
+        current = getattr(self, key)
+        if not isinstance(value, dict):
+            self._logger().log_warning(
+                "{}: '{}' in {} must be an object; keeping subsection defaults".format(
+                    self._log_prefix(), key, PMON_DAEMON_CONTROL_FILE))
+            return
+        current._merge(value)
+        current._post_merge()
+
+    def _with_legacy_aliases(self, section, platform_file):
+        """Return a copy of section with deprecated keys routed to their targets.
+
+        For each LEGACY_ALIASES entry whose deprecated key is present (in the
+        daemon section for scope='section', or the whole file for scope='file'),
+        the raw value is optionally transformed and written to the alias target
+        only if the nested form is absent, so an explicit nested value always
+        wins. A used alias logs a deprecation warning. Section-scoped legacy keys
+        are consumed so _merge does not also report them as unknown.
+        """
+        if not self.LEGACY_ALIASES:
+            return section
+        section = section if isinstance(section, dict) else {}
+        platform_file = platform_file or {}
+        overrides = copy.deepcopy(section)
+        logger = self._logger()
+        prefix = self._log_prefix()
+        for old_key, alias in self.LEGACY_ALIASES.items():
+            source = platform_file if alias.scope == 'file' else overrides
+            if not isinstance(source, dict) or old_key not in source:
+                continue
+            raw = source.get(old_key)
+            if alias.scope == 'section':
+                # Consume the flat key so _merge does not also flag it unknown.
+                overrides.pop(old_key, None)
+            if raw is None:
+                continue
+            logger.log_warning(
+                "{}: '{}' in {} is deprecated; set '{}' instead".format(
+                    prefix, old_key, PMON_DAEMON_CONTROL_FILE, alias.target))
+            value = raw
+            if alias.transform is not None:
+                try:
+                    value = alias.transform(raw)
+                except (TypeError, ValueError):
+                    logger.log_warning(
+                        "{}: invalid value {!r} for deprecated '{}' in {}; keeping "
+                        "default".format(prefix, raw, old_key, PMON_DAEMON_CONTROL_FILE))
+                    continue
+            self._inject_alias_value(overrides, alias.target, value)
+        return overrides
+
+    @staticmethod
+    def _inject_alias_value(overrides, target, value):
+        """Write value at the dotted target in overrides, never overwriting.
+
+        setdefault gives the nested form precedence: if the destination key is
+        already present (an explicit nested value), the alias value is dropped.
+        """
+        parts = target.split('.')
+        if len(parts) == 1:
+            overrides.setdefault(parts[0], value)
+            return
+        sub, field_name = parts[0], parts[1]
+        subdict = overrides.get(sub)
+        if not isinstance(subdict, dict):
+            subdict = {}
+            overrides[sub] = subdict
+        subdict.setdefault(field_name, value)
+
     @classmethod
     def _read_platform_section(cls):
         """Return this daemon's dict from pmon_daemon_control.json, or {} if absent.
 
+        Thin wrapper over _read_platform_control for callers that only need the
+        daemon's own section and not the sibling top-level keys.
+        """
+        return cls._read_platform_control()[0]
+
+    @classmethod
+    def _read_platform_control(cls):
+        """Return (section, whole_file) from pmon_daemon_control.json.
+
+        section is this daemon's own object (or {} if absent/malformed);
+        whole_file is the entire parsed file, needed so a scope='file' legacy
+        alias can read a top-level key that lives outside the daemon section.
+
         Mirrors docker_init.j2: the hwsku file takes precedence over the platform
         file, and only the first existing file is consulted (no cross-file merge).
-        Any failure degrades to {} so the daemon starts on its built-in defaults.
+        Any failure degrades to ({}, {}) so the daemon starts on its defaults.
         """
         logger = cls._logger()
         prefix = cls._log_prefix()
@@ -302,7 +491,7 @@ class PmonDaemonConfig:
         except Exception as exc:  # device_info can raise if platform is undetermined
             logger.log_warning(
                 "{}: unable to determine platform/hwsku dirs: {}".format(prefix, exc))
-            return {}
+            return {}, {}
 
         for directory in (hwsku_path, platform_path):
             if not directory:
@@ -316,12 +505,16 @@ class PmonDaemonConfig:
             except (OSError, ValueError) as exc:
                 logger.log_warning(
                     "{}: failed to read {}: {}".format(prefix, path, exc))
-                return {}
+                return {}, {}
+            if not isinstance(data, dict):
+                logger.log_warning(
+                    "{}: {} is not an object; ignoring".format(prefix, path))
+                return {}, {}
             section = data.get(cls.SECTION_NAME, {})
             if not isinstance(section, dict):
                 logger.log_warning(
                     "{}: '{}' section in {} is not an object; ignoring".format(
                         prefix, cls.SECTION_NAME, path))
-                return {}
-            return section
-        return {}
+                return {}, data
+            return section, data
+        return {}, {}

--- a/src/sonic-py-common/tests/pmon_daemon_config_test.py
+++ b/src/sonic-py-common/tests/pmon_daemon_config_test.py
@@ -1,0 +1,452 @@
+"""
+Unit tests for PmonDaemonConfig: the shared resolver for pmon daemon tunables.
+
+Precedence under test (highest wins):
+  1. the daemon's section of pmon_daemon_control.json (hwsku file over platform file)
+  2. built-in dataclass defaults
+
+The base is exercised through small test-only subclasses so it is covered
+independently of any real daemon's schema.
+"""
+import json
+import os
+import sys
+
+from dataclasses import dataclass
+from typing import Optional
+
+if sys.version_info.major == 3:
+    from unittest import mock
+else:
+    import mock
+
+import pytest
+
+from sonic_py_common import pmon_daemon_config
+from sonic_py_common.pmon_daemon_config import (
+    FieldSpec, PmonDaemonConfig, PMON_DAEMON_CONTROL_FILE, to_bool)
+
+PATHS_FN = "sonic_py_common.pmon_daemon_config.device_info.get_paths_to_platform_and_hwsku_dirs"
+
+# The quiet_logger fixture below patches get_config_logger for every test; keep a
+# handle on the real one so its own caching can still be exercised.
+REAL_GET_CONFIG_LOGGER = pmon_daemon_config.get_config_logger
+
+
+@dataclass
+class SampleConfig(PmonDaemonConfig):
+    """A stand-in daemon schema covering every FieldSpec feature."""
+
+    SECTION_NAME = 'sampled'
+    FIELD_SPECS = {
+        'interval': FieldSpec(caster=int, minimum=0, maximum=86400),
+        'ratio': FieldSpec(caster=float, minimum=0.0),          # unbounded above
+        'enabled': FieldSpec(caster=to_bool),                   # unbounded
+        'mode': FieldSpec(choices=('fast', 'slow')),            # no caster
+        'freeform': FieldSpec(),                                # neither
+    }
+
+    interval: Optional[int] = None
+    ratio: Optional[float] = None
+    enabled: bool = False
+    mode: Optional[str] = None
+    freeform: Optional[str] = None
+
+
+@dataclass
+class OtherConfig(PmonDaemonConfig):
+    """A second schema, to prove sections do not bleed into each other."""
+
+    SECTION_NAME = 'otherd'
+    FIELD_SPECS = {'interval': FieldSpec(caster=int, minimum=0)}
+
+    interval: Optional[int] = None
+
+
+@dataclass
+class ClampedConfig(PmonDaemonConfig):
+    """Exercises the _post_merge hook for a cross-field constraint."""
+
+    SECTION_NAME = 'clampedd'
+    FIELD_SPECS = {
+        'window': FieldSpec(caster=int, minimum=1),
+        'heartbeat': FieldSpec(caster=int, minimum=1),
+    }
+
+    window: int = 300
+    heartbeat: int = 30
+
+    def _post_merge(self):
+        if self.heartbeat >= self.window:
+            self.heartbeat = max(1, self.window // 2)
+
+
+@pytest.fixture(autouse=True)
+def quiet_logger():
+    """Keep tests off rsyslogd; the unit test environment has none."""
+    with mock.patch.object(pmon_daemon_config, 'get_config_logger',
+                           return_value=mock.MagicMock()) as logger_fn:
+        yield logger_fn
+
+
+def write_control_file(directory, payload):
+    """Write a pmon_daemon_control.json with the given dict into directory."""
+    os.makedirs(directory, exist_ok=True)
+    path = os.path.join(directory, PMON_DAEMON_CONTROL_FILE)
+    with open(path, "w") as f:
+        json.dump(payload, f)
+    return path
+
+
+class TestToBool:
+    @pytest.mark.parametrize("value", [True, "true", "True", " TRUE ", "yes", "on", "1", 1])
+    def test_truthy_spellings(self, value):
+        assert to_bool(value) is True
+
+    @pytest.mark.parametrize("value", [False, "false", "False", " FALSE ", "no", "off", "0", 0])
+    def test_falsy_spellings(self, value):
+        # The case bool() gets wrong: bool("false") is True.
+        assert to_bool(value) is False
+
+    @pytest.mark.parametrize("value", ["maybe", "", 2, -1, 1.5, None, [], {}])
+    def test_uninterpretable_raises(self, value):
+        with pytest.raises(ValueError):
+            to_bool(value)
+
+
+class TestFieldSpec:
+    def test_no_caster_passes_value_through(self):
+        assert FieldSpec().coerce("as-is") == "as-is"
+
+    def test_caster_failure_propagates(self):
+        with pytest.raises(ValueError):
+            FieldSpec(caster=int).coerce("not-a-number")
+
+    def test_unbounded_spec_accepts_anything(self):
+        assert FieldSpec(caster=int).rejection_reason(-999999) is None
+
+    def test_bounds_are_inclusive(self):
+        spec = FieldSpec(caster=int, minimum=0, maximum=10)
+        assert spec.rejection_reason(0) is None
+        assert spec.rejection_reason(10) is None
+        assert spec.rejection_reason(-1) is not None
+        assert spec.rejection_reason(11) is not None
+
+    def test_incomparable_value_is_rejected_not_raised(self):
+        # A dict where an int was declared must not blow up the comparison.
+        assert FieldSpec(minimum=0).rejection_reason({}) is not None
+
+    def test_choices_enforced(self):
+        spec = FieldSpec(choices=('fast', 'slow'))
+        assert spec.rejection_reason('fast') is None
+        assert spec.rejection_reason('turbo') is not None
+
+    def test_describe_range_reports_open_bounds(self):
+        assert FieldSpec(minimum=0).describe_range() == "[0, +inf]"
+        assert FieldSpec(maximum=9).describe_range() == "[-inf, 9]"
+
+
+class TestDefaults:
+    def test_defaults_when_no_overrides(self):
+        cfg = SampleConfig.resolve(platform_section={})
+        assert cfg.interval is None
+        assert cfg.ratio is None
+        assert cfg.enabled is False
+        assert cfg.mode is None
+
+    def test_bare_construction_matches_defaults(self):
+        assert SampleConfig() == SampleConfig.resolve(platform_section={})
+
+
+class TestMerge:
+    def test_section_overrides_defaults(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": 5, "mode": "fast"})
+        assert cfg.interval == 5
+        assert cfg.mode == "fast"
+
+    def test_partial_section_leaves_other_fields_at_default(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": 5})
+        assert cfg.interval == 5
+        assert cfg.ratio is None
+
+    def test_none_value_does_not_override(self):
+        cfg = SampleConfig.resolve(platform_section={"enabled": None})
+        assert cfg.enabled is False
+
+    def test_string_value_is_coerced(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": "30"})
+        assert cfg.interval == 30
+        assert isinstance(cfg.interval, int)
+
+    def test_uncoercible_value_keeps_default(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": "not-a-number"})
+        assert cfg.interval is None
+
+    def test_unknown_key_is_ignored(self):
+        cfg = SampleConfig.resolve(platform_section={
+            "interval": 5, "some_future_unknown_key": 99})
+        assert cfg.interval == 5
+        assert not hasattr(cfg, "some_future_unknown_key")
+
+    def test_field_without_spec_is_stored_as_is(self):
+        cfg = SampleConfig.resolve(platform_section={"freeform": {"anything": 1}})
+        assert cfg.freeform == {"anything": 1}
+
+    def test_bool_string_false_disables(self):
+        # Without to_bool this would store the truthy string "false".
+        cfg = SampleConfig.resolve(platform_section={"enabled": "false"})
+        assert cfg.enabled is False
+
+    def test_bool_string_true_enables(self):
+        cfg = SampleConfig.resolve(platform_section={"enabled": "true"})
+        assert cfg.enabled is True
+
+
+class TestRangeValidation:
+    def test_below_minimum_keeps_default(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": -1})
+        assert cfg.interval is None
+
+    def test_above_maximum_keeps_default(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": 86401})
+        assert cfg.interval is None
+
+    def test_boundaries_are_accepted(self):
+        assert SampleConfig.resolve(platform_section={"interval": 0}).interval == 0
+        assert SampleConfig.resolve(platform_section={"interval": 86400}).interval == 86400
+
+    def test_validation_runs_after_coercion(self):
+        # "-5" coerces to int fine, then fails the range check.
+        cfg = SampleConfig.resolve(platform_section={"interval": "-5"})
+        assert cfg.interval is None
+
+    def test_unbounded_above_accepts_large_value(self):
+        cfg = SampleConfig.resolve(platform_section={"ratio": "1e9"})
+        assert cfg.ratio == 1e9
+
+    def test_choices_violation_keeps_default(self):
+        cfg = SampleConfig.resolve(platform_section={"mode": "turbo"})
+        assert cfg.mode is None
+
+    def test_rejection_is_logged_as_warning(self):
+        logger = mock.MagicMock()
+        with mock.patch.object(pmon_daemon_config, 'get_config_logger', return_value=logger):
+            SampleConfig.resolve(platform_section={"interval": -1})
+        assert logger.log_warning.called
+        message = logger.log_warning.call_args[0][0]
+        assert "interval" in message and "keeping default" in message
+
+    def test_one_bad_field_does_not_drop_the_others(self):
+        cfg = SampleConfig.resolve(platform_section={"interval": -1, "mode": "slow"})
+        assert cfg.interval is None
+        assert cfg.mode == "slow"
+
+
+class TestPostMergeHook:
+    def test_hook_is_a_noop_by_default(self):
+        assert SampleConfig.resolve(platform_section={"interval": 5}).interval == 5
+
+    def test_cross_field_constraint_applied_after_merge(self):
+        cfg = ClampedConfig.resolve(platform_section={"window": 20, "heartbeat": 50})
+        assert cfg.heartbeat == 10
+
+    def test_constraint_sees_defaults_too(self):
+        # Lowering only window must still pull the default heartbeat under it.
+        cfg = ClampedConfig.resolve(platform_section={"window": 10})
+        assert cfg.heartbeat == 5
+
+    def test_in_range_values_untouched(self):
+        cfg = ClampedConfig.resolve(platform_section={"window": 100, "heartbeat": 40})
+        assert cfg.heartbeat == 40
+
+
+class TestReadPlatformSection:
+    def test_missing_files_yield_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        with mock.patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_reads_platform_file_when_no_hwsku_file(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"sampled": {"interval": 30}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert SampleConfig._read_platform_section() == {"interval": 30}
+
+    def test_hwsku_file_takes_precedence_over_platform_file(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"sampled": {"interval": 30}})
+        write_control_file(hwsku_dir, {"sampled": {"interval": 99}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            # Mirrors docker_init: the hwsku file wins; no cross-file merge.
+            assert SampleConfig._read_platform_section() == {"interval": 99}
+
+    def test_hwsku_file_without_section_does_not_fall_back(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        hwsku_dir = str(tmp_path / "hwsku")
+        write_control_file(platform_dir, {"sampled": {"interval": 30}})
+        write_control_file(hwsku_dir, {"skip_sampled": False})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, hwsku_dir)):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_each_subclass_reads_its_own_section(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {
+            "sampled": {"interval": 30},
+            "otherd": {"interval": 99},
+        })
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert SampleConfig.resolve().interval == 30
+            assert OtherConfig.resolve().interval == 99
+
+    def test_no_section_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"skip_ledd": True})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_malformed_json_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        os.makedirs(platform_dir)
+        with open(os.path.join(platform_dir, PMON_DAEMON_CONTROL_FILE), "w") as f:
+            f.write("{ this is not valid json")
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_non_dict_section_yields_empty(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"sampled": "oops-not-an-object"})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_device_info_failure_yields_empty(self):
+        with mock.patch(PATHS_FN, side_effect=RuntimeError("platform undetermined")):
+            assert SampleConfig._read_platform_section() == {}
+
+    def test_empty_dir_path_is_skipped(self, tmp_path):
+        # get_paths_to_platform_and_hwsku_dirs may return an empty hwsku path;
+        # that entry is skipped rather than joined into a bogus path.
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"sampled": {"interval": 30}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            assert SampleConfig._read_platform_section() == {"interval": 30}
+
+
+class TestResolveEndToEnd:
+    def test_resolve_reads_from_disk(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"sampled": {"interval": 5, "enabled": "true"}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            cfg = SampleConfig.resolve()
+        assert cfg.interval == 5
+        assert cfg.enabled is True
+
+    def test_resolve_defaults_when_nothing_on_disk(self, tmp_path):
+        with mock.patch(PATHS_FN, return_value=(str(tmp_path / "platform"), "")):
+            cfg = SampleConfig.resolve()
+        assert cfg.interval is None
+        assert cfg.enabled is False
+
+
+class TestSchemaGuard:
+    """A spec keyed by the wrong name is inert, so the schema must not compile.
+
+    These are developer errors in static code, caught at import; bad values in
+    the platform file stay non-fatal.
+    """
+
+    def test_spec_for_nonexistent_field_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Typo(PmonDaemonConfig):
+                SECTION_NAME = 'typod'
+                FIELD_SPECS = {'intervl': FieldSpec(caster=int, minimum=0)}
+
+                interval: Optional[int] = None
+
+        assert 'intervl' in str(excinfo.value)
+
+    def test_field_without_a_spec_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Unspecced(PmonDaemonConfig):
+                SECTION_NAME = 'unspeccedd'
+                FIELD_SPECS = {'covered': FieldSpec(caster=int)}
+
+                covered: Optional[int] = None
+                forgotten: Optional[int] = None
+
+        assert 'forgotten' in str(excinfo.value)
+
+    def test_explicitly_unbounded_field_is_accepted(self):
+        @dataclass
+        class Unbounded(PmonDaemonConfig):
+            SECTION_NAME = 'unboundedd'
+            FIELD_SPECS = {'anything': FieldSpec()}
+
+            anything: Optional[str] = None
+
+        assert Unbounded.resolve(platform_section={"anything": "x"}).anything == "x"
+
+    def test_classvars_are_not_treated_as_tunables(self):
+        # SECTION_NAME/FIELD_SPECS/SYSLOG_IDENTIFIER are ClassVars on the base;
+        # a schema declaring no fields at all must still be legal.
+        @dataclass
+        class NoTunables(PmonDaemonConfig):
+            SECTION_NAME = 'notunablesd'
+
+        assert NoTunables._declared_tunables() == set()
+
+    def test_inherited_fields_need_inherited_specs(self):
+        # Extending a schema: the new field needs its own spec, the inherited
+        # ones are already covered.
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Extended(SampleConfig):
+                SECTION_NAME = 'extendedd'
+
+                extra: Optional[int] = None
+
+        assert 'extra' in str(excinfo.value)
+
+    def test_extending_a_schema_with_a_spec_is_accepted(self):
+        @dataclass
+        class Extended(SampleConfig):
+            SECTION_NAME = 'extended2d'
+            FIELD_SPECS = dict(SampleConfig.FIELD_SPECS,
+                               extra=FieldSpec(caster=int, minimum=0))
+
+            extra: Optional[int] = None
+
+        cfg = Extended.resolve(platform_section={"extra": "7", "interval": 5})
+        assert cfg.extra == 7
+        assert cfg.interval == 5
+
+
+class TestLoggerIdentifier:
+    def test_identifier_defaults_to_section_name(self, quiet_logger):
+        SampleConfig._logger()
+        quiet_logger.assert_called_with('sampled_config')
+
+    def test_explicit_identifier_wins(self, quiet_logger):
+        @dataclass
+        class Named(PmonDaemonConfig):
+            SECTION_NAME = 'named'
+            SYSLOG_IDENTIFIER = 'custom_identifier'
+
+        Named._logger()
+        quiet_logger.assert_called_with('custom_identifier')
+
+    def test_one_logger_instance_per_identifier(self):
+        # Real factory: repeated lookups must not build a new SysLogger each time.
+        with mock.patch.object(pmon_daemon_config, 'SysLogger') as syslogger_cls:
+            pmon_daemon_config._LOGGERS.clear()
+            try:
+                first = REAL_GET_CONFIG_LOGGER('dedupe_test')
+                second = REAL_GET_CONFIG_LOGGER('dedupe_test')
+            finally:
+                pmon_daemon_config._LOGGERS.clear()
+        assert first is second
+        assert syslogger_cls.call_count == 1

--- a/src/sonic-py-common/tests/pmon_daemon_config_test.py
+++ b/src/sonic-py-common/tests/pmon_daemon_config_test.py
@@ -2,8 +2,10 @@
 Unit tests for PmonDaemonConfig: the shared resolver for pmon daemon tunables.
 
 Precedence under test (highest wins):
-  1. the daemon's section of pmon_daemon_control.json (hwsku file over platform file)
-  2. built-in dataclass defaults
+  1. nested subsection keys in the daemon's section of pmon_daemon_control.json
+     (hwsku file over platform file)
+  2. legacy aliases - deprecated flat section keys and top-level file keys
+  3. built-in dataclass defaults
 
 The base is exercised through small test-only subclasses so it is covered
 independently of any real daemon's schema.
@@ -12,7 +14,7 @@ import json
 import os
 import sys
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 if sys.version_info.major == 3:
@@ -22,9 +24,30 @@ else:
 
 import pytest
 
+# pmon_daemon_config imports device_info, which does a top-level
+# `from swsscommon.swsscommon import ...`. Real swsscommon bindings are present
+# in CI but absent in a plain venv, where their absence would fail collection of
+# this whole module (and can take unrelated tests down with it). Stub the module
+# with the local mock_swsscommon classes only when the real one is unavailable,
+# matching the sibling tests (device_info_test, test_security_cipher).
+try:
+    import swsscommon.swsscommon  # noqa: F401
+except ImportError:
+    import types
+
+    from .mock_swsscommon import ConfigDBConnector, SonicV2Connector
+
+    _swss_inner = types.ModuleType("swsscommon.swsscommon")
+    _swss_inner.ConfigDBConnector = ConfigDBConnector
+    _swss_inner.SonicV2Connector = SonicV2Connector
+    _swss_outer = types.ModuleType("swsscommon")
+    _swss_outer.swsscommon = _swss_inner
+    sys.modules.setdefault("swsscommon", _swss_outer)
+    sys.modules.setdefault("swsscommon.swsscommon", _swss_inner)
+
 from sonic_py_common import pmon_daemon_config
 from sonic_py_common.pmon_daemon_config import (
-    FieldSpec, PmonDaemonConfig, PMON_DAEMON_CONTROL_FILE, to_bool)
+    FieldSpec, LegacyAlias, PmonDaemonConfig, PMON_DAEMON_CONTROL_FILE, to_bool)
 
 PATHS_FN = "sonic_py_common.pmon_daemon_config.device_info.get_paths_to_platform_and_hwsku_dirs"
 
@@ -79,6 +102,35 @@ class ClampedConfig(PmonDaemonConfig):
     def _post_merge(self):
         if self.heartbeat >= self.window:
             self.heartbeat = max(1, self.window // 2)
+
+
+@dataclass
+class LeafConfig(PmonDaemonConfig):
+    """A subsection schema: it declares no SUBSECTIONS of its own."""
+
+    FIELD_SPECS = {
+        'interval': FieldSpec(caster=int, minimum=0, maximum=86400),
+        'enabled': FieldSpec(caster=to_bool),
+    }
+
+    interval: Optional[int] = None
+    enabled: Optional[bool] = None
+
+
+@dataclass
+class NestedConfig(PmonDaemonConfig):
+    """A schema with one-level subsections and legacy aliases routing into them."""
+
+    SECTION_NAME = 'nestedd'
+    SUBSECTIONS = {'group': LeafConfig, 'mgr': LeafConfig}
+    LEGACY_ALIASES = {
+        'group_interval': LegacyAlias('group.interval'),
+        'skip_mgr': LegacyAlias('mgr.enabled', scope='file',
+                                transform=lambda v: not to_bool(v)),
+    }
+
+    group: LeafConfig = field(default_factory=LeafConfig)
+    mgr: LeafConfig = field(default_factory=lambda: LeafConfig(enabled=True))
 
 
 @pytest.fixture(autouse=True)
@@ -260,6 +312,75 @@ class TestPostMergeHook:
         assert cfg.heartbeat == 40
 
 
+class TestSubsections:
+    def test_nested_dict_merges_into_subsection(self):
+        cfg = NestedConfig.resolve(platform_section={"group": {"interval": 5, "enabled": "true"}})
+        assert cfg.group.interval == 5
+        assert cfg.group.enabled is True
+
+    def test_partial_nested_dict_keeps_sibling_defaults(self):
+        cfg = NestedConfig.resolve(platform_section={"group": {"interval": 5}})
+        assert cfg.group.interval == 5
+        assert cfg.group.enabled is None
+
+    def test_subsection_default_factory_is_preserved(self):
+        # mgr's default_factory sets enabled=True; an untouched subsection keeps it.
+        cfg = NestedConfig.resolve(platform_section={})
+        assert cfg.mgr.enabled is True
+        assert cfg.group.enabled is None
+
+    def test_subsection_range_validation_applies(self):
+        cfg = NestedConfig.resolve(platform_section={"group": {"interval": -1}})
+        assert cfg.group.interval is None
+
+    def test_non_dict_subsection_keeps_defaults(self):
+        cfg = NestedConfig.resolve(platform_section={"mgr": "oops-not-an-object"})
+        assert cfg.mgr.enabled is True
+
+    def test_unknown_key_in_subsection_is_ignored(self):
+        cfg = NestedConfig.resolve(platform_section={"group": {"interval": 5, "bogus": 1}})
+        assert cfg.group.interval == 5
+        assert not hasattr(cfg.group, "bogus")
+
+
+class TestLegacyAliases:
+    def test_section_alias_routes_into_subsection(self):
+        cfg = NestedConfig.resolve(platform_section={"group_interval": 5})
+        assert cfg.group.interval == 5
+
+    def test_file_alias_reads_top_level_and_transforms(self):
+        # skip_mgr lives at the file top level, not in the daemon section, and
+        # inverts into mgr.enabled.
+        cfg = NestedConfig.resolve(platform_section={}, platform_file={"skip_mgr": True})
+        assert cfg.mgr.enabled is False
+
+    def test_nested_form_wins_over_section_alias(self):
+        cfg = NestedConfig.resolve(platform_section={
+            "group_interval": 5, "group": {"interval": 9}})
+        assert cfg.group.interval == 9
+
+    def test_nested_form_wins_over_file_alias(self):
+        cfg = NestedConfig.resolve(platform_section={"mgr": {"enabled": True}},
+                                   platform_file={"skip_mgr": True})
+        assert cfg.mgr.enabled is True
+
+    def test_section_alias_out_of_range_keeps_default(self):
+        cfg = NestedConfig.resolve(platform_section={"group_interval": -1})
+        assert cfg.group.interval is None
+
+    def test_consumed_alias_key_is_not_reported_as_unknown(self):
+        cfg = NestedConfig.resolve(platform_section={"group_interval": 5})
+        assert cfg.group.interval == 5
+        assert not hasattr(cfg, "group_interval")
+
+    def test_using_an_alias_logs_a_deprecation_warning(self):
+        logger = mock.MagicMock()
+        with mock.patch.object(pmon_daemon_config, 'get_config_logger', return_value=logger):
+            NestedConfig.resolve(platform_section={"group_interval": 5})
+        assert logger.log_warning.called
+        assert any("deprecated" in c[0][0] for c in logger.log_warning.call_args_list)
+
+
 class TestReadPlatformSection:
     def test_missing_files_yield_empty(self, tmp_path):
         platform_dir = str(tmp_path / "platform")
@@ -333,6 +454,24 @@ class TestReadPlatformSection:
         with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
             assert SampleConfig._read_platform_section() == {"interval": 30}
 
+    def test_read_platform_control_returns_section_and_whole_file(self, tmp_path):
+        # A scope='file' alias needs the sibling top-level keys, so the control
+        # read returns the whole file alongside the daemon's own section.
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"skip_mgr": True, "nestedd": {"group": {"interval": 5}}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            section, whole = NestedConfig._read_platform_control()
+        assert section == {"group": {"interval": 5}}
+        assert whole["skip_mgr"] is True
+
+    def test_read_platform_control_whole_file_available_without_section(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"skip_mgr": True})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            section, whole = NestedConfig._read_platform_control()
+        assert section == {}
+        assert whole["skip_mgr"] is True
+
 
 class TestResolveEndToEnd:
     def test_resolve_reads_from_disk(self, tmp_path):
@@ -348,6 +487,13 @@ class TestResolveEndToEnd:
             cfg = SampleConfig.resolve()
         assert cfg.interval is None
         assert cfg.enabled is False
+
+    def test_resolve_applies_file_scope_alias_from_disk(self, tmp_path):
+        platform_dir = str(tmp_path / "platform")
+        write_control_file(platform_dir, {"skip_mgr": True, "nestedd": {}})
+        with mock.patch(PATHS_FN, return_value=(platform_dir, "")):
+            cfg = NestedConfig.resolve()
+        assert cfg.mgr.enabled is False
 
 
 class TestSchemaGuard:
@@ -423,6 +569,69 @@ class TestSchemaGuard:
         cfg = Extended.resolve(platform_section={"extra": "7", "interval": 5})
         assert cfg.extra == 7
         assert cfg.interval == 5
+
+    def test_field_in_both_field_specs_and_subsections_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Both(PmonDaemonConfig):
+                SECTION_NAME = 'bothd'
+                FIELD_SPECS = {'group': FieldSpec()}
+                SUBSECTIONS = {'group': LeafConfig}
+
+                group: Optional[LeafConfig] = None
+
+        assert 'group' in str(excinfo.value)
+
+    def test_subsection_naming_no_field_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Ghost(PmonDaemonConfig):
+                SECTION_NAME = 'ghostd'
+                SUBSECTIONS = {'ghost': LeafConfig}
+
+        assert 'ghost' in str(excinfo.value)
+
+    def test_field_that_is_neither_specced_nor_subsectioned_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class Uncovered(PmonDaemonConfig):
+                SECTION_NAME = 'uncoveredd'
+
+                group: Optional[LeafConfig] = None
+
+        assert 'group' in str(excinfo.value)
+
+    def test_two_level_nesting_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class TwoLevel(PmonDaemonConfig):
+                SECTION_NAME = 'twoleveld'
+                SUBSECTIONS = {'outer': NestedConfig}  # NestedConfig has SUBSECTIONS
+
+                outer: Optional[NestedConfig] = None
+
+        assert 'one level' in str(excinfo.value)
+
+    def test_alias_target_naming_no_field_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class BadAlias(PmonDaemonConfig):
+                SECTION_NAME = 'badaliasd'
+                SUBSECTIONS = {'group': LeafConfig}
+                LEGACY_ALIASES = {'x': LegacyAlias('group.nope')}
+
+                group: LeafConfig = field(default_factory=LeafConfig)
+
+        assert 'group.nope' in str(excinfo.value)
+
+    def test_alias_target_naming_no_subsection_is_rejected(self):
+        with pytest.raises(TypeError) as excinfo:
+            @dataclass
+            class BadAlias(PmonDaemonConfig):
+                SECTION_NAME = 'badalias2d'
+                LEGACY_ALIASES = {'x': LegacyAlias('missing.field')}
+
+        assert 'missing.field' in str(excinfo.value)
 
 
 class TestLoggerIdentifier:


### PR DESCRIPTION
#### Why I did it

pmon daemon tunables are plumbed end-to-end as command-line flags. A platform sets a value in the daemon's section of `pmon_daemon_control.json`, `sonic-cfggen` loads that file while rendering `docker-pmon.supervisord.conf.j2`, the template flattens it into `--flag value`, `argparse` re-parses it, and the daemon constructor grows another parameter. Adding one knob means editing four places, and it has to be redone for every daemon.

This is not specific to one daemon. `thermalctld` carries the pattern today with five tunables, `xcvrd` carries it with several, and every future pmon tunable would repeat it.

There is a second problem the flag path leaves unsolved: nothing validates the value. A negative interval parses as a perfectly good `int`, and consumers disagree about what happens next. In `xcvrd`, `DomInfoUpdateTask` checks for a negative `dom_update_interval` and falls back to its 60s default, while `DomThermalInfoUpdateTask` never checks `poll_interval` at all — a negative value there leaves the next scheduled poll permanently in the past, so the sweep runs back-to-back with no delay. A typo like `-60` produces maximum transceiver I2C load instead of one poll per minute.

Design discussion: sonic-net/SONiC#2362 (HLD Rev 0.3).

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Added `sonic_py_common/pmon_daemon_config.py`, which owns everything that is not specific to a daemon: locating `pmon_daemon_control.json` (hwsku over platform, mirroring `docker_init.j2`), extracting the daemon's section, layering it over the built-in defaults, coercing types, validating ranges, and degrading to defaults on any error.

A daemon adopts it by declaring a dataclass subclass. Three schema options are available:

- **`FIELD_SPECS`** — per-field type coercion and inclusive `minimum`/`maximum`/`choices`. Bounds are checked after coercion, so `"-1"` is caught as well as `-1`. An unbounded field declares `FieldSpec(caster=...)` with no bounds, keeping "unbounded" an explicit choice.
- **`SUBSECTIONS`** — group related fields one level deep, each a nested `PmonDaemonConfig` subclass with its own `FIELD_SPECS`. `__init_subclass__` enforces that a field is either a scalar or a subsection group (not both), that every subsection is a `PmonDaemonConfig` subclass, and that subsections are exactly one level deep.
- **`LEGACY_ALIASES`** — route a deprecated flat or top-level key to its new (possibly nested) target for a compatibility window. `LegacyAlias(target, scope, transform)` supports an optional value transform; aliases are applied before the nested form is merged and never overwrite an explicit nested value (`setdefault` gives the nested key precedence). A used alias logs a deprecation warning.

Example schema:

```python
@dataclass
class DomConfig(PmonDaemonConfig):
    SECTION_NAME = 'dom'
    FIELD_SPECS = {'update_interval': FieldSpec(caster=int, minimum=0, maximum=86400)}
    update_interval: Optional[int] = None

@dataclass
class XcvrdConfig(PmonDaemonConfig):
    SECTION_NAME = 'xcvrd'
    SUBSECTIONS = {'dom': DomConfig}
    LEGACY_ALIASES = {'dom_update_interval': LegacyAlias('dom.update_interval')}
    dom: DomConfig = field(default_factory=DomConfig)
```

Adoption is per-daemon and independent — a daemon that has not migrated is unaffected.

Supporting details:

- **`to_bool`** exists because `bool()` cannot be a caster for boolean tunables: `bool("false")` is `True`, so a platform writing the string `"false"` would enable the feature it meant to turn off.
- **`resolve()`** accepts an optional `platform_file`, and `_read_platform_control()` returns `(section, whole_file)` so a `scope='file'` alias can read a sibling top-level key.
- **`_merge_subsection()`** merges into the default-factory subsection so per-subsection defaults survive an omitted key.
- Nothing here raises on *input*. An unreadable file, a malformed section, an uncoercible value, or an out-of-range value keeps the built-in default and logs a warning, so a bad tunable can never keep a pmon daemon down.

**Scope of this PR:** `sonic_py_common` only — the resolver plus its unit tests. There is no in-tree consumer yet and no behavior change to any existing daemon. The `docker-pmon.supervisord.conf.j2` template change is intentionally **not** part of this PR; it is carried by sonic-net/sonic-buildimage#28306, which lands together with the xcvrd flag removal in sonic-net/sonic-platform-daemons#854. The first adopter (#854) imports from here and therefore needs this to merge first.

#### How to verify it

```
cd src/sonic-py-common
pytest tests/pmon_daemon_config_test.py
```

`pmon_daemon_config_test.py` (76 test functions) covers defaults and overrides, coercion, inclusive range boundaries, `choices`, `to_bool` spellings (including `"false"` → `False`), the schema guards (scalar-vs-subsection, one-level nesting, alias targets), subsection merging with per-subsection defaults, legacy alias routing/precedence and transform failures, section isolation between two schemas, hwsku-over-platform file precedence, and every degradation path (missing file, malformed JSON, non-dict section, empty directory entry, `device_info` failure).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Not applicable — this is a new feature, not a fix.

#### Tested branch

- [x] master

#### Test result

master: `pytest tests/pmon_daemon_config_test.py` → all passed.

#### Description for the changelog

Add a shared `PmonDaemonConfig` resolver (with nested subsections and legacy key aliasing) so pmon daemons can read validated runtime tunables from their `pmon_daemon_control.json` section instead of command-line flags.

#### Link to config_db schema for YANG module changes

N/A — no YANG or Config DB changes. Tunables are sourced from the per-platform `pmon_daemon_control.json`, not from Config DB.
