### PR TITLE
Fix PASSWD_CMDS patterns in sudoers

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -51,7 +51,17 @@ Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
                               /usr/local/bin/config snmp community add *, \
                               /usr/local/bin/config snmp community del *, \
                               /usr/local/bin/config snmp community replace * *, \
-                              /usr/sbin/chpasswd *
+                              /usr/sbin/chpasswd *, \
+                              /usr/bin/sudo config tacacs passkey *, \
+                              /usr/bin/sudo config radius passkey *, \
+                              /usr/bin/sudo config snmp community add *, \
+                              /usr/bin/sudo config snmp community del *, \
+                              /usr/bin/sudo config snmp community replace * *, \
+                              /usr/bin/sudo /usr/local/bin/config tacacs passkey *, \
+                              /usr/bin/sudo /usr/local/bin/config radius passkey *, \
+                              /usr/bin/sudo /usr/local/bin/config snmp community add *, \
+                              /usr/bin/sudo /usr/local/bin/config snmp community del *, \
+                              /usr/bin/sudo /usr/local/bin/config snmp community replace * *
 
 # User privilege specification
 root    ALL=(ALL:ALL) ALL

--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -19,8 +19,8 @@ Subject: [PATCH] Remove user secret from accounting log.
  unittest/mock.h          |  17 +++
  unittest/mock_helper.c   |  65 ++++++++++
  unittest/mock_helper.h   |  48 ++++++++
- unittest/password_test.c | 199 +++++++++++++++++++++++++++++++
- unittest/sudoers         |   5 +
+ unittest/password_test.c | 215 +++++++++++++++++++++++++++++++++
+ unittest/sudoers         |   7 +
  17 files changed, 941 insertions(+), 4 deletions(-)
  create mode 100644 password.c
  create mode 100644 password.h
@@ -974,7 +974,7 @@ index 0000000..606ecc5
 +
 +    release_password_setting();
 +
-+    CU_ASSERT_EQUAL(loaded_regex_count, 4);
++    CU_ASSERT_EQUAL(loaded_regex_count, 6);
 +}
 +
 +/* Test convert setting string to regex string*/
@@ -1042,6 +1042,20 @@ index 0000000..606ecc5
 +
 +    debug_printf("Fixed command: %s\n", result_buffer);
 +    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/sbin/unfinishedcommand ********** ,");
++
++    /* sudo short form: sudo config tacacs passkey KEY */
++    snprintf(result_buffer, sizeof(result_buffer), "%s", "/usr/bin/sudo config tacacs passkey testsecret");
++    remove_password(result_buffer);
++
++    debug_printf("Fixed command: %s\n", result_buffer);
++    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/bin/sudo config tacacs passkey **********");
++
++    /* sudo long form: sudo /usr/local/bin/config tacacs passkey KEY */
++    snprintf(result_buffer, sizeof(result_buffer), "%s", "/usr/bin/sudo /usr/local/bin/config tacacs passkey testsecret");
++    remove_password(result_buffer);
++
++    debug_printf("Fixed command: %s\n", result_buffer);
++    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/bin/sudo /usr/local/bin/config tacacs passkey **********");
 +
 +    /* Regular command not change */
 +    snprintf(result_buffer, sizeof(result_buffer), "%s", "command no password");
@@ -1142,7 +1156,9 @@ index 0000000..4e36873
 +
 +Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
 +                              /usr/sbin/unfinished\
-+command * \, ,/usr/sbin/chpasswd *   , /usr/sbin/setpasswd *
++command * \, ,/usr/sbin/chpasswd *   , /usr/sbin/setpasswd *, \
++                              /usr/bin/sudo config tacacs passkey *, \
++                              /usr/bin/sudo /usr/local/bin/config tacacs passkey *
 \ No newline at end of file
 -- 
 2.17.1.windows.2

--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -17,7 +17,7 @@ Subject: [PATCH] Remove user secret from accounting log.
  trace.h                  |  10 ++
  unittest/Makefile        |  21 ++++
  unittest/mock.h          |  17 +++
- unittest/mock_helper.c   |  65 ++++++++++
+ unittest/mock_helper.c   |  68 ++++++++++
  unittest/mock_helper.h   |  48 ++++++++
  unittest/password_test.c | 215 +++++++++++++++++++++++++++++++++
  unittest/sudoers         |   7 +
@@ -805,7 +805,7 @@ new file mode 100644
 index 0000000..cd6433d
 --- /dev/null
 +++ b/unittest/mock_helper.c
-@@ -0,0 +1,65 @@
+@@ -0,0 +1,68 @@
 +/* mock_helper.c -- mock helper for bash plugin UT. */
 +#include <stdarg.h>
 +#include <stdio.h>
@@ -871,6 +871,9 @@ index 0000000..cd6433d
 +    debug_printf("MOCK: free memory count: %d\n", memory_allocate_count);
 +    free(ptr);
 +}
++
++/* Provide tacacs_ctrl for unit test linking */
++int tacacs_ctrl = 0;
 \ No newline at end of file
 diff --git a/unittest/mock_helper.h b/unittest/mock_helper.h
 new file mode 100644
@@ -932,7 +935,7 @@ new file mode 100644
 index 0000000..606ecc5
 --- /dev/null
 +++ b/unittest/password_test.c
-@@ -0,0 +1,199 @@
+@@ -0,0 +1,213 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <string.h>
@@ -1151,7 +1154,7 @@ new file mode 100644
 index 0000000..4e36873
 --- /dev/null
 +++ b/unittest/sudoers
-@@ -0,0 +1,5 @@
+@@ -0,0 +1,7 @@
 +# test file for read user secret setting
 +
 +Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \


### PR DESCRIPTION
#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

Fix a bug in `/etc/sudoers` where `PASSWD_CMDS` did not match all invocation forms of the listed commands.

#### How I did it

Added missing command patterns to `PASSWD_CMDS` in `/etc/sudoers`. Updated `audisp-tacplus` unit tests to cover the additional patterns.

#### How to verify it

Unit tests in `src/tacacs/audisp/audisp-tacplus/unittest/` pass with the updated patterns.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master
- [ ] N/A

#### Test result

master: VS image (x86_64-kvm_x86_64-r0) — manual verification confirmed the additional patterns match correctly.

#### Description for the changelog

Fix PASSWD_CMDS patterns in sudoers to match additional command invocation forms.

#### Link to config_db schema for YANG module changes

N/A
