### PR TITLE
[build] Align gRPC versions in slave snapshots

### DIFF
--- a/files/build/versions-public/build/build-sonic-slave-bookworm/versions-py3
+++ b/files/build/versions-public/build/build-sonic-slave-bookworm/versions-py3
@@ -10,8 +10,8 @@ enlighten==1.14.1
 enum34==1.1.10
 execnet==2.1.2
 filelock==3.32.2
-grpcio==1.66.2
-grpcio-tools==1.66.2
+grpcio==1.71.0
+grpcio-tools==1.71.0
 ijson==3.5.1
 inotify==0.2.12
 invoke==3.0.3

--- a/files/build/versions-public/build/build-sonic-slave-trixie/versions-py3
+++ b/files/build/versions-public/build/build-sonic-slave-trixie/versions-py3
@@ -6,8 +6,8 @@ docker-image-py==0.2.0
 enum34==1.1.10
 execnet==2.1.2
 freezegun==1.5.5
-grpcio==1.66.2
-grpcio-tools==1.66.2
+grpcio==1.71.0
+grpcio-tools==1.71.0
 inotify==0.2.12
 ipaddress==1.0.23
 jsondiff==2.2.1


### PR DESCRIPTION
#### Why I did it

PR #28909 aligned the sonic-slave Dockerfiles and sonic-py-common with grpcio/grpcio-tools 1.71.0, but the build-slave version snapshots still constrain both packages to 1.66.2. During version-controlled master builds, those stale constraints can downgrade the shared Python environment and reproduce the sonic-ycabled generated-code/runtime mismatch.

#### How I did it

Update the Bookworm and Trixie build-slave Python snapshots to pin grpcio and grpcio-tools at 1.71.0, matching the Dockerfiles and sonic-py-common.

#### How to verify it

Run the regular master image build with Python version control enabled and confirm sonic_ycabled builds and its tests collect without the grpcio 1.66.2 versus generated-code 1.71.0 error.