### PR TITLE
[docker-macsec] Clarify the profile-in-use error on profile deletion

### DIFF
--- a/dockers/docker-macsec/cli/config/plugins/macsec.py
+++ b/dockers/docker-macsec/cli/config/plugins/macsec.py
@@ -192,7 +192,8 @@ def del_profile( profile):
     for port in config_db.get_keys('PORT'):
         attr = config_db.get_entry('PORT', port)
         if 'macsec' in attr and attr['macsec'] == profile:
-            ctx.fail("{} is being used by port {}, Please remove the MACsec from the port firstly".format(profile, port))
+            ctx.fail("{} is in use by port {}. You must remove the profile from the interface "
+                     "before deleting.".format(profile, port))
 
     config_db.set_entry("MACSEC_PROFILE", profile, None)
 


### PR DESCRIPTION
#### Why I did it

The error raised when deleting a MACsec profile that is still bound to a port reads:

```
MACSEC_PROFILE_X is being used by port Ethernet32, Please remove the MACsec from the port firstly
```

The grammar is awkward and the phrasing ("remove the MACsec") is imprecise about what the operator must actually do (unbind the profile from the interface). Documentation quoting this message reads poorly.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Reworded the `ctx.fail` string in `dockers/docker-macsec/cli/config/plugins/macsec.py` to:

```
MACSEC_PROFILE_X is in use by port Ethernet32. You must remove the profile from the interface before deleting.
```

Message text only — no control-flow or return-code change; the command still aborts before `set_entry`.

#### How to verify it

- `config macsec profile del <profile>` while the profile is attached to a port emits the new message and still fails the command.
- No test in-tree asserts on the old wording (grepped `*.py`/`*.md`).

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

- [ ] <!-- image version 1 -->

#### Description for the changelog

Clarify the error message shown when deleting a MACsec profile that is still bound to a port.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

