### PR TITLE
Downgrade containerd.io to 1.7.27-1 to fix bgp wedge after config-reload

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -28,7 +28,7 @@ CONFIGURED_ARCH=$([ -f .arch ] && cat .arch || echo amd64)
 
 ## docker engine version (with platform)
 DOCKER_VERSION=5:28.5.2-1~debian.13~$IMAGE_DISTRO
-CONTAINERD_IO_VERSION=1.7.28-2~debian.13~$IMAGE_DISTRO
+CONTAINERD_IO_VERSION=1.7.27-1
 LINUX_KERNEL_VERSION=6.12.41+deb13
 
 ## Working directory to prepare the file system

--- a/files/build/versions-public/host-image/versions-deb-trixie
+++ b/files/build/versions-public/host-image/versions-deb-trixie
@@ -22,7 +22,7 @@ ca-certificates==20250419
 cgroup-tools==3.1.0-2+b2
 chrony==4.6.1-3+deb13u2
 conntrack==1:1.4.8-2
-containerd.io==1.7.28-2~debian.13~trixie
+containerd.io==1.7.27-1
 cpio==2.15+dfsg-2
 cpp==4:14.2.0-1
 cpp-14==14.2.0-19


### PR DESCRIPTION
## Problem

After `config reload`, the bgp container becomes permanently inaccessible via `docker exec` with:

```
OCI runtime exec failed: error starting setns process: fork/exec /proc/self/fd/N: no such file or directory
```

This is a race condition during container teardown: bgp overruns dockerd's stop grace periods, causing dockerd to abandon the stop with the containerd task still in "running" state. When SONiC's same-ID `docker start` reuses the old container ID, it collides with the stale task (`cannot delete running task: failed precondition`), leaving the container permanently wedged.

## Root Cause

The regression was introduced between containerd.io `1.7.27-1` and `1.7.28-0`. With `1.7.28+`, after `context deadline exceeded`, containerd leaves the task in a stale "running" state that causes the collision on restart. With `1.7.27-1`, containerd recovers cleanly after the deadline and the wedge does not occur.

## Fix

Downgrade `containerd.io` from `1.7.28-2` to `1.7.27-1`.

## Evidence

Tested under full sonic-mgmt regression with `1.7.27-1`:
- `docker exec bgp echo ok` succeeded across all observed config reloads
- Zero `setns … no such file or directory` in syslog (across all rotated logs)
- Zero `cannot delete running task` in syslog
- `context deadline exceeded` still occurs (bgp still overruns the kill grace) but containerd recovers cleanly — confirming the fix is in containerd's post-deadline task cleanup, not in the timeout path itself

Confirmed reproducing versions: `1.7.28-2`, `2.2.5-1`.