### PR TITLE
[Arista][BCM] Enable sai_fec_stats_cumulative for fabric ports

### DIFF
--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/0/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/1/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/10/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/11/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/2/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/3/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/4/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/5/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/6/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/7/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/8/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/ramon-a7800-7804r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7804R3-FM/9/ramon-a7800-7804r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/0/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/1/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/10/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/11/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/12/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/13/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/14/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/15/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/16/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/17/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/2/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/3/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/4/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/5/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/6/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/7/ramon-a7800-7808r3-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/8/ramon-a7800-7808r3-fm.config.bcm
@@ -224,3 +224,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/ramon-a7800-7808r3-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3-FM/9/ramon-a7800-7808r3-fm.config.bcm
@@ -223,3 +223,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/0/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/1/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/10/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/11/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/2/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/3/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/4/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/5/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/6/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/7/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/8/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
+++ b/device/arista/x86_64-arista_7800_sup/Arista-7808R3A-FM/9/ramon-a7800-7808r3a-fm.config.bcm
@@ -222,3 +222,5 @@ tdma_timeout_usec=5000000
 tslam_dma_enable=1
 tslam_intr_enable=0
 tslam_timeout_usec=5000000
+sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/jr2-a7280cr3-32d4-40x100G.config.bcm
@@ -868,3 +868,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1022,3 +1022,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1022,3 +1022,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1039,3 +1039,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1039,3 +1039,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1059,3 +1059,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/j2p-a7800r3a-36d-36x400G.config.bcm
@@ -1059,3 +1059,4 @@ appl_param_active_links_thr_low=1
 custom_feature_start_tx_threshold=20
 sai_ecmp_group_members_increment=8
 sai_instru_stat_accum_enable=1
+sai_fec_stats_cumulative=1

--- a/src/sonic-device-data/tests/permitted_list
+++ b/src/sonic-device-data/tests/permitted_list
@@ -373,3 +373,4 @@ port_priorities_sch
 sai_lag_default_crc_hash
 sai_ecmp_group_members_increment
 sai_instru_stat_accum_enable
+sai_fec_stats_cumulative


### PR DESCRIPTION
#### Why I did it
This change mimics Nokia's PR (https://github.com/sonic-net/sonic-buildimage/pull/28483) for Arista DNX SKUs to address https://github.com/sonic-net/sonic-buildimage/issues/23806

Fixes https://github.com/sonic-net/sonic-buildimage/issues/28926

#### How to verify it
Confirmed on Arista platforms against the master branch that the fabric counters accumulate with this change

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] msft-202601
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [X] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result


#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
