### PR TITLE
[sonic-py-common] Avoid resolving gRPC build dependencies

### DIFF
--- a/src/sonic-py-common/generate_protos.py
+++ b/src/sonic-py-common/generate_protos.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 import os
+from packaging.version import Version
 from pathlib import Path
 import tempfile
 
@@ -81,11 +82,11 @@ def generate(package_root=PACKAGE_ROOT):
         installed_version = version("grpcio-tools")
     except PackageNotFoundError:
         raise RuntimeError(
-            f"grpcio-tools {GENERATOR_VERSION} is required; not installed"
+            f"grpcio-tools >={GENERATOR_VERSION} is required; not installed"
         ) from None
-    if installed_version != GENERATOR_VERSION:
+    if Version(installed_version) < Version(GENERATOR_VERSION):
         raise RuntimeError(
-            f"grpcio-tools {GENERATOR_VERSION} is required; found "
+            f"grpcio-tools >={GENERATOR_VERSION} is required; found "
             f"{installed_version}"
         )
 

--- a/src/sonic-py-common/setup.py
+++ b/src/sonic-py-common/setup.py
@@ -5,7 +5,6 @@ import sys
 from setuptools import setup
 from setuptools.command.build_py import build_py
 import pkg_resources
-from packaging import version
 
 
 def target_architecture():
@@ -17,13 +16,12 @@ include_sonic_grpc = sys.version_info >= (3, 9) and target_architecture() != 'ar
 
 extra_packages = []
 extra_dependencies = []
-extra_setup_requires = []
-extra_testing_requires = []
+build_dependencies = []
 cmdclass = {}
 license_files = None
 
 if include_sonic_grpc:
-    from generate_protos import generate
+    from generate_protos import GENERATOR_VERSION, generate
 
     class BuildPy(build_py):
         def run(self):
@@ -38,17 +36,15 @@ if include_sonic_grpc:
         'grpcio>=1.71.0',
         'protobuf>=5.29.6,<8',
     ]
-    extra_setup_requires = ['grpcio-tools==1.71.0']
-    extra_testing_requires = [
-        'grpcio==1.71.0',
-        'grpcio-tools==1.71.0',
-        'protobuf==5.29.6',
+    build_dependencies = [
+        'grpcio-tools>={}'.format(GENERATOR_VERSION),
     ]
     cmdclass = {'build_py': BuildPy}
     license_files = ['proto/LICENSE']
 
-# sonic_dependencies, version requirement only supports '>='
-sonic_dependencies = ['redis-dump-load']
+# SONiC supplies these dependencies before building this wheel. Check them here
+# so pip cannot resolve a missing or incompatible package from PyPI.
+sonic_dependencies = ['redis-dump-load'] + extra_dependencies
 
 dependencies = [
     'natsort',
@@ -56,16 +52,15 @@ dependencies = [
 ]
 
 dependencies += sonic_dependencies
-for package in sonic_dependencies:
+for package in sonic_dependencies + build_dependencies:
+    requirement = pkg_resources.Requirement.parse(package)
     try:
-        package_dist = pkg_resources.get_distribution(package.split(">=")[0])
+        package_dist = pkg_resources.get_distribution(requirement.project_name)
     except pkg_resources.DistributionNotFound:
         print(package + " is not found!", file=sys.stderr)
         print("Please build and install SONiC python wheels dependencies from sonic-buildimage", file=sys.stderr)
         exit(1)
-    if ">=" in package:
-        if version.parse(package_dist.version) >= version.parse(package.split(">=")[1]):
-            continue
+    if package_dist.version not in requirement:
         print(package + " version not match!", file=sys.stderr)
         exit(1)
 
@@ -79,7 +74,7 @@ setup_args = dict(
     url='https://github.com/Azure/SONiC',
     maintainer='Joe LeVeque',
     maintainer_email='jolevequ@microsoft.com',
-    install_requires=dependencies + extra_dependencies,
+    install_requires=dependencies,
     packages=[
         'sonic_py_common',
     ] + extra_packages,
@@ -87,13 +82,13 @@ setup_args = dict(
     setup_requires= [
         'pytest-runner',
         'wheel',
-    ] + extra_setup_requires,
+    ],
     tests_require=[
         'pytest',
         'mock==3.0.5' # For python 2. Version >=4.0.0 drops support for py2
-    ] + extra_testing_requires,
+    ],
     extras_require={
-        'testing': ['pytest'] + extra_testing_requires,
+        'testing': ['pytest'],
     },
     entry_points={
         'console_scripts': [

--- a/src/sonic-py-common/tests/test_generate_protos.py
+++ b/src/sonic-py-common/tests/test_generate_protos.py
@@ -26,8 +26,21 @@ def test_missing_generator_reports_required_version(monkeypatch, tmp_path):
     with pytest.raises(
         RuntimeError,
         match=(
-            rf"grpcio-tools {re.escape(generate_protos.GENERATOR_VERSION)} "
+            rf"grpcio-tools >={re.escape(generate_protos.GENERATOR_VERSION)} "
             r"is required; not installed"
+        ),
+    ):
+        generate_protos.generate(tmp_path)
+
+
+def test_older_generator_reports_minimum_version(monkeypatch, tmp_path):
+    monkeypatch.setattr(generate_protos, "version", lambda _name: "1.66.2")
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            rf"grpcio-tools >={re.escape(generate_protos.GENERATOR_VERSION)} "
+            r"is required; found 1\.66\.2"
         ),
     ):
         generate_protos.generate(tmp_path)

--- a/src/sonic-py-common/tests/test_setup.py
+++ b/src/sonic-py-common/tests/test_setup.py
@@ -9,11 +9,20 @@ import setuptools
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+class Distribution:
+    def __init__(self, version):
+        self.version = version
+
+
 @pytest.mark.parametrize("architecture", ["armv6l", "armv7l", "armv8l"])
 def test_configured_armhf_alias_excludes_sonic_grpc(monkeypatch, architecture):
     setup_args = {}
     monkeypatch.setenv("CONFIGURED_ARCH", architecture)
-    monkeypatch.setattr(pkg_resources, "get_distribution", lambda _name: object())
+    monkeypatch.setattr(
+        pkg_resources,
+        "get_distribution",
+        lambda _name: Distribution("1.0"),
+    )
     monkeypatch.setattr(setuptools, "setup", lambda **kwargs: setup_args.update(kwargs))
 
     runpy.run_path(os.path.join(PROJECT_ROOT, "setup.py"), run_name="__main__")
@@ -23,3 +32,48 @@ def test_configured_armhf_alias_excludes_sonic_grpc(monkeypatch, architecture):
         dependency.startswith(("grpcio", "protobuf"))
         for dependency in setup_args["install_requires"]
     )
+
+
+def test_grpc_dependencies_must_be_preinstalled(monkeypatch):
+    setup_args = {}
+    installed = {
+        "redis-dump-load": Distribution("1.0"),
+        "grpcio": Distribution("1.71.0"),
+        "grpcio-tools": Distribution("1.71.0"),
+        "protobuf": Distribution("5.29.6"),
+    }
+    monkeypatch.setenv("CONFIGURED_ARCH", "amd64")
+    monkeypatch.setattr(
+        pkg_resources,
+        "get_distribution",
+        lambda name: installed[name],
+    )
+    monkeypatch.setattr(setuptools, "setup", lambda **kwargs: setup_args.update(kwargs))
+
+    runpy.run_path(os.path.join(PROJECT_ROOT, "setup.py"), run_name="__main__")
+
+    assert "grpcio>=1.71.0" in setup_args["install_requires"]
+    assert "protobuf>=5.29.6,<8" in setup_args["install_requires"]
+    assert not any(
+        dependency.startswith(("grpcio", "protobuf"))
+        for dependency in setup_args["setup_requires"]
+    )
+    assert setup_args["extras_require"]["testing"] == ["pytest"]
+
+
+def test_missing_grpc_dependency_stops_before_setup(monkeypatch):
+    def get_distribution(name):
+        if name == "grpcio":
+            raise pkg_resources.DistributionNotFound
+        return Distribution("1.0")
+
+    monkeypatch.setenv("CONFIGURED_ARCH", "amd64")
+    monkeypatch.setattr(pkg_resources, "get_distribution", get_distribution)
+    monkeypatch.setattr(
+        setuptools,
+        "setup",
+        lambda **_kwargs: pytest.fail("setup must not resolve missing dependencies"),
+    )
+
+    with pytest.raises(SystemExit):
+        runpy.run_path(os.path.join(PROJECT_ROOT, "setup.py"), run_name="__main__")


### PR DESCRIPTION
#### Why I did it

PR #28341 added exact gRPC requirements to `setup_requires` and test extras. That caused pip to modify the shared build environment and added `grpcio==1.66.2` and `grpcio-tools==1.66.2` to the active version constraints.

Those constraints later caused widespread `armhf` failures in `sonic-ycabled`: its generated code requires `grpcio>=1.71.0`, but pip installed constrained `grpcio 1.66.2`.

PR #28968 now aligns the active build-slave constraints to `1.71.0`. This PR prevents `sonic-py-common` from introducing the same problem again.

#### Work item tracking

Microsoft ADO: 39249685

#### How I did it

- Remove gRPC packages from `setup_requires` and test extras.
- Keep runtime requirements in wheel metadata.
- Check that SONiC preinstalled compatible `grpcio`, `grpcio-tools`, and `protobuf` packages.
- Use minimum versions instead of exact pins.
- Keep `armhf` excluded from `sonic_grpc` packaging.

#### How to verify it

The full Azure.sonic-buildimage pipeline is the main verification and is pending after rebasing onto PR #28968.

Focused checks completed locally:

- Trixie: 44 focused tests passed.
- Trixie: source and wheel distributions built with `python3 -m build -n`.
- Bookworm with `CONFIGURED_ARCH=armhf`: 5 focused setup tests passed.

These focused checks do not replace the full CI pipeline.

#### Which release branch to backport

- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master

#### Description for the changelog

Prevent sonic-py-common builds from resolving gRPC build dependencies from PyPI.
