### PR TITLE
[build] Install aligned gRPC packages on armhf

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -1415,3 +1415,4 @@ sudo cp $IMAGE_CONFIGS/set-vrf-strict-mode/set-vrf-strict-mode.service $FILESYST
 # Install set-vrf-strict-mode service
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable set-vrf-strict-mode
 {% endif %}
+

--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -193,7 +193,7 @@ sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install blkinf
 sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install ipaddr
 
 # Install Python module for grpcio and grpcio-tools
-if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 ]]; then
+if [[ $CONFIGURED_ARCH == amd64 || $CONFIGURED_ARCH == arm64 || $CONFIGURED_ARCH == armhf ]]; then
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio==1.71.0"
     sudo https_proxy=$https_proxy LANG=C chroot $FILESYSTEM_ROOT pip3 install "grpcio-tools==1.71.0"
 fi
@@ -1415,4 +1415,3 @@ sudo cp $IMAGE_CONFIGS/set-vrf-strict-mode/set-vrf-strict-mode.service $FILESYST
 # Install set-vrf-strict-mode service
 sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable set-vrf-strict-mode
 {% endif %}
-


### PR DESCRIPTION
#### Why I did it

PR #28909 installs `grpcio==1.71.0` and `grpcio-tools==1.71.0` in target filesystems for `amd64` and `arm64` only.

The `armhf` image therefore installed constrained `grpcio 1.66.2`. `sonic-ycabled` generated code requires `grpcio>=1.71.0`, so recent `marvell_prestera_armhf` builds failed during test collection.

#### How I did it

Add `armhf` to the existing target-filesystem installation condition. Both packages publish CPython 3.13 ARMv7 wheels at version `1.71.0`.

#### How to verify it

The full Azure.sonic-buildimage pipeline is the main verification and is pending.

The focused package check downloaded these ARMv7 wheels successfully:

- `grpcio-1.71.0-cp313-cp313-linux_armv7l.whl`
- `grpcio_tools-1.71.0-cp313-cp313-linux_armv7l.whl`

#### Which release branch to backport

- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master

#### Description for the changelog

Install compatible gRPC runtime and generator packages in armhf target filesystems.
