### PR TITLE
fix(docker-ptf): backport vulnerable pip removal to 202605

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -191,9 +191,9 @@ RUN set -eux \
     && ln -sf /usr/local/bin/influxdb3 /usr/local/bin/influxd \
     && rm -f "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \
-    && pip3 install --target /usr/local/lib/influxdb3-python/lib/python3.13/site-packages "pip>=26.1" \
-    && NEWPIP=$(ls -d /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info | sort -V | tail -1) \
-    && find /usr/local/lib/influxdb3-python/lib/python3.13/site-packages -maxdepth 1 -name 'pip-*.dist-info' ! -path "$NEWPIP" -exec rm -rf {} +
+    && rm -rf /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip \
+        /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info \
+    && rm -f /usr/local/lib/influxdb3-python/bin/pip*
 {% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}
@@ -456,6 +456,12 @@ ENV PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 # Install the python-saithrift into the virtual environment
 RUN echo "/usr/lib/python3/dist-packages/saithrift-0.9-py3.11.egg" >> /root/env-python3/lib/python3.11/site-packages/easy-install.pth
 {% endif %}
+
+# pip is only needed to assemble the virtualenv. Remove it after the last
+# package installation to avoid shipping its vulnerable vendored dependencies.
+RUN rm -rf /root/env-python3/lib/python*/site-packages/pip \
+        /root/env-python3/lib/python*/site-packages/pip-*.dist-info \
+    && rm -f /root/env-python3/bin/pip*
 
 # {% if PTF_ENV_PY_VER == "py3" %}
 # # Create symlink so that test scripts and ptf_runner invocation path


### PR DESCRIPTION
#### Why I did it

This is the combined 202605 backport of #28866 and its follow-up #28902.

The docker-ptf Trivy scan reports vulnerable `msgpack` and `setuptools` copies vendored by pip in two locations: the Python runtime bundled with InfluxDB 3 Core and the build virtualenv. The follow-up completes the original remediation, so both changes are included in one backport.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Applied both source changes as one commit:

- Removed pip, its distribution metadata, and its entry points from the bundled InfluxDB Python runtime.
- Removed build-only pip, its distribution metadata, and its entry points from the docker-ptf virtualenv after the final Python package installation.

The InfluxDB runtime, installed virtualenv packages, and system `python3-pip` package remain available.

#### How to verify it

1. Build `docker-ptf`.
2. Run the Trivy vulnerability scan.
3. Confirm GHSA-6v7p-g79w-8964, CVE-2025-47273, and CVE-2026-59890 are absent.
4. Run the sonic-mgmt docker-ptf and HFT InfluxDB tests.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

This PR directly targets 202605. No additional release backport is requested from this PR.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A - combined backport of #28866 and #28902
Failure type: other - vulnerable vendored Python dependencies

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- #28866 extracted the exact InfluxDB 3 Core 3.9.0 archive, removed the bundled pip artifacts, and verified InfluxDB health, database creation, HFT-style writes, and InfluxQL queries.
- #28902 reproduced the three findings with pip 26.2.1, removed the virtualenv pip artifacts, confirmed the findings decreased to zero, and verified an installed runtime package remained importable.
- Both changes applied cleanly to 202605 and pass `git diff --check`. Target-branch build and scan results will be provided by PR CI.

#### Description for the changelog

Remove vulnerable bundled pip artifacts from the InfluxDB runtime and docker-ptf build virtualenv.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
