### PR TITLE
buffers_config.j2: fall back to 'def' postfix when hwsku lacks topology-specific buffer defaults

### DIFF
--- a/files/build_templates/buffers_config.j2
+++ b/files/build_templates/buffers_config.j2
@@ -40,7 +40,11 @@ def
 
 {# Allow includer to pre-package defs without needing an import #}
 {%- if defs is not defined -%}
-    {# Import default values from device HWSKU folder #}
+    {# Import default values from device HWSKU folder, falling back to the #}
+    {# generic 'def' postfix if the hwsku doesn't ship a topology-specific file #}
+    {%- if not template_exists('buffers_defaults_%s.j2' % filename_postfix) -%}
+        {%- set filename_postfix = 'def' %}
+    {%- endif -%}
     {%- import 'buffers_defaults_%s.j2' % filename_postfix as defs with context %}
     {%- set default_cable = defs.default_cable -%}
 {%- endif -%}


### PR DESCRIPTION
### Description of PR
`UpperRegionalHub`/`LowerRegionalHub` device type maps to `filename_postfix='t2'`, but hwskus like `Force10-S6000` (used for URH/DRH KVM testbeds) only ship `buffers_defaults_t0.j2`/`t1.j2`/`def.j2`, not a `t2` variant. This caused an unhandled `jinja2.exceptions.TemplateNotFound` during `config load_minigraph` -> `config qos reload`, crashing `deploy-mg` entirely on these hwskus.

Mirrors the existing `template_exists()` fallback pattern already used by `qos_config.j2`: when `buffers_defaults_<postfix>.j2` doesn't exist for the device's hwsku, fall back to `buffers_defaults_def.j2` instead of crashing.

### Motivation and context
Companion fix for a new native URH KVM testbed being added in `sonic-mgmt` (sonic-net/sonic-mgmt PR pending, will cross-link once opened) — that testbed cannot deploy config on the `Force10-S6000` KVM hwsku without this fallback.

### Type of change
- [x] Bug fix

### Test
Verified on a live KVM testbed: `config load_minigraph --override_config -y` previously failed with `TemplateNotFound` for `Force10-S6000` + `UpperRegionalHub`; with this fix `deploy-mg` completes cleanly end-to-end (all 6 BGP neighbors Established, ~102k route full-table convergence).