### PR TITLE
[build] upgrade socat to 1.8.0.2-1

### DIFF
--- a/rules/socat.mk
+++ b/rules/socat.mk
@@ -1,6 +1,6 @@
 # socat packages
 
-SOCAT_VERSION = 1.7.4.1-3
+SOCAT_VERSION = 1.8.0.2-1
 
 export SOCAT_VERSION
 

--- a/src/socat/Makefile
+++ b/src/socat/Makefile
@@ -4,20 +4,21 @@ SHELL = /bin/bash
 
 MAIN_TARGET = socat_$(SOCAT_VERSION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = socat-dbgsym_$(SOCAT_VERSION)_$(CONFIGURED_ARCH).deb
+SOCAT_UPSTREAM_VERSION = $(word 1,$(subst -, ,$(SOCAT_VERSION)))
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	# Remove any stale files
-	rm -rf ./socat-1.7.4.1
+	rm -rf ./socat-$(SOCAT_UPSTREAM_VERSION)
 
 	# Get source package
-	wget -NO socat_$(SOCAT_VERSION).dsc "$(BUILD_PUBLIC_URL)/debian/socat_1.7.4.1-3.dsc"
-	wget -NO socat_$(SOCAT_VERSION).debian.tar.xz "$(BUILD_PUBLIC_URL)/debian/socat_1.7.4.1-3.debian.tar.xz"
-	wget -NO socat_1.7.4.1.orig.tar.gz "$(BUILD_PUBLIC_URL)/debian/socat_1.7.4.1.orig.tar.gz"
+	wget -NO socat_$(SOCAT_VERSION).dsc "$(BUILD_PUBLIC_URL)/debian/socat_$(SOCAT_VERSION).dsc"
+	wget -NO socat_$(SOCAT_VERSION).debian.tar.xz "$(BUILD_PUBLIC_URL)/debian/socat_$(SOCAT_VERSION).debian.tar.xz"
+	wget -NO socat_$(SOCAT_UPSTREAM_VERSION).orig.tar.bz2 "$(BUILD_PUBLIC_URL)/debian/socat_$(SOCAT_UPSTREAM_VERSION).orig.tar.bz2"
 
 	dpkg-source -x socat_$(SOCAT_VERSION).dsc
 
 	# Build source and Debian packages
-	pushd socat-1.7.4.1
+	pushd socat-$(SOCAT_UPSTREAM_VERSION)
 	patch -p0 < ../patch/enable_readline.patch
 ifeq ($(CROSS_BUILD_ENVIRON), y)
 	dpkg-buildpackage -rfakeroot -b -us -uc -a$(CONFIGURED_ARCH) -Pcross,nocheck -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)

--- a/src/socat/patch/enable_readline.patch
+++ b/src/socat/patch/enable_readline.patch
@@ -1,5 +1,5 @@
---- debian/rules.old	2021-12-14 10:51:09.641165521 -0800
-+++ debian/rules	2021-12-14 10:52:36.494048522 -0800
+--- debian/rules.old
++++ debian/rules
 @@ -11,9 +11,6 @@
  # upsteram maintains config.h.in manually
  export AUTOHEADER = true
@@ -8,7 +8,7 @@
 -	dh_auto_configure -- --disable-readline
 -
  override_dh_auto_test:
- ifneq (, filter $(DEB_BUILD_ARCH_OS), kfreebsd hurd)
+ ifneq (,$(filter $(DEB_HOST_ARCH_OS), linux))
  	dh_auto_test
 @@ -24,4 +21,4 @@
  %:
@@ -16,14 +16,15 @@
  
 -.PHONY: override_dh_auto_configure override_dh_auto_test
 +.PHONY: override_dh_auto_test
---- debian/control.old	2021-12-14 11:30:49.166051931 -0800
-+++ debian/control	2021-12-14 11:30:57.590153464 -0800
-@@ -3,7 +3,7 @@
+--- debian/control.old
++++ debian/control
+@@ -2,7 +2,7 @@
+ Section: net
  Priority: optional
  Maintainer: Laszlo Boszormenyi (GCS) <gcs@debian.org>
- Homepage: http://www.dest-unreach.org/socat/
--Build-Depends: debhelper-compat (= 12), libssl-dev, libwrap0-dev, openssl <!nocheck>, net-tools <!nocheck>, iproute2 [linux-any] <!nocheck>, netbase <!nocheck>
-+Build-Depends: debhelper-compat (= 12), libssl-dev, libwrap0-dev, libreadline-dev, openssl <!nocheck>, net-tools <!nocheck>, iproute2 [linux-any] <!nocheck>, netbase <!nocheck>
- Standards-Version: 4.5.1
+-Build-Depends: debhelper-compat (= 13), libssl-dev, libwrap0-dev, openssl <!nocheck>, net-tools <!nocheck>, iproute2 [linux-any] <!nocheck>, netbase <!nocheck>, procps <!nocheck>
++Build-Depends: debhelper-compat (= 13), libssl-dev, libwrap0-dev, libreadline-dev, openssl <!nocheck>, net-tools <!nocheck>, iproute2 [linux-any] <!nocheck>, netbase <!nocheck>, procps <!nocheck>
+ Standards-Version: 4.6.2
  Rules-Requires-Root: no
- 
+ Homepage: https://www.dest-unreach.org/socat/
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Upgrade socat from 1.7.4.1-3 to 1.8.0.2-1 to address CVE-2024-54661.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Upgraded `SOCAT_VERSION` from 1.7.4.1-3 to 1.8.0.2-1.
- Updated the source package recipe for the new Debian source files.
- Changed the upstream source archive from `.orig.tar.gz` to `.orig.tar.bz2`.
- Derived the upstream source version from `SOCAT_VERSION` to avoid hard-coded source directory names.
- Refreshed `enable_readline.patch` for the Debian 1.8.0.2-1 packaging layout.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
