### PR TITLE
[docker-fpm-frr]: Add configurable BGP policy hooks

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/bgpd.main.conf.j2
@@ -28,6 +28,18 @@ ip prefix-list PL_LoopbackV4 permit {{ lo0_ipv4 }}/32
 {% set disagg_rh = "true" %}
 {% endif%}
 {% endif %}
+{% set device_metadata = DEVICE_METADATA['localhost'] if DEVICE_METADATA is defined and 'localhost' in DEVICE_METADATA else {} %}
+{% set device_type = device_metadata['type'] | default("") | lower %}
+{% set extra_confederation_device_types = constants.bgp.extra_confederation_device_types | default([]) %}
+{% set loopback_route_map = constants.bgp.loopback_advertisement_route_map | default({}) %}
+{% set loopback_route_map_device_types = loopback_route_map.device_types | default([]) %}
+{% set use_loopback_route_map = loopback_route_map.name is defined and loopback_route_map.community is defined and device_type in loopback_route_map_device_types %}
+{% set suppress_storage_backend_loopback = false %}
+{% if constants.bgp.suppress_storage_backend_loopback | default(false) %}
+{% if device_metadata['storage_device'] | default("false") | string | lower == "true" and "backend" in device_type %}
+{% set suppress_storage_backend_loopback = true %}
+{% endif %}
+{% endif %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
 {% if ( ('localhost' in DEVICE_METADATA) and ('bgp_adv_lo_prefix_as_128' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true') ) %}
@@ -91,10 +103,15 @@ route-map HIDE_INTERNAL permit 20
 !
 {% endif %}
 !
+{% if use_loopback_route_map %}
+route-map {{ loopback_route_map.name }} permit 100
+  set community {{ loopback_route_map.community }}
+!
+{% endif %}
 {% if (DEVICE_METADATA is defined) and ('localhost' in DEVICE_METADATA) and ('bgp_asn' in DEVICE_METADATA['localhost']) and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'none') and (DEVICE_METADATA['localhost']['bgp_asn'].lower() != 'null') %}
 router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 !
-{% if disagg_t2  == "true" or disagg_rh == "true" %}
+{% if disagg_t2 == "true" or disagg_rh == "true" or device_type in extra_confederation_device_types %}
 {% if (BGP_DEVICE_GLOBAL is defined) and ('CONFED' in BGP_DEVICE_GLOBAL) and ('asn' in BGP_DEVICE_GLOBAL['CONFED'] )  %}
   bgp confederation identifier {{ BGP_DEVICE_GLOBAL['CONFED']['asn'] }}
 {% endif %}
@@ -157,25 +174,35 @@ router bgp {{ DEVICE_METADATA['localhost']['bgp_asn'] }}
 {% endif %}
 !
 {# advertise loopback #}
-{% if lo0_ipv4 is not none %}
+{% if lo0_ipv4 is not none and not suppress_storage_backend_loopback %}
+{% if use_loopback_route_map %}
+  network {{ lo0_ipv4 }}/32 route-map {{ loopback_route_map.name }}
+{% else %}
   network {{ lo0_ipv4 }}/32
+{% endif %}
 {% endif %}
 {% if lo4096_ipv4 is not none and ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (voq_chassis is defined)) %}
   network {{ lo4096_ipv4 }}/32 route-map HIDE_INTERNAL
 {% endif %}
 !
+{% if not suppress_storage_backend_loopback %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") != 'None' %}
   address-family ipv6
 {% if ( ('localhost' in DEVICE_METADATA) and ('bgp_adv_lo_prefix_as_128' in  DEVICE_METADATA['localhost']) and
         (DEVICE_METADATA['localhost']['bgp_adv_lo_prefix_as_128'] == 'true') ) %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128
 {% else %}
+{% if use_loopback_route_map %}
+    network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64 route-map {{ loopback_route_map.name }}
+{% else %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/64
+{% endif %}
 {% if voq_chassis is defined or DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
     network {{ get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback0") | ip }}/128 route-map HIDE_INTERNAL
 {% endif %}
 {% endif %}
   exit-address-family
+{% endif %}
 {% endif %}
 {% if ((multi_asic is defined and DEVICE_METADATA['localhost']['switch_type'] != 'chassis-packet') or (voq_chassis is defined)) %}
 {% if get_ipv6_loopback_address(LOOPBACK_INTERFACE, "Loopback4096") != 'None' %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/policies.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/sentinels/policies.conf.j2
@@ -10,6 +10,20 @@ route-map FROM_BGP_SENTINEL permit 100
 !
 route-map FROM_BGP_SENTINEL deny 200
 !
+{% set device_metadata = CONFIG_DB__DEVICE_METADATA['localhost'] if CONFIG_DB__DEVICE_METADATA is defined and 'localhost' in CONFIG_DB__DEVICE_METADATA else {} %}
+{% set device_type = device_metadata['type'] | default("") | lower %}
+{% set aggregate_route_community = constants.bgp.sentinel_aggregate_route_community | default("") %}
+{% set aggregate_route_device_types = constants.bgp.sentinel_aggregate_route_device_types | default([]) %}
+{% if aggregate_route_community and device_type in aggregate_route_device_types %}
+route-map TO_BGP_SENTINEL permit 50
+ match ip address prefix-list AGGREGATE_ROUTES_V4
+ set community {{ aggregate_route_community }} additive
+!
+route-map TO_BGP_SENTINEL permit 60
+ match ipv6 address prefix-list AGGREGATE_ROUTES_V6
+ set community {{ aggregate_route_community }} additive
+!
+{% endif %}
 route-map TO_BGP_SENTINEL permit 100
 !
 ! end of template: bgpd/templates/sentinels/policies.conf.j2

--- a/src/sonic-bgpcfgd/tests/data/sentinels/policies.conf/param_aggregate.json
+++ b/src/sonic-bgpcfgd/tests/data/sentinels/policies.conf/param_aggregate.json
@@ -1,0 +1,16 @@
+{
+    "constants": {
+        "bgp": {
+            "sentinel_community": "12345:12346",
+            "sentinel_aggregate_route_community": "12345:654",
+            "sentinel_aggregate_route_device_types": [
+                "leafrouter"
+            ]
+        }
+    },
+    "CONFIG_DB__DEVICE_METADATA": {
+        "localhost": {
+            "type": "LeafRouter"
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sentinels/policies.conf/result_aggregate.conf
+++ b/src/sonic-bgpcfgd/tests/data/sentinels/policies.conf/result_aggregate.conf
@@ -1,0 +1,22 @@
+!
+! template: bgpd/templates/sentinels/policies.conf.j2
+!
+bgp community-list standard sentinel_community permit 12345:12346 no-export
+!
+route-map FROM_BGP_SENTINEL permit 100
+ match community sentinel_community
+!
+route-map FROM_BGP_SENTINEL deny 200
+!
+route-map TO_BGP_SENTINEL permit 50
+ match ip address prefix-list AGGREGATE_ROUTES_V4
+ set community 12345:654 additive
+!
+route-map TO_BGP_SENTINEL permit 60
+ match ipv6 address prefix-list AGGREGATE_ROUTES_V6
+ set community 12345:654 additive
+!
+route-map TO_BGP_SENTINEL permit 100
+!
+! end of template: bgpd/templates/sentinels/policies.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.conf
@@ -1,0 +1,29 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+route-map LOOPBACK_ROUTE_MAP permit 100
+  set community 12345:8888
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32 route-map LOOPBACK_ROUTE_MAP
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_lrh_route_map.json
@@ -1,0 +1,32 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "LowerRegionalHub"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED": {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "loopback_advertisement_route_map": {
+                "name": "LOOPBACK_ROUTE_MAP",
+                "community": "12345:8888",
+                "device_types": [
+                    "lowerregionalhub"
+                ]
+            },
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.conf
@@ -1,0 +1,26 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+router bgp 65001
+!
+  bgp confederation identifier 65000
+  bgp confederation peers 65001 65002
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+  bgp router-id 55.55.55.55
+!
+  network 55.55.55.55/32
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/single_asic_ma_confed.json
@@ -1,0 +1,28 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "65001",
+            "type": "UpperMgmtAggregator"
+        }
+    },
+    "BGP_DEVICE_GLOBAL": {
+        "CONFED": {
+            "asn": "65000",
+            "peers": "65001;65002"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {},
+        "Loopback1|fc00::1/128": {}
+    },
+    "constants": {
+        "bgp": {
+            "extra_confederation_device_types": [
+                "uppermgmtaggregator"
+            ],
+            "multipath_relax": {},
+            "graceful_restart": {},
+            "maximum_paths": {}
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.conf
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.conf
@@ -1,0 +1,43 @@
+!
+! template: bgpd/bgpd.main.conf.j2
+!
+! bgp multiple-instance
+!
+! BGP configuration
+!
+! TSA configuration
+!
+ip prefix-list PL_LoopbackV4 permit 55.55.55.55/32
+!
+!
+ip prefix-list LOCAL_VLAN_IPV4_PREFIX seq 5 permit 10.10.10.0/24
+!
+!
+!
+!
+router bgp 55555
+!
+  bgp log-neighbor-changes
+  bgp suppress-fib-pending
+  no bgp default ipv4-unicast
+  no bgp ebgp-requires-policy
+!
+!
+!
+  bgp router-id 55.55.55.55
+!
+!
+!
+  network 10.10.10.1/24
+!
+!
+!
+  address-family ipv4
+    maximum-paths 64
+  exit-address-family
+  address-family ipv6
+    maximum-paths 64
+  exit-address-family
+!
+! end of template: bgpd/bgpd.main.conf.j2
+!

--- a/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.json
+++ b/src/sonic-bgpcfgd/tests/data/sonic-cfggen/bgpd.main.conf.j2/storage_backend.json
@@ -1,0 +1,28 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "bgp_asn": "55555",
+            "type": "BackEndToRRouter",
+            "storage_device": "true"
+        }
+    },
+    "LOOPBACK_INTERFACE": {
+        "Loopback0|55.55.55.55/32": {}
+    },
+    "VLAN_INTERFACE": {
+        "Vlan10|10.10.10.1/24": {}
+    },
+    "constants": {
+        "bgp": {
+            "suppress_storage_backend_loopback": true,
+            "multipath_relax": {},
+            "graceful_restart": {
+                "enabled": true,
+                "restart_time": 480
+            },
+            "maximum_paths": {
+                "enabled": true
+            }
+        }
+    }
+}

--- a/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
+++ b/src/sonic-bgpcfgd/tests/test_sonic-cfggen.py
@@ -260,6 +260,24 @@ def test_bgp_confed_urh_single_asic():
              "bgpd.main.conf.j2/single_asic_urh.json",
              "bgpd.main.conf.j2/single_asic_urh.conf")
 
+def test_bgp_loopback_advertisement_route_map():
+    run_test("BGP loopback advertisement route-map",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_lrh_route_map.json",
+             "bgpd.main.conf.j2/single_asic_lrh_route_map.conf")
+
+def test_bgp_storage_backend_loopback_suppression():
+    run_test("BGP storage backend loopback suppression",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/storage_backend.json",
+             "bgpd.main.conf.j2/storage_backend.conf")
+
+def test_bgp_extra_confederation_device_type():
+    run_test("BGP extra confederation device type",
+             "bgpd/bgpd.main.conf.j2",
+             "bgpd.main.conf.j2/single_asic_ma_confed.json",
+             "bgpd.main.conf.j2/single_asic_ma_confed.conf")
+
 def _render_bgpd_main(json_path):
     template_path = os.path.join(TEMPLATE_PATH, "bgpd/bgpd.main.conf.j2")
     json_full_path = os.path.join(DATA_PATH, json_path)


### PR DESCRIPTION
#### Why I did it

Downstream deployments currently modify shared FRR templates to add device-specific confederation handling, loopback advertisement policy, storage-device behavior, and BGP sentinel tagging. Those inline changes repeatedly conflict when public `master` is synchronized downstream.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added dormant, constants-driven hooks for:

- additional BGP confederation device types;
- an optional Loopback0 advertisement route-map;
- optional storage backend Loopback0 suppression;
- optional sentinel aggregate-route community tagging.

All options default to disabled, so existing public rendering is unchanged. Added focused rendering fixtures for each hook.

#### How to verify it

```text
cd src/sonic-bgpcfgd
pytest -q tests/test_sonic-cfggen.py -k \
  'bgp_loopback_advertisement_route_map or bgp_storage_backend_loopback_suppression or bgp_extra_confederation_device_type or bgpd_main_conf'
pytest -q tests/test_templates.py
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- 11 focused `bgpd.main.conf.j2` rendering tests passed.
- 18 FRR peer-template rendering tests passed.

#### Description for the changelog

Add configurable FRR hooks for downstream BGP policy.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
