### PR TITLE
[Mellanox] Link libsai with -Wl,-Bsymbolic to prevent SAI metadata preemption

### DIFF
--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -10,7 +10,7 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	wget -c $(MLNX_SAI_SOURCE_BASE_URL)/$(MLNX_SAI_VERSION).tar.gz -O - | tar -xz
 	pushd mlnx_sai
 
-	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG"' -us -uc -d -b
+	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-Bsymbolic"' -us -uc -d -b
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/


### PR DESCRIPTION
#### Why I did it

`libsai.so` and SONiC's `libsaimetadata.so` both define the SAI metadata symbols. `syncd` lists `libsaimetadata.so` ahead of `libsai.so` in `DT_NEEDED`, so ELF global symbol resolution makes SONiC's definitions preempt the vendor library's own — including for the vendor library's *internal* references.

Where the two disagree, the vendor library then sizes buffers from SONiC's view while writing its own. For `sai_acl_bind_point_type_t` that is 5 vs 6 values: a 20-byte allocation followed by a 24-byte access, i.e. a heap-buffer-overflow on ACL table create. Under ASAN this aborts `syncd`; without ASAN it is silent heap corruption.

#### How I did it

Link `libsai.so` with `-Wl,-Bsymbolic`, so its intra-library references bind to its own definitions instead of resolving through the global scope.

Plain `-Bsymbolic`, **not** `-Bsymbolic-functions`: the metadata is data, and `-functions` was tested and does not fix it.

#### How to verify it

Binary level, on the produced `mlnx-sai` deb:

```
readelf -d usr/lib/libsai.so.0.0.0 | grep -i symbolic
# before: no DT_FLAGS      after: FLAGS  SYMBOLIC

readelf -rW usr/lib/libsai.so.0.0.0 | grep -c sai_metadata_enum_sai_acl_bind_point_type_t
# before: 4                after: 0
```

Runtime, on an ASAN image on a non-Spectrum-1 switch:

```
sudo config acl add table TEST L3 -p Ethernet0 -s ingress
ls /var/log/asan/
```

**Before:** `syncd` is killed and an ASAN report appears — `heap-buffer-overflow`, `READ of size 24`, `0 bytes after 20-byte region`, through `check_attribs_metadata` / `mlnx_create_acl_table`.

**After:** `syncd` survives, no ASAN report, and the ACL table reaches `Active`.

Verified on Spectrum-3. Spectrum-1 does not reproduce — the extra bind-point entries are written only on later ASIC generations. Re-verified with a second port, a MIRROR table, and repeated delete/recreate cycles.

The metadata mismatch is still 5 vs 6 on the fixed image, so the difference is attributable to the link flag alone.

#### Notes

This is containment, not a schema fix. The two metadata copies still differ, so the vendor library will report values SONiC's metadata cannot name. Those degrade to numeric serialization with a warning on each side of the channel, return `SAI_STATUS_SUCCESS`, and are not consumed by anything today — the same pattern that already exists for other custom-range enums. Aligning the generated metadata with the vendor headers is the only change that removes the divergence.

The equivalent upstream form is a single `target_link_options` on the `sai_shared` target in the SAI build, which is narrower than the flag used here — this change applies the flag to every shared library produced by that build.
