### PR TITLE
fix(docker-ptf): remove build-only virtualenv pip

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -465,6 +465,12 @@ RUN PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') \
 RUN /root/env-python3/bin/python -c "import switch_sai_thrift.switch_sai_rpc"
 {% endif %}
 
+# pip is only needed to assemble the virtualenv. Remove it after the last
+# package installation to avoid shipping its vulnerable vendored dependencies.
+RUN rm -rf /root/env-python3/lib/python*/site-packages/pip \
+        /root/env-python3/lib/python*/site-packages/pip-*.dist-info \
+    && rm -f /root/env-python3/bin/pip*
+
 # {% if PTF_ENV_PY_VER == "py3" %}
 # # Create symlink so that test scripts and ptf_runner invocation path
 # # is same across python 2 and python 3 envs. Note that for virtual-env


### PR DESCRIPTION
#### Why I did it

Follow-up to #28866.

The docker-ptf Trivy scan in [build 1186159](https://dev.azure.com/mssonic/build/_build/results?buildId=1186159&view=logs&s=859b8d9a-8fd6-5a5c-6f5e-f84f1990894e) still reports:

- `msgpack` 1.1.2: GHSA-6v7p-g79w-8964
- `setuptools` 70.3.0: CVE-2025-47273
- `setuptools` 70.3.0: CVE-2026-59890

#28866 removed the copy bundled with InfluxDB. The remaining findings come from `root/env-python3/lib/python3.13/site-packages/pip-26.2.1`, which vendors the same affected dependencies.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Removed pip, its distribution metadata, and its entry points from the docker-ptf virtualenv after the final Python package installation.

Pip is only used while assembling the virtualenv. The installed runtime packages and the system `python3-pip` package remain available.

#### How to verify it

1. Build `docker-ptf`.
2. Run the Trivy vulnerability scan.
3. Confirm GHSA-6v7p-g79w-8964, CVE-2025-47273, and CVE-2026-59890 are absent.
4. Run the sonic-mgmt docker-ptf tests.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [x] 202611

The affected virtualenv pip installation is present in `202511` and `202605`. Please also cherry-pick this fix to `202611` when that release branch becomes available.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): #28866
Failure type: other - vulnerable vendored Python dependencies

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] 202611
- [ ] N/A

#### Test result

- Reproduced the exact three findings using Trivy 0.70.0 against a virtualenv containing pip 26.2.1.
- Applied the same cleanup used by this change and confirmed the targeted Trivy findings decreased from three to zero.
- Confirmed an installed runtime package remained importable after pip removal.
- Full docker-ptf build, Trivy scan, and sonic-mgmt testing will run in PR CI.

#### Description for the changelog

Remove build-only virtualenv pip and its vulnerable vendored dependencies from docker-ptf.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
