### PR TITLE
[docker-ptf]: Remove vulnerable bundled pip from InfluxDB

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -160,9 +160,9 @@ RUN set -eux \
     && ln -sf /usr/local/bin/influxdb3 /usr/local/bin/influxd \
     && rm -f "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \
-    && pip3 install --target /usr/local/lib/influxdb3-python/lib/python3.13/site-packages "pip>=26.1" \
-    && NEWPIP=$(ls -d /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info | sort -V | tail -1) \
-    && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} +
+    && rm -rf /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip \
+        /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info \
+    && rm -f /usr/local/lib/influxdb3-python/bin/pip*
 {% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}


### PR DESCRIPTION
#### Why I did it

The docker-ptf vulnerability scan reports the following Python package vulnerabilities from the Python runtime bundled with InfluxDB 3 Core:

- `msgpack` 1.1.2: GHSA-6v7p-g79w-8964
- `setuptools` 70.3.0: CVE-2025-47273
- `setuptools` 70.3.0: CVE-2026-59890

These packages are vendored inside the bundled `pip` package. The current `pip>=26.1` target installation does not replace the existing `pip` directory, and current pip releases still vendor these affected versions.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Removed the bundled `pip` package, distribution metadata, and entry points after installing the InfluxDB runtime. The embedded Python runtime and shared library remain available for InfluxDB itself.

The sonic-mgmt HFT test only uses `influxdb3 serve`, database creation, and HTTP write/query operations. It does not use InfluxDB Processing Engine plugin package installation.

#### How to verify it

1. Build `docker-ptf`.
2. Run the Trivy Python vulnerability scan and confirm the three findings above are absent.
3. Run the sonic-mgmt HFT end-to-end InfluxDB test.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [x] 202611

The `202511` and `202605` branches contain the same vulnerable InfluxDB pip installation block. Please also cherry-pick this fix to `202611` when that release branch becomes available.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - Trivy vulnerability remediation
Failure type: other - vulnerable vendored Python dependencies

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] 202611
- [ ] N/A

#### Test result

- Extracted the exact InfluxDB 3 Core 3.9.0 archive used by docker-ptf and confirmed the vulnerable versions were under `pip/_vendor`.
- Removed the bundled pip package and entry points.
- Successfully started InfluxDB, passed its health check, created a database, wrote HFT-style line protocol data, and queried the data through the InfluxQL endpoint.
- Full docker-ptf build and Trivy image scan will run in PR CI.

#### Description for the changelog

Remove unused bundled InfluxDB pip components that contain vulnerable vendored Python dependencies.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
