### PR TITLE
[sonic-py-common] Align gRPC build and runtime dependencies

### DIFF
--- a/files/build/versions-public/dockers/sonic-slave-bookworm/versions-py3
+++ b/files/build/versions-public/dockers/sonic-slave-bookworm/versions-py3
@@ -45,8 +45,8 @@ fsspec==2026.7.0
 gbp==0.9.30
 gcovr==5.2
 gpg==1.18.0
-grpcio==1.51.1
-grpcio-tools==1.51.1
+grpcio==1.71.0
+grpcio-tools==1.71.0
 html5lib==1.1
 httplib2==0.20.4
 hyperlink==21.0.0

--- a/files/build/versions-public/host-image/versions-py3
+++ b/files/build/versions-public/host-image/versions-py3
@@ -20,8 +20,8 @@ docker==7.1.0
 docker-image-py==0.2.0
 enlighten==1.11.2
 filelock==3.32.2
-grpcio==1.66.2
-grpcio-tools==1.66.2
+grpcio==1.71.0
+grpcio-tools==1.71.0
 idna==3.18
 ijson==3.4.0
 inflect==7.3.1

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -194,8 +194,8 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
 # Install Python module for grpcio and grpcio-tools
 if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
-    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.66.2"
-    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.66.2"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.71.0"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.70.0"
 fi
 
 # Install Python module for smbus2

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -195,7 +195,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 # Install Python module for grpcio and grpcio-tools
 if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.71.0"
-    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.70.0"
+    sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.71.0"
 fi
 
 # Install Python module for smbus2

--- a/sonic-slave-bookworm/Dockerfile.j2
+++ b/sonic-slave-bookworm/Dockerfile.j2
@@ -575,9 +575,8 @@ RUN pip3 install fastentrypoints mock
 RUN pip3 install jsonpath_ng!=1.8.0
 RUN pip3 install pyyaml-include
 
-# For building sonic_ycabled
-# Note: Match version in bookworm
-RUN pip3 install grpcio==1.51.1 grpcio-tools==1.51.1 --no-build-isolation
+# For building sonic_ycabled and sonic-py-common
+RUN pip3 install grpcio==1.71.0 grpcio-tools==1.71.0 protobuf==5.29.6 --no-build-isolation
 
 # For running Python unit tests
 RUN pip3 install pytest-runner==5.2

--- a/sonic-slave-trixie/Dockerfile.j2
+++ b/sonic-slave-trixie/Dockerfile.j2
@@ -594,9 +594,8 @@ RUN pip3 install fastentrypoints mock
 # In version 1.8.0, dict is flattened to a list, which causes type error in DASH.
 RUN pip3 install jsonpath_ng!=1.8.0 pyyaml-include
 
-# For building sonic_ycabled
-# Note: Match version in trixie
-RUN pip3 install grpcio==1.71.0 grpcio-tools==1.71.0
+# For building sonic_ycabled and sonic-py-common
+RUN pip3 install grpcio==1.71.0 grpcio-tools==1.71.0 protobuf==5.29.6
 
 # For running Python unit tests
 RUN pip3 install pytest-runner==5.2

--- a/src/sonic-py-common/generate_protos.py
+++ b/src/sonic-py-common/generate_protos.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import tempfile
 
 
-GENERATOR_VERSION = "1.66.2"
+GENERATOR_VERSION = "1.71.0"
 PROTO_NAMES = ("types", "common", "system", "file")
 PROJECT_ROOT = Path(__file__).resolve().parent
 PROTO_ROOT = PROJECT_ROOT / "proto"

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -35,13 +35,13 @@ if include_sonic_grpc:
         'sonic_grpc.gnoi',
     ]
     extra_dependencies = [
-        'grpcio>=1.66.2',
+        'grpcio>=1.71.0',
         'protobuf>=5.29.6,<8',
     ]
-    extra_setup_requires = ['grpcio-tools==1.66.2']
+    extra_setup_requires = ['grpcio-tools==1.71.0']
     extra_testing_requires = [
-        'grpcio==1.66.2',
-        'grpcio-tools==1.66.2',
+        'grpcio==1.71.0',
+        'grpcio-tools==1.71.0',
         'protobuf==5.29.6',
     ]
     cmdclass = {'build_py': BuildPy}

--- a/src/sonic-py-common/tests/test_generate_protos.py
+++ b/src/sonic-py-common/tests/test_generate_protos.py
@@ -2,6 +2,7 @@
 
 import inspect
 from pathlib import Path
+import re
 import shutil
 import subprocess
 import sys
@@ -24,7 +25,10 @@ def test_missing_generator_reports_required_version(monkeypatch, tmp_path):
 
     with pytest.raises(
         RuntimeError,
-        match="grpcio-tools 1.66.2 is required; not installed",
+        match=(
+            rf"grpcio-tools {re.escape(generate_protos.GENERATOR_VERSION)} "
+            r"is required; not installed"
+        ),
     ):
         generate_protos.generate(tmp_path)
 


### PR DESCRIPTION
#### Why I did it

Building `sonic-py-common` with `BUILD_SKIP_TEST=y` failed because the required version of `grpcio-tools` was not consistently available in the Bookworm and Trixie build environments.

Installing `grpcio-tools==1.66.2` allowed package generation to proceed in one environment, but generated gNOI code required `grpcio>=1.71.0` at runtime. This caused the `sonic-vs.img.gz` build to fail with a generated-code compatibility
error.

#### Work item tracking

N/A

#### How I did it

- Aligned `grpcio` and `grpcio-tools` on version 1.71.0.
- Updated the Bookworm and Trixie slave build environments.
- Updated the `sonic-py-common` build, test, and runtime requirements.
- Updated the protobuf generator version to 1.71.0.
- Added `protobuf==5.29.6` to the slave build environments.
- Updated the host-image and public dependency version manifests.

The generator remains exactly pinned to ensure reproducible generated code, while the runtime dependency accepts `grpcio>=1.71.0`, matching the minimum version required by code generated with `grpcio-tools==1.71.0`.

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A

Failure type: Build failure

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Description for the changelog

Allow `sonic-py-common` to build with compatible `grpcio-tools` versions at or above `1.66.2`.

#### Link to config_db schema for YANG module changes

N/A