### PR TITLE
[build]: Generate Docker image manifests for installers

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1921,6 +1921,11 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		TARGET_PATH="$(TARGET_PATH)" \
 			./build_image.sh $(LOG)
 
+		printf '%s\n' $${installer_images} | \
+			awk -F'|' -v machine="$(dep_machine)" \
+				'$$3 == "" || $$3 == machine { image = $$4; sub(/:[^:]*$$/, "", image); print image }' \
+				> "$(TARGET_PATH)/$(subst $($*_MACHINE),$(dep_machine),$*).dockers"
+
 		# SBOM emit runs AFTER build_image.sh so the artifact (.bin /
 		# .swi / .img.gz) already exists on disk: sbom_emit_provenance.py
 		# needs it to compute the subject SHA-256 for the in-toto


### PR DESCRIPTION
#### Why I did it

Generate a machine-specific `.dockers` manifest for each SONiC installer. The manifest records the Docker archive paths selected from `installer_images` for that installer build.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

After `build_image.sh` completes, the installer recipe writes a `.dockers` manifest beside the generated installer:

- Read the existing `installer_images` entries, whose pipe-delimited fields contain package name, path, machine, and versioned image archive.
- Select entries whose machine field is empty or matches the current `dep_machine`.
- Extract the image archive from the fourth field and remove its appended version tag.
- Write one image archive path per line to `target/<installer>.dockers`.
- Derive the manifest name with the same machine substitution used by the installer target, producing files such as `target/sonic-vs.dockers`.

The manifest is generated after the installer build and does not change the Docker images or files embedded in the installer.

#### How to verify it

1. Build a SONiC installer target.
2. Confirm a matching `target/sonic-*.dockers` manifest is created.
3. Verify every line contains an unversioned Docker archive path.
4. For a dependent-machine build, verify the manifest contains entries with an empty machine field and entries matching that machine, while excluding entries for other machines.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result

Not run; the change only records the Docker image set already resolved for the installer build.

#### Description for the changelog

Generate machine-specific Docker image manifests for SONiC installers.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)