### PR TITLE
VPP: Keep mod_sonic counter polling when mod_vpp runs with osIndex=on

### DIFF
--- a/src/sflow/hsflowd/patch/0002-vpp-osindex-counter-sampling.patch
+++ b/src/sflow/hsflowd/patch/0002-vpp-osindex-counter-sampling.patch
@@ -1,0 +1,19 @@
+diff -ruN a/src/Linux/mod_vpp.c b/src/Linux/mod_vpp.c
+--- a/src/Linux/mod_vpp.c
++++ b/src/Linux/mod_vpp.c
+@@ -428,11 +428,15 @@
+ 	  if(nio->poller) {
++	    // In osIndex=on mode, mod_vpp is translation-only. Counter
++	    // samples remain owned by mod_sonic and honor polling_interval.
++	    if(sp->vpp.osIndex == NO) {
+ 	    // Make sure it does not call back on it's own schedule.
+ 	    nio->poller->getCountersFn = NULL;
+ 	    if(newPort) {
+ 	      // reset the seqNo in case hsflowd had already found and sent
+ 	      // counters samples for this port (e.g. if found in Linux).
+ 	      sfl_poller_resetCountersSeqNo(nio->poller);
+ 	    }
+ 	    SFL_COUNTERS_SAMPLE_TYPE cs = {};
+ 	    sendInterfaceCounterSample(mod, nio->poller, adaptor, &cs);
++	    }
+ 	  }

--- a/src/sflow/hsflowd/patch/series
+++ b/src/sflow/hsflowd/patch/series
@@ -1,1 +1,2 @@
 0001-host_sflow_debian.patch
+0002-vpp-osindex-counter-sampling.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This PR creates the fix for passing some of the sonic-mgmt test. Specifically it fixes tests related to polling that were previously failing. 

Note, this PR is currently failing the CI/CD because of two upstream test issues.

1) `test_multiasic_cacl_application` PR: https://github.com/sonic-net/sonic-mgmt/pull/27183
2) `test_dhcp_relay_stress` PR: https://github.com/sonic-net/sonic-mgmt/pull/27220

Try running again once these two have been merged.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Created a new patch for hsflowd that wrap mod_vpp's counter emission and poller-disabling logic in `if (sp->vpp.osIndex == NO)`. When `osIndex = on`, mod_vpp now only maintains VPP-to-SONiC interface mapping, while mod_sonic controls counter polling according to the `polling_interval`. 

#### How to verify it

To verify, I re-ran the sonic-mgmt tests with these changes, and went from 10/15 test passing to 13/15 passing. The remaining 2 are related to everflow and am awaiting a fix for it. 

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
