### PR TITLE
[ci][202511] stop publishing docker-ptf in official vs build

### DIFF
--- a/.azure-pipelines/azure-pipelines-image-template.yml
+++ b/.azure-pipelines/azure-pipelines-image-template.yml
@@ -102,20 +102,6 @@ jobs:
             echo "##vso[task.setvariable variable=PTF_MODIFIED;isOutput=true]False"
           fi
 
-          if [[ "$BUILD_REASON" != "PullRequest" && "$BUILD_DEFINITIONNAME" == "Azure.sonic-buildimage.official.vs" ]]
-          then
-            PORT=443
-            DOCKERS=$(ls target/docker-ptf.gz)
-            BRANCH=$(Build.SourceBranchName)
-            echo "Branch = $BRANCH"
-            LABELS="$BRANCH"
-            [[ "$BRANCH" == "master" ]] && LABELS="$LABELS latest"
-            for f in $DOCKERS; do
-              echo $f
-              echo "Labels = $LABELS"
-              ./push_docker.sh $f $(REGISTRY_SERVER_PUBLIC) $PORT $(REGISTRY_USERNAME) "$REGISTRY_PASSWD" "$LABELS"
-            done
-          fi
           mkdir -p $(Build.ArtifactStagingDirectory)/target
           mv target/* $(Build.ArtifactStagingDirectory)/target/
         env:


### PR DESCRIPTION
#### Why I did it
Cherry-pick of #28278 to 202511 branch.
Stop publishing docker-ptf images in official VS builds.

#### How I did it
Removed the publish block for docker-ptf in the official VS build pipeline.

#### How to verify it
Verify that official VS builds no longer attempt to publish docker-ptf images.