### PR TITLE
[tph] Fix crash on dead sniffer and empty portchannel cache

### DIFF
--- a/dockers/docker-orchagent/tunnel_packet_handler.py
+++ b/dockers/docker-orchagent/tunnel_packet_handler.py
@@ -98,7 +98,7 @@ class TunnelPacketHandler(object):
             (list) Tuples of a portchannel interface name (str) and
                    associated IPv4 address (str)
         """
-        if self._portchannel_intfs is None:
+        if not self._portchannel_intfs:
             intf_keys = self.config_db.get_keys(PORTCHANNEL_INTERFACE_TABLE)
             portchannel_intfs = []
 
@@ -385,7 +385,9 @@ class TunnelPacketHandler(object):
             else:
                 lag, _, fvs = lag_table.pop()
                 if self.sniffer_restart_required(lag, fvs):
-                    self.sniffer.stop()
+                    if self.sniffer and getattr(self.sniffer, 'running', False):
+                        self.sniffer.stop()
+                    self.sniffer = None
                     start = datetime.now()
                     # wait up to 3 seconds for the kernel interface to be synced with APPL_DB status
                     while (datetime.now() - start).seconds < 3:


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Two bugs in tunnel_packet_handler.py interact to produce the spurious error ERR: All portchannels failed to come up within 3 minutes on dual-ToR setups, even when all portchannel interfaces are healthy. They may be triggered by VRF bind/unbind operations that cause portchannel interfaces to briefly go admin-down.

First, When portchannel interfaces undergo brief admin-down transitions during VRF bind/unbind operations, their AF_PACKET sockets may receive ENETDOWN. Scapy closes each affected socket and removes it from the sniffer's internal sniff_sockets dict. If all portchannel sockets are removed before any portchannel recovery event arrives from APPL_DB, Scapy's sniff loop condition while sniff_sockets evaluates to False, the background thread exits, and sniffer.running is set to False. When the first portchannel then recovers and the APPL_DB LAG_TABLE fires, sniffer_restart_required() returns True and the code calls self.sniffer.stop() unconditionally on the now-dead sniffer, raising "scapy.error.Scapy_Exception: Not running ! (check .running attr)". This crashes the tunnel_packet_handler process, which supervisord immediately respawns.

Second, tunnel_packet_handler respawned during a window when portchannel IPv4 addresses are temporarily absent from CONFIG_DB (e.g. between config interface ip remove and config interface ip add during VRF setup), portchannel_intfs caches an empty list []. Because [] is not None, the original guard "if self._portchannel_intfs is None:" never re-queries CONFIG_DB, even after IPs are restored. As a result, get_up_portchannels() queries zero kernel interfaces and always returns an empty set — not because portchannels are down, but because the code is blind to them. After 3 minutes the error is logged and the process exits again.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a check to stop only running sniffers. 
Changed if condition to "if not self._portchannel_intfs" which returns true on empty list as well as None. This forces TPH to re-query until portchannels in config DB reach valid state.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
