### PR TITLE
Add support for a post-build hook

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1963,6 +1963,11 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 		rm sonic_debian_extension.sh,
 	)
 
+	# Provide a hook that modules may use for post-build activities
+	$(if $($*_POST_BUILD_HOOK), \
+		$($*_POST_BUILD_HOOK) $(LOG) || echo WARNING: Hook for module $* failed, continuing ... \
+	)
+
 	chmod a+x $@
 	$(FOOTER)
 


### PR DESCRIPTION

#### Why I did it

Add support for a hook that modules can trigger after completing the build.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Looks for any variables defined with the _POST_BUILD_HOOK suffix in the makefiles in the modules and call it. 

#### How to verify it

Added a hook for sonic-alpine and tested it

https://github.com/sonic-net/sonic-alpine/pull/39/files#diff-29ac415d935ae9bb5017f93c186e64f80d04d1cc57eea7aff36cdb2b4deb4a48R20

Invoking the new script at the end of the build :

```
~/code/upstream/hook/sonic-buildimage/target$ tail -n 20 sonic-alpinevs.img.gz.log 
Step 8/12 : COPY go.* /
 ---> 51f2b0db5230
Step 9/12 : RUN go mod download
 ---> Running in 013472d37a88
 ---> Removed intermediate container 013472d37a88
 ---> 7674d0a66af3
Step 10/12 : COPY *.go /
 ---> f0e9921f55aa
Step 11/12 : EXPOSE 22
 ---> Running in 5bf9ab5c636b
 ---> Removed intermediate container 5bf9ab5c636b
 ---> 555cd755706d
Step 12/12 : CMD [ "go" "run" "/main.go" ]
 ---> Running in 366e7c416172
 ---> Removed intermediate container 366e7c416172
 ---> 2a268611fecb
Successfully built 2a268611fecb
Successfully tagged alpine-vs:latest
Build end time: Thu Aug 13 18:52:20 UTC 2026
Elapsed time: 0h 18m 10s

```

```
root@sonic:/var/log# show ver

SONiC Software Version: SONiC.master.0-dirty-20260813.175458
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 13c984902
Build date: Thu Aug 13 18:35:02 UTC 2026
Built by: sbiyer@sbiyer.c.googlers.com

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 03:39:21 up  8:32,  1 user,  load average: 0.22, 0.23, 0.64
Date: Fri 14 Aug 2026 03:39:21

```

Confirmed that sonic-alpinevs-docker.tar.gz is created in the alpine artifacts. Ran the dataplane and sanity tests

#### Description for the changelog

Added support for a hook that can be called post-build for any of the modules
