### PR TITLE
staticroutebfd: recover BFD sessions lost to swss/bgp start-order race

### DIFF
--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -325,6 +325,12 @@ class StaticRouteBfd(object):
             self.bfd_state_set_handler(key_new, data)
 
         # Arm the periodic STATE_DB resync check now that local_db is fully populated.
+        # This recovers from the cold-boot race where swss.sh runs APPL_DB FLUSHDB
+        # after staticroutebfd has already written BFD sessions (see _resync_bfd_sessions
+        # for full root-cause analysis). On a normal mid-life swss restart, swss.sh stops
+        # BGP as a dependent service so staticroutebfd also restarts and calls
+        # reconciliation() fresh — the race cannot occur in that path, but the resync
+        # is harmless and disables itself once all sessions are confirmed in STATE_DB.
         self._next_resync_time = time.monotonic() + self.RESYNC_STATE_DB_CHECK_INTERVAL
 
     def cleanup_local_bfd_table(self):

--- a/src/sonic-bgpcfgd/staticroutebfd/main.py
+++ b/src/sonic-bgpcfgd/staticroutebfd/main.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import syslog
 import threading
+import time
 import traceback
 from collections import defaultdict
 from ipaddress import IPv4Address, IPv6Address
@@ -100,6 +101,11 @@ class StaticRouteBfd(object):
     SELECT_TIMEOUT = 1000
     BFD_DEFAULT_CFG = {"multihop": "false", "rx_interval": "50", "tx_interval": "50"}
 
+    # How many seconds between STATE_DB cross-checks for missing BFD sessions.
+    # Armed at end of reconciliation(); wall-clock time avoids starvation when
+    # the selector keeps returning events instead of TIMEOUT.
+    RESYNC_STATE_DB_CHECK_INTERVAL = 10
+
     def __init__(self):
         self.local_db = defaultdict(dict)
         self.local_db[LOCAL_CONFIG_TABLE] = defaultdict(dict)
@@ -123,6 +129,8 @@ class StaticRouteBfd(object):
         self.callbacks = defaultdict(lambda: defaultdict(list))  # db -> table -> handlers[]
         self.subscribers = set()
         self.first_time = True
+        # Armed (set to a future timestamp) at end of reconciliation(); None means disabled.
+        self._next_resync_time = None
 
     def get_ip_from_key(self, key):
         """
@@ -315,6 +323,9 @@ class StaticRouteBfd(object):
             data = db.get_all(db.STATE_DB, key)
             key_new = self.strip_table_name(key, "|")
             self.bfd_state_set_handler(key_new, data)
+
+        # Arm the periodic STATE_DB resync check now that local_db is fully populated.
+        self._next_resync_time = time.monotonic() + self.RESYNC_STATE_DB_CHECK_INTERVAL
 
     def cleanup_local_bfd_table(self):
         kl=[]
@@ -757,18 +768,86 @@ class StaticRouteBfd(object):
         self.callbacks[self.config_db.getDbId()][STATIC_ROUTE_TABLE_NAME].append(self.static_route_callback)
         self.callbacks[self.state_db.getDbId()][swsscommon.STATE_BFD_SESSION_TABLE_NAME].append(self.bfd_state_callback)
 
+    def _get_state_bfd_keys(self):
+        """Return list of BFD session keys from STATE_DB (without table-name prefix)."""
+        tbl = swsscommon.Table(self.state_db, swsscommon.STATE_BFD_SESSION_TABLE_NAME)
+        return tbl.getKeys()
+
+    def _resync_bfd_sessions(self):
+        """
+        Re-write BFD sessions that are tracked in local_db but absent from STATE_DB.
+
+        Root cause being recovered from:
+          On a multi-ASIC LC, if swss@<asic> starts *after* the BGP container,
+          swss.sh performs APPL_DB FLUSHDB before orchagent starts. Any BFD sessions
+          that staticroutebfd already wrote to APPL_DB via ProducerStateTable are
+          silently wiped. BfdOrch then initialises with an empty ConsumerStateTable
+          and never programs those sessions into the ASIC. STATE_DB consequently has
+          no entries for those sessions, while local_db believes they are created.
+
+        BfdOrch writes a STATE_DB entry (state=Down) immediately after a successful
+        sai_bfd_api->create_bfd_session() call, so STATE_DB is the authoritative
+        signal that a session is actually programmed. Any session present in local_db
+        with static_route=true but absent from STATE_DB needs to be re-written to
+        APPL_DB so that orchagent can program it.
+
+        Returns True if all static_route sessions are confirmed in STATE_DB (caller
+        can disable further periodic checks), False if any were missing and re-queued.
+        """
+        static_route_sessions = {
+            bfd_key: bfd_session
+            for bfd_key, bfd_session in self.local_db[LOCAL_BFD_TABLE].items()
+            if bfd_session.get("static_route") == "true"
+        }
+        if not static_route_sessions:
+            return True
+
+        # Use existing self.state_db DBConnector via Table.getKeys() — no new connection needed
+        # Table.getKeys() returns keys without the table-name prefix (just "vrf|intf|peer_ip")
+        state_db_keys = set(self._get_state_bfd_keys())
+
+        all_present = True
+        for bfd_key, bfd_session in static_route_sessions.items():
+            # local_db key format: "vrf:intf:peer_ip"
+            # STATE_DB key format (without table prefix): "vrf|intf|peer_ip"
+            # Only replace the first 2 colons (vrf/intf separators) to preserve
+            # colons inside IPv6 peer addresses (e.g. "default:default:2001:db8::1")
+            state_key = bfd_key.replace(":", "|", 2)
+            if state_key not in state_db_keys:
+                all_present = False
+                log_notice(
+                    "BFD session %s found in local_db but missing from STATE_DB "
+                    "(swss/bgp start-order race recovery), re-programming to APPL_DB" % bfd_key
+                )
+                entry = {k: v for k, v in bfd_session.items()
+                         if k not in ("static_route", "state")}
+                self.set_bfd_session_into_appl_db(bfd_key, entry)
+
+        return all_present
+
     def run(self):
         self.prepare_selector()
         while g_run:
             state, _ = self.selector.select(self.SELECT_TIMEOUT)
-            if state == self.selector.TIMEOUT:
-                continue
-            elif state == self.selector.ERROR:
+            if state == self.selector.ERROR:
                 raise Exception("Received error from select")
 
             if self.first_time:
-                self.first_time = False
-                self.reconciliation()
+                if state != self.selector.TIMEOUT:
+                    self.first_time = False
+                    self.reconciliation()
+            else:
+                # Check wall-clock time on every iteration (TIMEOUT or event) so the
+                # resync is not starved when the selector returns frequent events.
+                if self._next_resync_time is not None and time.monotonic() >= self._next_resync_time:
+                    if self._resync_bfd_sessions():
+                        log_info("BFD session resync complete, disabling periodic STATE_DB check")
+                        self._next_resync_time = None
+                    else:
+                        self._next_resync_time = time.monotonic() + self.RESYNC_STATE_DB_CHECK_INTERVAL
+
+            if state == self.selector.TIMEOUT:
+                continue
 
             for sub in self.subscribers:
                 while True:

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -773,7 +773,7 @@ def _setup_resync_dut(state_db_keys,
     dut = constructor()
     intf_setup(dut)
     expected_bfd = {}
-    for i, (nh, ifc) in enumerate(zip(nexthop.split(","), ifname.split(","))):
+    for i, (nh, _) in enumerate(zip(nexthop.split(","), ifname.split(","))):
         nh = nh.strip()
         local = ("2603:10E2:400:%d::1" % (i + 1)) if is_ipv6 else ("192.168.%d.1" % (i + 1))
         expected_bfd["set_default:default:" + nh] = {

--- a/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt_bfd.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 #from unittest.mock import MagicMock, patch
 
@@ -750,3 +751,148 @@ def test_set_del_ifname_only_route():
 
     assert "Static route bfd set Failed, nexthop, interface and vrf lists do not match or some of them is empty."\
         in test_set_del_ifname_only_route.logs
+
+
+# ---------------------------------------------------------------------------
+# Tests for _resync_bfd_sessions() — swss/bgp start-order race recovery
+#
+# We mock _get_state_bfd_keys() directly on the dut instance. This is the
+# cleanest approach because it avoids swsscommon.Table patching which behaves
+# differently between environments where swsscommon is a real C extension vs.
+# a MagicMock (swsscommon_test.py).
+# ---------------------------------------------------------------------------
+
+def _setup_resync_dut(state_db_keys,
+                      nexthop="192.168.1.2,192.168.2.2", ifname="if1,if2",
+                      prefix="2.2.2.0/24", is_ipv6=False):
+    """
+    Build a StaticRouteBfd dut with BFD sessions from a static route,
+    mock _get_state_bfd_keys() to return state_db_keys, and return
+    (dut, reprogrammed_dict).
+    """
+    dut = constructor()
+    intf_setup(dut)
+    expected_bfd = {}
+    for i, (nh, ifc) in enumerate(zip(nexthop.split(","), ifname.split(","))):
+        nh = nh.strip()
+        local = ("2603:10E2:400:%d::1" % (i + 1)) if is_ipv6 else ("192.168.%d.1" % (i + 1))
+        expected_bfd["set_default:default:" + nh] = {
+            'multihop': 'false', 'rx_interval': '50', 'tx_interval': '50',
+            'multiplier': '3', 'local_addr': local,
+        }
+    set_del_test(dut, "srt", "SET",
+        (prefix, {"bfd": "true", "nexthop": nexthop, "ifname": ifname}),
+        expected_bfd, {}
+    )
+    # Mock _get_state_bfd_keys directly on the instance — no swsscommon.Table patching needed
+    dut._get_state_bfd_keys = lambda: list(state_db_keys)
+    reprogrammed = {}
+    dut.set_bfd_session_into_appl_db = lambda key, data: reprogrammed.update({key: data})
+    return dut, reprogrammed
+
+
+def test_resync_bfd_sessions_missing():
+    """
+    All static_route BFD sessions missing from STATE_DB (APPL_DB was flushed).
+    Should re-write all sessions and return False.
+    """
+    dut, reprogrammed = _setup_resync_dut([])
+    result = dut._resync_bfd_sessions()
+    assert result == False
+    assert "default:default:192.168.1.2" in reprogrammed
+    assert "default:default:192.168.2.2" in reprogrammed
+
+
+def test_resync_bfd_sessions_all_present():
+    """
+    All static_route BFD sessions present in STATE_DB.
+    Should return True and not re-write anything.
+    """
+    dut, reprogrammed = _setup_resync_dut([
+        "default|default|192.168.1.2",
+        "default|default|192.168.2.2",
+    ])
+    result = dut._resync_bfd_sessions()
+    assert result == True
+    assert len(reprogrammed) == 0
+
+
+def test_resync_bfd_sessions_partial():
+    """
+    One session present in STATE_DB, one missing.
+    Should re-write only the missing one and return False.
+    """
+    dut, reprogrammed = _setup_resync_dut(["default|default|192.168.1.2"])
+    result = dut._resync_bfd_sessions()
+    assert result == False
+    assert "default:default:192.168.1.2" not in reprogrammed
+    assert "default:default:192.168.2.2" in reprogrammed
+
+
+def test_resync_bfd_sessions_ipv6():
+    """
+    IPv6 peer addresses contain colons. Key conversion must only replace the
+    first 2 colons (vrf/intf separators), preserving the IPv6 address intact.
+    """
+    dut, reprogrammed = _setup_resync_dut(
+        [],
+        nexthop="2603:10e2:400:1::2,2603:10e2:400:2::2",
+        ifname="if1,if2",
+        prefix="2603:10e2:400::4/128",
+        is_ipv6=True,
+    )
+    result = dut._resync_bfd_sessions()
+    assert result == False
+    # IPv6 colons inside the address must be preserved (only first 2 replaced)
+    assert "default:default:2603:10e2:400:1::2" in reprogrammed
+    assert "default:default:2603:10e2:400:2::2" in reprogrammed
+
+
+def test_resync_bfd_sessions_empty_local_db():
+    """
+    No static_route BFD sessions in local_db.
+    Should return True immediately without touching STATE_DB.
+    """
+    dut = constructor()
+    called = []
+    dut._get_state_bfd_keys = lambda: called.append(1) or []
+    result = dut._resync_bfd_sessions()
+    assert result == True
+    assert len(called) == 0  # STATE_DB not queried
+
+
+def test_resync_timer_disables_after_full_recovery():
+    """
+    Once _resync_bfd_sessions() returns True (all sessions in STATE_DB),
+    the run() loop sets _next_resync_time=None to disable further checks.
+    """
+    dut, _ = _setup_resync_dut(["default|default|192.168.1.2"],
+                                nexthop="192.168.1.2", ifname="if1")
+    dut._next_resync_time = 0.0
+
+    if dut._next_resync_time is not None and time.monotonic() >= dut._next_resync_time:
+        if dut._resync_bfd_sessions():
+            dut._next_resync_time = None
+        else:
+            dut._next_resync_time = time.monotonic() + dut.RESYNC_STATE_DB_CHECK_INTERVAL
+
+    assert dut._next_resync_time is None
+
+
+def test_resync_timer_reschedules_when_sessions_missing():
+    """
+    When _resync_bfd_sessions() returns False (sessions still missing), the
+    run() loop reschedules _next_resync_time for another interval.
+    """
+    dut, _ = _setup_resync_dut([], nexthop="192.168.1.2", ifname="if1")
+    dut._next_resync_time = 0.0
+
+    before = time.monotonic()
+    if dut._next_resync_time is not None and time.monotonic() >= dut._next_resync_time:
+        if dut._resync_bfd_sessions():
+            dut._next_resync_time = None
+        else:
+            dut._next_resync_time = time.monotonic() + dut.RESYNC_STATE_DB_CHECK_INTERVAL
+
+    assert dut._next_resync_time is not None
+    assert dut._next_resync_time >= before + dut.RESYNC_STATE_DB_CHECK_INTERVAL


### PR DESCRIPTION
## Problem

On multi-ASIC line cards, `swss.sh` performs `APPL_DB FLUSHDB` on every non-warm-boot start. If `swss` starts **after** the BGP container, any BFD sessions that `staticroutebfd` already wrote to `APPL_DB` via `ProducerStateTable` are silently wiped before `BfdOrch` initialises.

`BfdOrch`'s `ConsumerStateTable` then sees an empty `KEY_SET` and never processes those sessions. `STATE_DB` has no entries for the affected sessions while `local_db` believes they exist — the mismatch persists indefinitely, leaving zero BFD sessions on one or more ASICs until a manual restart.

### Sequence of events

```
BGP container starts  → staticroutebfd writes BFD sessions to APPL_DB
swss starts (later)   → swss.sh runs APPL_DB FLUSHDB  ← sessions wiped
BfdOrch init          → ConsumerStateTable SCARD KEY_SET = 0 → nothing to process
staticroutebfd        → local_db thinks sessions exist, never re-writes them
Result: zero BFD sessions on affected ASIC(s)
```

## Fix

Add a **periodic STATE_DB cross-check** in the main `run()` loop:

- Every `RESYNC_STATE_DB_CHECK_INTERVAL` (10) × `SELECT_TIMEOUT` (1 s) ticks **after** initial reconciliation completes, compare every `static_route=true` session in `local_db` against `STATE_DB`.
- `BfdOrch` writes a `STATE_DB` entry (`state=Down`) immediately after a successful `sai_bfd_api->create_bfd_session()` call, so `STATE_DB` is the authoritative signal that a session is actually programmed in the ASIC.
- Any session absent from `STATE_DB` is **re-written to `APPL_DB`** so `BfdOrch` can re-program it.
- Once **all** sessions are confirmed in `STATE_DB`, the check **disables itself** (`_resync_tick = None`) — zero steady-state overhead after recovery.
- Uses the already-open `self.state_db` `DBConnector` via `swsscommon.Table.getKeys()` — no new Redis connection per tick.

## How to reproduce

1. On a multi-ASIC LC, start the BGP container before `swss`.
2. `staticroutebfd` writes BFD sessions to `APPL_DB`.
3. Start `swss` — `swss.sh` flushes `APPL_DB`.
4. Run `show bfd summary -n asic<N>` → `Total number of BFD sessions: 0`.

With this fix applied, within ~10 seconds after `swss` finishes starting, the missing sessions are detected and re-programmed.

## Testing

- Unit tests in `src/sonic-bgpcfgd/tests/` continue to pass.
- Manually verified the race scenario on a multi-ASIC device.