### PR TITLE
[sbom]: Skip Syft scan for armhf builds

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -82,7 +82,7 @@
 SONIC_CACHE_RECIPE_VER := 2
 # Git object hash of slave.mk when SONIC_CACHE_RECIPE_VER was last set/bumped.
 # Used by the guard below to detect unreviewed slave.mk changes.
-SONIC_CACHE_RECIPE_VER_BASELINE := 57a423c0b31ad2869422ec0d2c13ee0492b8ecb9
+SONIC_CACHE_RECIPE_VER_BASELINE := d0bedc4d0ecd77de5ac368e24399f42e5999e993
 
 # Guard: warn if slave.mk changed since SONIC_CACHE_RECIPE_VER was last reviewed.
 # This catches the case where someone modifies slave.mk build recipes without

--- a/README.sbom.md
+++ b/README.sbom.md
@@ -67,7 +67,7 @@ publishes the sibling files alongside it.
 |---|---|---|
 | `ENABLE_SBOM` | `n` | Master switch. When `n`, no SBOM hooks fire and no extra tools are installed. |
 | `SBOM_FORMAT` | `both` | `cyclonedx`, `spdx`, or `both`. SPDX is a downstream conversion via `cyclonedx-cli` (auto-fetched), so emitting both is essentially free. |
-| `SBOM_SCAN_TOOL` | `syft` | Binary scanner for transitive deps: `syft` or `trivy`. |
+| `SBOM_SCAN_TOOL` | `syft` | Binary scanner for transitive deps: `syft`, `trivy`, or `none`. ARMHF builds automatically replace `syft` with `none` because Syft does not publish a Linux ARMHF binary; recipe, observation, and lockfile inputs remain enabled. |
 | `SBOM_INCLUDE_LICENSES` | `y` | Whether to harvest copyrights and resolve SPDX licenses. |
 | `SBOM_STRICT` | `y` | When `y`, the build fails if a critical SBOM input is missing — host rootfs (`fsroot-<machine>/`), any `.gz` in `SBOM_INSTALLER_DOCKERS`, or the scanner binary. Set to `n` for debugging or one-off partial emits. Soft optional features (SPDX conversion, provenance, license resolution) always warn-and-continue regardless. |
 
@@ -160,6 +160,11 @@ SBOMs automatically because the build invokes different recipes.
 `SONIC_VERSION_CONTROL_COMPONENTS` overrides (where pins float to
 mirror-latest) are reflected too — observation records what was
 actually installed.
+
+ARMHF builds omit the Syft scanner source because Syft's official
+Linux release assets do not include ARMHF. The recipe, observation,
+and lockfile sources still run, and `SBOM_STRICT=y` continues to
+enforce the host rootfs and installer-container inputs.
 
 ## Component categories
 

--- a/rules/config
+++ b/rules/config
@@ -437,8 +437,13 @@ SBOM_FORMAT ?= both
 
 # SBOM_SCAN_TOOL - binary scanner used to enumerate transitive apt/pip
 # dependencies that no SONiC recipe names directly.
-# Valid values: syft, trivy.
+# Valid values: syft, trivy, none.
 SBOM_SCAN_TOOL ?= syft
+
+# Syft does not publish a Linux armhf binary. Keep the other SBOM data
+# sources and strict input validation enabled, but skip Syft scanning for
+# armhf builds instead of failing while trying to install the scanner.
+SBOM_EFFECTIVE_SCAN_TOOL = $(if $(and $(filter armhf,$(CONFIGURED_ARCH)),$(filter syft,$(SBOM_SCAN_TOOL))),none,$(SBOM_SCAN_TOOL))
 
 # SBOM_INCLUDE_LICENSES - harvest /usr/share/doc/<pkg>/copyright before
 # build_debian.sh strips it, and resolve SPDX license expressions for

--- a/slave.mk
+++ b/slave.mk
@@ -539,6 +539,7 @@ $(info "ENABLE_MULTIDB"                  : "$(ENABLE_MULTIDB)")
 $(info "ENABLE_SBOM"                     : "$(ENABLE_SBOM)")
 $(info "SBOM_FORMAT"                     : "$(SBOM_FORMAT)")
 $(info "SBOM_SCAN_TOOL"                  : "$(SBOM_SCAN_TOOL)")
+$(info "SBOM_EFFECTIVE_SCAN_TOOL"        : "$(SBOM_EFFECTIVE_SCAN_TOOL)")
 $(info "SBOM_INCLUDE_LICENSES"           : "$(SBOM_INCLUDE_LICENSES)")
 $(info "SBOM_STRICT"                     : "$(SBOM_STRICT)")
 $(info )
@@ -1938,7 +1939,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		#   sonic-vs.img.gz          -> sonic-vs.img.gz (single machine)
 		ENABLE_SBOM="$(ENABLE_SBOM)" \
 		SBOM_FORMAT="$(SBOM_FORMAT)" \
-		SBOM_SCAN_TOOL="$(SBOM_SCAN_TOOL)" \
+		SBOM_SCAN_TOOL="$(SBOM_EFFECTIVE_SCAN_TOOL)" \
 		SBOM_INCLUDE_LICENSES="$(SBOM_INCLUDE_LICENSES)" \
 		SBOM_STRICT="$(SBOM_STRICT)" \
 		SBOM_TARGET_ARTIFACT="$(subst $($*_MACHINE),$(dep_machine),$*)" \
@@ -1950,7 +1951,11 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		SBOM_INSTALLER_DOCKERS="$($*_DOCKERS)" \
 		SBOM_INSTALLER_DEBS="$($*_INSTALLS) $($*_LAZY_INSTALLS) $($*_LAZY_BUILD_INSTALLS)" \
 		SBOM_INSTALLER_WHEELS="$($*_PYTHON_WHEELS)" \
-			./scripts/build_sbom.sh $(LOG)
+			./scripts/build_sbom.sh $(LOG) || { \
+				rc=$$?; \
+				rm -f "$@" "$(TARGET_PATH)/$(subst $($*_MACHINE),$(dep_machine),$*)"; \
+				exit $$rc; \
+			}
 	)
 
 	$(foreach docker, $($*_DOCKERS), \


### PR DESCRIPTION
#### Why I did it

ARMHF installer builds with `ENABLE_SBOM=y` fail in strict mode because Syft v1.44.0 does not publish a Linux ARMHF binary. The retry can then incorrectly succeed from the installer artifact left behind by the failed SBOM step.

This follows up on the SBOM support introduced in #27455.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Use `none` as the effective scanner when `SBOM_SCAN_TOOL=syft` and `CONFIGURED_ARCH=armhf`.
- Keep recipe, observation, and lockfile SBOM inputs enabled, including strict validation of the rootfs and installer containers.
- Remove both the primary Make target and the current variant artifact when SBOM generation fails so retries cannot pass using stale installers.
- Document the ARMHF scanner limitation and update the reviewed `slave.mk` cache baseline.

#### How to verify it

1. Configure `PLATFORM=marvell-prestera PLATFORM_ARCH=armhf`.
2. Build with `ENABLE_SBOM=y target/sonic-marvell-prestera-armhf.bin`.
3. Verify the installer and CycloneDX SBOM are generated without attempting to install Syft.
4. Verify amd64/arm64 builds continue using Syft.

Static verification completed:
- ARMHF + Syft expands to effective scanner `none`.
- ARM64 + Syft remains `syft`.
- Diff and cache-baseline consistency checks pass.

ARMHF installer validation will be performed by CI.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result

Static Make expansion checks passed. ARMHF installer build is delegated to CI.

#### Description for the changelog

Allow strict SBOM generation for ARMHF installers without an unavailable Syft binary.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
