### PR TITLE
Fix for switch create timeout on high cpu stress

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -142,6 +142,12 @@ elif [ "$platform" == "marvell-prestera" ]; then
     if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
         ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
     fi
+elif [ "$platform" == "cisco-8000" ]; then
+    ORCHAGENT_ARGS+="-m $MAC_ADDRESS"
+    CREATE_SWITCH_TIMEOUT=`cat $HWSKU_DIR/sai.profile | grep "createSwitchTimeout" | cut -d'=' -f 2`
+    if [[ ! -z $CREATE_SWITCH_TIMEOUT ]]; then
+        ORCHAGENT_ARGS+=" -t $CREATE_SWITCH_TIMEOUT"
+    fi
 else
     # Should we use the fallback MAC in case it is not found in Device.Metadata
     ORCHAGENT_ARGS+="-m $MAC_ADDRESS"


### PR DESCRIPTION

#### Why I did it
Create switch is taking time while cpu stress is at 100%

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Controlling the switch create timeout value on high cpu for cisco platforms.

#### How to verify it
Execute multiple config reloads while cpu is stressed at 100%

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->
Infra Update

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
Validated with testcase test_po_cleanup_after_reload.py 
202605: [test_po_cleanup_2026-08-26-08-39-34.log](https://github.com/user-attachments/files/31456097/test_po_cleanup_2026-08-26-08-39-34.log)

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
