### PR TITLE
[PDDF] Fix use-after-free panic when unloading pddf_custom_fpga_algo

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
+++ b/platform/broadcom/sonic-platform-modules-nexthop/common/modules/pddf_custom_fpga_algo.c
@@ -138,6 +138,7 @@ struct fpgalogic_i2c {
 static struct fpgalogic_i2c fpgalogic_i2c[I2C_PCI_MAX_BUS];
 extern void __iomem *(*get_fpga_ctl_addr)(const char *);
 extern int (*pddf_i2c_multifpgapci_add_numbered_bus)(struct i2c_adapter *, int);
+extern void (*pddf_i2c_multifpgapci_del_bus)(struct i2c_adapter *);
 static int xiic_reinit(struct fpgalogic_i2c *i2c);
 
 
@@ -619,10 +620,24 @@ static int pddf_i2c_multifpgapci_add_numbered_bus_default (struct i2c_adapter *a
 {
     int ret = 0;
 
-    adap_data_init(adap, index);
+    ret = adap_data_init(adap, index);
+    if (ret)
+        return ret;
+
     adap->algo  = &axi_iic_algorithm;
     ret = i2c_add_numbered_adapter(adap);
-    return ret;
+    if (ret)
+        return ret;
+
+    __module_get(THIS_MODULE);
+    return 0;
+}
+
+static void pddf_i2c_multifpgapci_del_bus_default (struct i2c_adapter *adap)
+{
+    i2c_del_adapter(adap);
+    /* Nothing references our algo/algo_data any more. Must stay last. */
+    module_put(THIS_MODULE);
 }
 
 /*
@@ -667,12 +682,15 @@ static int __init pddf_custom_fpga_algo_init(void)
 {
 	pddf_dbg(FPGA, KERN_INFO "[%s]\n", __FUNCTION__);
 	pddf_i2c_multifpgapci_add_numbered_bus = pddf_i2c_multifpgapci_add_numbered_bus_default;
+	pddf_i2c_multifpgapci_del_bus = pddf_i2c_multifpgapci_del_bus_default;
 	return 0;
 }
 static void __exit pddf_custom_fpga_algo_exit(void)
 {
 	pddf_dbg(FPGA, KERN_INFO "[%s]\n", __FUNCTION__);
+	/* Reaching here means no adapter holds a reference on us. */
 	pddf_i2c_multifpgapci_add_numbered_bus = NULL;
+	pddf_i2c_multifpgapci_del_bus = NULL;
 	return;
 }
 

--- a/platform/pddf/i2c/modules/multifpgapci/i2c/pddf_multifpgapci_i2c_module.c
+++ b/platform/pddf/i2c/modules/multifpgapci/i2c/pddf_multifpgapci_i2c_module.c
@@ -32,6 +32,22 @@ DEFINE_XARRAY(i2c_drvdata_map);
 int (*pddf_i2c_multifpgapci_add_numbered_bus)(struct i2c_adapter *, int) = NULL;
 EXPORT_SYMBOL(pddf_i2c_multifpgapci_add_numbered_bus);
 
+/*
+ * Counterpart of pddf_i2c_multifpgapci_add_numbered_bus. The algorithm module
+ * that installed adap->algo needs to know when an adapter goes away so it can
+ * drop the reference it took while the adapter was live.
+ */
+void (*pddf_i2c_multifpgapci_del_bus)(struct i2c_adapter *) = NULL;
+EXPORT_SYMBOL(pddf_i2c_multifpgapci_del_bus);
+
+static void multifpgapci_del_i2c_adapter(struct i2c_adapter *adap)
+{
+	if (pddf_i2c_multifpgapci_del_bus)
+		pddf_i2c_multifpgapci_del_bus(adap);
+	else
+		i2c_del_adapter(adap);
+}
+
 ssize_t new_i2c_adapter(struct device *dev, struct device_attribute *da,
 			const char *buf, size_t count)
 {
@@ -147,7 +163,7 @@ ssize_t del_i2c_adapter(struct device *dev, struct device_attribute *da,
 		 KERN_INFO "[%s] Attempting delete of bus index: %d\n",
 		 __FUNCTION__, index);
 
-	i2c_del_adapter(&i2c_privdata->i2c_adapters[index]);
+	multifpgapci_del_i2c_adapter(&i2c_privdata->i2c_adapters[index]);
 
 	i2c_privdata->i2c_adapter_registered[index] = false;
 
@@ -291,7 +307,9 @@ static void pddf_multifpgapci_i2c_detach(struct pci_dev *pci_dev,
 				 KERN_INFO "[%s] deleting i2c adapter: %s\n",
 				 __FUNCTION__,
 				 i2c_privdata->i2c_adapters[i].name);
-			i2c_del_adapter(&i2c_privdata->i2c_adapters[i]);
+			multifpgapci_del_i2c_adapter(
+				&i2c_privdata->i2c_adapters[i]);
+			i2c_privdata->i2c_adapter_registered[i] = false;
 		}
 	}
 	if (i2c_privdata->i2c_kobj) {


### PR DESCRIPTION
#### Why I did it

Unloading `pddf_custom_fpga_algo` while I2C adapters created through `pddf_multifpgapci_i2c_module` were still registered caused a kernel use-after-free panic. The registered adapters' `algo` and `algo_data` point into memory owned by the algorithm module, but nothing pinned that module while the adapters were live, so any I2C transfer (or the adapter teardown itself) after the module was unloaded dereferenced freed memory.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added a new exported hook `pddf_i2c_multifpgapci_del_bus` in `pddf_multifpgapci_i2c_module.c` as the counterpart of the existing `pddf_i2c_multifpgapci_add_numbered_bus` hook, so the algorithm module that installed `adap->algo` is notified when an adapter goes away. Adapter deletion paths (`del_i2c_adapter` sysfs handler and PCI detach) now call the hook, falling back to plain `i2c_del_adapter()` when no algorithm module is loaded.
- In `pddf_custom_fpga_algo.c`, take a module reference (`__module_get`) after an adapter is successfully registered and drop it (`module_put`) only after `i2c_del_adapter()` completes in the new del-bus callback. This makes `rmmod pddf_custom_fpga_algo` fail with "module is in use" while adapters still reference it, instead of panicking later.
- Also propagate errors from `adap_data_init()` and `i2c_add_numbered_adapter()` instead of ignoring them, and clear the `i2c_adapter_registered` flag when adapters are deleted on PCI detach.

#### How to verify it

On a PDDF platform that uses the multi-FPGA PCI I2C framework:

1. Load `pddf_multifpgapci_i2c_module` and `pddf_custom_fpga_algo`, and create I2C adapters through the PDDF sysfs interface.
2. Attempt `rmmod pddf_custom_fpga_algo` while the adapters are still registered. Before this change the unload succeeded and the kernel later panicked with a use-after-free; with this change the unload is refused because the module refcount is held by the live adapters.
3. Delete the adapters (or detach the PCI device), then unload the modules. Unload now completes cleanly with no panic.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [x] master

#### Test result

- master: verified adapter create/delete and module unload sequence on a PDDF multi-FPGA PCI platform; no panic after the fix.

#### Description for the changelog

Fix use-after-free kernel panic when unloading pddf_custom_fpga_algo while FPGA I2C adapters are still registered.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
