### PR TITLE
[swss] use lock probe + --job-mode=fail to avoid killing peer ExecStar…

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -9,6 +9,7 @@ LOCKFILE="/tmp/swss-syncd-lock$DEV"
 NAMESPACE_PREFIX="asic"
 ETC_SONIC_PATH="/etc/sonic/"
 TSA_TSB_SERVICE="startup_tsa_tsb.service"
+FLOCK_BUSY_RC=100
 
 . /usr/local/bin/asic_status.sh
 
@@ -364,6 +365,21 @@ start_peer_and_dependent_services() {
     fi
 }
 
+# Returns true (0) when the peer's state-change lock is currently held,
+# meaning the peer is in the middle of its own start or stop sequence.
+# syncd_common.sh acquires /tmp/swss-syncd-lock$DEV at the top of start()
+# and holds it across the entire ExecStartPre (syncd_common.sh:107-133).
+# swss has already released its own copy of the lock before reaching this
+# function, so a held lock can only mean the peer is changing state on its
+# own and must not be interrupted.
+peer_state_change_in_progress() {
+    local lockfile="/tmp/swss-${1}-lock${DEV}"
+    local rc=0
+    [[ -e ${lockfile} ]] || return 1
+    /usr/bin/flock -n -E "${FLOCK_BUSY_RC}" "${lockfile}" -c true || rc=$?
+    [[ ${rc} -eq ${FLOCK_BUSY_RC} ]]
+}
+
 stop_peer_and_dependent_services() {
     # if warm/fast start enabled or peer lock exists, don't stop peer service docker
     if [[ x"$WARM_BOOT" != x"true" ]] && [[ x"$FAST_BOOT" != x"true" ]]; then
@@ -378,10 +394,21 @@ stop_peer_and_dependent_services() {
             /bin/systemctl stop ${dep}
         done
         for peer in ${PEER}; do
-            if [[ ! -z $DEV ]]; then
-                /bin/systemctl stop ${peer}@$DEV
-            else
-                /bin/systemctl stop ${peer}
+            local peer_service="${peer}${DEV:+@$DEV}"
+
+            # Primary guard: if the peer holds its state-change lock it is
+            # already running its own start or stop sequence — do not interfere.
+            if peer_state_change_in_progress "${peer}"; then
+                debug "${peer_service} holds the state change lock, start or stop in progress; not stopping it"
+                continue
+            fi
+
+            # Backstop for the probe-to-stop gap: if the peer enters
+            # 'activating' (ExecStartPre starts) between the lock probe above
+            # and the stop below, systemd refuses the stop atomically instead
+            # of canceling the pending start job and killing ExecStartPre.
+            if ! stop_err=$(/bin/systemctl stop --job-mode=fail "${peer_service}" 2>&1); then
+                debug "Stop of ${peer_service} refused: ${stop_err}"
             fi
         done
     fi


### PR DESCRIPTION
When a peer service (e.g. syncd) exits unexpectedly, docker-wait-any-rs causes swss to restart. swss ExecStop calls stop_peer_and_dependent_services() which unconditionally calls 'systemctl stop <peer>' regardless of whether the peer is still running.

If the peer's Restart=always has already scheduled or started its ExecStartPre, the 'systemctl stop' arrives while ExecStartPre is in progress and kills it with SIGTERM, producing 'Failed with result signal'. This causes an unnecessary failed restart attempt that should not happen.

Fix: two-layer guard in stop_peer_and_dependent_services().

Primary guard - lock probe:
syncd_common.sh holds /tmp/swss-syncd-lock$DEV across its entire ExecStartPre (start():107-133). swss has already released its own copy of the lock before reaching this function, so a successful non-blocking flock attempt means the peer is idle; a busy lock means the peer is in the middle of its own start or stop and must not be interrupted. This covers the RestartSec delay window where no systemd job is queued yet and --job-mode=fail would not refuse the stop.

Backstop - --job-mode=fail:
If the peer enters 'activating' (ExecStartPre starts) between the lock probe and the stop call, systemd refuses the stop atomically rather than canceling the pending start job and killing ExecStartPre. stderr is captured and logged instead of discarded so genuine failures are visible.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
