### PR TITLE
Make sure Debian hardening flags get propagated to target builds

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -79,10 +79,10 @@
 #   Bump it when a slave.mk change genuinely affects package build output
 #   (e.g., dpkg build recipe changes, compiler flag changes, install logic changes).
 #
-SONIC_CACHE_RECIPE_VER := 1
+SONIC_CACHE_RECIPE_VER := 2
 # Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
 # Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 348388b6882c0c90f4a1c7170d0e33cf9c0e645b
+SONIC_CACHE_RECIPE_VER_BASELINE := 57a423c0b31ad2869422ec0d2c13ee0492b8ecb9
 
 # Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
 # This catches the case where someone modifies slave.mk build recipes without

--- a/slave.mk
+++ b/slave.mk
@@ -436,7 +436,7 @@ export ENABLE_FIPS
 ###############################################################################
 ## Build Options
 ###############################################################################
-export DEB_BUILD_OPTIONS = hardening=+all
+export DEB_BUILD_OPTIONS = hardening=+all $(DEB_BUILD_OPTIONS_GENERIC)
 
 ###############################################################################
 ## Dumping key config attributes associated to current building exercise
@@ -935,7 +935,7 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_MAKE_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		if [ -f $($*_SRC_PATH).patch/series ]; then pushd $($*_SRC_PATH) && ( quilt pop -a -f 1>/dev/null 2>&1 || true ) && QUILT_PATCHES=../$(notdir $($*_SRC_PATH)).patch quilt push -a; popd; fi $(LOG)
 		# Build project and take package
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
-		$(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) make -j$(SONIC_CONFIG_MAKE_JOBS) DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
+		$(CCACHE_ENV) $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) make -j$(SONIC_CONFIG_MAKE_JOBS) DEST=$(shell pwd)/$(DEBS_PATH) -C $($*_SRC_PATH) $(shell pwd)/$(DEBS_PATH)/$* $(LOG)
 		# Archive patched source for static analysis (patches still applied)
 		$(call ARCHIVE_PATCHED_SOURCE,$*)
 		# Clean up
@@ -986,8 +986,8 @@ $(addprefix $(DEBS_PATH)/, $(SONIC_DPKG_DEBS)) : $(DEBS_PATH)/% : .platform $$(a
 		if [ -f ./autogen.sh ]; then ./autogen.sh $(LOG); fi
 		$(SETUP_OVERLAYFS_FOR_DPKG_ADMINDIR)
 		$(if $($*_DPKG_TARGET),
-			${$*_BUILD_ENV} $(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" DEB_BUILD_PROFILES="${$*_DEB_BUILD_PROFILES}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) timeout --preserve-status -s 9 -k 10 $(BUILD_PROCESS_TIMEOUT) dpkg-buildpackage -rfakeroot -b $(ANT_DEB_CROSS_OPT) -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --as-root -T$($*_DPKG_TARGET) --admindir $$mergedir $(LOG),
-			${$*_BUILD_ENV} $(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS_GENERIC} ${$*_DEB_BUILD_OPTIONS}" DEB_BUILD_PROFILES="${$*_DEB_BUILD_PROFILES}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) timeout --preserve-status -s 9 -k 10 $(BUILD_PROCESS_TIMEOUT) dpkg-buildpackage -rfakeroot -b $(ANT_DEB_CROSS_OPT) -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $$mergedir $(LOG)
+			${$*_BUILD_ENV} $(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} ${$*_DEB_BUILD_OPTIONS}" DEB_BUILD_PROFILES="${$*_DEB_BUILD_PROFILES}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) timeout --preserve-status -s 9 -k 10 $(BUILD_PROCESS_TIMEOUT) dpkg-buildpackage -rfakeroot -b $(ANT_DEB_CROSS_OPT) -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --as-root -T$($*_DPKG_TARGET) --admindir $$mergedir $(LOG),
+			${$*_BUILD_ENV} $(CCACHE_ENV) DEB_BUILD_OPTIONS="${DEB_BUILD_OPTIONS} ${$*_DEB_BUILD_OPTIONS}" DEB_BUILD_PROFILES="${$*_DEB_BUILD_PROFILES}" $(ANT_DEB_CONFIG) $(CROSS_COMPILE_FLAGS) timeout --preserve-status -s 9 -k 10 $(BUILD_PROCESS_TIMEOUT) dpkg-buildpackage -rfakeroot -b $(ANT_DEB_CROSS_OPT) -us -uc -tc -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $$mergedir $(LOG)
 		)
 		popd $(LOG_SIMPLE)
 		# Archive patched source for static analysis (patches still applied)


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The Debian hardening flags attempted to get enabled in `slave.mk`, via `DEB_BUILD_OPTIONS`. However, because `slave.mk` sets `DEB_BUILD_OPTIONS` to `DEB_BUILD_OPTIONS_GENERIC` on the command line for deb package builds, the hardening flag got overridden.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Fix this so that `DEB_BUILD_OPTIONS_GENERIC` is appended to `DEB_BUILD_OPTIONS`, and only export that variable at the top.

Also bump up the `slave.mk` cache variables to force a rebuild of everything, since build and runtime behavior will change.

#### How to verify it

For Debian Trixie, the only flag that gets added when setting `hardening=+all` from the default config is the linker flag `-Wl,-z,now` (for immediate binding of symbols). This means compiler options won't change, but linker options will change.

Without this change, the following builds were linking files (i.e. had `-Wl,-z,relro` present), but did not have `-Wl,-z,now` (obviously, this is not comprehensive; if some package is not using `-Wl,-z,relro`, they won't get looked at at all, but this was an easy filter for me to choose):

```
target/debs/trixie/audisp-tacplus_1.0.2_amd64.deb.log
target/debs/trixie/bash-tacplus_1.0.0_amd64.deb.log
target/debs/trixie/grub2-common_2.06-13+deb13u1_amd64.deb.log
target/debs/trixie/hsflowd_2.1.26-1_amd64.deb.log
target/debs/trixie/libnl-3-200_3.7.0-0.2+b1sonic1_amd64.deb.log
target/debs/trixie/libnss-radius_1.0.1-1_amd64.deb.log
target/debs/trixie/libteam5_1.31-1_amd64.deb.log
target/debs/trixie/linux-headers-6.12.41+deb13-common-sonic_6.12.41-1_all.deb.log
target/debs/trixie/lm-sensors_3.6.0-7.1_amd64.deb.log
target/debs/trixie/makedumpfile_1.7.7-1_amd64.deb.log
target/debs/trixie/psample_1.1-1_amd64.deb.log
target/debs/trixie/python3-libyang_3.1.0-1_amd64.deb.log
target/debs/trixie/rasdaemon_0.6.8-1_amd64.deb.log
target/debs/trixie/sflowtool_6.11_amd64.deb.log
target/debs/trixie/socat_1.7.4.1-3_amd64.deb.log
target/debs/trixie/sonic-mgmt-framework_1.0-01_amd64.deb.log
target/debs/trixie/stp_1.0.0_amd64.deb.log
target/debs/trixie/swss_1.0.0_amd64.deb.log
target/debs/trixie/sysmgr_1.0.0_amd64.deb.log
target/debs/trixie/systemd-sonic-generator_1.0.0_amd64.deb.log
```

With this change, the following builds do not have `-Wl,-z,now`:

```
target/debs/trixie/lm-sensors_3.6.0-7.1_amd64.deb.log
target/debs/trixie/socat_1.7.4.1-3_amd64.deb.log
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
