### PR TITLE
[Arista] Enable pci=aer_clear_on_recovery_failure on all platforms

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -780,6 +780,7 @@ write_platform_specific_cmdline() {
 
     cmdline_add "varlog_size=$varlog_size"
     cmdline_add "sonic.mode=$sonic_mode"
+    cmdline_add "pci=aer_clear_on_recovery_failure"
 }
 
 write_image_specific_cmdline() {


### PR DESCRIPTION
Support for this feature was recently added to sonic-linux-kernel. For more details, see https://github.com/sonic-net/sonic-linux-kernel/pull/589/