### PR TITLE
[yang-models] Fix NAT binding reload validation

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1817,9 +1817,10 @@
         },
         "NAT_BINDINGS": {
             "bind1": {
+                "access_list": "AclNatOut",
                 "nat_pool": "pool1",
                 "nat_type": "snat",
-                "twice_nat_id": "1"
+                "twice_nat_id": "NULL"
             }
         },
         "NAT_GLOBAL": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/nat.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/nat.json
@@ -95,5 +95,8 @@
     },
     "NAT_BINDING_WITHOUT_ACL_TABLE": {
         "desc": "Configuring a NAT Binding table without acl."
+    },
+    "NAT_BINDING_CLI_GENERATED": {
+        "desc": "Configuring a NAT Binding table shaped like the output of 'config nat add binding', including access_list and the NULL twice_nat_id sentinel."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/nat.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/nat.json
@@ -387,5 +387,29 @@
                 ]
             }
         }
+    },
+    "NAT_BINDING_CLI_GENERATED": {
+        "sonic-nat:sonic-nat": {
+            "sonic-nat:NAT_POOL": {
+                "NAT_POOL_LIST": [
+                    {
+                        "name": "pool1",
+                        "nat_ip": "125.56.90.1-125.56.90.100",
+                        "nat_port": "500-1000"
+                    }
+                ]
+            },
+            "sonic-nat:NAT_BINDINGS": {
+                "NAT_BINDINGS_LIST": [
+                    {
+                        "name": "bind1",
+                        "nat_pool": "pool1",
+                        "access_list": "AclNatOut",
+                        "nat_type": "snat",
+                        "twice_nat_id": "NULL"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-nat.yang
+++ b/src/sonic-yang-models/yang-models/sonic-nat.yang
@@ -273,6 +273,12 @@ module sonic-nat {
                     }
                 }
 
+                leaf access_list {
+                    description "Comma-separated list of ACL table names bound to this NAT binding";
+
+                    type string;
+                }
+
                 leaf nat_type {
                     description "Nat type for the binding - snat or dnat";
 
@@ -283,10 +289,15 @@ module sonic-nat {
                 leaf twice_nat_id {
                     description "Twice nat id for the binding to achieve the Dynamic twice nat";
 
-                    type uint16 {
-                        range "1..9999" {
-                            error-message "Invalid twice nat id for the binding.";
-                            error-app-tag twice-nat-id-invalid;
+                    type union {
+                        type uint16 {
+                            range "1..9999" {
+                                error-message "Invalid twice nat id for the binding.";
+                                error-app-tag twice-nat-id-invalid;
+                            }
+                        }
+                        type string {
+                            pattern "NULL";
                         }
                     }
                 }


### PR DESCRIPTION
#### Why I did it

Fixes #28719.

`config nat add binding` writes `NAT_BINDINGS` entries containing `access_list` and writes `twice_nat_id` as the literal string `"NULL"` when twice NAT is not configured. The current `sonic-nat.yang` model does not define `access_list` and models `twice_nat_id` only as `uint16`, so a saved NAT binding can fail the ConfigDB-to-YANG translation during `config reload`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Added optional `access_list` support to `NAT_BINDINGS_LIST` as a plain string, matching the existing ConfigDB/CLI representation.
- Updated only `NAT_BINDINGS_LIST.twice_nat_id` to accept either the existing numeric range `1..9999` or the existing `"NULL"` sentinel used by the CLI.
- Added a positive YANG regression case that matches the output of `config nat add binding` with both `access_list` and `twice_nat_id: "NULL"`.
- Updated the sample ConfigDB NAT binding so the existing SonicYang translation/reverse-translation coverage exercises the CLI-shaped entry.

The existing no-ACL and invalid/numeric twice-NAT-ID test cases remain unchanged and continue to pass.

#### How to verify it

From `src/sonic-yang-models` with the SONiC-pinned libyang 3.12.2 / patched libyang-python 3.1.0 environment:

```bash
python3 -m pytest tests/yang_model_tests/test_yang_model.py -k test_run_tests -v
```

Result: `1 passed`; the full YANG model suite passed, including the new `NAT_BINDING_CLI_GENERATED` case and the existing NAT binding tests.

Also verified the production `SonicYang.loadData()` / validation / reverse-translation path with:
- `access_list="AclNatOut"`, `twice_nat_id="NULL"`
- `access_list=""`, `twice_nat_id="100"`

Both configurations loaded, validated, and round-tripped successfully. The full 135-table `sample_config_db.json` also passed translation and reverse-translation equality checks.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: local unit/translation validation on current `master` — full YANG suite passed; ConfigDB-to-YANG and reverse-translation checks passed.

#### Description for the changelog

Allow CLI-generated NAT bindings with `access_list` and the `NULL` twice-NAT-ID sentinel to pass YANG validation and reload.

#### Link to config_db schema for YANG module changes

`Configuration.md` currently has no `NAT_BINDINGS` section. The NAT ConfigDB design is documented in the SONiC NAT design specification:
https://github.com/sonic-net/SONiC/blob/master/doc/nat/nat_design_spec.md

#### A picture of a cute animal (not mandatory but encouraged)
