### PR TITLE
Enable anchor-prefix table-map suppression for UpperRegionalHub

### DIFF
--- a/dockers/docker-fpm-frr/base_image_files/prefix_list
+++ b/dockers/docker-fpm-frr/base_image_files/prefix_list
@@ -45,7 +45,7 @@ read_device_metadata() {
 
 declare -A prefix_type_devices
 prefix_type_devices=(
-    ["ANCHOR_PREFIX"]="SpineRouter:UpstreamLC UpperSpineRouter"
+    ["ANCHOR_PREFIX"]="SpineRouter:UpstreamLC UpperSpineRouter UpperRegionalHub"
     ["SUPPRESS_PREFIX"]=""
 )
 

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -21,7 +21,7 @@
     neighbor PEER_UNNUMBERED soft-reconfiguration inbound
     neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_UNNUMBERED_V4 in
     neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_UNNUMBERED_V4 out
-{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
 {% endif %}
   exit-address-family
@@ -41,7 +41,7 @@
     neighbor PEER_UNNUMBERED soft-reconfiguration inbound
     neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_UNNUMBERED_V6 in
     neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_UNNUMBERED_V6 out
-{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
 {% endif %}
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2
@@ -14,7 +14,7 @@
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
-{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
 {% endif %}
   exit-address-family
@@ -29,7 +29,7 @@
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
-{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+{% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
 {% endif %}
   exit-address-family

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2
@@ -112,7 +112,8 @@ route-map TO_BGP_PEER_UNNUMBERED_V6 permit 100
 !
 {% if CONFIG_DB__DEVICE_METADATA and 'localhost' in CONFIG_DB__DEVICE_METADATA and 'type' in CONFIG_DB__DEVICE_METADATA['localhost'] %}
 {% if (CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'SpineRouter' and 'subtype' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['subtype'] == 'UpstreamLC') or
-CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
+CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' or
+CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperRegionalHub' %}
 bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_route_community }}
 bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit {{ constants.bgp.local_anchor_route_community }}
 bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit {{ constants.bgp.anchor_contributing_route_community }}

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py
@@ -10,6 +10,7 @@ PREFIX_TYPE_CONFIG = {
         "allowed_devices": [
             ("SpineRouter", "UpstreamLC"),
             ("UpperSpineRouter", None),
+            ("UpperRegionalHub", None),
         ],
         "prefix_list_name": lambda ipv: "ANCHOR_CONTRIBUTING_ROUTES",
         "log_label": "Anchor prefix",

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_UpperRegionalHub.json
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/param_UpperRegionalHub.json
@@ -1,0 +1,7 @@
+{
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "UpperRegionalHub"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperRegionalHub.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperRegionalHub.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/templates/general/peer-group.conf.j2
+!
+  neighbor PEER_V4 peer-group
+  neighbor PEER_V6 peer-group
+  address-family ipv4
+
+    neighbor PEER_V4 soft-reconfiguration inbound
+    neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
+    neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
+
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V4
+
+  exit-address-family
+  address-family ipv6
+
+    neighbor PEER_V6 soft-reconfiguration inbound
+    neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
+    neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
+
+    table-map SELECTIVE_ROUTE_DOWNLOAD_V6
+
+  exit-address-family
+!
+! end of template: bgpd/templates/general/peer-group.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperRegionalHub.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/peer-group.conf/result_UpperRegionalHub.conf
@@ -3,23 +3,25 @@
 !
   neighbor PEER_V4 peer-group
   neighbor PEER_V6 peer-group
+  neighbor PEER_UNNUMBERED peer-group
+  neighbor PEER_UNNUMBERED capability extended-nexthop
   address-family ipv4
-
     neighbor PEER_V4 soft-reconfiguration inbound
     neighbor PEER_V4 route-map FROM_BGP_PEER_V4 in
     neighbor PEER_V4 route-map TO_BGP_PEER_V4 out
-
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_UNNUMBERED_V4 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_UNNUMBERED_V4 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V4
-
   exit-address-family
   address-family ipv6
-
     neighbor PEER_V6 soft-reconfiguration inbound
     neighbor PEER_V6 route-map FROM_BGP_PEER_V6 in
     neighbor PEER_V6 route-map TO_BGP_PEER_V6 out
-
+    neighbor PEER_UNNUMBERED soft-reconfiguration inbound
+    neighbor PEER_UNNUMBERED route-map FROM_BGP_PEER_UNNUMBERED_V6 in
+    neighbor PEER_UNNUMBERED route-map TO_BGP_PEER_UNNUMBERED_V6 out
     table-map SELECTIVE_ROUTE_DOWNLOAD_V6
-
   exit-address-family
 !
 ! end of template: bgpd/templates/general/peer-group.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all_UpperRegionalHub.json
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/param_all_UpperRegionalHub.json
@@ -1,0 +1,24 @@
+{
+    "loopback0_ipv4": "10.10.10.10/32",
+    "constants": {
+        "bgp": {
+            "allow_list": {
+                "enabled": true,
+                "drop_community": "12345:12345"
+            },
+            "route_eligible_for_fallback_to_default_tag": "203",
+            "route_do_not_send_appdb_tag" : "202",
+            "internal_fallback_community": "1111:2222",
+            "local_anchor_route_community": "12345:555",
+            "anchor_route_community": "12345:666",
+            "anchor_contributing_route_community": "12345:777"
+        }
+    },
+    "allow_list_default_action": "permit",
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "UpperRegionalHub",
+            "switch_type": "voq"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperRegionalHub.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperRegionalHub.conf
@@ -1,25 +1,18 @@
 !
 ! template: bgpd/templates/general/policies.conf.j2
 !
-!
 ip prefix-list DEFAULT_IPV4 permit 0.0.0.0/0
 ipv6 prefix-list DEFAULT_IPV6 permit ::/0
-!
-
-!
 !
 ! please don't remove. 65535 entries are default rules
 ! which works when allow_list is enabled, but new configuration
 ! is not applied
-!
-
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
   set community 12345:12345 additive
 !
 route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
   set community 12345:12345 additive
-
 !
 bgp community-list standard allow_list_default_community permit no-export
 bgp community-list standard allow_list_default_community permit 12345:12345
@@ -30,7 +23,6 @@ route-map FROM_BGP_PEER_V4 permit 10
 !
 route-map FROM_BGP_PEER_V4 permit 11
   match community allow_list_default_community
-
 !
 route-map FROM_BGP_PEER_V6 permit 10
   call ALLOW_LIST_DEPLOYMENT_ID_0_V6
@@ -38,17 +30,11 @@ route-map FROM_BGP_PEER_V6 permit 10
 !
 route-map FROM_BGP_PEER_V6 permit 11
   match community allow_list_default_community
-
-!
-
-!
-!
 !
 route-map FROM_BGP_PEER_V4 permit 100
 !
 route-map TO_BGP_PEER_V4 permit 100
   call CHECK_IDF_ISOLATION
-!
 !
 route-map FROM_BGP_PEER_V6 permit 1
  on-match next
@@ -61,10 +47,16 @@ route-map TO_BGP_PEER_V6 permit 100
 !
 route-map CHECK_IDF_ISOLATION permit 10
 !
+route-map FROM_BGP_PEER_UNNUMBERED_V4 permit 100
 !
+route-map TO_BGP_PEER_UNNUMBERED_V4 permit 100
+  call CHECK_IDF_ISOLATION
 !
-
-
+route-map FROM_BGP_PEER_UNNUMBERED_V6 permit 100
+!
+route-map TO_BGP_PEER_UNNUMBERED_V6 permit 100
+  call CHECK_IDF_ISOLATION
+!
 bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit 12345:666
 bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit 12345:555
 bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit 12345:777
@@ -100,7 +92,5 @@ route-map TO_BGP_PEER_V4 permit 60
   set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
   on-match next
 !
-
-
 ! end of template: bgpd/templates/general/policies.conf.j2
 !

--- a/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperRegionalHub.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/policies.conf/result_all_UpperRegionalHub.conf
@@ -1,0 +1,106 @@
+!
+! template: bgpd/templates/general/policies.conf.j2
+!
+!
+ip prefix-list DEFAULT_IPV4 permit 0.0.0.0/0
+ipv6 prefix-list DEFAULT_IPV6 permit ::/0
+!
+
+!
+!
+! please don't remove. 65535 entries are default rules
+! which works when allow_list is enabled, but new configuration
+! is not applied
+!
+
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V4 permit 65535
+  set community 12345:12345 additive
+!
+route-map ALLOW_LIST_DEPLOYMENT_ID_0_V6 permit 65535
+  set community 12345:12345 additive
+
+!
+bgp community-list standard allow_list_default_community permit no-export
+bgp community-list standard allow_list_default_community permit 12345:12345
+!
+route-map FROM_BGP_PEER_V4 permit 10
+  call ALLOW_LIST_DEPLOYMENT_ID_0_V4
+  on-match next
+!
+route-map FROM_BGP_PEER_V4 permit 11
+  match community allow_list_default_community
+
+!
+route-map FROM_BGP_PEER_V6 permit 10
+  call ALLOW_LIST_DEPLOYMENT_ID_0_V6
+  on-match next
+!
+route-map FROM_BGP_PEER_V6 permit 11
+  match community allow_list_default_community
+
+!
+
+!
+!
+!
+route-map FROM_BGP_PEER_V4 permit 100
+!
+route-map TO_BGP_PEER_V4 permit 100
+  call CHECK_IDF_ISOLATION
+!
+!
+route-map FROM_BGP_PEER_V6 permit 1
+ on-match next
+ set ipv6 next-hop prefer-global
+!
+route-map FROM_BGP_PEER_V6 permit 100
+!
+route-map TO_BGP_PEER_V6 permit 100
+  call CHECK_IDF_ISOLATION
+!
+route-map CHECK_IDF_ISOLATION permit 10
+!
+!
+!
+
+
+bgp community-list standard ANCHOR_ROUTE_COMMUNITY permit 12345:666
+bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY permit 12345:555
+bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY permit 12345:777
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 deny 10
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 permit 1000
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 deny 10
+  match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
+!
+route-map TAG_ANCHOR_COMMUNITY permit 10
+  set community 12345:555 12345:666 additive
+!
+route-map TO_BGP_PEER_V6 permit 50
+  match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+  set community 12345:777 additive
+  on-match next
+!
+route-map TO_BGP_PEER_V6 permit 60
+  set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+  on-match next
+!
+route-map TO_BGP_PEER_V4 permit 50
+  match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+  set community 12345:777 additive
+  on-match next
+!
+route-map TO_BGP_PEER_V4 permit 60
+  set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+  on-match next
+!
+
+
+! end of template: bgpd/templates/general/policies.conf.j2
+!


### PR DESCRIPTION
#### Why I did it
`UpperRegionalHub` is a device type already recognized elsewhere in the SONiC config schema, yang models, and topology tooling (e.g. `topo_urh_min.yml`), but it was not yet included in the anchor-prefix / selective-route-download allowlist alongside `SpineRouter:UpstreamLC` and `UpperSpineRouter`. This PR extends that support to `UpperRegionalHub` so it can participate in the same ANCHOR_PREFIX / SELECTIVE_ROUTE_DOWNLOAD table-map mechanism.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- `src/sonic-bgpcfgd/bgpcfgd/managers_prefix_list.py`: add `("UpperRegionalHub", None)` to the `ANCHOR_PREFIX` `allowed_devices` list so `bgpcfgd`'s `PrefixListMgr` accepts `ANCHOR_PREFIX` config on this device type.
- `dockers/docker-fpm-frr/base_image_files/prefix_list`: add `UpperRegionalHub` to the CLI helper's allowed device list for `ANCHOR_PREFIX`.
- `dockers/docker-fpm-frr/frr/bgpd/templates/general/peer-group.conf.j2`: extend the existing `table-map SELECTIVE_ROUTE_DOWNLOAD_V4`/`V6` condition to also apply when `DEVICE_METADATA.type == 'UpperRegionalHub'`, matching the existing `SpineRouter`(`UpstreamLC`)/`UpperSpineRouter` behavior.
- `dockers/docker-fpm-frr/frr/bgpd/templates/general/policies.conf.j2`: extend the existing anchor-prefix community-list/route-map definition block (`ANCHOR_ROUTE_COMMUNITY`, `LOCAL_ANCHOR_ROUTE_COMMUNITY`, `ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY`, `TAG_ANCHOR_COMMUNITY`, anchor-tagging rules in `TO_BGP_PEER_V4`/`V6`) to also render for `UpperRegionalHub`, matching existing `SpineRouter`(`UpstreamLC`)/`UpperSpineRouter` behavior.

#### How to verify it
Verified live on a `urh_min`-topology KVM testbed DUT (`vlab-urh-01`, device type `UpperRegionalHub`) by comparing `show running-config` (bgpd) before and after this change. The only differences are the intended additions — `table-map SELECTIVE_ROUTE_DOWNLOAD_V4`/`V6` under each peer-group, the 3 new community-lists, `TAG_ANCHOR_COMMUNITY`, `SELECTIVE_ROUTE_DOWNLOAD_V4`/`V6` route-maps, and the anchor-tagging rules in `TO_BGP_PEER_V4`/`V6`. No pre-existing peer-group/session config was affected, and all BGP sessions (6 IPv4 + 6 IPv6 neighbors) remained/re-established as Established throughout.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch
- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
- master: `SELECTIVE_ROUTE_DOWNLOAD`/anchor-prefix rendering verified via `show running-config` before/after diff on `vlab-urh-01` (`urh_min` topology, device type `UpperRegionalHub`); BGP sessions unaffected.

<details>
<summary>show running-config diff (before → after)</summary>

```diff
--- before.txt	2026-08-19 15:59:47.839445129 +0000
+++ after.txt	2026-08-19 15:59:47.841445140 +0000
@@ -67,10 +67,50 @@
  set src fc00:10::1
 exit
 !
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 deny 10
+ match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+exit
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V4 permit 1000
+exit
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 deny 10
+ match community LOCAL_ANCHOR_ROUTE_COMMUNITY
+exit
+!
+route-map SELECTIVE_ROUTE_DOWNLOAD_V6 permit 1000
+exit
+!
+route-map TAG_ANCHOR_COMMUNITY permit 10
+ set community 12345:555 12345:666 additive
+exit
+!
+route-map TO_BGP_PEER_V4 permit 50
+ match ip address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+ on-match next
+ set community 12345:777 additive
+exit
+!
+route-map TO_BGP_PEER_V4 permit 60
+ on-match next
+ set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+exit
+!
 route-map TO_BGP_PEER_V4 permit 100
  call CHECK_IDF_ISOLATION
 exit
 !
+route-map TO_BGP_PEER_V6 permit 50
+ match ipv6 address prefix-list ANCHOR_CONTRIBUTING_ROUTES
+ on-match next
+ set community 12345:777 additive
+exit
+!
+route-map TO_BGP_PEER_V6 permit 60
+ on-match next
+ set comm-list LOCAL_ANCHOR_ROUTE_COMMUNITY delete
+exit
+!
 route-map TO_BGP_PEER_V6 permit 100
  call CHECK_IDF_ISOLATION
 exit
@@ -161,6 +201,7 @@
   neighbor 10.0.0.107 activate
   neighbor 10.0.0.1 activate
   neighbor 10.0.0.3 activate
+  table-map SELECTIVE_ROUTE_DOWNLOAD_V4
  exit-address-family
  !
  address-family ipv6 unicast
@@ -174,9 +215,13 @@
   neighbor fc00::1a activate
   neighbor fc00::2 activate
   neighbor fc00::6 activate
+  table-map SELECTIVE_ROUTE_DOWNLOAD_V6
  exit-address-family
 exit
 !
+bgp community-list standard ANCHOR_CONTRIBUTING_ROUTE_COMMUNITY seq 5 permit 12345:777
+bgp community-list standard ANCHOR_ROUTE_COMMUNITY seq 5 permit 12345:666
+bgp community-list standard LOCAL_ANCHOR_ROUTE_COMMUNITY seq 5 permit 12345:555
 bgp community-list standard allow_list_default_community seq 5 permit no-export
 bgp community-list standard allow_list_default_community seq 10 permit 5060:12345
 !
```
</details>


#### Description for the changelog
Add UpperRegionalHub support to the anchor-prefix table-map (SELECTIVE_ROUTE_DOWNLOAD) allowlist.