### PR TITLE
Fix Y2038 time_t issues in libteam, lldpd, and monit

### DIFF
--- a/src/libteam/patch/0020-libteam-Fix-Y2038-netlink-sequence-number.patch
+++ b/src/libteam/patch/0020-libteam-Fix-Y2038-netlink-sequence-number.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SONiC Build <build@sonic.net>
+Date: Thu, 6 Aug 2026 13:00:00 +0000
+Subject: [PATCH] libteam: Fix Y2038 netlink sequence number in team_init
+
+Coverity CID 1300485 (Y2K38_SAFETY): team_init() seeded nl_sock_seq from
+time(NULL), truncating 64-bit time_t into an unsigned int netlink sequence
+field.
+
+Netlink sequence numbers only need to match responses to requests. Start
+from 1 and let the existing increment logic assign later values.
+
+Signed-off-by: SONiC Build <build@sonic.net>
+---
+ libteam/libteam.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libteam/libteam.c b/libteam/libteam.c
+index 2a9053b..3ea4622 100644
+--- a/libteam/libteam.c
++++ b/libteam/libteam.c
+@@ -579,7 +579,7 @@ int team_init(struct team_handle *th, uint32_t ifindex)
+ 	}
+ 	th->ifindex = ifindex;
+ 
+-	th->nl_sock_seq = time(NULL);
++	th->nl_sock_seq = 1;
+ 	err = genl_connect(th->nl_sock);
+ 	if (err) {
+ 		err(th, "Failed to connect to netlink sock.");

--- a/src/libteam/patch/series
+++ b/src/libteam/patch/series
@@ -17,3 +17,4 @@
 0017-Specify-netlink-recv-buffer-size-to-avoid-a-syscall.patch
 0018-Replace-FD_SET-select-with-poll-to-avoid-FD_SETSIZE-abort.patch
 0019-fix-event-fd-init-and-free.patch
+0020-libteam-Fix-Y2038-netlink-sequence-number.patch

--- a/src/lldpd/patch/0003-Fix-Y2038-pcap-timestamp-in-test-common.patch
+++ b/src/lldpd/patch/0003-Fix-Y2038-pcap-timestamp-in-test-common.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SONiC Build <build@sonic.net>
+Date: Thu, 6 Aug 2026 13:00:00 +0000
+Subject: [PATCH] tests: Fix Y2038 pcap timestamp in pcap_send
+
+Coverity CID 1245653 (Y2K38_SAFETY): pcap_send() assigned time(NULL)
+directly to the 32-bit PCAP ts_sec field.
+
+Add an explicit conversion helper that caps values above UINT32_MAX.
+
+Signed-off-by: SONiC Build <build@sonic.net>
+---
+ tests/common.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/tests/common.c b/tests/common.c
+index cf5ca34..df696f4 100644
+--- a/tests/common.c
++++ b/tests/common.c
+@@ -18,6 +18,8 @@
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <unistd.h>
++#include <stdint.h>
++#include <limits.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <time.h>
+@@ -32,6 +34,16 @@ char macaddress[ETHER_ADDR_LEN] = { 0x5e, 0x10, 0x8e, 0xe7, 0x84, 0xad };
+ struct lldpd_hardware hardware;
+ struct lldpd_chassis chassis;
+ 
++static uint32_t pcap_timestamp_sec(void)
++{
++	time_t now = time(NULL);
++
++	if (now > (time_t)UINT32_MAX)
++		return UINT32_MAX;
++
++	return (uint32_t)now;
++}
++
+ int
+ pcap_send(struct lldpd *cfg, struct lldpd_hardware *hardware, char *buffer, size_t size)
+ {
+@@ -40,7 +52,7 @@ pcap_send(struct lldpd *cfg, struct lldpd_hardware *hardware, char *buffer, size
+ 	int n;
+ 
+ 	/* Write pcap record header */
+-	hdr.ts_sec = time(NULL);
++	hdr.ts_sec = pcap_timestamp_sec();
+ 	hdr.ts_usec = 0;
+ 	hdr.incl_len = hdr.orig_len = size;
+ 	n = write(dump, &hdr, sizeof(hdr));

--- a/src/lldpd/patch/series
+++ b/src/lldpd/patch/series
@@ -1,3 +1,4 @@
 # This series applies on GIT commit 7a595f1adfa4ae5302ba7953e14fd69c8579aa16
 0001-return-error-when-port-does-not-exist.patch
 0002-use-a-different-socket-for-changes-and-queries.patch
+0003-Fix-Y2038-pcap-timestamp-in-test-common.patch

--- a/src/monit/patch/0004-Fix-Y2038-time-handling-in-Net-and-rdate.patch
+++ b/src/monit/patch/0004-Fix-Y2038-time-handling-in-Net-and-rdate.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SONiC Build <build@sonic.net>
+Date: Thu, 6 Aug 2026 13:00:00 +0000
+Subject: [PATCH] Fix Y2038 time handling in Net and rdate protocol check
+
+Coverity Y2K38_SAFETY findings:
+- CID 1251252 / 1247271: Net_canRead/Net_canWrite cast time_t to int for poll()
+- CID 1286078: check_rdate() stored the 32-bit RDATE payload in a time_t variable
+
+Use a bounded poll timeout helper and read RDATE timestamps as uint32_t.
+
+Signed-off-by: SONiC Build <build@sonic.net>
+---
+ libmonit/src/system/Net.c | 14 ++++++++++++--
+ src/protocols/rdate.c     |  8 +++++---
+ 2 files changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/libmonit/src/system/Net.c b/libmonit/src/system/Net.c
+index 21e580e..a156db1 100644
+--- a/libmonit/src/system/Net.c
++++ b/libmonit/src/system/Net.c
+@@ -58,6 +58,16 @@
+ #include "system/System.h"
+ 
+ 
++static int net_poll_timeout_ms(time_t milliseconds)
++{
++        if (milliseconds <= 0)
++                return (int)milliseconds;
++        if (milliseconds > INT_MAX)
++                return INT_MAX;
++        return (int)milliseconds;
++}
++
++
+ /**
+  * Implementation of the Net Facade for Unix Systems.
+  *
+@@ -86,7 +96,7 @@ bool Net_canRead(int socket, time_t milliseconds) {
+         fds[0].fd = socket;
+         fds[0].events = POLLIN;
+         do {
+-                r = poll(fds, 1, (int)milliseconds);
++                r = poll(fds, 1, net_poll_timeout_ms(milliseconds));
+         } while (r == -1 && errno == EINTR);
+         return (r > 0);
+ }
+@@ -98,7 +108,7 @@ bool Net_canWrite(int socket, time_t milliseconds) {
+         fds[0].fd = socket;
+         fds[0].events = POLLOUT;
+         do {
+-                r = poll(fds, 1, (int)milliseconds);
++                r = poll(fds, 1, net_poll_timeout_ms(milliseconds));
+         } while (r == -1 && errno == EINTR);
+         return (r > 0);
+ }
+diff --git a/src/protocols/rdate.c b/src/protocols/rdate.c
+index 574ba97..eacc337 100644
+--- a/src/protocols/rdate.c
++++ b/src/protocols/rdate.c
+@@ -40,6 +40,8 @@
+ #include <arpa/inet.h>
+ #endif
+ 
++#include <stdint.h>
++
+ #include "protocol.h"
+ 
+ // libmonit
+@@ -57,11 +59,11 @@
+  */
+ void check_rdate(Socket_T socket) {
+         assert(socket);
+-        time_t time;
+-        if (Socket_read(socket, (char *)&time, sizeof(time)) <= 0)
++        uint32_t server_time;
++        if (Socket_read(socket, (char *)&server_time, sizeof(server_time)) <= 0)
+                 THROW(IOException, "RDATE: error receiving data -- %s", STRERROR);
+         // Compare system time with the RDATE server time (RDATE starts at 00:00:00 UTC, January 1, 1900 => add offset to 00:00:00 UTC, January 1, 1970)
+-        if (llabs((long long)Time_now() + 2208988800LL - (long long)ntohl(time)) > 3LL)
++        if (llabs((long long)Time_now() + 2208988800LL - (long long)ntohl(server_time)) > 3LL)
+                 THROW(ProtocolException, "RDATE error: time does not match system time");
+ }
+ 

--- a/src/monit/patch/series
+++ b/src/monit/patch/series
@@ -2,3 +2,4 @@
 #0001-used_system_memory_sysdep-Use-MemAvailable-value-if-.patch
 0002-change_monit_alert_log_error.patch
 #0003-fix-yacc-header-file-naming.patch
+0004-Fix-Y2038-time-handling-in-Net-and-rdate.patch


### PR DESCRIPTION
Add patches for Coverity Y2K38_SAFETY findings:
- libteam: replace time(NULL) netlink seq seed with static counter
- lldpd: clamp pcap ts_sec in test helper
- monit: bounded poll timeout and uint32_t RDATE timestamp

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
