### PR TITLE
[installer]: Prevent shim SBAT downgrades

### DIFF
--- a/installer/default_platform.conf
+++ b/installer/default_platform.conf
@@ -446,6 +446,8 @@ demo_install_uefi_shim()
     mkdir -p /boot/efi/EFI/$demo_volume_label
 
     local src_dir="$demo_mnt/$image_dir/boot"
+    local efi_downgrade_status=10
+    local efi_installed_invalid_status=11
 
     #
     # Validate required files
@@ -457,10 +459,53 @@ demo_install_uefi_shim()
         fi
     done
 
-    echo "copying signed shim, mm, grub from $src_dir to /boot/efi/EFI/$demo_volume_label directory"
-    cp "$src_dir/mmx64.efi" /boot/efi/EFI/$demo_volume_label/mmx64.efi
-    cp "$src_dir/shimx64.efi" /boot/efi/EFI/$demo_volume_label/shimx64.efi
-    cp "$src_dir/grubx64.efi" /boot/efi/EFI/$demo_volume_label/grubx64.efi
+    echo "evaluating signed shim, mm, grub from $src_dir for /boot/efi/EFI/$demo_volume_label"
+    local dst_dir="/boot/efi/EFI/$demo_volume_label"
+    local installed_bundle_complete=no
+    local replace_efi_files=yes
+
+    if [ -f "$dst_dir/mmx64.efi" ] &&
+       [ -f "$dst_dir/shimx64.efi" ] &&
+       [ -f "$dst_dir/grubx64.efi" ]; then
+        installed_bundle_complete=yes
+    fi
+
+    if [ -f "$dst_dir/shimx64.efi" ]; then
+        if ! command -v python3 >/dev/null 2>&1; then
+            echo "WARNING: python3 is unavailable; replacing installed Secure Boot components"
+        else
+            local compare_status=0
+            python3 ./efi_sbatlevel.py \
+                "$dst_dir/shimx64.efi" \
+                "$src_dir/shimx64.efi" || compare_status=$?
+            case $compare_status in
+                0)
+                    ;;
+                "$efi_downgrade_status")
+                    echo "EFI downgrade detected from shim SBAT level; preserving installed shim, grub, and MokManager"
+                    replace_efi_files=no
+                    ;;
+                "$efi_installed_invalid_status")
+                    echo "WARNING: installed shim SBAT level is unreadable; replacing installed Secure Boot components"
+                    ;;
+                *)
+                    echo "WARNING: unable to compare shim SBAT level timestamps; replacing installed Secure Boot components"
+                    ;;
+            esac
+        fi
+    fi
+
+    if [ "$replace_efi_files" = "no" ] &&
+       [ "$installed_bundle_complete" = "no" ]; then
+        echo "ERROR: cannot preserve an incomplete installed Secure Boot component set"
+        exit 1
+    fi
+
+    if [ "$replace_efi_files" = "yes" ]; then
+        cp "$src_dir/mmx64.efi" "$dst_dir/mmx64.efi"
+        cp "$src_dir/shimx64.efi" "$dst_dir/shimx64.efi"
+        cp "$src_dir/grubx64.efi" "$dst_dir/grubx64.efi"
+    fi
 
 
     # Configure EFI NVRAM Boot variables.  --create also sets the

--- a/installer/efi_sbatlevel.py
+++ b/installer/efi_sbatlevel.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import re
+import struct
+import sys
+
+
+EXIT_SUCCESS = 0
+EXIT_ERROR = 1
+EXIT_DOWNGRADE = 10
+EXIT_INSTALLED_INVALID = 11
+
+DOS_SIGNATURE = b"MZ"
+DOS_PE_HEADER_OFFSET = 0x3C
+PE_SIGNATURE = b"PE\0\0"
+PE_SIGNATURE_SIZE = len(PE_SIGNATURE)
+COFF_HEADER_SIZE = 20
+COFF_SECTION_COUNT_OFFSET = 2
+COFF_SYMBOL_TABLE_OFFSET = 8
+COFF_OPTIONAL_HEADER_SIZE_OFFSET = 16
+COFF_SYMBOL_SIZE = 18
+SECTION_HEADER_SIZE = 40
+SECTION_NAME_SIZE = 8
+SECTION_RAW_DATA_FIELDS_OFFSET = 16
+SBATLEVEL_SECTION_NAME = b".sbatlevel"
+SBATLEVEL_HEADER_SIZE = 12
+SBATLEVEL_VERSION_OFFSET = 0
+SBATLEVEL_SUPPORTED_VERSION = 0
+SBATLEVEL_OFFSET_BASE = 4
+SBATLEVEL_AUTOMATIC_OFFSET = 4
+
+TIMESTAMP_PATTERN = re.compile(
+    rb"sbat,\d+,(\d{8}|\d{10}|\d{12}|\d{14})\n"
+)
+
+
+class InstalledShimError(ValueError):
+    pass
+
+
+def get_section(data, section_name):
+    if data[:len(DOS_SIGNATURE)] != DOS_SIGNATURE:
+        raise ValueError("missing DOS header")
+
+    pe_offset = struct.unpack_from(
+        "<I", data, DOS_PE_HEADER_OFFSET
+    )[0]
+    if data[
+        pe_offset:pe_offset + PE_SIGNATURE_SIZE
+    ] != PE_SIGNATURE:
+        raise ValueError("missing PE signature")
+
+    coff_offset = pe_offset + PE_SIGNATURE_SIZE
+    section_count = struct.unpack_from(
+        "<H", data, coff_offset + COFF_SECTION_COUNT_OFFSET
+    )[0]
+    optional_header_size = struct.unpack_from(
+        "<H",
+        data,
+        coff_offset + COFF_OPTIONAL_HEADER_SIZE_OFFSET,
+    )[0]
+    section_offset = (
+        coff_offset + COFF_HEADER_SIZE + optional_header_size
+    )
+    symbol_table_offset, symbol_count = struct.unpack_from(
+        "<II", data, coff_offset + COFF_SYMBOL_TABLE_OFFSET
+    )
+    string_table_offset = (
+        symbol_table_offset + symbol_count * COFF_SYMBOL_SIZE
+    )
+
+    for index in range(section_count):
+        header_offset = section_offset + index * SECTION_HEADER_SIZE
+        raw_name = data[
+            header_offset:header_offset + SECTION_NAME_SIZE
+        ].rstrip(b"\0")
+        name = raw_name
+        if raw_name.startswith(b"/"):
+            try:
+                name_offset = int(raw_name[1:])
+            except ValueError as error:
+                raise ValueError(
+                    f"invalid section name {raw_name!r}"
+                ) from error
+            name_start = string_table_offset + name_offset
+            name_end = data.find(b"\0", name_start)
+            if name_end == -1:
+                raise ValueError("unterminated section name")
+            name = data[name_start:name_end]
+        raw_size, raw_offset = struct.unpack_from(
+            "<II",
+            data,
+            header_offset + SECTION_RAW_DATA_FIELDS_OFFSET,
+        )
+        if raw_offset + raw_size > len(data):
+            raise ValueError(f"section {name!r} exceeds file size")
+        if name == section_name:
+            return data[raw_offset:raw_offset + raw_size]
+
+    raise ValueError(
+        f"missing {section_name.decode('ascii')} section"
+    )
+
+
+def get_automatic_timestamp(path):
+    with open(path, "rb") as efi_file:
+        section = get_section(
+            efi_file.read(), SBATLEVEL_SECTION_NAME
+        )
+
+    if len(section) < SBATLEVEL_HEADER_SIZE:
+        raise ValueError("invalid .sbatlevel header")
+    version = struct.unpack_from("<I", section, SBATLEVEL_VERSION_OFFSET)[0]
+    if version != SBATLEVEL_SUPPORTED_VERSION:
+        raise ValueError(f"unsupported .sbatlevel version: {version}")
+    relative_offset = struct.unpack_from("<I", section, SBATLEVEL_AUTOMATIC_OFFSET)[0]
+    automatic_offset = SBATLEVEL_OFFSET_BASE + relative_offset
+    match = TIMESTAMP_PATTERN.match(section, automatic_offset)
+    if match is None:
+        raise ValueError(
+            "missing automatic timestamp in .sbatlevel section"
+        )
+
+    value = match.group(1).decode("ascii")
+    date = datetime.datetime.strptime(value[:8], "%Y%m%d").date()
+    sequence = int(value[8:] or "0")
+    return (date, sequence), value
+
+
+def compare_shims(installed_path, incoming_path):
+    incoming_timestamp, incoming_value = get_automatic_timestamp(incoming_path)
+    try:
+        installed_timestamp, installed_value = get_automatic_timestamp(
+            installed_path
+        )
+    except (OSError, struct.error, ValueError) as error:
+        raise InstalledShimError(str(error)) from error
+
+    relation = "same"
+    result = EXIT_SUCCESS
+    if incoming_timestamp < installed_timestamp:
+        relation = "downgrade"
+        result = EXIT_DOWNGRADE
+    elif incoming_timestamp > installed_timestamp:
+        relation = "upgrade"
+
+    print(
+        f"shim SBAT level: {relation} "
+        f"({installed_value} -> {incoming_value})"
+    )
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare shim automatic SBAT level timestamps"
+    )
+    parser.add_argument("installed_shim")
+    parser.add_argument("incoming_shim")
+    args = parser.parse_args()
+
+    try:
+        return compare_shims(
+            args.installed_shim, args.incoming_shim
+        )
+    except InstalledShimError as error:
+        print(
+            f"WARNING: unable to read installed shim SBAT level: {error}",
+            file=sys.stderr,
+        )
+        return EXIT_INSTALLED_INVALID
+    except (OSError, struct.error, ValueError) as error:
+        print(
+            f"ERROR: unable to compare shim SBAT levels: {error}",
+            file=sys.stderr,
+        )
+        return EXIT_ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/installer/tests/test_efi_sbatlevel.py
+++ b/installer/tests/test_efi_sbatlevel.py
@@ -1,0 +1,211 @@
+import importlib.util
+from pathlib import Path
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).parents[1] / "efi_sbatlevel.py"
+SPEC = importlib.util.spec_from_file_location(
+    "efi_sbatlevel", MODULE_PATH
+)
+efi_sbatlevel = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(efi_sbatlevel)
+
+
+def create_pe(timestamp, sbatlevel_version=0):
+    pe_offset = 0x40
+    optional_header_size = 0
+    section_header_offset = (
+        pe_offset
+        + len(efi_sbatlevel.PE_SIGNATURE)
+        + efi_sbatlevel.COFF_HEADER_SIZE
+    )
+    raw_offset = section_header_offset + efi_sbatlevel.SECTION_HEADER_SIZE
+    section = (
+        struct.pack("<III", sbatlevel_version, 8, 55)
+        + f"sbat,1,{timestamp}\nshim,4\n".encode()
+        + b"\0sbat,1,2099010100\nshim,99\n\0"
+    )
+    string_table = b".sbatlevel\0"
+    symbol_table_offset = raw_offset + len(section)
+    data = bytearray(
+        symbol_table_offset + 4 + len(string_table)
+    )
+    data[:2] = efi_sbatlevel.DOS_SIGNATURE
+    struct.pack_into(
+        "<I", data, efi_sbatlevel.DOS_PE_HEADER_OFFSET, pe_offset
+    )
+    data[pe_offset:pe_offset + 4] = efi_sbatlevel.PE_SIGNATURE
+    coff_offset = pe_offset + len(efi_sbatlevel.PE_SIGNATURE)
+    struct.pack_into(
+        "<H",
+        data,
+        coff_offset + efi_sbatlevel.COFF_SECTION_COUNT_OFFSET,
+        1,
+    )
+    struct.pack_into(
+        "<H",
+        data,
+        coff_offset + efi_sbatlevel.COFF_OPTIONAL_HEADER_SIZE_OFFSET,
+        optional_header_size,
+    )
+    struct.pack_into(
+        "<II",
+        data,
+        coff_offset + efi_sbatlevel.COFF_SYMBOL_TABLE_OFFSET,
+        symbol_table_offset,
+        0,
+    )
+    data[
+        section_header_offset:section_header_offset + 8
+    ] = b"/4\0\0\0\0\0\0"
+    struct.pack_into(
+        "<II",
+        data,
+        section_header_offset
+        + efi_sbatlevel.SECTION_RAW_DATA_FIELDS_OFFSET,
+        len(section),
+        raw_offset,
+    )
+    data[raw_offset:raw_offset + len(section)] = section
+    struct.pack_into(
+        "<I", data, symbol_table_offset, 4 + len(string_table)
+    )
+    data[symbol_table_offset + 4:] = string_table
+    return data
+
+
+class EfiSbatLevelTest(unittest.TestCase):
+    def write_shim(self, directory, name, timestamp):
+        path = Path(directory) / name
+        path.write_bytes(create_pe(timestamp))
+        return path
+
+    def test_uses_first_automatic_timestamp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = self.write_shim(
+                directory, "shimx64.efi", "2024010900"
+            )
+
+            _, value = efi_sbatlevel.get_automatic_timestamp(path)
+
+        self.assertEqual(value, "2024010900")
+
+    def test_rejects_unsupported_sbatlevel_version(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "shimx64.efi"
+            path.write_bytes(create_pe("2024010900", sbatlevel_version=1))
+
+            with self.assertRaisesRegex(
+                ValueError, "unsupported .sbatlevel version: 1"
+            ):
+                efi_sbatlevel.get_automatic_timestamp(path)
+
+    def test_upgrade(self):
+        with tempfile.TemporaryDirectory() as directory:
+            installed = self.write_shim(
+                directory, "installed.efi", "2024010900"
+            )
+            incoming = self.write_shim(
+                directory, "incoming.efi", "2024040900"
+            )
+
+            result = efi_sbatlevel.compare_shims(
+                installed, incoming
+            )
+
+        self.assertEqual(result, efi_sbatlevel.EXIT_SUCCESS)
+
+    def test_sequence_suffix_is_not_treated_as_time(self):
+        with tempfile.TemporaryDirectory() as directory:
+            installed = self.write_shim(
+                directory, "installed.efi", "2023012900"
+            )
+            incoming = self.write_shim(
+                directory, "incoming.efi", "2023012950"
+            )
+
+            result = efi_sbatlevel.compare_shims(
+                installed, incoming
+            )
+
+        self.assertEqual(result, efi_sbatlevel.EXIT_SUCCESS)
+
+    def test_downgrade(self):
+        with tempfile.TemporaryDirectory() as directory:
+            installed = self.write_shim(
+                directory, "installed.efi", "2024040900"
+            )
+            incoming = self.write_shim(
+                directory, "incoming.efi", "2024010900"
+            )
+
+            result = efi_sbatlevel.compare_shims(
+                installed, incoming
+            )
+
+        self.assertEqual(result, efi_sbatlevel.EXIT_DOWNGRADE)
+
+    def test_rejects_invalid_pe(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "invalid.efi"
+            path.write_bytes(b"not a PE image")
+
+            with self.assertRaisesRegex(
+                ValueError, "missing DOS header"
+            ):
+                efi_sbatlevel.get_automatic_timestamp(path)
+
+    def test_invalid_installed_shim_has_distinct_exit_status(self):
+        with tempfile.TemporaryDirectory() as directory:
+            installed = Path(directory) / "installed.efi"
+            installed.write_bytes(b"not a PE image")
+            incoming = self.write_shim(
+                directory, "incoming.efi", "2024040900"
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    str(installed),
+                    str(incoming),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(
+            result.returncode,
+            efi_sbatlevel.EXIT_INSTALLED_INVALID,
+        )
+
+    def test_invalid_incoming_shim_fails_comparison(self):
+        with tempfile.TemporaryDirectory() as directory:
+            installed = self.write_shim(
+                directory, "installed.efi", "2024040900"
+            )
+            incoming = Path(directory) / "incoming.efi"
+            incoming.write_bytes(b"not a PE image")
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(MODULE_PATH),
+                    str(installed),
+                    str(incoming),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, efi_sbatlevel.EXIT_ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Compare installed and incoming shim SBAT levels before replacing the UEFI Secure Boot component set. Preserve a complete installed bundle on downgrade or comparison failure, and repair an unreadable installed shim with the incoming bundle.

Work item: 39199982

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
