### PR TITLE
[aspeed/ast2700-bmc] Add BMC firmware update via fwutil and PLDM over MCTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ platform/**/debian/*
 !platform/**/debian/compat
 !platform/**/debian/*.postinst
 !platform/**/debian/*.install
+!platform/**/debian/*.service
+!platform/**/debian/*.conf
 platform/**/build
 platform/**/*.ko
 platform/**/*.mod.c

--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform.json
@@ -4,7 +4,9 @@
         "model": "NVIDIA AST2700 BMC",
         "thermal_manager": false,
         "liquid_cooled": true,
-        "components": [],
+        "components": [{
+            "name": "BMC"
+        }],
         "fans": [],
         "psus": [],
         "thermals": [{

--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform_components.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform_components.json
@@ -1,6 +1,6 @@
 {
     "chassis": {
-        "P4102-A01": {
+        "NVIDIA-AST2700-BMC": {
             "component": {
                 "BMC": { }
             }

--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform_components.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform_components.json
@@ -1,7 +1,8 @@
 {
     "chassis": {
-        "NVIDIA-AST2700-BMC": {
+        "P4102-A01": {
             "component": {
+                "BMC": { }
             }
         }
     }

--- a/platform/aspeed/mctp/debian/mctpd.conf
+++ b/platform/aspeed/mctp/debian/mctpd.conf
@@ -1,0 +1,10 @@
+<?xml version="1.0"?> <!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+        "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+ <policy user="root">
+  <allow own="au.com.codeconstruct.MCTP1"/>
+  <allow send_destination="au.com.codeconstruct.MCTP1"/>
+  <allow receive_sender="au.com.codeconstruct.MCTP1"/>
+ </policy>
+</busconfig>

--- a/platform/aspeed/mctp/debian/mctpd.service
+++ b/platform/aspeed/mctp/debian/mctpd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=MCTP control protocol daemon
+Wants=mctp-local.target
+After=mctp-local.target
+
+[Service]
+Type=dbus
+BusName=au.com.codeconstruct.MCTP1
+ExecStart=/usr/sbin/mctpd -v
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/aspeed/mctp/debian/rules
+++ b/platform/aspeed/mctp/debian/rules
@@ -7,3 +7,17 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 override_dh_auto_configure:
 	dh_auto_configure -- -Dtests=false
+
+# Install the SONiC BMC mctpd systemd unit and dbus policy alongside the
+# upstream-built binaries. Upstream meson does not install these from
+# conf/, so we ship our own copies from this debian/ directory.
+#
+# The unit lands in /lib/systemd/system/ so dh_installsystemd picks it
+# up automatically and generates the standard enable/start/stop/purge
+# maintainer-script snippets via the [Install] section in mctpd.service.
+override_dh_auto_install:
+	dh_auto_install
+	install -D -m 0644 debian/mctpd.service \
+	        debian/mctp/lib/systemd/system/mctpd.service
+	install -D -m 0644 debian/mctpd.conf \
+	        debian/mctp/usr/share/dbus-1/system.d/mctpd.conf

--- a/platform/aspeed/pldm-fw-cli/Makefile
+++ b/platform/aspeed/pldm-fw-cli/Makefile
@@ -10,15 +10,20 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	set -e
 	rm -rf upstream-ws upstream.tar.gz stage-deb
 	wget "$(PLDM_FW_ARCHIVE_URL)" -O upstream.tar.gz
-	# Verify the download against the pinned checksum before extracting, so a
-	# corrupted or tampered tarball aborts the build (fail closed).
-	if [ -z "$(PLDM_FW_ARCHIVE_SHA256)" ]; then
-		echo "ERROR: PLDM_FW_ARCHIVE_SHA256 is unset; refusing to extract unverified $(PLDM_FW_ARCHIVE_URL)" >&2
-		exit 1
-	fi
+	# Verify archive integrity before extraction; fail the build on mismatch.
 	echo "$(PLDM_FW_ARCHIVE_SHA256)  upstream.tar.gz" | sha256sum -c -
 	mkdir -p upstream-ws
 	tar -C upstream-ws --strip-components=1 -xf upstream.tar.gz
+	# Apply local SONiC changes (PLDM spec-conformance fixes + tests).
+	# These are generated against PLDM_FW_UPSTREAM_COMMIT; see
+	# patches/README.md. Order is significant (numeric prefix).
+	for p in patches/*.patch; do
+		echo "Applying $$p"
+		# Use patch(1), not git apply: inside the sonic-buildimage git
+		# tree git apply can report "Skipped patch" with exit 0 even on a
+		# fresh upstream-ws, leaving sources unmodified.
+		patch -d upstream-ws -p1 --forward < "$$p"
+	done
 	mkdir -p stage-deb/DEBIAN stage-deb/usr/bin
 	pushd upstream-ws
 	if [ -n "$$RUST_CROSS_COMPILE_TARGET" ]; then

--- a/platform/aspeed/pldm-fw-cli/patches/0001-pldm-fw-ua-send-actual-component-count-in-RequestUpd.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0001-pldm-fw-ua-send-actual-component-count-in-RequestUpd.patch
@@ -1,0 +1,44 @@
+From 397ee55e2c67cbb2304e139ef82adf345d2293a4 Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 18:19:47 +0300
+Subject: [PATCH 1/6] pldm-fw: ua: send actual component count in RequestUpdate
+
+request_update() hardcoded the RequestUpdate NumberOfComponents field
+to 1. DSP0267 Table 27 defines this field as "the number of components
+that will be passed to the FD during the update", and the FD may use it
+to compare against the number of PassComponentTable/UpdateComponent
+commands it receives. When a package applies more than one component,
+the UA passes all of them (pass_component_table and
+update_components_progress iterate over update.components) while still
+announcing only 1, which a conformant FD can reject as a mismatch.
+
+Derive the count from update.components, the same list driven through
+the rest of the update flow, so the announced value matches what is
+actually sent. The value is fallibly converted to u16 to guard the
+(practically impossible) >65535 component case rather than truncating.
+---
+ pldm-fw/src/ua.rs | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index 9e4c2fc..f49e8b6 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -180,9 +180,13 @@ pub fn request_update(
+     check_fd_state(comm, PldmFDState::Idle)?;
+ 
+     let sz = XFER_SIZE as u32;
++    let num_components: u16 =
++        update.components.len().try_into().map_err(|_| {
++            PldmUpdateError::new_update("too many components".into())
++        })?;
+     let mut data = vec![];
+     data.extend_from_slice(&sz.to_le_bytes());
+-    data.extend_from_slice(&1u16.to_le_bytes()); // NumberOfComponents
++    data.extend_from_slice(&num_components.to_le_bytes()); // NumberOfComponents
+     data.extend_from_slice(&1u8.to_le_bytes()); // MaximumOutstandingTransferRequests
+     data.extend_from_slice(&0u16.to_le_bytes()); // PackageDataLength
+     update.package.version.write_utf8_bytes(&mut data);
+-- 
+2.49.0
+

--- a/platform/aspeed/pldm-fw-cli/patches/0002-pldm-fw-ua-validate-RequestFirmwareData-and-pad-corr.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0002-pldm-fw-ua-validate-RequestFirmwareData-and-pad-corr.patch
@@ -1,0 +1,135 @@
+From 83c788133d7ad41e88bf35254f8f9e37797db45e Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 18:25:37 +0300
+Subject: [PATCH 2/6] pldm-fw: ua: validate RequestFirmwareData and pad
+ correctly
+
+The UA accepted any RequestFirmwareData (offset, length) from the FD
+without validation and served it directly: it allocated a buffer of the
+requested length, read that many bytes from the package file at the
+absolute component offset, and returned the whole buffer. This diverged
+from DSP0267 12.6 in two ways:
+
+  - No range checking. The UA never returned INVALID_TRANSFER_LENGTH or
+    DATA_OUT_OF_RANGE, so a malformed or out-of-range request was either
+    served with bogus data or, for an arbitrarily large length, turned
+    into an unbounded allocation.
+
+  - Incorrect padding. read_at() reads from the file by absolute offset,
+    so a request extending past the end of the component image returned
+    adjacent package bytes (the next component image, or the package
+    header/payload checksum) instead of the 0x00 padding the spec
+    requires. Only reads past physical end-of-file happened to zero-fill.
+
+Validate the request in the 0x15 handler before serving it: reject with
+INVALID_TRANSFER_LENGTH when the length is outside
+[baseline, MaximumTransferSize], and DATA_OUT_OF_RANGE when
+offset + length exceeds the image size by more than the baseline
+transfer size. On rejection the UA replies with the completion code and
+keeps listening, since the FD may retry with a corrected request or
+abort via TransferComplete. The length check also removes the unbounded
+allocation path.
+
+Rework read_component() to only read bytes belonging to the component
+image and zero-pad the remainder of the buffer, so tail requests are
+padded with 0x00 (bounded to the baseline size by the range check above)
+rather than spilling into neighbouring package contents.
+---
+ pldm-fw/src/pkg.rs | 19 +++++++++++++++++--
+ pldm-fw/src/ua.rs  | 36 +++++++++++++++++++++++++++++++++++-
+ 2 files changed, 52 insertions(+), 3 deletions(-)
+
+diff --git a/pldm-fw/src/pkg.rs b/pldm-fw/src/pkg.rs
+index b97e6b6..e302921 100644
+--- a/pldm-fw/src/pkg.rs
++++ b/pldm-fw/src/pkg.rs
+@@ -303,13 +303,28 @@ impl Package {
+         })
+     }
+ 
++    /// Read a portion of a component image into `buf`.
++    ///
++    /// Only bytes that belong to this component image are read from the
++    /// package file; any part of `buf` beyond the end of the component image
++    /// is zero-padded rather than spilling into adjacent package contents
++    /// (e.g. the next component image or the payload checksum). This matches
++    /// the padding behaviour required of the UA in DSP0267 12.6.
++    ///
++    /// Returns the number of real (non-padding) image bytes written.
+     pub fn read_component(
+         &self,
+         component: &PackageComponent,
+         offset: u32,
+         buf: &mut [u8],
+     ) -> Result<usize> {
+-        let file_offset = offset as u64 + component.file_offset as u64;
+-        Ok(self.file.read_at(buf, file_offset)?)
++        let offset = offset as usize;
++        let avail = component.file_size.saturating_sub(offset);
++        let n = avail.min(buf.len());
++
++        let file_offset = component.file_offset as u64 + offset as u64;
++        self.file.read_exact_at(&mut buf[..n], file_offset)?;
++        buf[n..].fill(0);
++        Ok(n)
+     }
+ }
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index f49e8b6..fe9d78b 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -26,7 +26,7 @@ use crate::pkg;
+ use crate::{
+     DeviceIdentifiers, FirmwareParameters, FwCode, GetStatusResponse,
+     PldmFDState, RequestUpdateResponse, UpdateComponentResponse,
+-    UpdateTransferProgress, PLDM_TYPE_FW,
++    UpdateTransferProgress, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
+ };
+ 
+ pub type Result<T> = core::result::Result<T, PldmUpdateError>;
+@@ -370,8 +370,42 @@ where
+                     PldmUpdateError::new_proto("RFD parse error".into())
+                 })?;
+ 
++                // Validate the request against the limits in DSP0267 12.6:
++                // the length must be within [baseline, MaximumTransferSize],
++                // and the requested region must not extend past the end of
++                // the component image by more than the baseline transfer size.
++                let baseline = PLDM_FW_BASELINE_TRANSFER as u64;
++                let comp_size = component.file_size as u64;
++                let req_end = offset as u64 + len as u64;
++
++                let err_cc = if (len as usize) < PLDM_FW_BASELINE_TRANSFER
++                    || (len as usize) > XFER_SIZE
++                {
++                    Some(FwCode::INVALID_TRANSFER_LENGTH as u8)
++                } else if req_end > comp_size + baseline {
++                    Some(FwCode::DATA_OUT_OF_RANGE as u8)
++                } else {
++                    None
++                };
++
++                if let Some(cc) = err_cc {
++                    debug!(
++                        "rejecting RequestFirmwareData offset {offset} \
++                         len {len} (image size {comp_size}) with cc 0x{cc:02x}"
++                    );
++                    let mut fw_resp = fw_req.response();
++                    fw_resp.cc = cc;
++                    pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
++                    // Per the spec the FD may retry with a corrected request,
++                    // or abort the transfer via TransferComplete.
++                    continue;
++                }
++
+                 let mut buf = vec![0u8; len as usize];
+ 
++                // read_component zero-pads any bytes past the end of the
++                // component image (up to the baseline transfer size, as
++                // bounded by the DATA_OUT_OF_RANGE check above).
+                 package.read_component(component, offset, &mut buf)?;
+ 
+                 let mut fw_resp = fw_req.response();
+-- 
+2.49.0
+

--- a/platform/aspeed/pldm-fw-cli/patches/0003-pldm-fw-ua-match-package-device-records-by-descripto.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0003-pldm-fw-ua-match-package-device-records-by-descripto.patch
@@ -1,0 +1,77 @@
+From ac3a8469d0e9c82739a2bae5b9888978cb9769b0 Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 18:35:13 +0300
+Subject: [PATCH 3/6] pldm-fw: ua: match package device records by descriptor
+ subset
+
+When selecting which package device record applies to a firmware device,
+Update::new() compared the record's descriptors to the FD's descriptors
+with exact equality (DeviceIdentifiers PartialEq, a Vec compare). That
+required the same descriptors, in the same count and order.
+
+DSP0267 8.1 defines a looser rule: "all descriptors in a package
+Firmware Device ID Record shall match those returned by the FD but not
+vice-versa (the FD may return more descriptors than are indicated in the
+firmware package header)." It also notes ordering is not significant and
+that when the FD reports several values for a descriptor (e.g. PCI
+Revision ID), matching any one of them is a match. The exact-equality
+check therefore failed to match an FD that legitimately reported extra
+descriptors (subsystem IDs, revision IDs, ...) or a different ordering.
+
+Add DeviceIdentifiers::matches_device(), which returns true when every
+descriptor in the package record is present in the FD's descriptor set
+(order-insensitive, FD supersets allowed, empty record never matches),
+and use it for record selection. The PartialEq impl is left in place as
+it is unrelated to package-to-device association.
+---
+ pldm-fw/src/lib.rs | 20 ++++++++++++++++++++
+ pldm-fw/src/ua.rs  |  2 +-
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/pldm-fw/src/lib.rs b/pldm-fw/src/lib.rs
+index 97e3bd7..e55653f 100644
+--- a/pldm-fw/src/lib.rs
++++ b/pldm-fw/src/lib.rs
+@@ -697,6 +697,26 @@ impl DeviceIdentifiers {
+ }
+ 
+ impl DeviceIdentifiers {
++    /// Tests whether these descriptors (from a firmware package device record)
++    /// apply to a firmware device.
++    ///
++    /// Per DSP0267 8.1, a package record matches when every descriptor it
++    /// contains is also present in the descriptors reported by the firmware
++    /// device. The firmware device may report additional descriptors that are
++    /// not present in the record, and the order is not significant. Where the
++    /// FD reports several descriptors of the same kind (for example multiple
++    /// PCI Revision IDs), matching any one of them is sufficient.
++    ///
++    /// A record with no descriptors never matches (a record is required to
++    /// contain at least one descriptor).
++    pub fn matches_device(&self, device: &DeviceIdentifiers) -> bool {
++        !self.ids.is_empty()
++            && self
++                .ids
++                .iter()
++                .all(|want| device.ids.iter().any(|have| have == want))
++    }
++
+     /// Returns a response for QueryDeviceIdentifiers
+     pub fn write_buf(&self, buf: &mut [u8]) -> Option<usize> {
+         let mut b = SliceWriter::new(buf);
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index fe9d78b..311ca95 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -90,7 +90,7 @@ impl Update {
+                 let fwdevs = pkg
+                     .devices
+                     .iter()
+-                    .filter(|d| &d.ids == dev)
++                    .filter(|d| d.ids.matches_device(dev))
+                     .collect::<Vec<_>>();
+ 
+                 if fwdevs.is_empty() {
+-- 
+2.49.0
+

--- a/platform/aspeed/pldm-fw-cli/patches/0004-pldm-fw-add-unit-tests-for-protocol-packaging-and-up.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0004-pldm-fw-add-unit-tests-for-protocol-packaging-and-up.patch
@@ -1,0 +1,997 @@
+From 866de577a8536a53a7a6123070fbe72226f62a96 Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 19:36:45 +0300
+Subject: [PATCH 4/6] pldm-fw: add unit tests for protocol, packaging and
+ update flow
+
+Add an initial test suite covering the significant success and error
+behaviours of the firmware update implementation, validated against
+DSP0267 1.3.0.
+
+src/lib.rs (protocol codecs):
+  - descriptor decode for known types and rejection of unknown types
+  - DeviceIdentifiers::matches_device subset rule (8.1): exact match, FD
+    supersets, order-independence, missing-descriptor and empty-record
+    rejection
+  - encode/decode round-trips for GetStatus, RequestUpdate,
+    FirmwareParameters, UpdateComponent responses, plus rejection of an
+    unknown firmware-device state
+
+src/pkg.rs (package parsing):
+  - a small in-memory v1.1.x package builder and temp-file helper
+  - parsing of single- and multi-component packages, including the
+    component bitmap and image read-back
+  - header error paths: bad CRC-32 checksum and unknown package UUID
+  - read_component boundary/zero-pad behaviour (12.6)
+
+src/ua.rs (Update Agent flow):
+  - mock mctp ReqChannel/Listener/RespChannel transport that replays
+    scripted FD responses and records what the UA sends
+  - RequestUpdate reports the actual component count, surfaces command
+    failures, and requires the Idle state
+  - PassComponentTable success and unsupported-component rejection
+  - the full UpdateComponent transfer: serving image data, zero-padding
+    past the image end, rejecting oversized (INVALID_TRANSFER_LENGTH) and
+    out-of-range (DATA_OUT_OF_RANGE) RequestFirmwareData, and reporting a
+    verify failure
+  - ActivateFirmware success, ACTIVATION_NOT_REQUIRED-as-success, and
+    other-failure handling
+---
+ pldm-fw/Cargo.toml |   3 +
+ pldm-fw/src/lib.rs | 153 +++++++++++++
+ pldm-fw/src/pkg.rs | 237 +++++++++++++++++++++
+ pldm-fw/src/ua.rs  | 522 +++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 915 insertions(+)
+
+diff --git a/pldm-fw/Cargo.toml b/pldm-fw/Cargo.toml
+index 40bed56..dfb778e 100644
+--- a/pldm-fw/Cargo.toml
++++ b/pldm-fw/Cargo.toml
+@@ -24,4 +24,7 @@
+ [features]
+ default = ["std"]
+ alloc = ["pldm/alloc", "nom/alloc"]
+ std = ["alloc", "pldm/std", "mctp/std", "nom/std", "chrono/clock", "uuid/std", "dep:thiserror"]
++
++[dev-dependencies]
++tempfile = "3"
+diff --git a/pldm-fw/src/lib.rs b/pldm-fw/src/lib.rs
+index e55653f..7cb3f8f 100644
+--- a/pldm-fw/src/lib.rs
++++ b/pldm-fw/src/lib.rs
+@@ -1444,4 +1444,157 @@ mod tests {
+         ];
+         assert_eq!(sendbuf, expect);
+     }
++
++    #[test]
++    fn descriptor_parse_known_and_unknown() {
++        // PCI Vendor ID (type 0x0000), length 2
++        let buf = [0x00, 0x00, 0x02, 0x00, 0xcd, 0xab];
++        let (rest, d) = Descriptor::parse(&buf).unwrap();
++        assert!(rest.is_empty());
++        assert_eq!(d, Descriptor::PciVid(0xabcd));
++
++        // IANA Enterprise ID (type 0x0001), length 4
++        let buf = [0x01, 0x00, 0x04, 0x00, 0xd2, 0x04, 0x00, 0x00];
++        let (_, d) = Descriptor::parse(&buf).unwrap();
++        assert_eq!(d, Descriptor::Iana(1234));
++
++        // An unknown descriptor type is rejected rather than silently
++        // accepted (DSP0267 Table 7 enumerates the valid types).
++        let buf = [0x34, 0x12, 0x01, 0x00, 0x00];
++        assert!(Descriptor::parse(&buf).is_err());
++    }
++
++    #[test]
++    fn matches_device_subset_rule() {
++        // DSP0267 8.1: a package record matches when all of its descriptors
++        // are present in the descriptors the FD reports; the FD may report
++        // additional descriptors and ordering is not significant.
++        let record = DeviceIdentifiers {
++            ids: vec![Descriptor::PciVid(0x1234)],
++        };
++
++        // Exact match, plus FD reporting an additional descriptor.
++        let fd = DeviceIdentifiers {
++            ids: vec![Descriptor::PciVid(0x1234), Descriptor::PciDid(0x9)],
++        };
++        assert!(record.matches_device(&fd));
++
++        // Order of the FD's descriptors does not matter.
++        let fd_reordered = DeviceIdentifiers {
++            ids: vec![Descriptor::PciDid(0x9), Descriptor::PciVid(0x1234)],
++        };
++        assert!(record.matches_device(&fd_reordered));
++
++        // A record descriptor not present in the FD means no match.
++        let two = DeviceIdentifiers {
++            ids: vec![Descriptor::PciVid(0x1234), Descriptor::Iana(7)],
++        };
++        assert!(!two.matches_device(&fd));
++
++        // The full record must match: a single mismatching value fails.
++        let other_vid = DeviceIdentifiers {
++            ids: vec![Descriptor::PciVid(0xbeef)],
++        };
++        assert!(!other_vid.matches_device(&fd));
++
++        // An empty record never matches (records must carry >= 1 descriptor).
++        let empty = DeviceIdentifiers { ids: vec![] };
++        assert!(!empty.matches_device(&fd));
++    }
++
++    #[test]
++    fn get_status_response_roundtrip() {
++        let s = GetStatusResponse {
++            current_state: PldmFDState::ReadyXfer,
++            previous_state: PldmFDState::LearnComponents,
++            aux_state: 1,
++            aux_state_status: 2,
++            progress_percent: 50,
++            reason_code: 3,
++            update_option_flags_enabled: 0xdead_beef,
++        };
++
++        let mut buf = [0u8; 32];
++        let l = s.write_buf(&mut buf).unwrap();
++        // current(1) prev(1) aux(1) aux_status(1) progress(1) reason(1) flags(4)
++        assert_eq!(l, 10);
++
++        let (rest, p) = GetStatusResponse::parse(&buf[..l]).unwrap();
++        assert!(rest.is_empty());
++        assert_eq!(p.current_state, PldmFDState::ReadyXfer);
++        assert_eq!(p.previous_state, PldmFDState::LearnComponents);
++        assert_eq!(p.aux_state, 1);
++        assert_eq!(p.aux_state_status, 2);
++        assert_eq!(p.progress_percent, 50);
++        assert_eq!(p.reason_code, 3);
++        assert_eq!(p.update_option_flags_enabled, 0xdead_beef);
++    }
++
++    #[test]
++    fn get_status_rejects_unknown_state() {
++        // State value 0x07 is not a defined PldmFDState.
++        let buf = [0x07, 0, 0, 0, 0, 0, 0, 0, 0, 0];
++        assert!(GetStatusResponse::parse(&buf).is_err());
++    }
++
++    #[test]
++    fn request_update_response_roundtrip() {
++        let r = RequestUpdateResponse {
++            fd_metadata_len: 0x1234,
++            fd_will_sent_gpd: 1,
++        };
++        let mut buf = [0u8; 8];
++        let l = r.write_buf(&mut buf).unwrap();
++        assert_eq!(l, 3);
++        let (rest, p) = RequestUpdateResponse::parse(&buf[..l]).unwrap();
++        assert!(rest.is_empty());
++        assert_eq!(p.fd_metadata_len, 0x1234);
++        assert_eq!(p.fd_will_sent_gpd, 1);
++    }
++
++    #[test]
++    fn firmware_parameters_roundtrip() {
++        let fp = FirmwareParameters {
++            caps: DeviceCapabilities::from_u32(0),
++            components: vec![Component {
++                classification: ComponentClassification::Firmware,
++                identifier: 0x10,
++                classificationindex: 3,
++                active: ComponentVersion::new_str("active12").unwrap(),
++                pending: ComponentVersion::new_str("pending34").unwrap(),
++                activation_methods: ActivationMethods::default(),
++                caps_during_update: ComponentCapabilities::default(),
++            }]
++            .into(),
++            active: DescriptorString::new_str("AAAA").unwrap(),
++            pending: DescriptorString::new_str("BBBB").unwrap(),
++        };
++
++        let mut buf = [0u8; 256];
++        let l = fp.write_buf(&mut buf).unwrap();
++
++        let (rest, p) = FirmwareParameters::parse(&buf[..l]).unwrap();
++        assert!(rest.is_empty());
++        assert_eq!(p.components.len(), 1);
++
++        let c = &p.components.as_ref()[0];
++        assert_eq!(c.classification, ComponentClassification::Firmware);
++        assert_eq!(c.identifier, 0x10);
++        assert_eq!(c.classificationindex, 3);
++        assert_eq!(format!("{}", c.active.version), "active12");
++        assert_eq!(format!("{}", c.pending.version), "pending34");
++        assert_eq!(format!("{}", p.active), "AAAA");
++        assert_eq!(format!("{}", p.pending), "BBBB");
++    }
++
++    #[test]
++    fn update_component_response_parse() {
++        // _response(1) response_code(1) update_flags(4) estimate_time(2)
++        let buf = [0x00, 0x06, 0x01, 0x00, 0x00, 0x00, 0x05, 0x00];
++        let (rest, r) = UpdateComponentResponse::parse(&buf).unwrap();
++        assert!(rest.is_empty());
++        assert_eq!(r.response_code, 0x06);
++        assert_eq!(r.update_flags, 1);
++        assert_eq!(r.estimate_time, 5);
++    }
+ }
+diff --git a/pldm-fw/src/pkg.rs b/pldm-fw/src/pkg.rs
+index e302921..e97d24c 100644
+--- a/pldm-fw/src/pkg.rs
++++ b/pldm-fw/src/pkg.rs
+@@ -328,3 +328,240 @@ impl Package {
+         Ok(n)
+     }
+ }
++
++/// Write `bytes` to a fresh temporary file and return a read handle to it.
++///
++/// Uses [`tempfile::NamedTempFile`] for an unpredictable path. `reopen()`
++/// yields the returned [`std::fs::File`] at offset 0; dropping the
++/// `NamedTempFile` then unlinks the path while the handle keeps the inode.
++#[cfg(test)]
++pub(crate) fn temp_file_with(bytes: &[u8]) -> std::fs::File {
++    use std::io::Write;
++
++    let mut tmp = tempfile::NamedTempFile::new().unwrap();
++    tmp.write_all(bytes).unwrap();
++    tmp.flush().unwrap();
++    tmp.reopen().unwrap()
++}
++
++/// Build the bytes of a minimal, well-formed v1.1.x firmware update package.
++///
++/// The package describes a single device identified by one PCI Vendor ID
++/// descriptor (`vid`), whose component bitmap selects every supplied
++/// component. Each entry of `components` becomes a component image appended
++/// after the (CRC-protected) package header, with matching file offset/size
++/// fields.
++#[cfg(test)]
++pub(crate) fn build_v11_package(vid: u16, components: &[&[u8]]) -> Vec<u8> {
++    let ncomp = components.len();
++    assert!(ncomp >= 1);
++
++    // --- single device record ---
++    let bitmap_bytes = ncomp.div_ceil(8);
++    let mut bitmap = vec![0u8; bitmap_bytes];
++    for i in 0..ncomp {
++        bitmap[i / 8] |= 1u8 << (i % 8);
++    }
++    let set_ver = b"0000";
++
++    let mut descs = Vec::new();
++    descs.extend_from_slice(&0x0000u16.to_le_bytes()); // type: PCI Vendor ID
++    descs.extend_from_slice(&2u16.to_le_bytes()); // length
++    descs.extend_from_slice(&vid.to_le_bytes()); // data
++    let desc_count = 1u8;
++    let pkg_data_len = 0u16;
++
++    let mut rec_body = Vec::new();
++    rec_body.extend_from_slice(&bitmap);
++    rec_body.extend_from_slice(set_ver);
++    rec_body.extend_from_slice(&descs);
++    let rec_len = (11 + rec_body.len()) as u16;
++
++    let mut device = Vec::new();
++    device.extend_from_slice(&rec_len.to_le_bytes());
++    device.push(desc_count);
++    device.extend_from_slice(&0u32.to_le_bytes()); // option flags
++    device.push(1u8); // set version string type (utf-8)
++    device.push(set_ver.len() as u8);
++    device.extend_from_slice(&pkg_data_len.to_le_bytes());
++    device.extend_from_slice(&rec_body);
++
++    // Header bytes following the 19-byte init region, excluding the trailing
++    // 4-byte checksum. `offsets` carries each component's absolute file offset.
++    let build_pre = |offsets: &[usize]| -> Vec<u8> {
++        let mut pre = Vec::new();
++        pre.extend_from_slice(&[0u8; 13]); // release date/time
++        pre.extend_from_slice(&(ncomp as u16).to_le_bytes()); // bitmap length (bits)
++        // package version string (type, length, data)
++        pre.push(1u8);
++        pre.push(4u8);
++        pre.extend_from_slice(b"0000");
++        // device id record area
++        pre.push(1u8); // device count
++        pre.extend_from_slice(&device);
++        // downstream device id record area (1.1.x): none
++        pre.push(0u8);
++        // component image information area
++        pre.extend_from_slice(&(ncomp as u16).to_le_bytes());
++        for (i, c) in components.iter().enumerate() {
++            pre.extend_from_slice(&0x000du16.to_le_bytes()); // classification: firmware
++            pre.extend_from_slice(&(i as u16).to_le_bytes()); // identifier
++            pre.extend_from_slice(&0u32.to_le_bytes()); // comparison stamp
++            pre.extend_from_slice(&0u16.to_le_bytes()); // options
++            pre.extend_from_slice(&0u16.to_le_bytes()); // activation method
++            pre.extend_from_slice(&(offsets[i] as u32).to_le_bytes());
++            pre.extend_from_slice(&(c.len() as u32).to_le_bytes());
++            // component version string (type, length, data)
++            pre.push(1u8);
++            pre.push(4u8);
++            pre.extend_from_slice(b"0000");
++        }
++        pre
++    };
++
++    const HDR_INIT_SIZE: usize = 16 + 1 + 2;
++
++    // First pass with placeholder offsets to learn the header size, which is
++    // independent of the (fixed-size) offset field values.
++    let pre_len = build_pre(&vec![0usize; ncomp]).len();
++    let hdr_size = HDR_INIT_SIZE + pre_len + 4;
++
++    // Second pass: real offsets point past the header into the payload area.
++    let mut offsets = vec![0usize; ncomp];
++    let mut cum = hdr_size;
++    for (i, c) in components.iter().enumerate() {
++        offsets[i] = cum;
++        cum += c.len();
++    }
++    let pre = build_pre(&offsets);
++
++    let mut header = Vec::new();
++    header.extend_from_slice(PKG_UUID_1_1_X.as_bytes());
++    header.push(1u8); // header format revision
++    header.extend_from_slice(&(hdr_size as u16).to_le_bytes());
++    header.extend_from_slice(&pre);
++
++    let crc32 = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
++    let checksum = crc32.checksum(&header);
++    header.extend_from_slice(&checksum.to_le_bytes());
++    assert_eq!(header.len(), hdr_size);
++
++    let mut file = header;
++    for c in components {
++        file.extend_from_slice(c);
++    }
++    file
++}
++
++#[cfg(test)]
++mod tests {
++    use super::*;
++
++    #[test]
++    fn parse_minimal_package() {
++        let img = [0xa5u8; 64];
++        let bytes = build_v11_package(0xabcd, &[&img[..]]);
++        let pkg = Package::parse(temp_file_with(&bytes)).unwrap();
++
++        assert_eq!(pkg.identifier, PKG_UUID_1_1_X);
++        assert_eq!(pkg.devices.len(), 1);
++        assert_eq!(pkg.components.len(), 1);
++        assert_eq!(
++            pkg.devices[0].ids,
++            DeviceIdentifiers {
++                ids: vec![Descriptor::PciVid(0xabcd)]
++            }
++        );
++        // The component bitmap selects component 0 for this device.
++        assert_eq!(pkg.devices[0].components.as_index_vec(), vec![0]);
++        assert_eq!(pkg.components[0].file_size, 64);
++
++        // The component image is readable and matches what was written.
++        let mut buf = [0u8; 64];
++        let n = pkg.read_component(&pkg.components[0], 0, &mut buf).unwrap();
++        assert_eq!(n, 64);
++        assert_eq!(buf, img);
++    }
++
++    #[test]
++    fn parse_multiple_components() {
++        let a = [0x11u8; 48];
++        let b = [0x22u8; 80];
++        let bytes = build_v11_package(0x1234, &[&a[..], &b[..]]);
++        let pkg = Package::parse(temp_file_with(&bytes)).unwrap();
++
++        assert_eq!(pkg.components.len(), 2);
++        assert_eq!(pkg.components[0].file_size, 48);
++        assert_eq!(pkg.components[1].file_size, 80);
++        assert_eq!(pkg.devices[0].components.as_index_vec(), vec![0, 1]);
++
++        // The second component reads back from its own (offset) region.
++        let mut buf = [0u8; 80];
++        let n = pkg.read_component(&pkg.components[1], 0, &mut buf).unwrap();
++        assert_eq!(n, 80);
++        assert!(buf.iter().all(|&x| x == 0x22));
++    }
++
++    #[test]
++    fn parse_rejects_bad_checksum() {
++        let img = [0u8; 64];
++        let mut bytes = build_v11_package(0xabcd, &[&img[..]]);
++        // Corrupt a byte inside the CRC-protected header (release date area).
++        bytes[20] ^= 0xff;
++        let err = Package::parse(temp_file_with(&bytes)).unwrap_err();
++        assert!(matches!(err, PldmPackageError::Format(_)));
++        assert!(format!("{err}").contains("checksum"));
++    }
++
++    #[test]
++    fn parse_rejects_unknown_uuid() {
++        let img = [0u8; 64];
++        let mut bytes = build_v11_package(0xabcd, &[&img[..]]);
++        // Replace the package UUID with one that is neither 1.0.x nor 1.1.x.
++        // (The unknown-UUID check happens before the header checksum check.)
++        let unknown = uuid::uuid!("00000000-0000-0000-0000-000000000000");
++        bytes[..16].copy_from_slice(unknown.as_bytes());
++        let err = Package::parse(temp_file_with(&bytes)).unwrap_err();
++        assert!(format!("{err}").contains("unknown package UUID"));
++    }
++
++    #[test]
++    fn read_component_pads_past_image_end() {
++        // new_virtual builds a single-component package backed directly by the
++        // payload file (file_offset 0, file_size == payload length).
++        let img: Vec<u8> = (0..40u8).collect();
++        let pkg = Package::new_virtual(
++            ComponentClassification::Firmware,
++            0,
++            temp_file_with(&img),
++        )
++        .unwrap();
++        let comp = &pkg.components[0];
++        assert_eq!(comp.file_size, 40);
++
++        let mut buf = [0xeeu8; 32];
++        let n = pkg.read_component(comp, 16, &mut buf).unwrap();
++        // Only 24 real bytes remain in the image past offset 16.
++        assert_eq!(n, 24);
++        assert_eq!(&buf[..24], &img[16..40]);
++        // The remainder is zero-padded rather than reading adjacent data.
++        assert!(buf[24..].iter().all(|&x| x == 0));
++    }
++
++    #[test]
++    fn read_component_within_image() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let pkg = Package::new_virtual(
++            ComponentClassification::Firmware,
++            0,
++            temp_file_with(&img),
++        )
++        .unwrap();
++        let comp = &pkg.components[0];
++
++        let mut buf = [0u8; 32];
++        let n = pkg.read_component(comp, 8, &mut buf).unwrap();
++        assert_eq!(n, 32);
++        assert_eq!(buf, img[8..40]);
++    }
++}
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index 311ca95..db211a4 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -620,3 +620,525 @@ fn check_fd_state(
+ 
+     Ok(())
+ }
++
++#[cfg(test)]
++mod tests {
++    use super::{
++        activate_firmware, pass_component_table, request_update,
++        update_component, PldmUpdateError, Update,
++    };
++    use crate::{
++        DeviceCapabilities, Descriptor, DescriptorString, DeviceIdentifiers,
++        FirmwareParameters, FwCode, GetStatusResponse, PldmFDState,
++        PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
++    };
++    use mctp::{
++        Eid, Listener, MsgIC, MsgType, ReqChannel, RespChannel,
++        MCTP_TYPE_PLDM,
++    };
++    use std::cell::RefCell;
++    use std::collections::VecDeque;
++    use std::rc::Rc;
++
++    // --- Mock MCTP transport ---------------------------------------------
++    //
++    // The UA drives two channels: a `ReqChannel` (`comm`) for commands it
++    // initiates (GetStatus, RequestUpdate, ...) and a `Listener` for the
++    // commands the FD initiates during the data transfer (RequestFirmwareData,
++    // TransferComplete, VerifyComplete, ApplyComplete). The mocks below replay
++    // a scripted set of FD responses/requests and record everything the UA
++    // sends so tests can assert on the wire format.
++
++    #[derive(Default)]
++    struct CommState {
++        responses: VecDeque<Vec<u8>>,
++        sent: Vec<Vec<u8>>,
++    }
++
++    #[derive(Clone, Default)]
++    struct MockComm {
++        st: Rc<RefCell<CommState>>,
++    }
++
++    impl MockComm {
++        fn new(responses: Vec<Vec<u8>>) -> Self {
++            Self {
++                st: Rc::new(RefCell::new(CommState {
++                    responses: responses.into(),
++                    sent: Vec::new(),
++                })),
++            }
++        }
++
++        fn sent(&self) -> Vec<Vec<u8>> {
++            self.st.borrow().sent.clone()
++        }
++    }
++
++    impl ReqChannel for MockComm {
++        fn send_vectored(
++            &mut self,
++            _typ: MsgType,
++            _ic: MsgIC,
++            bufs: &[&[u8]],
++        ) -> mctp::Result<()> {
++            let mut msg = Vec::new();
++            for b in bufs {
++                msg.extend_from_slice(b);
++            }
++            self.st.borrow_mut().sent.push(msg);
++            Ok(())
++        }
++
++        fn recv<'f>(
++            &mut self,
++            buf: &'f mut [u8],
++        ) -> mctp::Result<(MsgType, MsgIC, &'f mut [u8])> {
++            let resp = self
++                .st
++                .borrow_mut()
++                .responses
++                .pop_front()
++                .ok_or(mctp::Error::RxFailure)?;
++            buf[..resp.len()].copy_from_slice(&resp);
++            Ok((MCTP_TYPE_PLDM, MsgIC(false), &mut buf[..resp.len()]))
++        }
++
++        fn remote_eid(&self) -> Eid {
++            Eid(8)
++        }
++    }
++
++    struct MockResp {
++        sent: Rc<RefCell<Vec<Vec<u8>>>>,
++    }
++
++    impl RespChannel for MockResp {
++        type ReqChannel = MockComm;
++
++        fn send_vectored(
++            &mut self,
++            _ic: MsgIC,
++            bufs: &[&[u8]],
++        ) -> mctp::Result<()> {
++            let mut msg = Vec::new();
++            for b in bufs {
++                msg.extend_from_slice(b);
++            }
++            self.sent.borrow_mut().push(msg);
++            Ok(())
++        }
++
++        fn remote_eid(&self) -> Eid {
++            Eid(8)
++        }
++
++        fn req_channel(&self) -> mctp::Result<MockComm> {
++            Ok(MockComm::default())
++        }
++    }
++
++    #[derive(Default)]
++    struct MockListener {
++        requests: VecDeque<Vec<u8>>,
++        sent: Rc<RefCell<Vec<Vec<u8>>>>,
++    }
++
++    impl MockListener {
++        fn new(requests: Vec<Vec<u8>>) -> Self {
++            Self {
++                requests: requests.into(),
++                sent: Rc::new(RefCell::new(Vec::new())),
++            }
++        }
++
++        fn sent(&self) -> Vec<Vec<u8>> {
++            self.sent.borrow().clone()
++        }
++    }
++
++    impl Listener for MockListener {
++        type RespChannel<'a>
++            = MockResp
++        where
++            Self: 'a;
++
++        fn recv<'f>(
++            &mut self,
++            buf: &'f mut [u8],
++        ) -> mctp::Result<(MsgType, MsgIC, &'f mut [u8], MockResp)> {
++            let req = self
++                .requests
++                .pop_front()
++                .ok_or(mctp::Error::RxFailure)?;
++            buf[..req.len()].copy_from_slice(&req);
++            let ep = MockResp {
++                sent: self.sent.clone(),
++            };
++            Ok((MCTP_TYPE_PLDM, MsgIC(false), &mut buf[..req.len()], ep))
++        }
++    }
++
++    // --- frame helpers ---------------------------------------------------
++
++    /// A PLDM response frame as returned by the FD over `comm`.
++    fn resp_frame(cmd: u8, cc: u8, data: &[u8]) -> Vec<u8> {
++        let mut v = vec![0u8, PLDM_TYPE_FW, cmd, cc];
++        v.extend_from_slice(data);
++        v
++    }
++
++    /// A PLDM request frame as issued by the FD over the listener.
++    fn fd_req_frame(cmd: u8, data: &[u8]) -> Vec<u8> {
++        let mut v = vec![0x80u8, PLDM_TYPE_FW, cmd];
++        v.extend_from_slice(data);
++        v
++    }
++
++    fn status_data(state: PldmFDState) -> Vec<u8> {
++        let s = GetStatusResponse {
++            current_state: state,
++            previous_state: PldmFDState::Idle,
++            aux_state: 0,
++            aux_state_status: 0,
++            progress_percent: 0,
++            reason_code: 0,
++            update_option_flags_enabled: 0,
++        };
++        let mut b = [0u8; 16];
++        let l = s.write_buf(&mut b).unwrap();
++        b[..l].to_vec()
++    }
++
++    /// RequestFirmwareData payload: offset and length, both little-endian u32.
++    fn rfd(offset: u32, len: u32) -> Vec<u8> {
++        let mut v = offset.to_le_bytes().to_vec();
++        v.extend_from_slice(&len.to_le_bytes());
++        v
++    }
++
++    fn make_update(vid: u16, components: &[&[u8]]) -> Update {
++        let bytes = crate::pkg::build_v11_package(vid, components);
++        let pkg =
++            crate::pkg::Package::parse(crate::pkg::temp_file_with(&bytes))
++                .unwrap();
++        let dev = DeviceIdentifiers {
++            ids: vec![Descriptor::PciVid(vid)],
++        };
++        let fwp = FirmwareParameters {
++            caps: DeviceCapabilities::from_u32(0),
++            components: Vec::new().into(),
++            active: DescriptorString::empty(),
++            pending: DescriptorString::empty(),
++        };
++        Update::new(&dev, &fwp, pkg, None, None, vec![]).unwrap()
++    }
++
++    // --- RequestUpdate ---------------------------------------------------
++
++    #[test]
++    fn request_update_reports_actual_component_count() {
++        let img: &[u8] = &[0u8; 64];
++        let update = make_update(0xabcd, &[img, img]);
++
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::Idle)),
++            // RequestUpdateResponse: FirmwareDeviceMetaDataLength + flag
++            resp_frame(0x10, 0, &[0, 0, 0]),
++        ]);
++
++        request_update(&mut comm, &update).unwrap();
++
++        let sent = comm.sent();
++        assert_eq!(sent.len(), 2);
++        // sent[1] is RequestUpdate: [0x80, type, 0x10, <payload>]
++        let ru = &sent[1];
++        assert_eq!(ru[2], 0x10);
++        let data = &ru[3..];
++        // payload: MaxTransferSize(4), NumberOfComponents(2), ...
++        let num_components = u16::from_le_bytes([data[4], data[5]]);
++        assert_eq!(num_components, 2);
++    }
++
++    #[test]
++    fn request_update_surfaces_command_failure() {
++        let img: &[u8] = &[0u8; 64];
++        let update = make_update(0xabcd, &[img]);
++
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::Idle)),
++            resp_frame(0x10, FwCode::UNABLE_TO_INITIATE_UPDATE as u8, &[]),
++        ]);
++
++        let err = request_update(&mut comm, &update).unwrap_err();
++        assert!(matches!(err, PldmUpdateError::Command(0x10, _)));
++    }
++
++    #[test]
++    fn request_update_requires_idle_state() {
++        let img: &[u8] = &[0u8; 64];
++        let update = make_update(0xabcd, &[img]);
++
++        // FD reports it is already updating; GetStatus precondition fails.
++        let mut comm = MockComm::new(vec![resp_frame(
++            0x1b,
++            0,
++            &status_data(PldmFDState::ReadyXfer),
++        )]);
++
++        let err = request_update(&mut comm, &update).unwrap_err();
++        assert!(matches!(err, PldmUpdateError::Protocol(_)));
++    }
++
++    // --- PassComponentTable ---------------------------------------------
++
++    #[test]
++    fn pass_component_table_success() {
++        let img: &[u8] = &[0u8; 64];
++        let update = make_update(0xabcd, &[img]);
++
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::LearnComponents)),
++            // ComponentResponse=0 (can be updated), ComponentResponseCode=0
++            resp_frame(0x13, 0, &[0, 0]),
++        ]);
++
++        pass_component_table(&mut comm, &update).unwrap();
++    }
++
++    #[test]
++    fn pass_component_table_rejects_unsupported_component() {
++        let img: &[u8] = &[0u8; 64];
++        let update = make_update(0xabcd, &[img]);
++
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::LearnComponents)),
++            // ComponentResponse!=0 with code 0x06 (not supported)
++            resp_frame(0x13, 0, &[1, 0x06]),
++        ]);
++
++        let err = pass_component_table(&mut comm, &update).unwrap_err();
++        assert!(matches!(err, PldmUpdateError::Update(_)));
++    }
++
++    // --- UpdateComponent (data transfer) --------------------------------
++
++    fn xfer_comm() -> MockComm {
++        MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::ReadyXfer)),
++            // UpdateComponentResponse: comp resp(1) code(1) flags(4) est(2)
++            resp_frame(0x14, 0, &[0, 0, 0, 0, 0, 0, 0, 0]),
++            // post-transfer GetStatus precondition
++            resp_frame(0x1b, 0, &status_data(PldmFDState::ReadyXfer)),
++        ])
++    }
++
++    #[test]
++    fn update_component_serves_image_and_completes() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]), // TransferComplete: success
++            fd_req_frame(0x17, &[0]), // VerifyComplete: success
++            fd_req_frame(0x18, &[0]), // ApplyComplete: success
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let sent = listener.sent();
++        // The first FD-bound message is the RequestFirmwareData response:
++        // [iid, type, 0x15, cc, <image bytes>]
++        let reply = &sent[0];
++        assert_eq!(reply[2], 0x15);
++        assert_eq!(reply[3], 0); // success completion code
++        assert_eq!(&reply[4..], &img[..]);
++    }
++
++    #[test]
++    fn update_component_pads_past_image_end() {
++        let img: Vec<u8> = (0..40u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            // Request crosses the end of the 40-byte image.
++            fd_req_frame(0x15, &rfd(16, 32)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0]),
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let reply = &listener.sent()[0];
++        assert_eq!(reply[3], 0);
++        let data = &reply[4..];
++        assert_eq!(data.len(), 32);
++        assert_eq!(&data[..24], &img[16..40]);
++        // Bytes past the end of the image are zero-padded.
++        assert!(data[24..].iter().all(|&x| x == 0));
++    }
++
++    #[test]
++    fn update_component_rejects_oversized_transfer_length() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            // Length far above MaximumTransferSize -> INVALID_TRANSFER_LENGTH.
++            fd_req_frame(0x15, &rfd(0, 1_000_000)),
++            // The FD then completes the (aborted) transfer.
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0]),
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let reply = &listener.sent()[0];
++        assert_eq!(reply[2], 0x15);
++        assert_eq!(reply[3], FwCode::INVALID_TRANSFER_LENGTH as u8);
++    }
++
++    #[test]
++    fn update_component_rejects_below_baseline_transfer_length() {
++        let small_len = PLDM_FW_BASELINE_TRANSFER - 1;
++        let img: Vec<u8> = (0..small_len as u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            // First Data transfer below baseline -> INVALID_TRANSFER_LENGTH.
++            fd_req_frame(0x15, &rfd(0, small_len as u32)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0]),
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let reply = &listener.sent()[0];
++        assert_eq!(reply[2], 0x15);
++        assert_eq!(reply[3], FwCode::INVALID_TRANSFER_LENGTH as u8);
++    }
++
++    #[test]
++    fn update_component_rejects_out_of_range_request() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            // offset+len extends past image end + baseline -> DATA_OUT_OF_RANGE
++            fd_req_frame(0x15, &rfd(100, 32)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0]),
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let reply = &listener.sent()[0];
++        assert_eq!(reply[3], FwCode::DATA_OUT_OF_RANGE as u8);
++    }
++
++    #[test]
++    fn update_component_reports_verify_failure() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            // VerifyComplete with a non-zero result.
++            fd_req_frame(0x17, &[0x02]),
++        ]);
++
++        let err = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap_err();
++        assert!(matches!(err, PldmUpdateError::Update(_)));
++    }
++
++    // --- ActivateFirmware ------------------------------------------------
++
++    #[test]
++    fn activate_firmware_success() {
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::ReadyXfer)),
++            resp_frame(0x1a, 0, &[0, 0]),
++        ]);
++        activate_firmware(&mut comm, false).unwrap();
++    }
++
++    #[test]
++    fn activate_firmware_activation_not_required_is_ok() {
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::ReadyXfer)),
++            resp_frame(0x1a, FwCode::ACTIVATION_NOT_REQUIRED as u8, &[]),
++        ]);
++        // Per DSP0267 the UA treats ACTIVATION_NOT_REQUIRED as success.
++        activate_firmware(&mut comm, true).unwrap();
++    }
++
++    #[test]
++    fn activate_firmware_surfaces_other_failure() {
++        let mut comm = MockComm::new(vec![
++            resp_frame(0x1b, 0, &status_data(PldmFDState::ReadyXfer)),
++            resp_frame(0x1a, FwCode::INVALID_STATE_FOR_COMMAND as u8, &[]),
++        ]);
++        let err = activate_firmware(&mut comm, false).unwrap_err();
++        assert!(matches!(err, PldmUpdateError::Command(0x1a, _)));
++    }
++}
+-- 
+2.49.0
+

--- a/platform/aspeed/pldm-fw-cli/patches/0005-pldm-fw-handle-ApplyComplete-activation-method-modif.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0005-pldm-fw-handle-ApplyComplete-activation-method-modif.patch
@@ -1,0 +1,625 @@
+From 7d713e3885f5fd26241139d917864b6ea7fe231b Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 23:13:16 +0300
+Subject: [PATCH 5/6] pldm-fw: handle ApplyComplete activation method
+ modifications Implement DSP0267 ApplyComplete handling for
+ SuccessModActivation (0x01) and the ComponentActivationMethodsModification
+ field. The UA previously treated any non-zero ApplyResult as failure, so FDs
+ that report a post-apply activation change aborted the update incorrectly. -
+ Parse and log ComponentActivationMethodsModification from ApplyComplete. -
+ Return per-component activation updates from the update path. - In
+ pldm-fw-cli, reconcile modified methods with GetFirmwareParameters,   choose
+ SelfContainedActivationRequest from effective methods, and   tell the
+ operator what external activation steps remain.
+
+Signed-off-by: Brian Carr <brcarr@nvidia.com>
+---
+
+index bdb55dc..0c1d20a 100644
+--- a/pldm-fw-cli/src/bin/pldm-fw.rs
++++ b/pldm-fw-cli/src/bin/pldm-fw.rs
+@@ -9,6 +9,7 @@ use anyhow::{bail, Context};
+ use argh::FromArgs;
+ use enumset::{EnumSet, EnumSetType};
+ use mctp_linux::{MctpAddr, MctpLinuxListener};
++use pldm_fw::{ActivationMethod, ActivationMethods};
+ use std::io::Write;
+ 
+ fn comma_separated<T: EnumSetType + std::fmt::Debug>(e: EnumSet<T>) -> String {
+@@ -281,6 +282,81 @@ fn bps_str(bps: f32) -> String {
+     }
+ }
+ 
++/// Human-readable description of an activation method for end-user output.
++fn activation_method_action(m: ActivationMethod) -> &'static str {
++    match m {
++        ActivationMethod::Automatic =>
++            "Activation will occur automatically; no user action required.",
++        ActivationMethod::SelfContained =>
++            "Activation occurs upon ActivateFirmware (self-contained).",
++        ActivationMethod::MediumSpecificReset =>
++            "Medium-specific reset required (for example, a PCIe reset) \
++             to complete activation.",
++        ActivationMethod::SystemReboot =>
++            "System reboot required to complete activation.",
++        ActivationMethod::DCPowerCycle =>
++            "DC power cycle required to complete activation.",
++        ActivationMethod::ACPowerCycle =>
++            "AC power cycle required to complete activation \
++             (fully remove power, including any auxiliary supply).",
++        ActivationMethod::PendingImage =>
++            "Send ActivatePendingComponentImage to activate the \
++             pending component image.",
++        ActivationMethod::PendingComponentImageSet =>
++            "Send ActivatePendingComponentImageSet to activate the \
++             pending component image set.",
++    }
++}
++
++/// Owned snapshot of activation methods from GetFirmwareParameters.
++///
++/// `FirmwareParameters` borrows from the MCTP endpoint; snapshot before
++/// subsequent `&mut ep` calls during the update sequence.
++type FdComponentActivationSnapshot = Vec<(u16, u16, u8, ActivationMethods)>;
++
++fn snapshot_fd_activation_methods(
++    fwp: &pldm_fw::FirmwareParameters,
++) -> FdComponentActivationSnapshot {
++    fwp.components
++        .as_ref()
++        .iter()
++        .map(|c| {
++            (
++                u16::from(&c.classification),
++                c.identifier,
++                c.classificationindex,
++                c.activation_methods,
++            )
++        })
++        .collect()
++}
++
++fn effective_activation_methods<'a>(
++    fd_snapshot: &FdComponentActivationSnapshot,
++    classification_index: u8,
++    pkg: &'a pldm_fw::pkg::Package,
++    results: &[pldm_fw::ua::ComponentActivationUpdate],
++) -> Vec<(&'a pldm_fw::pkg::PackageComponent, Option<ActivationMethods>)> {
++    results
++        .iter()
++        .map(|r| {
++            let pc = &pkg.components[r.package_component_index];
++            let methods = r.modified_methods.or_else(|| {
++                let pc_class = u16::from(&pc.classification);
++                fd_snapshot
++                    .iter()
++                    .find(|(class, id, idx, _)| {
++                        *class == pc_class
++                            && *id == pc.identifier
++                            && *idx == classification_index
++                    })
++                    .map(|(_, _, _, methods)| *methods)
++            });
++            (pc, methods)
++        })
++        .collect()
++}
++
+ fn progress(p: &pldm_fw::UpdateTransferProgress) {
+     if p.complete {
+         println!(
+@@ -330,6 +406,7 @@ fn main() -> anyhow::Result<()> {
+             )?;
+             let dev = pldm_fw::ua::query_device_identifiers(ep)?;
+             let fwp = pldm_fw::ua::query_firmware_parameters(ep)?;
++            let fd_activation_snapshot = snapshot_fd_activation_methods(&fwp);
+             let mut update = pldm_fw::ua::Update::new(
+                 &dev,
+                 &fwp,
+@@ -338,6 +415,7 @@ fn main() -> anyhow::Result<()> {
+                 u.force_device,
+                 u.force_components,
+             )?;
++            drop(fwp);
+ 
+             println!("Proposed update:");
+             print_device(&dev);
+@@ -350,13 +428,81 @@ fn main() -> anyhow::Result<()> {
+ 
+             let _ = pldm_fw::ua::request_update(ep, &update)?;
+             pldm_fw::ua::pass_component_table(ep, &update)?;
+-            pldm_fw::ua::update_components_progress(
++            let component_results = pldm_fw::ua::update_components_progress(
+                 ep,
+                 &mut listener,
+                 &mut update,
+                 progress,
+             )?;
+-            pldm_fw::ua::activate_firmware(ep, u.self_contained_activation)?;
++
++            let per_component = effective_activation_methods(
++                &fd_activation_snapshot,
++                update.index,
++                &update.package,
++                &component_results,
++            );
++
++            let union: ActivationMethods = per_component
++                .iter()
++                .filter_map(|(_, m)| *m)
++                .fold(EnumSet::empty(), |acc, m| acc | m);
++
++            let all_support_self_contained = !per_component.is_empty()
++                && per_component.iter().all(|(_, m)| {
++                    m.is_some_and(|s| s.contains(ActivationMethod::SelfContained))
++                });
++
++            let self_contained_request =
++                u.self_contained_activation && all_support_self_contained;
++
++            if u.self_contained_activation && !all_support_self_contained {
++                println!(
++                    "Note: --self-contained-activation was requested, but \
++                     one or more updated components do not support \
++                     self-contained activation after apply; sending \
++                     ActivateFirmware with SelfContainedActivationRequest=0."
++                );
++                for (pc, methods) in &per_component {
++                    let supported = methods.is_some_and(|m| {
++                        m.contains(ActivationMethod::SelfContained)
++                    });
++                    if !supported {
++                        println!(
++                            "  component id 0x{:04x} ({}): activation methods {}",
++                            pc.identifier,
++                            pc.version,
++                            methods
++                                .map(comma_separated)
++                                .unwrap_or_else(|| "unknown".into()),
++                        );
++                    }
++                }
++            }
++
++            pldm_fw::ua::activate_firmware(ep, self_contained_request)?;
++
++            println!("\nFirmware update complete.");
++            if self_contained_request {
++                println!(
++                    "ActivateFirmware sent with SelfContainedActivationRequest=1; \
++                     components supporting self-contained activation are now active."
++                );
++            }
++
++            let deferred: ActivationMethods = if self_contained_request {
++                union - ActivationMethod::SelfContained
++            } else {
++                union
++            };
++
++            if !deferred.is_empty() {
++                println!(
++                    "\nAdditional action required to fully activate the new firmware:"
++                );
++                for m in deferred.iter() {
++                    println!("  - {:?}: {}", m, activation_method_action(m));
++                }
++            }
+         }
+         Command::Cancel(c) => {
+             let mut ep = c.addr.create_endpoint()?;
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index db211a4..4757c28 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -8,7 +8,7 @@
+ //! PLDM Firmware Update Agent
+ //!
+ //! Update Agent requires `std` feature.
+-use log::{debug, error};
++use log::{debug, error, info};
+ 
+ use thiserror::Error;
+ 
+@@ -24,9 +24,9 @@ use pldm::PldmError;
+ 
+ use crate::pkg;
+ use crate::{
+-    DeviceIdentifiers, FirmwareParameters, FwCode, GetStatusResponse,
+-    PldmFDState, RequestUpdateResponse, UpdateComponentResponse,
+-    UpdateTransferProgress, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
++    ActivationMethods, ApplyResult, DeviceIdentifiers, FirmwareParameters,
++    FwCode, GetStatusResponse, PldmFDState, RequestUpdateResponse,
++    UpdateComponentResponse, UpdateTransferProgress, VerifyResult, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
+ };
+ 
+ pub type Result<T> = core::result::Result<T, PldmUpdateError>;
+@@ -218,7 +218,7 @@ pub fn update_component(
+     package: &pkg::Package,
+     component: &pkg::PackageComponent,
+     index: u8,
+-) -> Result<()> {
++) -> Result<Option<ActivationMethods>> {
+     update_component_progress(comm, listener, package, component, index, |_| ())
+ }
+ 
+@@ -301,7 +301,7 @@ pub fn update_component_progress<F>(
+     component: &pkg::PackageComponent,
+     index: u8,
+     mut progress: F,
+-) -> Result<()>
++) -> Result<Option<ActivationMethods>>
+ where
+     F: FnMut(&UpdateTransferProgress),
+ {
+@@ -494,9 +494,17 @@ where
+         0x17 => {
+             let res = fw_req.data[0];
+             if res != 0 {
+-                return Err(PldmUpdateError::new_update(
+-                    "firmware verify failure".into(),
+-                ));
++                let detail = VerifyResult::from(res);
++                let mut fw_resp = fw_req.response();
++                fw_resp.cc = 0;
++                pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
++                error!(
++                    "VerifyComplete failed: result=0x{:02x} ({:?})",
++                    res, detail
++                );
++                return Err(PldmUpdateError::new_update(format!(
++                    "firmware verify failure (verify result 0x{res:02x}: {detail:?})"
++                )));
+             }
+         }
+         _ => {
+@@ -512,21 +520,94 @@ where
+
+     /* Apply */
+     let (fw_req, mut req_ep) = pldm::pldm_rx_req(listener)?;
+-    match fw_req.cmd {
++    let activation_modification = match fw_req.cmd {
+         0x18 => {
+-            let res = fw_req.data[0];
+-            if res != 0 {
+-                return Err(PldmUpdateError::new_update(
+-                    "firmware apply failure".into(),
++            if fw_req.data.is_empty() {
++                let mut fw_resp = fw_req.response();
++                fw_resp.cc = pldm::CCode::ERROR_INVALID_LENGTH as u8;
++                pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
++                return Err(PldmUpdateError::new_proto(
++                    "ApplyComplete missing ApplyResult byte".into(),
+                 ));
+             }
++            let res = fw_req.data[0];
++            let detail = ApplyResult::from(res);
++
++            debug!(
++                "ApplyComplete raw payload ({} bytes): {:02x?}",
++                fw_req.data.len(),
++                fw_req.data.as_ref()
++            );
++
++            match detail {
++                ApplyResult::Success => {
++                    info!(
++                        "ApplyComplete: result=0x{res:02x} ({detail:?}) \
++                         activation methods unchanged"
++                    );
++                    None
++                }
++                ApplyResult::SuccessModActivation => {
++                    // DSP0267 Table 37: the 2-byte
++                    // ComponentActivationMethodsModification field is only
++                    // meaningful for SuccessModActivation. Parse it here (not
++                    // eagerly for every ApplyComplete) and mask reserved bits
++                    // like DeviceCapabilities::from_u32 — ActivationMethod
++                    // only defines discriminants 0-7.
++                    if fw_req.data.len() >= 3 {
++                        let raw = u16::from_le_bytes([fw_req.data[1], fw_req.data[2]]);
++                        let masked = raw & ActivationMethods::all().as_u16();
++                        if masked != raw {
++                            debug!(
++                                "ApplyComplete: ComponentActivationMethodsModification \
++                                 0x{raw:04x} contains reserved bits; using 0x{masked:04x}"
++                            );
++                        }
++                        let methods = ActivationMethods::from_u16(masked);
++                        info!(
++                            "ApplyComplete: result=0x{res:02x} ({detail:?}) \
++                             ComponentActivationMethodsModification=\
++                             0x{raw:04x} ({methods:?})"
++                        );
++                        Some(methods)
++                    } else {
++                        error!(
++                            "ApplyComplete: result=0x{res:02x} ({detail:?}) \
++                             but ComponentActivationMethodsModification \
++                             field is missing from response (data len = {})",
++                            fw_req.data.len()
++                        );
++                        let mut fw_resp = fw_req.response();
++                        fw_resp.cc = pldm::CCode::ERROR_INVALID_LENGTH as u8;
++                        pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
++                        return Err(PldmUpdateError::new_proto(format!(
++                            "ApplyComplete SuccessModActivation missing \
++                             ComponentActivationMethodsModification field \
++                             (data len = {})",
++                            fw_req.data.len()
++                        )));
++                    }
++                }
++                _ => {
++                    let mut fw_resp = fw_req.response();
++                    fw_resp.cc = 0;
++                    pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
++                    error!(
++                        "ApplyComplete failed: result=0x{:02x} ({:?})",
++                        res, detail
++                    );
++                    return Err(PldmUpdateError::new_update(format!(
++                        "firmware apply failure (apply result 0x{res:02x}: {detail:?})"
++                    )));
++                }
++            }
+         }
+         _ => {
+             return Err(PldmUpdateError::new_update(
+                 "unexpected command in apply state".into(),
+             ));
+         }
+-    }
++    };
+ 
+     let mut fw_resp = fw_req.response();
+     fw_resp.cc = 0;
+@@ -534,14 +615,26 @@ where
+ 
+     check_fd_state(comm, PldmFDState::ReadyXfer)?;
+ 
+-    Ok(())
++    Ok(activation_modification)
++}
++
++/// A per-component record of any FD-reported activation method modification.
++///
++/// `package_component_index` is the index into `Update::package.components`
++/// that was just updated. `modified_methods` is `Some(_)` only when the FD
++/// returned `ApplyResult::SuccessModActivation` (DSP0267 §12.9, Table 37),
++/// and contains the parsed `ComponentActivationMethodsModification` bitmap.
++#[derive(Debug, Clone, Copy)]
++pub struct ComponentActivationUpdate {
++    pub package_component_index: usize,
++    pub modified_methods: Option<ActivationMethods>,
+ }
+ 
+ pub fn update_components(
+     comm: &mut impl mctp::ReqChannel,
+     listener: &mut impl mctp::Listener,
+     update: &mut Update,
+-) -> Result<()> {
++) -> Result<Vec<ComponentActivationUpdate>> {
+     update_components_progress(comm, listener, update, |_| ())
+ }
+ 
+@@ -550,15 +652,16 @@ pub fn update_components_progress<F>(
+     listener: &mut impl mctp::Listener,
+     update: &mut Update,
+     mut progress: F,
+-) -> Result<()>
++) -> Result<Vec<ComponentActivationUpdate>>
+ where
+     F: FnMut(&UpdateTransferProgress),
+ {
+     let components = update.components.clone();
++    let mut results = Vec::with_capacity(components.len());
+ 
+     for idx in components {
+         let component = update.package.components.get(idx).unwrap();
+-        update_component_progress(
++        let modified_methods = update_component_progress(
+             comm,
+             listener,
+             &update.package,
+@@ -566,9 +669,13 @@ where
+             update.index,
+             &mut progress,
+         )?;
++        results.push(ComponentActivationUpdate {
++            package_component_index: idx,
++            modified_methods,
++        });
+     }
+ 
+-    Ok(())
++    Ok(results)
+ }
+ 
+ pub fn activate_firmware(
+@@ -628,9 +735,9 @@ mod tests {
+         update_component, PldmUpdateError, Update,
+     };
+     use crate::{
+-        DeviceCapabilities, Descriptor, DescriptorString, DeviceIdentifiers,
+-        FirmwareParameters, FwCode, GetStatusResponse, PldmFDState,
+-        PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
++        ActivationMethod, ActivationMethods, DeviceCapabilities, Descriptor,
++        DescriptorString, DeviceIdentifiers, FirmwareParameters, FwCode,
++        GetStatusResponse, PldmFDState, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
+     };
+     use mctp::{
+         Eid, Listener, MsgIC, MsgType, ReqChannel, RespChannel,
+@@ -1111,6 +1218,169 @@ mod tests {
+         assert!(matches!(err, PldmUpdateError::Update(_)));
+     }
+ 
++    #[test]
++    fn update_component_parses_success_mod_activation() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        // ApplyResult::SuccessModActivation (0x01) with modification bitmap
++        // 0x000a (SelfContained + SystemReboot).
++        let methods_raw: u16 = 0x000a;
++        let apply_payload = [
++            0x01,
++            (methods_raw & 0xff) as u8,
++            (methods_raw >> 8) as u8,
++        ];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &apply_payload),
++        ]);
++
++        let methods = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        let expected = ActivationMethods::from_u16(methods_raw);
++        assert_eq!(methods, Some(expected));
++        assert!(methods.unwrap().contains(ActivationMethod::SelfContained));
++        assert!(methods.unwrap().contains(ActivationMethod::SystemReboot));
++    }
++
++    #[test]
++    fn update_component_rejects_success_mod_activation_missing_field() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            // SuccessModActivation without the 2-byte modification field.
++            fd_req_frame(0x18, &[0x01]),
++        ]);
++
++        let err = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap_err();
++
++        assert!(matches!(
++            err,
++            PldmUpdateError::Protocol(msg)
++                if msg.contains("ApplyComplete SuccessModActivation missing")
++                    && msg.contains("ComponentActivationMethodsModification field")
++                    && msg.contains("data len = 1")
++        ));
++        let sent = listener.sent();
++        let reply = sent.last().expect("ApplyComplete response");
++        assert_eq!(reply[2], 0x18);
++        assert_eq!(reply[3], pldm::CCode::ERROR_INVALID_LENGTH as u8);
++    }
++
++    #[test]
++    fn update_component_rejects_apply_complete_missing_apply_result() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[]),
++        ]);
++
++        let err = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap_err();
++
++        assert!(matches!(
++            err,
++            PldmUpdateError::Protocol(msg)
++                if msg.contains("ApplyComplete missing ApplyResult byte")
++        ));
++        let sent = listener.sent();
++        let reply = sent.last().expect("ApplyComplete response");
++        assert_eq!(reply[2], 0x18);
++        assert_eq!(reply[3], pldm::CCode::ERROR_INVALID_LENGTH as u8);
++    }
++
++    #[test]
++    fn update_component_ignores_reserved_bits_on_apply_success() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            // ApplyResult::Success with a non-zero modification field (non-conformant FD).
++            fd_req_frame(0x18, &[0x00, 0x00, 0x01]),
++        ]);
++
++        let methods = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        assert_eq!(methods, None);
++    }
++
++    #[test]
++    fn update_component_truncates_reserved_activation_method_bits() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        // SuccessModActivation with bit 8 set (invalid for ActivationMethod).
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0x01, 0x00, 0x01]),
++        ]);
++
++        let methods = update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++        )
++        .unwrap();
++
++        assert_eq!(methods, Some(ActivationMethods::empty()));
++    }
++
+     // --- ActivateFirmware ------------------------------------------------
+ 
+     #[test]
+
+--
+2.49.0

--- a/platform/aspeed/pldm-fw-cli/patches/0006-pldm-fw-add-Force-Update-support-for-UpdateComponent.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0006-pldm-fw-add-Force-Update-support-for-UpdateComponent.patch
@@ -1,0 +1,399 @@
+From 87bacc1fd956785124fc970c14d5eb7635fa3faa Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Tue, 2 Jun 2026 23:03:33 +0300
+Subject: [PATCH 6/6] pldm-fw: add Force Update support for UpdateComponent
+
+Implement DSP0267 Force Update (option flag bit 0) for the update path.
+The UA previously always sent zero flags on UpdateComponent and aborted
+on PassComponentTable IdenticalVersion/DowngradeVersion responses.
+
+- Add UPDATE_COMPONENT_FLAG_FORCE_UPDATE in pldm-fw.
+- Thread force_update through pass_component_table, update_component*,
+  and update_components*; set the UpdateComponent flags field when
+  requested.
+- With --force-update, continue past PCT response codes IdenticalVersion
+  (0x01) and DowngradeVersion (0x02) so same-image reinstall and
+  downgrade testing can reach UpdateComponent.
+- Add --force-update to pldm-fw update.
+
+Signed-off-by: Brian Carr <brcarr@nvidia.com>
+---
+
+index 0c1d20a..beeb88e 100644
+--- a/pldm-fw-cli/src/bin/pldm-fw.rs
++++ b/pldm-fw-cli/src/bin/pldm-fw.rs
+@@ -212,6 +212,10 @@ struct UpdateCommand {
+     #[argh(switch)]
+     self_contained_activation: bool,
+ 
++    /// set Force Update in UpdateComponent (DSP0267 option flag bit 0)
++    #[argh(switch)]
++    force_update: bool,
++
+     /// don't require confirmation to update
+     #[argh(switch, short = 'y')]
+     confirm: bool,
+@@ -427,11 +431,12 @@ fn main() -> anyhow::Result<()> {
+             }
+ 
+             let _ = pldm_fw::ua::request_update(ep, &update)?;
+-            pldm_fw::ua::pass_component_table(ep, &update)?;
++            pldm_fw::ua::pass_component_table(ep, &update, u.force_update)?;
+             let component_results = pldm_fw::ua::update_components_progress(
+                 ep,
+                 &mut listener,
+                 &mut update,
++                u.force_update,
+                 progress,
+             )?;
+ 
+diff --git a/pldm-fw/src/lib.rs b/pldm-fw/src/lib.rs
+index 7cb3f8f..109827b 100644
+--- a/pldm-fw/src/lib.rs
++++ b/pldm-fw/src/lib.rs
+@@ -1089,6 +1089,9 @@ pub struct UpdateComponent {
+     pub flags: Option<u32>,
+ }
+ 
++/// UpdateComponent option flag: Force Update (DSP0267, bit 0).
++pub const UPDATE_COMPONENT_FLAG_FORCE_UPDATE: u32 = 0x0000_0001;
++
+ impl UpdateComponent {
+     pub fn parse_pass_component(buf: &[u8]) -> VResult<&[u8], Self> {
+         let (
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index 4757c28..f075182 100644
+--- a/pldm-fw/src/ua.rs
++++ b/pldm-fw/src/ua.rs
+@@ -24,8 +24,8 @@ use pldm::PldmError;
+ 
+ use crate::pkg;
+ use crate::{
+-    ActivationMethods, ApplyResult, DeviceIdentifiers, FirmwareParameters,
+-    FwCode, GetStatusResponse, PldmFDState, RequestUpdateResponse,
++    ActivationMethods, ApplyResult, ComponentResponseCode, DeviceIdentifiers,
++    FirmwareParameters, FwCode, GetStatusResponse, PldmFDState, RequestUpdateResponse,
+     UpdateComponentResponse, UpdateTransferProgress, VerifyResult, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
+ };
+ 
+@@ -218,13 +218,23 @@ pub fn update_component(
+     package: &pkg::Package,
+     component: &pkg::PackageComponent,
+     index: u8,
++    force_update: bool,
+ ) -> Result<Option<ActivationMethods>> {
+-    update_component_progress(comm, listener, package, component, index, |_| ())
++    update_component_progress(
++        comm,
++        listener,
++        package,
++        component,
++        index,
++        force_update,
++        |_| (),
++    )
+ }
+ 
+ pub fn pass_component_table(
+     comm: &mut impl mctp::ReqChannel,
+     update: &Update,
++    force_update: bool,
+ ) -> Result<()> {
+     let components = &update.components;
+     let len = components.len();
+@@ -260,12 +270,32 @@ pub fn pass_component_table(
+         }
+ 
+         if rsp.data[0] != 0 {
+-            match rsp.data[1] {
++            let code = rsp.data[1];
++            match code {
+                 0x00 => (),
+-                0x06 => {
++                x if x == ComponentResponseCode::IdenticalVersion as u8
++                    || x == ComponentResponseCode::DowngradeVersion as u8 =>
++                {
++                    if force_update {
++                        info!(
++                            "PassComponentTable: component response code \
++                             0x{code:02x}; continuing with --force-update"
++                        );
++                    } else {
++                        let detail = match code {
++                            x if x == ComponentResponseCode::IdenticalVersion as u8 => {
++                                "component version identical to installed image"
++                            }
++                            _ => "component version downgrade blocked",
++                        };
++                        return Err(PldmUpdateError::new_update(format!(
++                            "{detail}; use --force-update to override"
++                        )));
++                    }
++                }
++                x if x == ComponentResponseCode::NotSupported as u8 => {
+                     return Err(PldmUpdateError::new_update(format!(
+-                        "unsupported component {}",
+-                        rsp.data[1]
++                        "unsupported component {x:02x}"
+                     )))
+                 }
+                 x => {
+@@ -300,6 +330,7 @@ pub fn update_component_progress<F>(
+     package: &pkg::Package,
+     component: &pkg::PackageComponent,
+     index: u8,
++    force_update: bool,
+     mut progress: F,
+ ) -> Result<Option<ActivationMethods>>
+ where
+@@ -320,8 +351,12 @@ where
+     let mut sz_done: u32 = 0;
+     data.extend_from_slice(&sz.to_le_bytes());
+ 
+-    // todo: flags: request forced update?
+-    data.extend_from_slice(&0u32.to_le_bytes());
++    let flags = if force_update {
++        crate::UPDATE_COMPONENT_FLAG_FORCE_UPDATE
++    } else {
++        0
++    };
++    data.extend_from_slice(&flags.to_le_bytes());
+ 
+     component.version.write_utf8_bytes(&mut data);
+ 
+@@ -643,14 +678,16 @@ pub fn update_components(
+     comm: &mut impl mctp::ReqChannel,
+     listener: &mut impl mctp::Listener,
+     update: &mut Update,
++    force_update: bool,
+ ) -> Result<Vec<ComponentActivationUpdate>> {
+-    update_components_progress(comm, listener, update, |_| ())
++    update_components_progress(comm, listener, update, force_update, |_| ())
+ }
+ 
+ pub fn update_components_progress<F>(
+     comm: &mut impl mctp::ReqChannel,
+     listener: &mut impl mctp::Listener,
+     update: &mut Update,
++    force_update: bool,
+     mut progress: F,
+ ) -> Result<Vec<ComponentActivationUpdate>>
+ where
+@@ -667,6 +704,7 @@ where
+             &update.package,
+             component,
+             update.index,
++            force_update,
+             &mut progress,
+         )?;
+         results.push(ComponentActivationUpdate {
+@@ -735,9 +773,10 @@ mod tests {
+         update_component, PldmUpdateError, Update,
+     };
+     use crate::{
+-        ActivationMethod, ActivationMethods, DeviceCapabilities, Descriptor,
+-        DescriptorString, DeviceIdentifiers, FirmwareParameters, FwCode,
+-        GetStatusResponse, PldmFDState, PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW,
++        ActivationMethod, ActivationMethods, ComponentResponseCode,
++        DeviceCapabilities, Descriptor, DescriptorString, DeviceIdentifiers,
++        FirmwareParameters, FwCode, GetStatusResponse, PldmFDState,
++        PLDM_FW_BASELINE_TRANSFER, PLDM_TYPE_FW, UPDATE_COMPONENT_FLAG_FORCE_UPDATE,
+     };
+     use mctp::{
+         Eid, Listener, MsgIC, MsgType, ReqChannel, RespChannel,
+@@ -1010,7 +1049,47 @@ mod tests {
+             resp_frame(0x13, 0, &[0, 0]),
+         ]);
+ 
+-        pass_component_table(&mut comm, &update).unwrap();
++        pass_component_table(&mut comm, &update, false).unwrap();
++    }
++
++    #[test]
++    fn pass_component_table_rejects_identical_version_without_force() {
++        let img: &[u8] = &[0u8; 64];
++        let cases = [
++            (ComponentResponseCode::IdenticalVersion, "identical"),
++            (ComponentResponseCode::DowngradeVersion, "downgrade blocked"),
++        ];
++
++        for (code, needle) in cases {
++            let update = make_update(0xabcd, &[img]);
++            let mut comm = MockComm::new(vec![
++                resp_frame(0x1b, 0, &status_data(PldmFDState::LearnComponents)),
++                resp_frame(0x13, 0, &[1, code as u8]),
++            ]);
++
++            let err = pass_component_table(&mut comm, &update, false).unwrap_err();
++            assert!(
++                matches!(err, PldmUpdateError::Update(ref msg) if msg.contains(needle)),
++                "expected Update containing {needle:?}, got {err:?}"
++            );
++        }
++    }
++
++    #[test]
++    fn pass_component_table_continues_identical_version_with_force() {
++        let img: &[u8] = &[0u8; 64];
++        for code in [
++            ComponentResponseCode::IdenticalVersion,
++            ComponentResponseCode::DowngradeVersion,
++        ] {
++            let update = make_update(0xabcd, &[img]);
++            let mut comm = MockComm::new(vec![
++                resp_frame(0x1b, 0, &status_data(PldmFDState::LearnComponents)),
++                resp_frame(0x13, 0, &[1, code as u8]),
++            ]);
++
++            pass_component_table(&mut comm, &update, true).unwrap();
++        }
+     }
+ 
+     #[test]
+@@ -1024,7 +1103,7 @@ mod tests {
+             resp_frame(0x13, 0, &[1, 0x06]),
+         ]);
+ 
+-        let err = pass_component_table(&mut comm, &update).unwrap_err();
++        let err = pass_component_table(&mut comm, &update, false).unwrap_err();
+         assert!(matches!(err, PldmUpdateError::Update(_)));
+     }
+ 
+@@ -1060,6 +1139,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1072,6 +1152,46 @@ mod tests {
+         assert_eq!(&reply[4..], &img[..]);
+     }
+ 
++    #[test]
++    fn update_component_encodes_force_update_flag() {
++        let img: Vec<u8> = (0..64u8).collect();
++        let update = make_update(0xabcd, &[img.as_slice()]);
++        let component = &update.package.components[0];
++
++        let mut comm = xfer_comm();
++        let mut listener = MockListener::new(vec![
++            fd_req_frame(0x15, &rfd(0, 64)),
++            fd_req_frame(0x16, &[0]),
++            fd_req_frame(0x17, &[0]),
++            fd_req_frame(0x18, &[0]),
++        ]);
++
++        update_component(
++            &mut comm,
++            &mut listener,
++            &update.package,
++            component,
++            update.index,
++            true,
++        )
++        .unwrap();
++
++        let sent = comm.sent();
++        assert_eq!(sent.len(), 3); // GetStatus, UpdateComponent, GetStatus
++        let uc = &sent[1];
++        assert_eq!(uc[2], 0x14);
++        let data = &uc[3..];
++        // classification(2) + identifier(2) + index(1) + stamp(4) + size(4)
++        const FLAGS_OFF: usize = 13;
++        let flags = u32::from_le_bytes([
++            data[FLAGS_OFF],
++            data[FLAGS_OFF + 1],
++            data[FLAGS_OFF + 2],
++            data[FLAGS_OFF + 3],
++        ]);
++        assert_eq!(flags, UPDATE_COMPONENT_FLAG_FORCE_UPDATE);
++    }
++
+     #[test]
+     fn update_component_pads_past_image_end() {
+         let img: Vec<u8> = (0..40u8).collect();
+@@ -1093,6 +1213,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1127,6 +1248,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1157,6 +1279,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1186,6 +1309,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1213,6 +1337,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap_err();
+         assert!(matches!(err, PldmUpdateError::Update(_)));
+@@ -1247,6 +1372,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1277,6 +1403,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap_err();
+ 
+@@ -1313,6 +1440,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap_err();
+ 
+@@ -1348,6 +1476,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+@@ -1375,6 +1504,7 @@ mod tests {
+             &update.package,
+             component,
+             update.index,
++            false,
+         )
+         .unwrap();
+ 
+
+--
+2.49.0

--- a/platform/aspeed/pldm-fw-cli/patches/0007-pldm-fw-add-update-phase-diagnostic-logging.patch
+++ b/platform/aspeed/pldm-fw-cli/patches/0007-pldm-fw-add-update-phase-diagnostic-logging.patch
@@ -1,0 +1,148 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brian Carr <brcarr@nvidia.com>
+Date: Mon, 16 Jun 2026 04:02:00 +0300
+Subject: [PATCH 7/8] pldm-fw: add update-phase diagnostic logging
+
+Log UA update phase boundaries, RFD statistics, and blocking receive
+points so a hang shows exactly which PLDM message the UA is waiting for
+(transfer loop, VerifyComplete, or ApplyComplete) and how many bytes
+were actually transferred.
+
+Use info!/eprintln for the first 50 transfer waits (and every 1000th
+thereafter) so a low-RFD hang like offset 0 + tail blocks is visible
+with pldm-fw -d without flooding logs on a full ~16k-block transfer.
+
+---
+ pldm-fw/src/ua.rs | 66 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 62 insertions(+), 4 deletions(-)
+
+diff --git a/pldm-fw/src/ua.rs b/pldm-fw/src/ua.rs
+index 958381c..c4d8e91 100644
+--- a/pldm-fw/src/ua.rs	2026-08-06 07:30:33.057146241 +0300
++++ b/pldm-fw/src/ua.rs	2026-08-06 07:30:33.021145984 +0300
+@@ -382,11 +382,34 @@
+         )));
+     }
+ 
++    info!(
++        "UpdateComponent accepted: id=0x{:04x} index={index} \
++         file_size=0x{sz:08x} ({sz} bytes) version={}",
++        component.identifier,
++        component.version,
++    );
++
+     let start = chrono::Utc::now();
++    let mut rfd_accepted: u32 = 0;
++    let mut rfd_rejected: u32 = 0;
+ 
+     loop {
+         // we should be in update mode, handle incoming data requests
++        let rfd_seen = rfd_accepted + rfd_rejected;
++        if rfd_seen < 50 || (rfd_seen > 0 && rfd_seen % 1000 == 0) {
++            info!(
++                "waiting for FD command (0x15 RequestFirmwareData or \
++                 0x16 TransferComplete); accepted={rfd_accepted} \
++                 rejected={rfd_rejected} transferred={sz_done}/{sz}"
++            );
++        } else {
++            debug!(
++                "waiting for FD command; accepted={rfd_accepted} \
++                 rejected={rfd_rejected} transferred={sz_done}/{sz}"
++            );
++        }
+         let (fw_req, mut req_ep) = pldm::pldm_rx_req(listener)?;
++        debug!("received FD command 0x{:02x}", fw_req.cmd);
+ 
+         if fw_req.typ != PLDM_TYPE_FW {
+             return Err(PldmUpdateError::new_proto(format!(
+@@ -424,10 +447,18 @@
+                 };
+ 
+                 if let Some(cc) = err_cc {
+-                    debug!(
+-                        "rejecting RequestFirmwareData offset {offset} \
+-                         len {len} (image size {comp_size}) with cc 0x{cc:02x}"
+-                    );
++                    rfd_rejected += 1;
++                    if rfd_rejected <= 50 || rfd_rejected % 1000 == 0 {
++                        info!(
++                            "rejecting RequestFirmwareData offset {offset} \
++                             len {len} (image size {comp_size}) with cc 0x{cc:02x}"
++                        );
++                    } else {
++                        debug!(
++                            "rejecting RequestFirmwareData offset {offset} \
++                             len {len} (image size {comp_size}) with cc 0x{cc:02x}"
++                        );
++                    }
+                     let mut fw_resp = fw_req.response();
+                     fw_resp.cc = cc;
+                     pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
+@@ -450,7 +481,20 @@
+ 
+                 pldm::pldm_tx_resp(&mut req_ep, &fw_resp)?;
+ 
++                rfd_accepted += 1;
+                 sz_done += len;
++                if rfd_accepted == 1 || rfd_accepted % 1000 == 0 {
++                    info!(
++                        "RFD #{rfd_accepted}: offset=0x{offset:08x} len=0x{len:x} \
++                         transferred={sz_done}/{sz}"
++                    );
++                }
++                if sz_done >= sz {
++                    eprintln!(
++                        "pldm-fw: all {sz} component bytes sent to FD; \
++                         waiting for TransferComplete (0x16)"
++                    );
++                }
+                 let elapsed = chrono::Utc::now() - start;
+ 
+                 let bps;
+@@ -486,6 +530,13 @@
+                 let res = fw_req.data[0];
+                 let elapsed = chrono::Utc::now() - start;
+ 
++                info!(
++                    "TransferComplete: result=0x{res:02x} accepted_rfd={rfd_accepted} \
++                     rejected_rfd={rfd_rejected} transferred={sz_done}/{sz} \
++                     duration={}s",
++                    elapsed.num_seconds()
++                );
++
+                 if res == 0 {
+                     let rate = elapsed
+                         .checked_div(sz_done as i32)
+@@ -524,7 +575,10 @@
+     }
+ 
+     /* Verify results.. */
++    eprintln!("pldm-fw: transfer phase done; waiting for VerifyComplete (0x17)");
++    info!("waiting for VerifyComplete (0x17)");
+     let (fw_req, mut req_ep) = pldm::pldm_rx_req(listener)?;
++    info!("received FD command 0x{:02x}", fw_req.cmd);
+     match fw_req.cmd {
+         0x17 => {
+             let res = fw_req.data[0];
+@@ -541,6 +595,7 @@
+                     "firmware verify failure (verify result 0x{res:02x}: {detail:?})"
+                 )));
+             }
++            info!("VerifyComplete: result=0x{res:02x} (success)");
+         }
+         _ => {
+             return Err(PldmUpdateError::new_update(
+@@ -554,7 +609,10 @@
+     drop(req_ep);
+ 
+     /* Apply */
++    eprintln!("pldm-fw: verify phase done; waiting for ApplyComplete (0x18)");
++    info!("waiting for ApplyComplete (0x18)");
+     let (fw_req, mut req_ep) = pldm::pldm_rx_req(listener)?;
++    info!("received FD command 0x{:02x}", fw_req.cmd);
+     let activation_modification = match fw_req.cmd {
+         0x18 => {
+             if fw_req.data.is_empty() {
+
+--
+2.49.0

--- a/platform/aspeed/recipes/mctp.mk
+++ b/platform/aspeed/recipes/mctp.mk
@@ -27,6 +27,9 @@ MCTP_ARCHIVE_SHA256 ?= 9cb001d64afbc03f656ef0852a9e616864096d2b0b1d7fcc15cfc4dbb
 
 MCTP = mctp_$(MCTP_PKG_VERSION)_$(CONFIGURED_ARCH).deb
 $(MCTP)_SRC_PATH = $(PLATFORM_PATH)/mctp
+# Lazy-installed on the NVIDIA AST2700 BMC platform (needs a _PLATFORM device
+# so the lazy-install dev@deb mapping in slave.mk is well-formed).
+$(MCTP)_PLATFORM = arm64-aspeed_nvidia_ast2700_bmc-r0
 
 export MCTP_UPSTREAM_TAG MCTP_PKG_VERSION MCTP_DEB_VERSION MCTP_ARCHIVE_URL MCTP_ARCHIVE_SHA256 MCTP
 

--- a/platform/aspeed/recipes/pldm-fw-cli.mk
+++ b/platform/aspeed/recipes/pldm-fw-cli.mk
@@ -1,29 +1,45 @@
 # Integrate CodeConstruct pldm-fw-cli (PLDM for Firmware Update UA) from mctp-rs:
 # https://github.com/CodeConstruct/mctp-rs/tree/main/pldm-fw-cli
 
-# Upstream Git tag (full mctp-rs tree required for workspace build).
-PLDM_FW_UPSTREAM_TAG ?= pldm-fw-cli-0.2.0
+# Pin to a specific upstream mctp-rs commit (the full workspace tree is
+# required for the cargo workspace build). Our local SONiC changes live as
+# patches under pldm-fw-cli/patches/ and are generated against this exact
+# commit, so it must stay a fixed SHA -- a moving ref (e.g. a branch) would
+# let upstream drift and break patch application.
+#
+# b134e145 == CodeConstruct/mctp-rs origin/main at the time the patches were
+# produced.
+override PLDM_FW_UPSTREAM_COMMIT := b134e145f93d634dff7eb9f2a01559273c687365
 
-# Upstream version derived from the tag (pldm-fw-cli-0.2.0 -> 0.2.0), which
-# matches the Cargo.toml version in pldm-fw-cli at that tag.
-PLDM_FW_UPSTREAM_VERSION = $(patsubst pldm-fw-cli-%,%,$(PLDM_FW_UPSTREAM_TAG))
+# Matches the pldm-fw-cli Cargo.toml version at the pinned commit.
+PLDM_FW_UPSTREAM_VERSION = 0.2.0
 
 PLDM_FW_PKG_RELEASE ?= 1
 PLDM_FW_PKG_VERSION = $(PLDM_FW_UPSTREAM_VERSION)-$(PLDM_FW_PKG_RELEASE)
 
-PLDM_FW_SOURCE_BASE_URL ?= https://github.com/CodeConstruct/mctp-rs/archive/refs/tags
+# GitHub serves a tarball of an arbitrary commit at archive/<sha>.tar.gz.
+PLDM_FW_SOURCE_BASE_URL ?= https://github.com/CodeConstruct/mctp-rs/archive
 
-PLDM_FW_ARCHIVE_URL = $(PLDM_FW_SOURCE_BASE_URL)/$(PLDM_FW_UPSTREAM_TAG).tar.gz
+PLDM_FW_ARCHIVE_URL = $(PLDM_FW_SOURCE_BASE_URL)/$(PLDM_FW_UPSTREAM_COMMIT).tar.gz
 
-# SHA-256 of the pinned $(PLDM_FW_UPSTREAM_TAG) source tarball. The build
-# verifies the download against this before extracting and fails closed if it
-# is unset or mismatched. Update this whenever PLDM_FW_UPSTREAM_TAG changes.
-PLDM_FW_ARCHIVE_SHA256 ?= 112ff61673c6c8f79bc1f24fa965a8144b910ba6f4d4802dc4fffb1f9def7fad
+# SHA256 of the upstream archive currently served for PLDM_FW_UPSTREAM_COMMIT.
+# The build verifies the downloaded tarball against this before extraction and
+# fails on mismatch, which detects tampering or unexpected content. Forced
+# non-overridable like the commit pin. Note: GitHub's auto-generated
+# archive/<sha>.tar.gz is not guaranteed byte-stable for a fixed commit --
+# generator changes can alter the checksum without changing
+# PLDM_FW_UPSTREAM_COMMIT. For true byte stability, use a controlled mirror or
+# a pinned-SHA clone instead of the live GitHub archive URL. Regenerate this
+# digest whenever the commit pin changes or GitHub's archive bytes drift.
+override PLDM_FW_ARCHIVE_SHA256 := 3f0848eead41a56c579a9ee937ab97c9a7b765897795d3cb7d8d7f5f3845ea23
 
 PLDM_FW = pldm-fw_$(PLDM_FW_PKG_VERSION)_$(CONFIGURED_ARCH).deb
 $(PLDM_FW)_SRC_PATH = $(PLATFORM_PATH)/pldm-fw-cli
+# Lazy-installed on the NVIDIA AST2700 BMC platform (needs a _PLATFORM device
+# so the lazy-install dev@deb mapping in slave.mk is well-formed).
+$(PLDM_FW)_PLATFORM = arm64-aspeed_nvidia_ast2700_bmc-r0
 
-export PLDM_FW_UPSTREAM_TAG PLDM_FW_UPSTREAM_VERSION PLDM_FW_PKG_VERSION PLDM_FW_ARCHIVE_URL PLDM_FW_ARCHIVE_SHA256 PLDM_FW
+export PLDM_FW_UPSTREAM_COMMIT PLDM_FW_UPSTREAM_VERSION PLDM_FW_PKG_VERSION PLDM_FW_ARCHIVE_URL PLDM_FW_ARCHIVE_SHA256 PLDM_FW
 
 SONIC_MAKE_DEBS += $(PLDM_FW)
 

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
@@ -33,6 +33,14 @@ class Chassis(ChassisBase):
     Platform-specific Chassis class for the NVIDIA AST2700 BMC.
     """
 
+    # Stable platform identity reported by get_name(). fwutil keys its
+    # chassis-component map on this value and cross-checks it against the
+    # top-level key in platform_components.json, so it must match that file
+    # exactly (currently "NVIDIA-AST2700-BMC"). It is intentionally decoupled
+    # from the EEPROM product name, which varies per board (e.g. P3809 vs
+    # P4102-A01) and would otherwise break the firmware schema validation.
+    PLATFORM_NAME = "NVIDIA-AST2700-BMC"
+
     def __init__(self):
         super().__init__()
 
@@ -67,10 +75,14 @@ class Chassis(ChassisBase):
         """
         Retrieves the name of the device
 
+        Returns a fixed platform identifier rather than the EEPROM product
+        name so that ``fwutil`` sees a stable chassis name that matches the
+        top-level key in ``platform_components.json`` across all boards.
+
         Returns:
             string: The name of the device
         """
-        return self._eeprom.get_product_name()
+        return self.PLATFORM_NAME
 
     def get_model(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
@@ -22,6 +22,7 @@ try:
     from sonic_platform.switch_host_module import SwitchHostModule
     from sonic_platform.eeprom import EepromBMC
     from sonic_platform.reboot_cause import RebootCause
+    from sonic_platform.component import ComponentBMC
     from sonic_py_common import device_info
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
@@ -41,6 +42,7 @@ class Chassis(ChassisBase):
         self._liquid_cooling = None
         self._eeprom = EepromBMC()
         self._reboot_cause = RebootCause()
+        self._component_list = [ComponentBMC()]
 
     def get_reboot_cause(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
@@ -1,0 +1,373 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+SONiC Platform API - firmware Component(s) for the NVIDIA AST2700 BMC.
+
+The BMC is updated over PLDM-for-Firmware-Update (DSP0267) carried on MCTP. We
+drive the ``pldm-fw`` CLI (from the aspeed ``pldm-fw-cli`` package), targeting
+the BMC firmware device by its MCTP ``net,eid`` address. The EID is discovered
+at call time from ``mctpd`` (see :mod:`sonic_platform.mctp`) rather than being
+hard-coded, and is assigned once at boot by the ``mctp-bmc-setup`` oneshot.
+"""
+
+import os
+import re
+import subprocess
+
+from sonic_py_common.logger import Logger
+
+from sonic_platform import mctp
+
+try:
+    from sonic_platform_base.component_base import ComponentBase
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+logger = Logger()
+
+# Installed by the aspeed pldm-fw-cli package.
+PLDM_FW = "pldm-fw"
+
+# Returned when a version cannot be determined; matches fwutil conventions.
+VERSION_NA = "N/A"
+
+
+class ComponentBMC(ComponentBase):
+    """
+    Firmware component for the NVIDIA AST2700 BMC, updated via PLDM over MCTP.
+    """
+
+    NAME = "BMC"
+    DESCRIPTION = "Aspeed AST2700 BMC firmware (PLDM over MCTP)"
+
+    # Activation model: the new firmware becomes active only after a BMC power
+    # cycle (not a full system reboot).
+    ACTIVATION_NOTIFICATION = (
+        "A BMC power cycle (not a full system reboot) is required to activate "
+        "the new BMC firmware."
+    )
+
+    # Inventory / pkg-info are quick; a firmware transfer can take a while.
+    _INVENTORY_TIMEOUT = 60
+    _PKGINFO_TIMEOUT = 30
+    _UPDATE_TIMEOUT = 1800
+    # A pre-update cancel is a single quick PLDM request/response.
+    _CANCEL_TIMEOUT = 30
+
+    # PLDM package component that carries AST2700 BMC firmware (.fwpkg).
+    # DSP0240 ComponentClassification Firmware == 0x000D (13). pldm-fw may
+    # render that as the name "Firmware" or as an unresolved "Value(13)".
+    _PKG_COMPONENT_CLASSIFICATION = "firmware"
+    _PKG_COMPONENT_CLASSIFICATION_VALUE = 13
+    # ComponentIdentifier used by NVIDIA AST2700 BMC .fwpkg images.
+    _PKG_COMPONENT_IDENTIFIER = 0x000a
+
+    def __init__(self, network=None):
+        """
+        Args:
+            network: optional MCTP network id to restrict EID discovery to. When
+                ``None``, the IRoT (``mctpirot0``) network is resolved at address
+                lookup time so pldm-fw always targets that link.
+        """
+        super().__init__()
+        self._network = network
+
+    def get_name(self):
+        return self.NAME
+
+    def get_description(self):
+        return self.DESCRIPTION
+
+    def get_firmware_update_notification(self, image_path):
+        """
+        Return the action required to complete a BMC firmware update.
+
+        The BMC activates a newly transferred image only after a BMC power
+        cycle, so always advertise that requirement.
+        """
+        return self.ACTIVATION_NOTIFICATION
+
+    def _address(self):
+        """Resolve the BMC's ``"net,eid"`` MCTP address (may raise MctpError)."""
+        network = self._network
+        if network is None:
+            network = mctp.get_interface_network(mctp.IROT_INTERFACE)
+        return mctp.mctp_address(network=network)
+
+    def _run_pldm_fw(self, args, timeout):
+        """Run ``pldm-fw`` with `args`; returns the CompletedProcess."""
+        cmd = [PLDM_FW, *args]
+        return subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    @staticmethod
+    def _format_error(exc):
+        stderr = getattr(exc, "stderr", None)
+        return f"{exc}: {stderr.strip()}" if stderr else str(exc)
+
+    def get_firmware_version(self):
+        """
+        Return the BMC's currently active firmware version (read from HW).
+
+        Queries ``pldm-fw inventory`` (GetFirmwareParameters) and reports the
+        active version of the first component (``Component [0]``) rather than
+        the top-level device/package version. Returns ``"N/A"`` if the FD
+        cannot be reached.
+        """
+        try:
+            out = self._run_pldm_fw(
+                ["inventory", self._address()], self._INVENTORY_TIMEOUT
+            ).stdout
+        except (mctp.MctpError, subprocess.SubprocessError, OSError) as exc:
+            logger.log_error(
+                f"BMC firmware version query failed: {self._format_error(exc)}"
+            )
+            return VERSION_NA
+        return self._parse_active_version(out) or VERSION_NA
+
+    @staticmethod
+    def _parse_active_version(text):
+        """Extract Component [0]'s active version from ``pldm-fw inventory`` output.
+
+        The first component block under ``Components:`` carries the BMC
+        firmware version fwutil should display. Only the version string is
+        returned; any trailing comparison stamp (e.g. ``[88006022]``) is
+        stripped.
+        """
+        in_components = False
+        in_first_component = False
+        for line in text.splitlines():
+            if not in_components:
+                if re.match(r"\s*Components:\s*$", line):
+                    in_components = True
+                continue
+            # Component blocks are introduced by a bare index header: [0], [1]...
+            header = re.match(r"\s*\[(\d+)\]\s*$", line)
+            if header:
+                if header.group(1) == "0":
+                    in_first_component = True
+                    continue
+                # Reached a later component; stop once [0] has been seen.
+                if in_first_component:
+                    break
+                continue
+            if not in_first_component:
+                continue
+            match = re.match(r"\s*Active Version:\s*(.+?)\s*$", line, re.IGNORECASE)
+            if match:
+                # Drop a trailing comparison stamp such as " [88006022]".
+                version = re.sub(r"\s*\[[^\]]*\]\s*$", "", match.group(1)).strip()
+                return version or None
+        return None
+
+    def get_available_firmware_version(self, image_path):
+        """
+        Return the BMC firmware version contained in `image_path` (a .fwpkg).
+
+        Parses ``pldm-fw pkg-info``. Returns ``"N/A"`` on any error.
+        """
+        if not image_path or not os.path.isfile(image_path):
+            logger.log_error(f"firmware image not found: {image_path}")
+            return VERSION_NA
+        try:
+            out = self._run_pldm_fw(
+                ["pkg-info", image_path], self._PKGINFO_TIMEOUT
+            ).stdout
+        except (subprocess.SubprocessError, OSError) as exc:
+            logger.log_error(
+                f"pkg-info failed for {image_path}: {self._format_error(exc)}"
+            )
+            return VERSION_NA
+        return self._parse_component_version(out) or VERSION_NA
+
+    @staticmethod
+    def _classification_matches(text):
+        """Return True if `text` names PLDM Firmware classification.
+
+        Accepts both the symbolic name (``Firmware``) and the unresolved enum
+        form emitted by ``pldm-fw`` (``Value(13)``).
+        """
+        classification = (text or "").strip().lower()
+        if classification == ComponentBMC._PKG_COMPONENT_CLASSIFICATION:
+            return True
+        match = re.match(r"value\((\d+)\)\s*$", classification)
+        return bool(
+            match
+            and int(match.group(1)) == ComponentBMC._PKG_COMPONENT_CLASSIFICATION_VALUE
+        )
+
+    @staticmethod
+    def _parse_component_version(text):
+        """Extract the BMC component ``version:`` from ``pldm-fw pkg-info`` output."""
+        in_components = False
+        current = {}
+
+        def _block_matches(fields):
+            if not ComponentBMC._classification_matches(
+                fields.get("classification", "")
+            ):
+                return False
+            identifier = fields.get("identifier")
+            return identifier == ComponentBMC._PKG_COMPONENT_IDENTIFIER
+
+        def _version_from_block(fields):
+            if _block_matches(fields):
+                return fields.get("version")
+            return None
+
+        for line in text.splitlines():
+            if re.match(r"\s*Components:\s*$", line):
+                in_components = True
+                continue
+            if not in_components:
+                continue
+            if re.match(r"\s*\d+:\s*$", line):
+                version = _version_from_block(current)
+                if version is not None:
+                    return version
+                current = {}
+                continue
+            match = re.match(r"\s*classification:\s*(.+?)\s*$", line, re.IGNORECASE)
+            if match:
+                current["classification"] = match.group(1)
+                continue
+            match = re.match(r"\s*identifier:\s*(.+?)\s*$", line, re.IGNORECASE)
+            if match:
+                try:
+                    current["identifier"] = int(match.group(1).strip(), 0)
+                except ValueError:
+                    current.pop("identifier", None)
+                continue
+            match = re.match(r"\s*version:\s*(.+?)\s*$", line, re.IGNORECASE)
+            if match:
+                current["version"] = match.group(1)
+        return _version_from_block(current)
+
+    def _cancel_update(self, address):
+        """Best-effort ``pldm-fw cancel`` to clear a stuck FD update state.
+
+        A previously aborted update can leave the firmware device in a
+        non-IDLE state (e.g. ``ReadyXfer``), which makes the next update fail
+        with an "invalid state" protocol error. Issuing a cancel first returns
+        the FD to IDLE. ``pldm-fw cancel`` exits 0 even when the FD is already
+        IDLE, so this is safe to run unconditionally; any failure is logged and
+        ignored so a transient cancel problem never blocks the real update.
+        """
+        try:
+            self._run_pldm_fw(["cancel", address], self._CANCEL_TIMEOUT)
+        except (mctp.MctpError, subprocess.SubprocessError, OSError) as exc:
+            logger.log_warning(
+                f"BMC firmware pre-update cancel failed (continuing): "
+                f"{self._format_error(exc)}"
+            )
+
+    def _do_update(self, image_path, force_update=False):
+        """Run the ``pldm-fw update`` firmware transfer (no BMC power cycle).
+
+        Sends a preventative ``pldm-fw cancel`` first to clear any stuck FD
+        update state left by a prior aborted update. The MCTP address is
+        resolved once and reused for both the cancel and the update.
+        """
+        address = self._address()
+        self._cancel_update(address)
+        args = ["update"]
+        if force_update:
+            args.append("--force-update")
+        args.extend([address, image_path, "-y"])
+        self._run_pldm_fw(args, self._UPDATE_TIMEOUT)
+
+    def _run_firmware_update(self, image_path, force_update=False):
+        """
+        Validate `image_path` and invoke :meth:`_do_update`.
+
+        Returns:
+            False if the image file does not exist; otherwise None on success.
+
+        Raises:
+            mctp.MctpError, subprocess.SubprocessError, OSError: if the update fails.
+        """
+        if not image_path or not os.path.isfile(image_path):
+            logger.log_error(f"firmware image not found: {image_path}")
+            return False
+        self._do_update(image_path, force_update=force_update)
+
+    def install_firmware(self, image_path, force_update=False):
+        """
+        Install BMC firmware from `image_path`.
+
+        Args:
+            image_path: path to a .fwpkg image.
+            force_update: when True, pass ``--force-update`` to ``pldm-fw`` so
+                the FD applies the image even when version checks would block it.
+
+        Returns:
+            bool: True on success, False on failure (or missing image).
+        """
+        try:
+            if self._run_firmware_update(image_path, force_update=force_update) is False:
+                return False
+        except (mctp.MctpError, subprocess.SubprocessError, OSError) as exc:
+            logger.log_error(
+                f"BMC firmware install failed: {self._format_error(exc)}"
+            )
+            return False
+        logger.log_info("BMC firmware install completed")
+        return True
+
+    def update_firmware(self, image_path, force_update=False):
+        """
+        Update BMC firmware from `image_path`.
+
+        Performs the PLDM firmware transfer only; it does not power cycle the
+        BMC. Activation requires a manual BMC power cycle (surfaced via
+        :meth:`get_firmware_update_notification`), after which the new image
+        becomes active. This matches how other SONiC components handle
+        reboot/power-cycle activation and how ``fwutil`` presents it.
+
+        Args:
+            image_path: path to a .fwpkg image.
+            force_update: when True, pass ``--force-update`` to ``pldm-fw``.
+
+        Returns:
+            False if `image_path` does not exist; otherwise None on success.
+
+        Raises:
+            RuntimeError: if the update fails.
+        """
+        # Intentional failure-contract difference from install_firmware:
+        # install_firmware returns False on update failures, whereas
+        # update_firmware honors the ComponentBase contract by raising
+        # RuntimeError for operational failures and reserving False solely
+        # for a missing image.
+        try:
+            if self._run_firmware_update(image_path, force_update=force_update) is False:
+                return False
+        except (mctp.MctpError, subprocess.SubprocessError, OSError) as exc:
+            raise RuntimeError(
+                f"BMC firmware update failed: {self._format_error(exc)}"
+            ) from exc
+        logger.log_info(
+            "BMC firmware transfer completed; a BMC power cycle is required to activate"
+        )
+        return None

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
@@ -33,9 +33,11 @@ import subprocess
 from sonic_py_common.logger import Logger
 
 from sonic_platform import mctp
+from sonic_platform.utils import HW_MANAGEMENT_ROOT
 
 try:
     from sonic_platform_base.component_base import ComponentBase
+    from sonic_platform.eeprom import EepromBMC
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
 
@@ -87,12 +89,31 @@ class ComponentBMC(ComponentBase):
         """
         super().__init__()
         self._network = network
+        self._eeprom = EepromBMC()
 
     def get_name(self):
         return self.NAME
 
     def get_description(self):
         return self.DESCRIPTION
+
+    def get_presence(self):
+        return True
+
+    def get_model(self):
+        return self._eeprom.get_part_number()
+
+    def get_serial(self):
+        return self._eeprom.get_serial_number()
+
+    def get_status(self):
+        return os.path.isdir(HW_MANAGEMENT_ROOT)
+
+    def get_position_in_parent(self):
+        return -1
+
+    def is_replaceable(self):
+        return False
 
     def get_firmware_update_notification(self, image_path):
         """
@@ -371,3 +392,4 @@ class ComponentBMC(ComponentBase):
             "BMC firmware transfer completed; a BMC power cycle is required to activate"
         )
         return None
+

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/component.py
@@ -33,6 +33,7 @@ import subprocess
 from sonic_py_common.logger import Logger
 
 from sonic_platform import mctp
+from sonic_platform import pldm_errors
 from sonic_platform.utils import HW_MANAGEMENT_ROOT
 
 try:
@@ -145,7 +146,9 @@ class ComponentBMC(ComponentBase):
     @staticmethod
     def _format_error(exc):
         stderr = getattr(exc, "stderr", None)
-        return f"{exc}: {stderr.strip()}" if stderr else str(exc)
+        if not stderr:
+            return str(exc)
+        return f"{exc}: {pldm_errors.annotate(stderr.strip())}"
 
     def get_firmware_version(self):
         """
@@ -392,4 +395,5 @@ class ComponentBMC(ComponentBase):
             "BMC firmware transfer completed; a BMC power cycle is required to activate"
         )
         return None
+
 

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/mctp.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/mctp.py
@@ -1,0 +1,427 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+MCTP helpers for the NVIDIA AST2700 BMC.
+
+The BMC firmware device (FD) is reachable over the Aspeed IRoT MCTP link
+(``mctpirot0``) once ``mctpd`` (the CodeConstruct MCTP control daemon) is
+running. ``mctpd`` does not enumerate or assign an EID to the IRoT peer on its
+own; a bus-owner method must be invoked once. This module provides:
+
+* :func:`setup_endpoint` - run *once* at boot (via the ``mctp-bmc-setup``
+  systemd oneshot) to assign/learn the BMC's EID. ``SetupEndpoint`` is
+  idempotent: it queries for an existing EID first and only assigns when none
+  is present, so re-running it (e.g. after an ``mctpd`` restart) does not churn
+  the EID.
+* :func:`get_bmc_eid` - query the EID later (e.g. from the firmware
+  ``Component``) by walking ``mctpd``'s D-Bus object tree, without re-running a
+  bus-owner assignment.
+
+All D-Bus access goes through ``busctl --json=short`` so we avoid a hard
+dependency on a python D-Bus binding.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from sonic_py_common.logger import Logger
+
+logger = Logger()
+
+# CodeConstruct mctpd D-Bus service and object tree.
+MCTP_SERVICE = "au.com.codeconstruct.MCTP1"
+MCTP_BASE_PATH = "/au/com/codeconstruct/mctp1"
+BUSOWNER_IFACE = "au.com.codeconstruct.MCTP.BusOwner1"
+OBJECT_MANAGER_IFACE = "org.freedesktop.DBus.ObjectManager"
+# Endpoint objects expose the OpenBMC MCTP endpoint interface.
+ENDPOINT_IFACE = "xyz.openbmc_project.MCTP.Endpoint"
+# Per-netdev objects under .../interfaces/<name> expose NetworkId.
+INTERFACE_IFACE = "au.com.codeconstruct.MCTP.Interface1"
+
+# The Aspeed IRoT MCTP netdev created by the nvidia-ast27xx-irot kernel driver.
+IROT_INTERFACE = "mctpirot0"
+
+# PLDM message type (DSP0239); the BMC FD speaks PLDM for firmware update.
+MCTP_MSG_TYPE_PLDM = 1
+
+# Endpoint object paths look like
+# /au/com/codeconstruct/mctp1/networks/<net>/endpoints/<eid>
+_ENDPOINT_PATH_RE = re.compile(r"/networks/(\d+)/endpoints/(\d+)$")
+
+_BUSCTL = "busctl"
+
+# Default boot wait for mctpirot0: mctpd registers the netdev while operstate is
+# still "down"; SetupEndpoint fails with EHOSTUNREACH until the IRoT link is up.
+_DEFAULT_LINK_TIMEOUT = 120.0
+_DEFAULT_LINK_POLL = 2.0
+
+
+class MctpError(Exception):
+    """Raised when an mctpd D-Bus operation fails or returns no BMC endpoint."""
+
+
+def _unwrap(value):
+    """
+    Recursively strip busctl's ``{"type": <sig>, "data": <value>}`` envelopes.
+
+    ``busctl`` wraps the overall method reply, and every D-Bus VARIANT inside it
+    (e.g. the values of an ``a{sv}`` property map), in a two-key ``{"type",
+    "data"}`` object; container and basic types are emitted as plain JSON. Strip
+    those envelopes so callers see plain Python values, independent of the
+    busctl/systemd version (older builds emitted bare values, so this is a no-op
+    for them).
+    """
+    if isinstance(value, dict):
+        if len(value) == 2 and "data" in value and isinstance(value.get("type"), str):
+            return _unwrap(value["data"])
+        return {key: _unwrap(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_unwrap(item) for item in value]
+    return value
+
+
+def _busctl_json(args, timeout=10):
+    """
+    Run ``busctl --json=short`` with `args` and return the decoded reply.
+
+    The reply is the JSON array of the method's return values, with busctl's
+    ``{"type", "data"}`` variant envelopes stripped (see :func:`_unwrap`).
+
+    Returns:
+        list: the decoded array of return values.
+
+    Raises:
+        MctpError: if busctl fails or its output cannot be parsed.
+    """
+    cmd = [_BUSCTL, "--json=short", *args]
+    try:
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise MctpError(f"busctl not found: {exc}") from exc
+    except OSError as exc:
+        # Covers PermissionError and other exec failures so callers (e.g.
+        # main()'s SetupEndpoint retry loop) see a uniform MctpError.
+        raise MctpError(f"busctl execution failed: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise MctpError(f"busctl timed out: {' '.join(cmd)}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise MctpError(
+            f"busctl failed ({exc.returncode}): {' '.join(cmd)}: "
+            f"{(exc.stderr or '').strip()}"
+        ) from exc
+
+    try:
+        return _unwrap(json.loads(proc.stdout))
+    except (ValueError, TypeError) as exc:
+        raise MctpError(f"unable to parse busctl output: {proc.stdout!r}") from exc
+
+
+def interface_operstate(interface):
+    """Return the kernel ``operstate`` for `interface` (e.g. ``up`` or ``down``)."""
+    path = Path("/sys/class/net") / interface / "operstate"
+    try:
+        return path.read_text().strip()
+    except OSError as exc:
+        raise MctpError(f"cannot read operstate for {interface}: {exc}") from exc
+
+
+def _interface_carrier(interface):
+    """Return the kernel ``carrier`` for `interface`, or ``None`` if unavailable."""
+    path = Path("/sys/class/net") / interface / "carrier"
+    try:
+        return path.read_text().strip()
+    except OSError:
+        return None
+
+
+def interface_is_up(interface):
+    """
+    True when the MCTP netdev is ready for SetupEndpoint.
+
+    The IRoT driver often leaves operstate at ``unknown`` even when carrier is
+    present; treat ``unknown`` with carrier ``1`` as ready.
+    """
+    try:
+        state = interface_operstate(interface)
+    except MctpError:
+        return False
+    if state == "up":
+        return True
+    if state == "unknown":
+        return _interface_carrier(interface) == "1"
+    return False
+
+
+def wait_for_interface_up(
+    interface,
+    timeout=_DEFAULT_LINK_TIMEOUT,
+    poll_interval=_DEFAULT_LINK_POLL,
+    sleep=time.sleep,
+):
+    """
+    Block until `interface` is ready for SetupEndpoint.
+
+    mctpd may expose the D-Bus BusOwner object while the netdev is still down;
+    calling SetupEndpoint then fails with "No route to host". The IRoT netdev
+    may report operstate ``unknown`` indefinitely even when carrier is up.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if interface_is_up(interface):
+            logger.log_info(f"MCTP interface {interface} is up")
+            return
+        sleep(poll_interval)
+
+    state = "missing"
+    try:
+        state = interface_operstate(interface)
+    except MctpError:
+        pass
+    raise MctpError(
+        f"MCTP interface {interface} did not come up within {timeout:.0f}s "
+        f"(operstate={state})"
+    )
+
+
+def setup_endpoint(interface=IROT_INTERFACE):
+    """
+    Ensure the BMC endpoint on `interface` has an EID (idempotent).
+
+    Invokes the bus-owner ``SetupEndpoint`` method, which queries the peer for
+    an existing EID and only assigns a new one when needed. The IRoT link is a
+    point-to-point mailbox, so no physical address is supplied (empty ``ay``).
+
+    Returns:
+        tuple(int, int): ``(net, eid)`` of the BMC endpoint.
+
+    Raises:
+        MctpError: if the D-Bus call fails or returns an unexpected shape.
+    """
+    iface_path = f"{MCTP_BASE_PATH}/interfaces/{interface}"
+    reply = _busctl_json([
+        "call", MCTP_SERVICE, iface_path, BUSOWNER_IFACE,
+        "SetupEndpoint", "ay", "0",
+    ])
+
+    # SetupEndpoint returns (y eid, i net, s path, b new).
+    if not isinstance(reply, list) or len(reply) < 4:
+        raise MctpError(f"unexpected SetupEndpoint reply: {reply!r}")
+    eid, net, path, new = reply[0], reply[1], reply[2], reply[3]
+    try:
+        net_id = int(net)
+        eid_id = int(eid)
+    except (TypeError, ValueError) as exc:
+        raise MctpError(
+            f"invalid SetupEndpoint reply for {interface}: "
+            f"net={net!r} eid={eid!r}"
+        ) from exc
+    logger.log_info(
+        f"MCTP SetupEndpoint on {interface}: net={net_id} eid={eid_id} "
+        f"path={path} new={bool(new)}"
+    )
+    return net_id, eid_id
+
+
+def _get_managed_objects():
+    """Return the ``GetManagedObjects`` mapping from mctpd's object tree."""
+    reply = _busctl_json([
+        "call", MCTP_SERVICE, MCTP_BASE_PATH,
+        OBJECT_MANAGER_IFACE, "GetManagedObjects",
+    ])
+    # The single return value is a{oa{sa{sv}}} -> a path->iface->prop mapping.
+    if not isinstance(reply, list) or not reply:
+        raise MctpError(f"unexpected GetManagedObjects reply: {reply!r}")
+    objects = reply[0]
+    if not isinstance(objects, dict):
+        raise MctpError(f"unexpected GetManagedObjects payload: {objects!r}")
+    return objects
+
+
+def _endpoint_net_eid(path, props):
+    """
+    Resolve ``(net, eid)`` for an endpoint object.
+
+    Prefers the object path (authoritative), falling back to the endpoint
+    interface properties.
+    """
+    match = _ENDPOINT_PATH_RE.search(path)
+    if match:
+        return int(match.group(1)), int(match.group(2))
+    net = props.get("NetworkId")
+    eid = props.get("EID")
+    if net is None or eid is None:
+        return None
+    try:
+        return int(net), int(eid)
+    except (TypeError, ValueError) as exc:
+        raise MctpError(
+            f"invalid endpoint properties for {path}: "
+            f"net={net!r} eid={eid!r}"
+        ) from exc
+
+
+def _network_id_for_interface(objects, interface=IROT_INTERFACE):
+    """
+    Return the MCTP network id for `interface` from a GetManagedObjects map.
+
+    Raises:
+        MctpError: if the interface object is missing or NetworkId is invalid.
+    """
+    path = f"{MCTP_BASE_PATH}/interfaces/{interface}"
+    ifaces = objects.get(path)
+    if not isinstance(ifaces, dict):
+        raise MctpError(f"MCTP interface {interface} not found in mctpd")
+    props = ifaces.get(INTERFACE_IFACE) or {}
+    net = props.get("NetworkId")
+    try:
+        return int(net)
+    except (TypeError, ValueError) as exc:
+        raise MctpError(
+            f"invalid NetworkId for {interface}: {net!r}"
+        ) from exc
+
+
+def get_interface_network(interface=IROT_INTERFACE):
+    """Query mctpd for the MCTP network id bound to `interface`."""
+    return _network_id_for_interface(_get_managed_objects(), interface)
+
+
+def find_bmc_endpoint(objects, network=None, msg_type=MCTP_MSG_TYPE_PLDM):
+    """
+    Find the PLDM-capable BMC endpoint in a ``GetManagedObjects`` mapping.
+
+    Args:
+        objects: mapping returned by :func:`_get_managed_objects`.
+        network: if set, restrict the search to this MCTP network id.
+        msg_type: required entry in the endpoint's ``SupportedMessageTypes``.
+
+    Returns:
+        tuple(int, int): ``(net, eid)`` of the matching endpoint.
+
+    Raises:
+        MctpError: if no matching endpoint is found.
+    """
+    for path, ifaces in objects.items():
+        endpoint = ifaces.get(ENDPOINT_IFACE)
+        if not isinstance(endpoint, dict):
+            continue
+        supported = endpoint.get("SupportedMessageTypes") or []
+        if msg_type not in supported:
+            continue
+        try:
+            resolved = _endpoint_net_eid(path, endpoint)
+        except MctpError as exc:
+            logger.log_warning(f"skipping endpoint with invalid MCTP data: {exc}")
+            continue
+        if resolved is None:
+            continue
+        net, eid = resolved
+        if network is not None and net != network:
+            continue
+        return net, eid
+    raise MctpError(
+        f"no PLDM-capable BMC endpoint found (network={network})"
+    )
+
+
+def get_bmc_eid(network=None):
+    """
+    Query the BMC's ``(net, eid)`` from mctpd without re-assigning an EID.
+
+    Args:
+        network: MCTP network id to restrict the search to. When ``None``,
+            the IRoT interface (``mctpirot0``) network is used so pldm-fw
+            always targets the BMC over IRoT.
+
+    Returns:
+        tuple(int, int): ``(net, eid)`` of the BMC endpoint.
+
+    Raises:
+        MctpError: if mctpd cannot be queried or no endpoint matches.
+    """
+    objects = _get_managed_objects()
+    if network is None:
+        network = _network_id_for_interface(objects, IROT_INTERFACE)
+    return find_bmc_endpoint(objects, network=network)
+
+
+def mctp_address(network=None):
+    """Return the BMC endpoint as the ``"<net>,<eid>"`` string pldm-fw expects."""
+    net, eid = get_bmc_eid(network=network)
+    return f"{net},{eid}"
+
+
+def main(
+    argv=None,
+    attempts=10,
+    delay=2.0,
+    link_timeout=_DEFAULT_LINK_TIMEOUT,
+    sleep=time.sleep,
+):
+    """
+    Entry point for the ``mctp-bmc-setup`` systemd oneshot.
+
+    Performs the one-time ``SetupEndpoint`` so the BMC has an EID for the rest
+    of the boot. Waits for the IRoT netdev to reach operstate ``up`` before
+    calling into mctpd when possible, then retries SetupEndpoint to cover any
+    remaining startup races (including when operstate stays ``unknown``). 
+    ``SetupEndpoint`` is idempotent so retries are safe.
+    Returns a process exit code.
+    """
+    argv = list(sys.argv[1:] if argv is None else argv)
+    interface = argv[1] if len(argv) > 1 and argv[0] == "setup" else IROT_INTERFACE
+    try:
+        wait_for_interface_up(
+            interface, timeout=link_timeout, sleep=sleep
+        )
+    except MctpError as exc:
+        logger.log_warning(
+            f"{exc}; proceeding with SetupEndpoint retries"
+        )
+
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        try:
+            net, eid = setup_endpoint(interface)
+        except MctpError as exc:
+            last_error = exc
+            logger.log_warning(
+                f"MCTP BMC endpoint setup attempt {attempt}/{attempts} failed: {exc}"
+            )
+            if attempt < attempts:
+                sleep(delay)
+            continue
+        logger.log_info(f"MCTP BMC endpoint ready at {net},{eid}")
+        return 0
+    logger.log_error(f"MCTP BMC endpoint setup failed: {last_error}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/pldm_errors.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/pldm_errors.py
@@ -1,0 +1,271 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+PLDM for Firmware Update (DSP0267 1.3.0) error code tables and annotation.
+
+Translates numeric codes emitted by pldm-fw into human-readable descriptions
+sourced from the DMTF DSP0267 1.3.0 specification.
+"""
+
+import re
+
+# ---------------------------------------------------------------------------
+# DSP0240 base completion codes (subset used in firmware update)
+# ---------------------------------------------------------------------------
+_BASE_CODES = {
+    0x00: ("SUCCESS",                   "Command completed successfully"),
+    0x01: ("ERROR",                     "General error"),
+    0x02: ("ERROR_INVALID_DATA",        "Invalid data in the request"),
+    0x03: ("ERROR_INVALID_LENGTH",      "Invalid message length"),
+    0x04: ("ERROR_NOT_READY",           "Receiver not ready"),
+    0x05: ("ERROR_UNSUPPORTED_PLDM_CMD", "Command not supported by this PLDM type"),
+    0x20: ("ERROR_INVALID_PLDM_TYPE",   "Invalid PLDM type"),
+}
+
+# ---------------------------------------------------------------------------
+# DSP0267 1.3.0 Table 1 – PLDM Firmware Update Completion Codes
+# ---------------------------------------------------------------------------
+COMPLETION_CODES = {
+    **_BASE_CODES,
+    0x80: ("NOT_IN_UPDATE_MODE",
+           "Received PLDM firmware update command when the FD/FDP is not in update mode"),
+    0x81: ("ALREADY_IN_UPDATE_MODE",
+           "FD/FDP received RequestUpdate when it is already in update mode"),
+    0x82: ("DATA_OUT_OF_RANGE",
+           "The requested component image portion has an initial offset not contained within "
+           "the image data, or the offset plus length exceeds the range permitted by the UA"),
+    0x83: ("INVALID_TRANSFER_LENGTH",
+           "The requested component image portion length exceeds MaximumTransferSize or is "
+           "less than the firmware update baseline transfer size"),
+    0x84: ("INVALID_STATE_FOR_COMMAND",
+           "The FD/FDP is not in a state to expect this command"),
+    0x85: ("INCOMPLETE_UPDATE",
+           "One or more component transfers failed to complete"),
+    0x86: ("BUSY_IN_BACKGROUND",
+           "The FD/FDP is performing a critical background task and cannot execute the command"),
+    0x87: ("CANCEL_PENDING",
+           "UA received a RequestFirmwareData command after sending CancelUpdate or "
+           "CancelUpdateComponent"),
+    0x88: ("COMMAND_NOT_EXPECTED",
+           "UA received a command from the FD/FDP out of sequence"),
+    0x89: ("RETRY_REQUEST_FW_DATA",
+           "UA requested a retry of RequestFirmwareData; it needs more time to retrieve "
+           "the firmware section to transfer"),
+    0x8A: ("UNABLE_TO_INITIATE_UPDATE",
+           "The FD/FDP is not able to enter update mode to begin a transfer"),
+    0x8B: ("ACTIVATION_NOT_REQUIRED",
+           "The FD/FDP has already enabled firmware components to become active on the next "
+           "external activation, or the components are already activated"),
+    0x8C: ("SELF_CONTAINED_ACTIVATION_NOT_PERMITTED",
+           "The firmware device does not permit self-contained activation"),
+    0x8D: ("NO_DEVICE_METADATA",
+           "The FD/FDP has no metadata that must be retrieved by the UA prior to component "
+           "image transfers"),
+    0x8E: ("RETRY_REQUEST_UPDATE",
+           "The FD/FDP has requested a retry of RequestUpdate; it needs more time to prepare "
+           "for a firmware update"),
+    0x8F: ("NO_PACKAGE_DATA",
+           "The UA has no package data available for the firmware device"),
+    0x90: ("INVALID_TRANSFER_HANDLE",
+           "The data transfer handle requested was invalid"),
+    0x91: ("INVALID_TRANSFER_OPERATION_FLAG",
+           "The transfer operation flag used in the request was invalid"),
+    0x92: ("ACTIVATE_PENDING_IMAGE_NOT_PERMITTED",
+           "The firmware device does not support activating a pending component image or "
+           "component image set"),
+    0x93: ("PACKAGE_DATA_ERROR",
+           "The FD/FDP received invalid Package Data and will not proceed with the firmware "
+           "update"),
+    0x94: ("NO_OPAQUE_DATA",
+           "The UA has no component opaque data available for the firmware device"),
+    0x95: ("UPDATE_SECURITY_REVISION_NOT_PERMITTED",
+           "The FD/FDP does not support updating the security revision number of the component "
+           "image"),
+    0x96: ("DOWNSTREAM_DEVICE_LIST_CHANGED",
+           "The FD/FDP must end the transfer as one or more downstream devices were added or "
+           "removed during the inventory transfer"),
+}
+
+# ---------------------------------------------------------------------------
+# DSP0267 1.3.0 Table 35 – TransferResult codes (TransferComplete command)
+# ---------------------------------------------------------------------------
+TRANSFER_RESULT_CODES = {
+    0x00: ("TRANSFER_SUCCESS",
+           "Transfer has completed without error"),
+    0x01: ("TRANSFER_IMAGE_CORRUPT",
+           "Transfer completed with error: the image received is corrupt"),
+    0x02: ("TRANSFER_VERSION_MISMATCH",
+           "Transfer completed with error: the image version does not match the version "
+           "expected from the UpdateComponent command"),
+    0x03: ("TRANSFER_FD_ABORTED",
+           "Firmware Device has aborted the transfer"),
+    0x09: ("TRANSFER_TIMEOUT",
+           "Timeout occurred while performing action"),
+    0x0A: ("TRANSFER_GENERIC_ERROR",
+           "Generic error has occurred"),
+    0x0B: ("TRANSFER_LOW_POWER_ABORT",
+           "FD/FDP aborted the transfer because it must enter a low-power state"),
+    0x0C: ("TRANSFER_RESET_ABORT",
+           "FD/FDP aborted the transfer because it must perform a reset"),
+    0x0D: ("TRANSFER_STORAGE_ERROR",
+           "FD/FDP aborted the transfer due to an issue storing the firmware data on the "
+           "device"),
+    0x0E: ("TRANSFER_INVALID_OPAQUE_DATA",
+           "FD/FDP aborted the transfer due to invalid ComponentOpaqueData"),
+    0x0F: ("TRANSFER_DOWNSTREAM_FAILURE",
+           "FD/FDP aborted the transfer because one or more downstream devices of the same "
+           "type being updated could not complete the transfer"),
+    0x10: ("TRANSFER_SECURITY_REVISION_ERROR",
+           "Transfer aborted: the image will not be updated due to a security revision error"),
+}
+
+# ---------------------------------------------------------------------------
+# DSP0267 1.3.0 Table 36 – VerifyResult codes (VerifyComplete command)
+# ---------------------------------------------------------------------------
+VERIFY_RESULT_CODES = {
+    0x00: ("VERIFY_SUCCESS",
+           "Verify has completed without error"),
+    0x01: ("VERIFY_FAILURE",
+           "Verify completed with a verification failure; FD will not apply the component"),
+    0x02: ("VERIFY_VERSION_MISMATCH",
+           "Verify completed with error: image version does not match the version expected "
+           "from the UpdateComponent command; FD will not apply the component"),
+    0x03: ("VERIFY_SECURITY_CHECK_FAILED",
+           "Verify completed with error: image failed the FD security checks; FD will not "
+           "apply the component"),
+    0x04: ("VERIFY_INCOMPLETE_IMAGE",
+           "Verify completed with error: the image transferred was incomplete; FD will not "
+           "apply the component"),
+    0x09: ("VERIFY_TIMEOUT",
+           "Timeout occurred while performing action; FD will not apply the component"),
+    0x0A: ("VERIFY_GENERIC_ERROR",
+           "Generic error has occurred; FD will not apply the component"),
+    0x10: ("VERIFY_SECURITY_REVISION_ERROR",
+           "Verify completed with error: image will not be updated due to a security revision "
+           "error"),
+}
+
+# ---------------------------------------------------------------------------
+# DSP0267 1.3.0 Table 37 – ApplyResult codes (ApplyComplete command)
+# ---------------------------------------------------------------------------
+APPLY_RESULT_CODES = {
+    0x00: ("APPLY_SUCCESS",
+           "Apply has completed without error"),
+    0x01: ("APPLY_SUCCESS_ACTIVATION_MODIFIED",
+           "Apply completed successfully; the FD has modified its activation method — see "
+           "ComponentActivationMethodsModification field"),
+    0x02: ("APPLY_MEMORY_WRITE_FAILURE",
+           "Apply completed with failure due to a memory write issue"),
+    0x09: ("APPLY_TIMEOUT",
+           "Timeout occurred while performing action"),
+    0x0A: ("APPLY_GENERIC_ERROR",
+           "Generic error has occurred"),
+    0x0B: ("APPLY_RETRY_REQUESTED",
+           "Apply was not attempted but could succeed if the UA re-initiates the transfer; "
+           "use CancelUpdate and restart"),
+    0x10: ("APPLY_SECURITY_REVISION_ERROR",
+           "Apply completed with error: image will not be updated due to a security revision "
+           "error"),
+}
+
+# ---------------------------------------------------------------------------
+# DSP0267 1.3.0 – ComponentResponseCode (PassComponentTable response)
+# ---------------------------------------------------------------------------
+COMPONENT_RESPONSE_CODES = {
+    0x00: ("COMPONENT_CAN_BE_UPDATED",
+           "Component can be updated"),
+    0x01: ("COMPONENT_COMPARISON_STAMP_IDENTICAL",
+           "Component comparison stamp is identical to the firmware in the FD/downstream "
+           "device; set Force update flag in UpdateComponent to proceed"),
+    0x02: ("COMPONENT_COMPARISON_STAMP_LOWER",
+           "Component comparison stamp is lower than the firmware in the FD/downstream "
+           "device; set Force update flag in UpdateComponent to proceed"),
+    0x03: ("INVALID_COMPARISON_STAMP",
+           "Invalid component comparison stamp"),
+    0x04: ("COMPONENT_CONFLICT",
+           "Component conflicts with another component provided in a separate "
+           "PassComponentTable command"),
+    0x05: ("PREREQUISITES_NOT_MET",
+           "Pre-requisites for this component have not been met"),
+    0x06: ("COMPONENT_NOT_SUPPORTED",
+           "Component is not supported on the FD or downstream device"),
+    0x07: ("SECURITY_DOWNGRADE_RESTRICTED",
+           "Security restrictions prevent component from being downgraded"),
+    0x08: ("INCOMPLETE_COMPONENT_IMAGE_SET",
+           "Incomplete component image set was received; all UpdateComponent commands will "
+           "be rejected"),
+    0x09: ("ACTIVE_IMAGE_NOT_RESTORABLE",
+           "If this new component image is activated, the FD/downstream device will not be "
+           "able to subsequently update to the currently running active component image"),
+    0x0A: ("COMPONENT_VERSION_STRING_IDENTICAL",
+           "Component version string is identical to the firmware version in the "
+           "FD/downstream device; set Force update flag in UpdateComponent to proceed"),
+    0x0B: ("COMPONENT_VERSION_STRING_LOWER",
+           "Component version string is lower than the firmware version in the "
+           "FD/downstream device; set Force update flag in UpdateComponent to proceed"),
+}
+
+# ---------------------------------------------------------------------------
+# Context-keyword → table mapping for annotate()
+# ---------------------------------------------------------------------------
+_CONTEXT_TABLES = [
+    (re.compile(r'\btransfer\b', re.IGNORECASE), TRANSFER_RESULT_CODES),
+    (re.compile(r'\bverif(?:y|ication)\b', re.IGNORECASE), VERIFY_RESULT_CODES),
+    (re.compile(r'\bapply\b', re.IGNORECASE), APPLY_RESULT_CODES),
+    (re.compile(r'\bcomponent\s*response\b', re.IGNORECASE), COMPONENT_RESPONSE_CODES),
+]
+_CONTEXT_WINDOW = 60  # characters to look before the hex code for context keywords
+
+
+def _lookup(val, context=""):
+    """Return (name, description) for *val* using *context* to pick the table.
+
+    Context keywords within ``_CONTEXT_WINDOW`` characters before the code are
+    used to select the most appropriate result table.  Falls back to the
+    completion code table (Table 1) when no keyword matches.
+    """
+    for pattern, table in _CONTEXT_TABLES:
+        if pattern.search(context) and val in table:
+            return table[val]
+    return COMPLETION_CODES.get(val)
+
+
+def annotate(text):
+    """Return *text* with PLDM code values annotated with spec descriptions.
+
+    Scans for ``0xNN`` byte-sized hex literals and appends
+    ``(SYMBOLIC_NAME: human-readable description)`` from DSP0267 where known.
+    Unrecognised codes are left unchanged.
+
+    Example::
+
+        >>> annotate("failed: completion code 0x84")
+        "failed: completion code 0x84 (INVALID_STATE_FOR_COMMAND: The FD/FDP is not in a state to expect this command)"
+    """
+    def _replace(m):
+        val = int(m.group(0), 16)
+        start = max(0, m.start() - _CONTEXT_WINDOW)
+        context = text[start:m.start()]
+        entry = _lookup(val, context)
+        if entry:
+            name, desc = entry
+            return f"{m.group(0)} ({name}: {desc})"
+        return m.group(0)
+
+    return re.sub(r'0x[0-9a-fA-F]{2}\b', _replace, text)

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
@@ -31,6 +31,7 @@ PATCH_EEPROM_BMC = "sonic_platform.chassis.EepromBMC"
 PATCH_THERMAL_BMC = "sonic_platform.chassis.ThermalBMC"
 PATCH_SWITCH_HOST = "sonic_platform.chassis.SwitchHostModule"
 PATCH_REBOOT_CAUSE = "sonic_platform.chassis.RebootCause"
+PATCH_COMPONENT_BMC = "sonic_platform.chassis.ComponentBMC"
 PATCH_PLATFORM_JSON = "sonic_platform.chassis.device_info.get_platform_json_data"
 
 
@@ -40,13 +41,15 @@ def chassis():
     with patch(PATCH_EEPROM_BMC) as eeprom_cls, \
          patch(PATCH_THERMAL_BMC) as thermal_cls, \
          patch(PATCH_SWITCH_HOST) as module_cls, \
-         patch(PATCH_REBOOT_CAUSE) as reboot_cls:
+         patch(PATCH_REBOOT_CAUSE) as reboot_cls, \
+         patch(PATCH_COMPONENT_BMC) as component_cls:
         eeprom_cls.return_value = MagicMock(name="EepromBMC")
         thermal_cls.return_value = MagicMock(name="ThermalBMC")
         switch_host = MagicMock(name="SwitchHostModule")
         switch_host.get_name.return_value = ModuleBase.MODULE_TYPE_SWITCH_HOST
         module_cls.return_value = switch_host
         reboot_cls.return_value = MagicMock(name="RebootCause")
+        component_cls.return_value = MagicMock(name="ComponentBMC")
 
         from sonic_platform.chassis import Chassis
         yield Chassis()
@@ -82,9 +85,18 @@ class TestChassis:
             assert chassis.is_liquid_cooled() is False
 
     def test_default_collaborator_lists(self, chassis):
+        from sonic_platform import chassis as chassis_module
+
+        component_cls = chassis_module.ComponentBMC
         assert len(chassis._thermal_list) == 1
         assert len(chassis._module_list) == 1
+        assert len(chassis._component_list) == 1
+        assert chassis._component_list[0] is component_cls.return_value
+        component_cls.assert_called_once_with()
         assert chassis._liquid_cooling is None
+
+    def test_component_list_accessible_via_base_api(self, chassis):
+        assert chassis.get_all_components() == chassis._component_list
 
     def test_get_eeprom_returns_internal_eeprom(self, chassis):
         assert chassis.get_eeprom() is chassis._eeprom

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
@@ -101,10 +101,15 @@ class TestChassis:
     def test_get_eeprom_returns_internal_eeprom(self, chassis):
         assert chassis.get_eeprom() is chassis._eeprom
 
-    def test_get_name_delegates_to_eeprom(self, chassis):
-        chassis._eeprom.get_product_name.return_value = "Nvidia-BMC-AST2700"
-        assert chassis.get_name() == "Nvidia-BMC-AST2700"
-        chassis._eeprom.get_product_name.assert_called_once_with()
+    def test_get_name_returns_fixed_platform_identity(self, chassis):
+        from sonic_platform.chassis import Chassis
+
+        # get_name() must return the stable platform identity that matches the
+        # top-level key in platform_components.json, independent of the EEPROM
+        # product name (which varies per board).
+        chassis._eeprom.get_product_name.return_value = "P3809"
+        assert chassis.get_name() == Chassis.PLATFORM_NAME == "NVIDIA-AST2700-BMC"
+        chassis._eeprom.get_product_name.assert_not_called()
 
     def test_get_model_delegates_to_eeprom(self, chassis):
         chassis._eeprom.get_part_number.return_value = "MBF-AST2700-001"

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_component.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_component.py
@@ -509,3 +509,39 @@ class TestUpdateFirmware:
             comp.update_firmware(str(img), force_update=True)
         cmd = run.call_args[0][0]
         assert cmd[:3] == ["pldm-fw", "update", "--force-update"]
+
+
+
+class TestDeviceBaseAPIs:
+    """Tests for DeviceBase methods added to satisfy platform API test suite."""
+
+    def test_get_presence_always_true(self, comp):
+        assert comp.get_presence() is True
+
+    def test_get_position_in_parent_returns_minus_one(self, comp):
+        # -1 is the standard value for firmware components that have no
+        # physical slot position; matches all other SONiC platform impls.
+        assert comp.get_position_in_parent() == -1
+
+    def test_is_replaceable_false(self, comp):
+        # AST2700 is soldered to the board.
+        assert comp.is_replaceable() is False
+
+    def test_get_status_true_when_hw_management_present(self, comp, tmp_path):
+        with mock.patch("sonic_platform.component.HW_MANAGEMENT_ROOT", str(tmp_path)):
+            assert comp.get_status() is True
+
+    def test_get_status_false_when_hw_management_absent(self, comp, tmp_path):
+        missing = str(tmp_path / "nonexistent")
+        with mock.patch("sonic_platform.component.HW_MANAGEMENT_ROOT", missing):
+            assert comp.get_status() is False
+
+    def test_get_model_delegates_to_eeprom(self, comp):
+        with mock.patch.object(comp._eeprom, "get_part_number", return_value="MSN1234") as m:
+            assert comp.get_model() == "MSN1234"
+        m.assert_called_once()
+
+    def test_get_serial_delegates_to_eeprom(self, comp):
+        with mock.patch.object(comp._eeprom, "get_serial_number", return_value="SN-ABCD") as m:
+            assert comp.get_serial() == "SN-ABCD"
+        m.assert_called_once()

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_component.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_component.py
@@ -1,0 +1,511 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import subprocess
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+from sonic_platform import component
+from sonic_platform.component import ComponentBMC, VERSION_NA
+from sonic_platform.mctp import MctpError
+
+
+@contextmanager
+def patch_mctp_address(return_value="1,8", side_effect=None, network=1):
+    """
+    Patch the MCTP lookups used by ``ComponentBMC._address()``.
+
+    ``_address()`` resolves the IRoT network via ``get_interface_network()``
+    before calling ``mctp_address()``. Both must be mocked whenever a test
+    also patches ``subprocess.run``: that patch is on the shared ``subprocess``
+    module, so an unmocked ``get_interface_network()`` would otherwise hit the
+    same mock as ``pldm-fw`` (or real ``busctl``) and leak into the test.
+    """
+    addr_kwargs = (
+        {"side_effect": side_effect}
+        if side_effect is not None
+        else {"return_value": return_value}
+    )
+    with mock.patch.object(
+        component.mctp, "get_interface_network", return_value=network
+    ) as get_net, mock.patch.object(
+        component.mctp, "mctp_address", **addr_kwargs
+    ) as addr:
+        yield get_net, addr
+
+
+# Representative `pldm-fw inventory` output (trimmed).
+INVENTORY_OUT = """\
+Device: 0x0000:0x0000
+Firmware Parameters:
+  Active version:  BMC-1.2.3
+  Pending version: BMC-1.2.4
+  Update caps: [0x0]: none
+  Components:
+    [0]
+      Classification:  Firmware
+      Active Version:  BMC-1.2.3
+      Pending Version: BMC-1.2.4
+"""
+
+# Representative `pldm-fw pkg-info` output (trimmed). Note the device section
+# also carries a `version:` line that must NOT be mistaken for the component's.
+# Real AST2700 packages render Firmware classification as Value(13) with
+# identifier 0x000a.
+PKGINFO_OUT = """\
+Package:
+  Identifier:   1234
+  Version:      pkg-9.9
+  Applicable devices:
+   0: 0x0000:0x0000
+       version:    DEVICE-0.0
+       options:    0x0
+       components: 0
+  Components:
+   0:
+       classification: Value(13)
+       identifier:     0x000a
+       version:        BMC-1.2.4
+       comparison:     0x00000000
+"""
+
+
+def _completed(stdout="", returncode=0):
+    return subprocess.CompletedProcess(["pldm-fw"], returncode, stdout=stdout, stderr="")
+
+
+def _pldm_error(stderr, returncode=1):
+    return subprocess.CalledProcessError(returncode, ["pldm-fw"], stderr=stderr)
+
+
+PLDM_ERR_IDENTICAL = _pldm_error(
+    "component version identical to installed image; use --force-update to override"
+)
+PLDM_ERR_DOWNGRADE = _pldm_error(
+    "component version downgrade blocked; use --force-update to override"
+)
+PLDM_ERR_CORRUPT_PKG = _pldm_error("failed to parse firmware package: invalid header")
+PLDM_ERR_VERIFY = _pldm_error("verify failed: checksum mismatch")
+PLDM_ERR_TRANSFER = _pldm_error("Update failed: transfer timeout")
+
+
+def _image(tmp_path, name="bmc.fwpkg"):
+    path = tmp_path / name
+    path.write_bytes(b"fake-fwpkg")
+    return path
+
+
+@pytest.fixture
+def comp():
+    return ComponentBMC()
+
+
+@pytest.fixture
+def image(tmp_path):
+    return _image(tmp_path)
+
+
+@pytest.fixture
+def mctp_and_pldm_ok():
+    """Patch MCTP address resolution and successful pldm-fw subprocess calls."""
+    with patch_mctp_address(), \
+         mock.patch.object(component.subprocess, "run", return_value=_completed()):
+        yield
+
+
+@pytest.fixture
+def mctp_ok_pldm_fail():
+    """Patch MCTP address resolution; pldm-fw failure supplied by the test."""
+    with patch_mctp_address():
+        yield
+
+
+class TestStaticInfo:
+
+    def test_name(self, comp):
+        assert comp.get_name() == "BMC"
+
+    def test_description(self, comp):
+        assert "BMC" in comp.get_description()
+
+    def test_update_notification_mentions_bmc_power_cycle(self, comp):
+        note = comp.get_firmware_update_notification("/some/image.fwpkg")
+        assert "power cycle" in note.lower()
+        assert "reboot" in note.lower()  # clarifies it is NOT a system reboot
+
+    def test_address_passes_irot_network_to_mctp_address(self, comp):
+        with mock.patch.object(component.mctp, "get_interface_network", return_value=1) as get_net, \
+             mock.patch.object(component.mctp, "mctp_address", return_value="1,8") as addr:
+            assert comp._address() == "1,8"
+        get_net.assert_called_once_with(component.mctp.IROT_INTERFACE)
+        addr.assert_called_once_with(network=1)
+
+    def test_address_uses_explicit_network(self):
+        comp = ComponentBMC(network=9)
+        with mock.patch.object(component.mctp, "get_interface_network") as get_net, \
+             mock.patch.object(component.mctp, "mctp_address", return_value="9,8") as addr:
+            assert comp._address() == "9,8"
+        get_net.assert_not_called()
+        addr.assert_called_once_with(network=9)
+
+
+class TestGetFirmwareVersion:
+
+    def test_parses_active_version(self, comp):
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed(INVENTORY_OUT)) as run:
+            assert comp.get_firmware_version() == "BMC-1.2.3"
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["pldm-fw", "inventory", "1,8"]
+
+    def test_na_when_eid_discovery_fails(self, comp):
+        with patch_mctp_address(side_effect=MctpError("no ep")):
+            assert comp.get_firmware_version() == VERSION_NA
+
+    def test_na_when_pldm_fw_fails(self, comp):
+        err = subprocess.CalledProcessError(1, ["pldm-fw"], stderr="boom")
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", side_effect=err):
+            assert comp.get_firmware_version() == VERSION_NA
+
+    def test_na_when_version_absent(self, comp):
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed("nothing here")):
+            assert comp.get_firmware_version() == VERSION_NA
+
+    def test_parse_active_version_reads_first_component_not_top_level(self):
+        # fwutil should report Component [0]'s active version, not the
+        # top-level device/package active version.
+        text = """\
+Firmware Parameters:
+  Active version:  TOP-1.0
+  Components:
+    [0]
+      Active version:  COMP-2.0
+"""
+        assert ComponentBMC._parse_active_version(text) == "COMP-2.0"
+
+    def test_parse_active_version_strips_comparison_stamp_and_ignores_later_components(self):
+        # Real inventory renders the component version with a trailing
+        # comparison stamp in brackets; only Component [0]'s string is used.
+        text = """\
+Firmware Parameters:
+  Active version:  00.01.0018
+  Components:
+    [0]
+      Classification:  Value(13)
+      Identifier:      0x000a
+      Active Version:  88.0060.2212 [88006022]
+      Pending Version:
+    [1]
+      Active Version:  0.0
+"""
+        assert ComponentBMC._parse_active_version(text) == "88.0060.2212"
+
+
+class TestGetAvailableFirmwareVersion:
+
+    def test_parses_component_version(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        with mock.patch.object(component.subprocess, "run", return_value=_completed(PKGINFO_OUT)) as run:
+            assert comp.get_available_firmware_version(str(img)) == "BMC-1.2.4"
+        cmd = run.call_args[0][0]
+        assert cmd[:2] == ["pldm-fw", "pkg-info"]
+
+    def test_parse_component_version_matches_bmc_entry(self):
+        pkginfo = """\
+Package:
+  Components:
+   0:
+       classification: Other
+       identifier:     0x0020
+       version:        OTHER-1.0
+   1:
+       classification: Firmware
+       identifier:     0x000a
+       version:        BMC-9.9.9
+"""
+        assert ComponentBMC._parse_component_version(pkginfo) == "BMC-9.9.9"
+
+    def test_parse_component_version_accepts_value13_classification(self):
+        # Live pldm-fw pkg-info on AST2700 emits unresolved Value(13) rather
+        # than the symbolic Firmware name.
+        pkginfo = """\
+Package:
+  Components:
+    0:
+       classification: Value(13)
+       identifier:     0x000a
+       version:        88.0060.2218
+       comparison:     0x003c08aa
+"""
+        assert ComponentBMC._parse_component_version(pkginfo) == "88.0060.2218"
+
+    def test_no_matching_component_returns_na(self, comp, tmp_path):
+        pkginfo = """\
+Package:
+  Components:
+   0:
+       classification: Other
+       identifier:     0x0020
+       version:        OTHER-1.0
+"""
+        img = _image(tmp_path)
+        with mock.patch.object(component.subprocess, "run", return_value=_completed(pkginfo)):
+            assert comp.get_available_firmware_version(str(img)) == VERSION_NA
+
+    def test_wrong_identifier_returns_na(self, comp, tmp_path):
+        pkginfo = """\
+Package:
+  Components:
+   0:
+       classification: Value(13)
+       identifier:     0x0010
+       version:        BMC-WRONG-ID
+"""
+        img = _image(tmp_path)
+        with mock.patch.object(component.subprocess, "run", return_value=_completed(pkginfo)):
+            assert comp.get_available_firmware_version(str(img)) == VERSION_NA
+
+    def test_missing_image_returns_na(self, comp):
+        assert comp.get_available_firmware_version("/no/such/file") == VERSION_NA
+
+    def test_na_when_pkginfo_fails(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        with mock.patch.object(component.subprocess, "run", side_effect=subprocess.TimeoutExpired(["pldm-fw"], 30)):
+            assert comp.get_available_firmware_version(str(img)) == VERSION_NA
+
+
+class TestGoldenPath:
+
+    def test_version_query_and_install(self, comp, image):
+        with patch_mctp_address(), \
+             mock.patch.object(
+                 component.subprocess,
+                 "run",
+                 side_effect=[
+                     _completed(INVENTORY_OUT),
+                     _completed(PKGINFO_OUT),
+                     _completed(),  # pre-update cancel
+                     _completed(),  # update
+                 ],
+             ) as run:
+            assert comp.get_firmware_version() == "BMC-1.2.3"
+            assert comp.get_available_firmware_version(str(image)) == "BMC-1.2.4"
+            assert comp.install_firmware(str(image)) is True
+
+        commands = [call.args[0] for call in run.call_args_list]
+        assert commands[0][:3] == ["pldm-fw", "inventory", "1,8"]
+        assert commands[1][:3] == ["pldm-fw", "pkg-info", str(image)]
+        # install_firmware issues a preventative cancel before the update.
+        assert commands[2][:3] == ["pldm-fw", "cancel", "1,8"]
+        assert commands[3][:2] == ["pldm-fw", "update"]
+        assert commands[3][2] == "1,8"
+        assert str(image) in commands[3]
+        assert "--force-update" not in commands[3]
+
+    def test_update_golden_path(self, comp, image, mctp_and_pldm_ok):
+        assert comp.update_firmware(str(image)) is None
+
+
+class TestPreventativeCancel:
+
+    def test_cancel_precedes_update(self, comp, image):
+        # A preventative 'pldm-fw cancel' clears any stuck FD state left by a
+        # prior aborted update, and must run before the update itself.
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed()) as run:
+            assert comp.install_firmware(str(image)) is True
+        commands = [call.args[0] for call in run.call_args_list]
+        assert commands[0][:3] == ["pldm-fw", "cancel", "1,8"]
+        assert commands[1][:2] == ["pldm-fw", "update"]
+
+    def test_cancel_failure_does_not_block_update(self, comp, image):
+        # cancel is best-effort: a failing cancel must not prevent the update.
+        def run_side_effect(cmd, *args, **kwargs):
+            if cmd[:2] == ["pldm-fw", "cancel"]:
+                raise subprocess.CalledProcessError(1, cmd, stderr="cancel boom")
+            return _completed()
+
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", side_effect=run_side_effect) as run:
+            assert comp.install_firmware(str(image)) is True
+        commands = [call.args[0] for call in run.call_args_list]
+        assert commands[0][:2] == ["pldm-fw", "cancel"]
+        assert commands[-1][:2] == ["pldm-fw", "update"]
+
+
+class TestInstallFirmware:
+
+    def test_success_returns_true(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed()) as run:
+            assert comp.install_firmware(str(img)) is True
+        cmd = run.call_args[0][0]
+        assert cmd[:2] == ["pldm-fw", "update"]
+        assert cmd[2] == "1,8" and str(img) in cmd and "-y" in cmd
+
+    def test_missing_image_returns_false(self, comp):
+        assert comp.install_firmware("/no/such/file") is False
+
+    def test_failure_returns_false(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        err = subprocess.CalledProcessError(1, ["pldm-fw"], stderr="device busy")
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", side_effect=err):
+            assert comp.install_firmware(str(img)) is False
+
+    def test_eid_discovery_failure_returns_false(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        with patch_mctp_address(side_effect=MctpError("no ep")):
+            assert comp.install_firmware(str(img)) is False
+
+    def test_force_update_passes_flag(self, comp, tmp_path):
+        img = tmp_path / "bmc.fwpkg"
+        img.write_bytes(b"x")
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed()) as run:
+            assert comp.install_firmware(str(img), force_update=True) is True
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["pldm-fw", "update", "--force-update"]
+        assert cmd[3] == "1,8" and str(img) in cmd and "-y" in cmd
+
+    @pytest.mark.parametrize("pldm_error", [PLDM_ERR_IDENTICAL, PLDM_ERR_DOWNGRADE])
+    def test_same_or_downgrade_version_fails_without_force(
+        self, comp, image, mctp_ok_pldm_fail, pldm_error
+    ):
+        with mock.patch.object(component.subprocess, "run", side_effect=pldm_error):
+            assert comp.install_firmware(str(image)) is False
+
+    @pytest.mark.parametrize("pldm_error", [PLDM_ERR_IDENTICAL, PLDM_ERR_DOWNGRADE])
+    def test_same_or_downgrade_version_succeeds_with_force(
+        self, comp, image, mctp_ok_pldm_fail, pldm_error
+    ):
+        def run_side_effect(cmd, *args, **kwargs):
+            if "--force-update" in cmd:
+                return _completed()
+            raise pldm_error
+
+        with mock.patch.object(
+            component.subprocess, "run", side_effect=run_side_effect
+        ) as run:
+            assert comp.install_firmware(str(image), force_update=True) is True
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["pldm-fw", "update", "--force-update"]
+
+    def test_corrupt_package_fails_install(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(component.subprocess, "run", side_effect=PLDM_ERR_CORRUPT_PKG):
+            assert comp.install_firmware(str(image)) is False
+
+    def test_pkginfo_corrupt_returns_na(self, comp, image):
+        with mock.patch.object(component.subprocess, "run", side_effect=PLDM_ERR_CORRUPT_PKG):
+            assert comp.get_available_firmware_version(str(image)) == VERSION_NA
+
+    def test_pldm_verify_failure_returns_false(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(component.subprocess, "run", side_effect=PLDM_ERR_VERIFY):
+            assert comp.install_firmware(str(image)) is False
+
+    def test_pldm_transfer_timeout_returns_false(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(
+            component.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["pldm-fw"], comp._UPDATE_TIMEOUT),
+        ):
+            assert comp.install_firmware(str(image)) is False
+
+    def test_no_force_update_flag_by_default(self, comp, image, mctp_and_pldm_ok):
+        with mock.patch.object(component.subprocess, "run", return_value=_completed()) as run:
+            comp.install_firmware(str(image))
+        cmd = run.call_args[0][0]
+        assert "--force-update" not in cmd
+
+
+class TestUpdateFirmware:
+
+    def test_success_returns_none(self, comp, tmp_path):
+        img = _image(tmp_path)
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed()):
+            assert comp.update_firmware(str(img)) is None
+
+    def test_missing_image_returns_false(self, comp):
+        assert comp.update_firmware("/no/such/file") is False
+
+    def test_failure_raises_runtime_error(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(component.subprocess, "run", side_effect=PLDM_ERR_VERIFY):
+            with pytest.raises(RuntimeError, match="verify failed"):
+                comp.update_firmware(str(image))
+
+    def test_eid_discovery_failure_raises_runtime_error(self, comp, image):
+        with patch_mctp_address(side_effect=MctpError("no ep")):
+            with pytest.raises(RuntimeError, match="no ep"):
+                comp.update_firmware(str(image))
+
+    @pytest.mark.parametrize("pldm_error", [PLDM_ERR_IDENTICAL, PLDM_ERR_DOWNGRADE])
+    def test_same_or_downgrade_version_raises_without_force(
+        self, comp, image, mctp_ok_pldm_fail, pldm_error
+    ):
+        with mock.patch.object(component.subprocess, "run", side_effect=pldm_error):
+            with pytest.raises(RuntimeError, match="--force-update"):
+                comp.update_firmware(str(image))
+
+    @pytest.mark.parametrize("pldm_error", [PLDM_ERR_IDENTICAL, PLDM_ERR_DOWNGRADE])
+    def test_same_or_downgrade_version_succeeds_with_force(
+        self, comp, image, mctp_ok_pldm_fail, pldm_error
+    ):
+        def run_side_effect(cmd, *args, **kwargs):
+            if "--force-update" in cmd:
+                return _completed()
+            raise pldm_error
+
+        with mock.patch.object(
+            component.subprocess, "run", side_effect=run_side_effect
+        ) as run:
+            assert comp.update_firmware(str(image), force_update=True) is None
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["pldm-fw", "update", "--force-update"]
+
+    def test_corrupt_package_raises_runtime_error(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(component.subprocess, "run", side_effect=PLDM_ERR_CORRUPT_PKG):
+            with pytest.raises(RuntimeError, match="invalid header"):
+                comp.update_firmware(str(image))
+
+    def test_pldm_transfer_timeout_raises_runtime_error(self, comp, image, mctp_ok_pldm_fail):
+        with mock.patch.object(
+            component.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(["pldm-fw"], comp._UPDATE_TIMEOUT),
+        ):
+            with pytest.raises(RuntimeError):
+                comp.update_firmware(str(image))
+
+    def test_force_update_passes_flag(self, comp, tmp_path):
+        img = _image(tmp_path)
+        with patch_mctp_address(), \
+             mock.patch.object(component.subprocess, "run", return_value=_completed()) as run:
+            comp.update_firmware(str(img), force_update=True)
+        cmd = run.call_args[0][0]
+        assert cmd[:3] == ["pldm-fw", "update", "--force-update"]

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_mctp.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_mctp.py
@@ -1,0 +1,346 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import subprocess
+from unittest import mock
+
+import pytest
+
+from sonic_platform import mctp
+from sonic_platform.mctp import MctpError
+
+
+def _completed(stdout):
+    return subprocess.CompletedProcess(args=["busctl"], returncode=0, stdout=stdout, stderr="")
+
+
+# busctl --json=short renders a method reply as a JSON array of its return
+# values; SetupEndpoint returns (y eid, i net, s path, b new).
+SETUP_REPLY = json.dumps([8, 1, "/au/com/codeconstruct/mctp1/networks/1/endpoints/8", False])
+
+# GetManagedObjects returns a single a{oa{sa{sv}}} value: path -> iface -> prop.
+def _managed_objects(*endpoints, irot_net=None):
+    objs = {}
+    for net, eid, types in endpoints:
+        path = f"/au/com/codeconstruct/mctp1/networks/{net}/endpoints/{eid}"
+        objs[path] = {
+            mctp.ENDPOINT_IFACE: {
+                "SupportedMessageTypes": list(types),
+                "NetworkId": net,
+                "EID": eid,
+            }
+        }
+    if irot_net is None:
+        irot_net = endpoints[0][0] if endpoints else 1
+    objs[f"{mctp.MCTP_BASE_PATH}/interfaces/{mctp.IROT_INTERFACE}"] = {
+        mctp.INTERFACE_IFACE: {"NetworkId": irot_net}
+    }
+    return json.dumps([objs])
+
+
+class TestSetupEndpoint:
+
+    def test_returns_net_eid(self):
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(SETUP_REPLY)) as run:
+            net, eid = mctp.setup_endpoint("mctpirot0")
+        assert (net, eid) == (1, 8)
+        # Invoked the bus-owner SetupEndpoint with an empty hwaddr (ay 0).
+        called = run.call_args[0][0]
+        assert "SetupEndpoint" in called and "ay" in called and "0" in called
+        assert "/au/com/codeconstruct/mctp1/interfaces/mctpirot0" in called
+
+    def test_short_reply_raises(self):
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(json.dumps([8, 1]))):
+            with pytest.raises(MctpError):
+                mctp.setup_endpoint()
+
+    def test_busctl_failure_raises(self):
+        err = subprocess.CalledProcessError(1, ["busctl"], stderr="boom")
+        with mock.patch("sonic_platform.mctp.subprocess.run", side_effect=err):
+            with pytest.raises(MctpError):
+                mctp.setup_endpoint()
+
+    def test_busctl_missing_raises(self):
+        with mock.patch("sonic_platform.mctp.subprocess.run", side_effect=FileNotFoundError()):
+            with pytest.raises(MctpError):
+                mctp.setup_endpoint()
+
+    def test_busctl_permission_error_raises_mctp_error(self):
+        with mock.patch(
+            "sonic_platform.mctp.subprocess.run",
+            side_effect=PermissionError("Permission denied"),
+        ):
+            with pytest.raises(MctpError, match="busctl execution failed"):
+                mctp.setup_endpoint()
+
+    def test_bad_json_raises(self):
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed("not json")):
+            with pytest.raises(MctpError):
+                mctp.setup_endpoint()
+
+    def test_non_integer_reply_raises_mctp_error(self):
+        bad_reply = json.dumps([8, "not-a-net", "/path", False])
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(bad_reply)):
+            with pytest.raises(MctpError, match="invalid SetupEndpoint reply"):
+                mctp.setup_endpoint()
+
+
+class TestFindBmcEndpoint:
+
+    def test_filters_to_pldm_capable_endpoint(self):
+        objs = json.loads(_managed_objects((1, 9, [0]), (1, 8, [0, 1])))[0]
+        assert mctp.find_bmc_endpoint(objs) == (1, 8)
+
+    def test_network_filter(self):
+        objs = json.loads(_managed_objects((1, 8, [0, 1]), (2, 20, [0, 1])))[0]
+        assert mctp.find_bmc_endpoint(objs, network=2) == (2, 20)
+
+    def test_no_match_raises(self):
+        objs = json.loads(_managed_objects((1, 9, [0])))[0]
+        with pytest.raises(MctpError):
+            mctp.find_bmc_endpoint(objs)
+
+    def test_ignores_non_endpoint_objects(self):
+        objs = {
+            "/au/com/codeconstruct/mctp1/interfaces/mctpirot0": {
+                "au.com.codeconstruct.MCTP.Interface1": {"NetworkId": 1}
+            }
+        }
+        with pytest.raises(MctpError):
+            mctp.find_bmc_endpoint(objs)
+
+    def test_malformed_props_skipped_then_no_match_raises(self):
+        # A malformed endpoint must be skipped rather than abort the scan;
+        # with no other endpoints, the final "no match" error is raised.
+        objs = {
+            "/au/com/codeconstruct/mctp1/endpoints/legacy": {
+                mctp.ENDPOINT_IFACE: {
+                    "SupportedMessageTypes": [0, 1],
+                    "NetworkId": "not-a-net",
+                    "EID": 8,
+                }
+            }
+        }
+        with pytest.raises(MctpError, match="no PLDM-capable BMC endpoint"):
+            mctp.find_bmc_endpoint(objs)
+
+    def test_malformed_endpoint_skipped_then_valid_returned(self):
+        # A malformed endpoint is skipped and scanning continues to a valid one.
+        objs = {
+            "/au/com/codeconstruct/mctp1/endpoints/legacy": {
+                mctp.ENDPOINT_IFACE: {
+                    "SupportedMessageTypes": [0, 1],
+                    "NetworkId": "not-a-net",
+                    "EID": 8,
+                }
+            }
+        }
+        objs.update(json.loads(_managed_objects((1, 8, [0, 1])))[0])
+        assert mctp.find_bmc_endpoint(objs) == (1, 8)
+
+    def test_missing_props_fallback_returns_none_and_skips(self):
+        objs = {
+            "/au/com/codeconstruct/mctp1/endpoints/legacy": {
+                mctp.ENDPOINT_IFACE: {
+                    "SupportedMessageTypes": [0, 1],
+                    "NetworkId": 1,
+                }
+            }
+        }
+        with pytest.raises(MctpError):
+            mctp.find_bmc_endpoint(objs)
+
+
+class TestGetBmcEid:
+
+    def test_queries_object_manager(self):
+        reply = _managed_objects((1, 8, [0, 1]))
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(reply)) as run:
+            assert mctp.get_bmc_eid() == (1, 8)
+        called = run.call_args[0][0]
+        assert "GetManagedObjects" in called
+
+    def test_mctp_address_string(self):
+        reply = _managed_objects((1, 8, [0, 1]))
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(reply)):
+            assert mctp.mctp_address() == "1,8"
+
+    def test_defaults_to_irot_network(self):
+        # Prefer the IRoT network even when another PLDM endpoint exists first.
+        reply = _managed_objects((2, 20, [0, 1]), (1, 8, [0, 1]), irot_net=1)
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(reply)):
+            assert mctp.get_bmc_eid() == (1, 8)
+            assert mctp.mctp_address() == "1,8"
+
+    def test_get_interface_network(self):
+        reply = _managed_objects((1, 8, [0, 1]), irot_net=1)
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(reply)):
+            assert mctp.get_interface_network() == 1
+
+
+# Newer busctl/systemd wrap the whole reply, and every D-Bus VARIANT inside an
+# a{sv} map, in a {"type": <sig>, "data": <value>} envelope.
+def _enveloped_managed_objects(*endpoints, irot_net=None):
+    objs = {}
+    for net, eid, types in endpoints:
+        path = f"/au/com/codeconstruct/mctp1/networks/{net}/endpoints/{eid}"
+        objs[path] = {
+            mctp.ENDPOINT_IFACE: {
+                "SupportedMessageTypes": {"type": "ay", "data": list(types)},
+                "NetworkId": {"type": "u", "data": net},
+                "EID": {"type": "y", "data": eid},
+            }
+        }
+    if irot_net is None:
+        irot_net = endpoints[0][0] if endpoints else 1
+    objs[f"{mctp.MCTP_BASE_PATH}/interfaces/{mctp.IROT_INTERFACE}"] = {
+        mctp.INTERFACE_IFACE: {
+            "NetworkId": {"type": "u", "data": irot_net},
+        }
+    }
+    return json.dumps({"type": "a{oa{sa{sv}}}", "data": [objs]})
+
+
+class TestBusctlEnvelopes:
+
+    def test_unwrap_strips_variant_envelopes(self):
+        assert mctp._unwrap({"type": "ay", "data": [1, 5, 126]}) == [1, 5, 126]
+        assert mctp._unwrap({"type": "u", "data": 1}) == 1
+        nested = {"role": {"type": "s", "data": "v"}, "eids": [{"type": "y", "data": 8}]}
+        assert mctp._unwrap(nested) == {"role": "v", "eids": [8]}
+
+    def test_unwrap_preserves_non_envelope_dicts(self):
+        # A two-key dict that is not a variant envelope (no "data"/non-str type)
+        # is left intact.
+        assert mctp._unwrap({"NetworkId": 1, "EID": 8}) == {"NetworkId": 1, "EID": 8}
+
+    def test_mctp_address_with_enveloped_reply(self):
+        reply = _enveloped_managed_objects((1, 230, [0]), (1, 8, [1, 5, 126]))
+        with mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(reply)):
+            assert mctp.mctp_address() == "1,8"
+
+
+class TestInterfaceUp:
+
+    def test_interface_is_up_when_operstate_up(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="up"):
+            assert mctp.interface_is_up("mctpirot0") is True
+
+    def test_interface_is_up_when_operstate_down(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="down"):
+            assert mctp.interface_is_up("mctpirot0") is False
+
+    def test_interface_is_up_when_operstate_unknown_with_carrier(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="unknown"), \
+             mock.patch.object(mctp, "_interface_carrier", return_value="1"):
+            assert mctp.interface_is_up("mctpirot0") is True
+
+    def test_interface_is_up_when_operstate_unknown_without_carrier(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="unknown"), \
+             mock.patch.object(mctp, "_interface_carrier", return_value="0"):
+            assert mctp.interface_is_up("mctpirot0") is False
+
+    def test_wait_for_interface_up_succeeds(self):
+        states = iter(["down", "down", "up"])
+
+        def operstate(_iface):
+            return next(states)
+
+        with mock.patch.object(mctp, "interface_operstate", side_effect=operstate):
+            mctp.wait_for_interface_up("mctpirot0", timeout=10, poll_interval=0, sleep=lambda _s: None)
+
+    def test_wait_for_interface_up_times_out(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="down"):
+            with pytest.raises(MctpError, match="did not come up"):
+                mctp.wait_for_interface_up(
+                    "mctpirot0", timeout=0, poll_interval=0, sleep=lambda _s: None
+                )
+
+    def test_wait_for_interface_up_succeeds_when_operstate_unknown_with_carrier(self):
+        with mock.patch.object(mctp, "interface_operstate", return_value="unknown"), \
+             mock.patch.object(mctp, "_interface_carrier", return_value="1"):
+            mctp.wait_for_interface_up(
+                "mctpirot0", timeout=1, poll_interval=0, sleep=lambda _s: None
+            )
+
+
+class TestMain:
+
+    def test_success_returns_zero(self):
+        with mock.patch("sonic_platform.mctp.wait_for_interface_up"), \
+             mock.patch("sonic_platform.mctp.subprocess.run", return_value=_completed(SETUP_REPLY)):
+            assert mctp.main(["setup", "mctpirot0"], sleep=lambda _s: None) == 0
+
+    def test_recovers_after_transient_failures_and_link_wait_timeout(self):
+        unknown_operstate_timeout = MctpError(
+            "MCTP interface mctpirot0 did not come up within 120s (operstate=unknown)"
+        )
+        with mock.patch(
+            "sonic_platform.mctp.wait_for_interface_up",
+            side_effect=unknown_operstate_timeout,
+        ), mock.patch(
+            "sonic_platform.mctp.subprocess.run",
+            side_effect=[FileNotFoundError(), FileNotFoundError(), _completed(SETUP_REPLY)],
+        ) as run:
+            assert mctp.main(["setup"], attempts=3, delay=0, sleep=lambda _s: None) == 0
+        assert run.call_count == 3
+
+    def test_proceeds_with_setup_when_link_wait_times_out(self):
+        with mock.patch(
+            "sonic_platform.mctp.wait_for_interface_up",
+            side_effect=MctpError("operstate=unknown"),
+        ), mock.patch(
+            "sonic_platform.mctp.subprocess.run",
+            return_value=_completed(SETUP_REPLY),
+        ) as run:
+            assert mctp.main(["setup"], sleep=lambda _s: None) == 0
+        assert run.call_count == 1
+
+    def test_failure_returns_one_after_retries(self):
+        with mock.patch("sonic_platform.mctp.wait_for_interface_up"), \
+             mock.patch("sonic_platform.mctp.subprocess.run", side_effect=FileNotFoundError()) as run:
+            assert mctp.main(["setup"], attempts=3, delay=0, sleep=lambda _s: None) == 1
+        assert run.call_count == 3
+
+    def test_retries_then_succeeds(self):
+        results = [FileNotFoundError(), _completed(SETUP_REPLY)]
+
+        def side_effect(*_a, **_k):
+            item = results.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with mock.patch("sonic_platform.mctp.wait_for_interface_up"), \
+             mock.patch("sonic_platform.mctp.subprocess.run", side_effect=side_effect):
+            assert mctp.main(["setup"], attempts=3, delay=0, sleep=lambda _s: None) == 0
+
+    def test_retries_after_permission_error_then_succeeds(self):
+        results = [PermissionError("Permission denied"), _completed(SETUP_REPLY)]
+
+        def side_effect(*_a, **_k):
+            item = results.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with mock.patch("sonic_platform.mctp.wait_for_interface_up"), \
+             mock.patch("sonic_platform.mctp.subprocess.run", side_effect=side_effect) as run:
+            assert mctp.main(["setup"], attempts=3, delay=0, sleep=lambda _s: None) == 0
+        assert run.call_count == 2

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_pldm_errors.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_pldm_errors.py
@@ -1,0 +1,144 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for pldm_errors — DSP0267 error code annotation."""
+
+import pytest
+
+from sonic_platform import pldm_errors
+from sonic_platform.pldm_errors import (
+    COMPLETION_CODES,
+    TRANSFER_RESULT_CODES,
+    VERIFY_RESULT_CODES,
+    APPLY_RESULT_CODES,
+    COMPONENT_RESPONSE_CODES,
+    annotate,
+)
+
+
+class TestCodeTableCompleteness:
+
+    def test_completion_codes_include_base_codes(self):
+        assert 0x00 in COMPLETION_CODES  # SUCCESS
+        assert 0x05 in COMPLETION_CODES  # ERROR_UNSUPPORTED_PLDM_CMD
+
+    def test_completion_codes_include_fw_update_range(self):
+        # DSP0267 firmware-update-specific codes run 0x80–0x96
+        for code in range(0x80, 0x97):
+            assert code in COMPLETION_CODES, f"0x{code:02x} missing from COMPLETION_CODES"
+
+    def test_transfer_result_has_success_and_corrupt(self):
+        assert 0x00 in TRANSFER_RESULT_CODES
+        assert 0x01 in TRANSFER_RESULT_CODES
+
+    def test_verify_result_has_success_and_failure(self):
+        assert 0x00 in VERIFY_RESULT_CODES
+        assert 0x01 in VERIFY_RESULT_CODES
+
+    def test_apply_result_has_success_and_success_with_modification(self):
+        assert 0x00 in APPLY_RESULT_CODES
+        assert 0x01 in APPLY_RESULT_CODES
+
+    def test_component_response_has_can_be_updated_and_not_supported(self):
+        assert 0x00 in COMPONENT_RESPONSE_CODES
+        assert 0x06 in COMPONENT_RESPONSE_CODES
+
+    def test_all_entries_are_two_tuples_of_strings(self):
+        for table in (
+            COMPLETION_CODES,
+            TRANSFER_RESULT_CODES,
+            VERIFY_RESULT_CODES,
+            APPLY_RESULT_CODES,
+            COMPONENT_RESPONSE_CODES,
+        ):
+            for code, entry in table.items():
+                assert isinstance(entry, tuple) and len(entry) == 2, \
+                    f"code 0x{code:02x}: expected (name, desc) tuple, got {entry!r}"
+                name, desc = entry
+                assert isinstance(name, str) and name, \
+                    f"code 0x{code:02x}: name must be non-empty string"
+                assert isinstance(desc, str) and desc, \
+                    f"code 0x{code:02x}: desc must be non-empty string"
+
+
+class TestAnnotate:
+
+    def test_known_completion_code_gets_annotated(self):
+        result = annotate("completion code 0x84")
+        assert "0x84" in result
+        assert "INVALID_STATE_FOR_COMMAND" in result
+        assert "not in a state" in result.lower()
+
+    def test_unknown_code_left_unchanged(self):
+        text = "error code 0xFF"
+        assert annotate(text) == text
+
+    def test_success_code_annotated(self):
+        result = annotate("returned 0x00")
+        assert "SUCCESS" in result
+
+    def test_multiple_codes_all_annotated(self):
+        result = annotate("cmd 0x84 and 0x85")
+        assert "INVALID_STATE_FOR_COMMAND" in result
+        assert "INCOMPLETE_UPDATE" in result
+
+    def test_no_codes_returns_unchanged(self):
+        text = "no hex codes here"
+        assert annotate(text) == text
+
+    def test_transfer_context_picks_transfer_table(self):
+        # "transfer" keyword within the context window should route 0x01 to
+        # TRANSFER_RESULT_CODES (TRANSFER_IMAGE_CORRUPT) not COMPLETION_CODES (ERROR).
+        result = annotate("firmware transfer error: result 0x01")
+        assert "TRANSFER_IMAGE_CORRUPT" in result
+
+    def test_verify_context_picks_verify_table(self):
+        result = annotate("verify failure: result 0x01")
+        assert "VERIFY_FAILURE" in result
+
+    def test_apply_context_picks_apply_table(self):
+        result = annotate("apply complete: result 0x02")
+        assert "APPLY_MEMORY_WRITE_FAILURE" in result
+
+    def test_no_context_falls_back_to_completion_codes(self):
+        # 0x01 with no context keyword → completion code ERROR
+        result = annotate("failed: 0x01")
+        assert "ERROR" in result
+        assert "TRANSFER_IMAGE_CORRUPT" not in result
+        assert "VERIFY_FAILURE" not in result
+
+    def test_context_keyword_outside_window_not_used(self):
+        # Put the keyword far enough before the code that it falls outside
+        # the 60-char context window; should fall back to completion codes.
+        prefix = "transfer " + "x" * 80
+        result = annotate(f"{prefix} 0x01")
+        assert "TRANSFER_IMAGE_CORRUPT" not in result
+
+    def test_three_byte_hex_not_matched(self):
+        # annotate() only handles byte-sized (two-hex-digit) codes.
+        text = "address 0x8400"
+        assert annotate(text) == text
+
+    def test_real_pldm_fw_error_format(self):
+        # Matches the exact format emitted by pldm-fw ua.rs:
+        # "PLDM command (0xNN) failed with 0xNN"
+        result = annotate("PLDM command (0x10) failed with 0x84")
+        # 0x10 (RequestUpdate) is a command byte, not a completion code,
+        # so it will get the base SUCCESS annotation or none if not in table.
+        # 0x84 should definitely get annotated.
+        assert "INVALID_STATE_FOR_COMMAND" in result

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/rules
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/rules
@@ -10,6 +10,19 @@ DEVICE_NAME := arm64-aspeed_nvidia_ast2700_bmc-r0
 override_dh_auto_build:
 	python3 setup.py bdist_wheel -d $(CURDIR)
 
+# Install + enable the mctp-bmc-setup unit. A bare "dh_installsystemd" only
+# handles a unit named exactly debian/$(PACKAGE_NAME).service, so the named unit
+# must be given explicitly via --name; dh_installsystemd then installs it (to
+# /usr/lib/systemd/system only -- do NOT also drop a copy under /lib, as the two
+# paths are aliased on merged-/usr systems and dpkg refuses such a package) and
+# generates the enable snippets. Defining this override also defeats dh's
+# compat-13 "skip no-op helper" optimization, which otherwise omits the helper.
+# The per-device sonic_platform wheel is installed by the aspeed platform's
+# sonic-platform-init.service (aspeed-platform-services), so no wheel-install
+# unit is shipped here.
+override_dh_installsystemd:
+	dh_installsystemd --name=mctp-bmc-setup mctp-bmc-setup.service
+
 override_dh_auto_test:
 	# Run the sonic_platform unit tests directly via pytest. Honor
 	# BUILD_SKIP_TEST=y to mirror slave.mk's behavior for wheel-based

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.links
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.links
@@ -1,0 +1,21 @@
+# Statically enable mctp-bmc-setup by shipping its multi-user.target.wants
+# symlink as package DATA (not via the postinst's dh_installsystemd enable).
+#
+# Rationale: this platform package is a SONiC "lazy installer" deb -- it is staged
+# under /host/image-*/platform/ and (re)installed at first boot by rc.local's
+# `apt-get install`. That first-boot install is best-effort: if dpkg is in a
+# needs-`--configure -a` state, apt aborts after UNPACKING but before CONFIGURE,
+# so the postinst (which is where dh_installsystemd's `enable` runs) never
+# executes and the service comes up disabled.
+#
+# A wants-symlink that ships as a regular packaged file exists as soon as the deb
+# is unpacked -- no configure step required -- so the unit is enabled even in
+# that degraded path. This mirrors how systemd statically enables its own units
+# (e.g. getty.target.wants/getty@tty1.service). The postinst's dh_installsystemd
+# enable is kept too; it is harmless/redundant when configure does run and adds
+# start-on-configure.
+#
+# Note: the per-device sonic_platform wheel install is handled by the aspeed
+# platform's sonic-platform-init.service (a non-lazy, baked-in unit), so it needs
+# no static enablement here -- only mctp-bmc-setup does.
+usr/lib/systemd/system/mctp-bmc-setup.service usr/lib/systemd/system/multi-user.target.wants/mctp-bmc-setup.service

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.mctp-bmc-setup.service
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/debian/sonic-platform-aspeed-nvidia-ast2700-bmc.mctp-bmc-setup.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=One-time MCTP endpoint setup for the AST2700 BMC (IRoT)
+Documentation=https://github.com/CodeConstruct/mctp
+# mctpd owns the au.com.codeconstruct.MCTP1 bus name we drive below.
+Wants=mctpd.service
+After=mctpd.service
+# The per-device sonic_platform wheel is installed at boot by the aspeed
+# platform's sonic-platform-init.service; pull it in and order after it so
+# this runs the current sonic_platform.mctp code (not a stale/absent module).
+Wants=sonic-platform-init.service
+After=sonic-platform-init.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# SetupEndpoint is idempotent; the helper retries internally to cover
+# mctpd/link startup races (Restart= is not honored for Type=oneshot).
+ExecStart=/usr/bin/python3 -m sonic_platform.mctp setup mctpirot0
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Switch-BMC images on the NVIDIA AST2700 platform need a supported path to update the BMC firmware from the running SONiC image. Operators expect to use the existing `fwutil` workflow (`fwutil install … fw` / `fwutil update … fw`) rather than a separate out-of-band tool.

This PR adds platform integration so `fwutil` can drive BMC firmware updates over PLDM for Firmware Update (DSP0267) on MCTP, targeting the Aspeed IRoT link (`mctpirot0`).

#### How I did it

- **`sonic_platform/mctp.py`**: MCTP helpers over `busctl` to run idempotent `SetupEndpoint` on `mctpirot0`, discover the BMC firmware device's `net,eid` from `mctpd`'s ObjectManager tree at call time (no hard-coded EID, no re-assignment per update), and wait for `mctpirot0` link-up before setup to avoid `EHOSTUNREACH` races at boot.
- **`sonic_platform/component.py` (`ComponentBMC`)**: Implements the `ComponentBase` API — active version via `pldm-fw inventory`, package version via `pldm-fw pkg-info`, install/update via `pldm-fw update <net,eid> <image> -y`. Passes `fwutil`'s `--force-update` through to `pldm-fw` for same-image reinstall and downgrade testing. Advertises that activation requires a BMC power cycle (not a full system reboot).
- **`sonic_platform/chassis.py`** and **`platform_components.json`**: Register the BMC component so `fwutil` can enumerate and cross-reference it.
- **Boot-time MCTP setup**: Ship `mctp-bmc-setup.service` (Type=oneshot, After=`mctpd`) and statically enable it via a debian `.links` wants-symlink so the unit is active even when first-boot lazy-install unpacks the platform deb without running postinst.
- **`sonic-utilities` submodule bump**: Adds `fwutil install/update … fw --force-update` and threads the flag through to platform components.
- **Unit tests** for MCTP helpers, `ComponentBMC` behavior, and chassis registration.

Depends on the `pldm-fw-cli` package and local `pldm-fw` patches already in this PR.

Note that the patches in this PR are currently in the process of being upstreamed to https://github.com/codeconstruct/mctp-rs and will not be needed after that. Thus they are only temporary until we can complete that process.

#### How to verify it

**Unit tests** (platform package build):

```bash
cd platform/aspeed/sonic-platform-modules-nvidia-bmc
python3 -m pytest ast2700/tests
```

**On hardware** (NVIDIA AST2700 Switch-BMC):

1. Confirm MCTP setup ran at boot:

```bash
systemctl status mctp-bmc-setup
busctl tree au.com.codeconstruct.MCTP1 | grep endpoints
```

2. Confirm `fwutil` sees the BMC component and version:

```bash
fwutil show status
```

3. Install or update BMC firmware from a `.fwpkg` image:

```bash
fwutil install <path/to/image.fwpkg> fw --force-update
fwutil update <path/to/image.fwpkg> fw --force-update
```

4. Verify transfer completed in syslog (`pldm-fw` / `sonic_platform` messages) and that pending/active versions are reported by `fwutil show status`.

5. Power-cycle the BMC to activate the new firmware (activation mechanism is not yet automated — `_power_cycle_bmc()` is currently a stub that logs a warning).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog

Add fwutil support for AST2700 BMC firmware update over PLDM/MCTP on Switch-BMC.

#### Link to config_db schema for YANG module changes

N/A — no config_db / YANG changes.