### PR TITLE
[Mellanox]: Add warmboot platform support

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/sai_5600.xml
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/sai_5600.xml
@@ -22,7 +22,7 @@
         <device-mac-address>00:02:03:04:05:00</device-mac-address>
 
         <!-- ISSU enabled -->
-        <issu-enabled>1</issu-enabled>
+        <issu-enabled>2</issu-enabled>
 
         <!-- Number of ports in the following port list -->
         <number-of-physical-ports>65</number-of-physical-ports>

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/sai_sn5600_128x400g_1x25g.xml
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/Mellanox-SN5600-O128/sai_sn5600_128x400g_1x25g.xml
@@ -21,7 +21,7 @@
         <device-mac-address>00:02:03:04:05:00</device-mac-address>
 
         <!-- ISSU enabled -->
-        <issu-enabled>1</issu-enabled>
+        <issu-enabled>0</issu-enabled>
 
         <!-- Number of ports in the following port list -->
         <number-of-physical-ports>65</number-of-physical-ports>

--- a/platform/mellanox/files/mlnx-fw-manager.service
+++ b/platform/mellanox/files/mlnx-fw-manager.service
@@ -22,7 +22,7 @@ Description=Mellanox Firmware Manager Service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecCondition=/bin/grep -qv '\\<SONIC_BOOT_TYPE=fastfast\\>' /proc/cmdline
+ExecCondition=/bin/bash -c '! grep -qE "(^|[[:space:]])SONIC_BOOT_TYPE=(fastfast|warm)([[:space:]]|$)" /proc/cmdline'
 ExecStart=/usr/local/bin/mlnx-fw-manager --clear-semaphore --verbose
 TimeoutSec=300
 User=root


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

**DEPENDS:**

1. https://github.com/sonic-net/sonic-sairedis/pull/2038
2. https://github.com/sonic-net/sonic-utilities/pull/4779

#### Why I did it

Enable **NVIDIA warmboot** platform defaults on SPC-4 (SN5600) and make the Mellanox
firmware-manager boot path safe for community warm-reboot (`SONIC_BOOT_TYPE=warm`).

On NVIDIA platforms:

* **fastfast** — `SONIC_BOOT_TYPE=fastfast`, SAI XML `<issu-enabled>1</issu-enabled>`
* **warmboot** — `SONIC_BOOT_TYPE=warm`, SAI XML `<issu-enabled>2</issu-enabled>`

NVIDIA warmboot uses community warm-reboot for in-place upgrade on capable platforms.
SPC-4 supports warmboot, so the ACS-SN5600 SAI XML default must advertise
`<issu-enabled>2</issu-enabled>`. Separately, ASIC FW is upgraded **before**
control-plane shutdown via `mlnx-fw-manager --upgrade`; after reboot the oneshot
service must **not** run again. It already skipped `fastfast`; without also skipping
`warm`, warmboot would re-run FW manager work on boot and extend control-plane downtime.

#### Work item tracking

* N/A

#### How I did it

1. **SPC-4 default warmboot mode** — update SN5600 SAI XML `<issu-enabled>`:

   * `device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/sai_5600.xml`
     (`<issu-enabled>1</issu-enabled>` → `<issu-enabled>2</issu-enabled>`)
     — ACS default is warmboot
   * `.../Mellanox-SN5600-O128/sai_sn5600_128x400g_1x25g.xml`
     (`<issu-enabled>1</issu-enabled>` → `<issu-enabled>0</issu-enabled>`)
     — O128 disables warmboot/fastfast by default

   Other SN5600 HWSKUs (`C224O8`, `C256S1`, `V256`) remain at
   `<issu-enabled>0</issu-enabled>` (unchanged).

   SAI XML `<issu-enabled>` selects the mode:
   `<issu-enabled>0</issu-enabled>` = disabled,
   `<issu-enabled>1</issu-enabled>` = fastfast,
   `<issu-enabled>2</issu-enabled>` = warmboot.

3. **Skip `mlnx-fw-manager.service` on warm and fastfast boots** — update
   `ExecCondition` in `platform/mellanox/files/mlnx-fw-manager.service`.
   Previously the unit was skipped only when `SONIC_BOOT_TYPE=fastfast` was on
   `/proc/cmdline`; it now skips for both `fastfast` and `warm`, so warmboot
   does not re-run FW manager work after reboot. Cold boot (neither boot type
   present) still runs `mlnx-fw-manager --clear-semaphore` as today.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

1. **Default mode on SN5600**
   * ACS-SN5600: SAI XML shows `<issu-enabled>2</issu-enabled>`; warm-reboot
     follows the warmboot path (`SONIC_BOOT_TYPE=warm`; warmboot pre-shutdown /
     restore logs, not fastfast)
   * O128: SAI XML shows `<issu-enabled>0</issu-enabled>` (warmboot/fastfast
     disabled by default)
   * C224O8 / C256S1 / V256: remain `<issu-enabled>0</issu-enabled>`

2. **Firmware manager on warmboot**
   * Run `sudo warm-reboot` on an SN5600 image with these changes
   * After boot: `systemctl status mlnx-fw-manager` — service skipped / inactive
     because `ExecCondition` failed (warm cmdline present)
   * Confirm `/proc/cmdline` contains `SONIC_BOOT_TYPE=warm`
   * Confirm FW upgrade still happened **pre**-shutdown (existing
     `mlnx-fw-manager --upgrade` in the reboot path), not again post-boot

4. **Regression — fastfast**
   * On a HWSKU with `<issu-enabled>1</issu-enabled>`, confirm
     `SONIC_BOOT_TYPE=fastfast` and that `mlnx-fw-manager.service` is still skipped

5. **Cold boot**
   * Cold reboot: no warm/fastfast boot type → `mlnx-fw-manager.service` runs
     `--clear-semaphore` as before

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

* N/A

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

* N/A

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

* N/A

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```