### PR TITLE
[platform]: Add Arista firmware override hook

### DIFF
--- a/platform/broadcom/platform-modules-arista.mk
+++ b/platform/broadcom/platform-modules-arista.mk
@@ -46,7 +46,8 @@ INSTALL_ARISTA_FWUTIL = y
 endif
 
 ARISTA_FIRMWARE_VERSION = 202511.1
-ARISTA_FIRMWARE = arista-firmware_$(ARISTA_FIRMWARE_VERSION)_all.deb
+-include $(PLATFORM_PATH)/platform-modules-arista.organization.mk
+ARISTA_FIRMWARE ?= arista-firmware_$(ARISTA_FIRMWARE_VERSION)_all.deb
 $(ARISTA_FIRMWARE)_PATH = $(PLATFORM_PATH)/extra-debs
 $(ARISTA_FIRMWARE)_PLATFORM = $(ARISTA_PLATFORMS)
 


### PR DESCRIPTION
#### Why I did it

Allow deployments that require an alternate Arista firmware package to select it without carrying a modification to the shared platform rule.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Added an optional `platform-modules-arista.organization.mk` include and changed the default `ARISTA_FIRMWARE` assignment to `?=`. Builds without an organization override retain the existing public firmware package.

#### How to verify it

Evaluate `platform-modules-arista.mk` with and without an `ARISTA_FIRMWARE` override and confirm that the public default and supplied override are selected respectively.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Make evaluation selected `arista-firmware_202511.1_all.deb` by default and honored a supplied `ARISTA_FIRMWARE` override.

#### Description for the changelog

Add an override hook for the Arista firmware package.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A
