### PR TITLE
[sonic-config-engine] Fix minigraph parsing bug on voq pizzabox

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -2932,7 +2932,7 @@ def parse_chassis_hwsku(root,chassis_hostname):
         if child.tag == str(QName(ns, "PngDec")):
             devices = child.find(str(QName(ns, "Devices")))
             for device in devices.findall(str(QName(ns, "Device"))):
-                if chassis_hostname.lower() ==  device.find(str(QName(ns, "Hostname"))).text.lower():
+                if chassis_hostname and (chassis_hostname.lower() ==  device.find(str(QName(ns, "Hostname"))).text.lower()):
                     hwsku =  device.find(str(QName(ns, "HwSku"))).text
                     return hwsku
     return None

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -5,6 +5,8 @@ import ipaddress
 import tests.common_utils as utils
 import minigraph
 
+from lxml import etree as ET
+from lxml.etree import QName
 from unittest import TestCase
 
 TOR_ROUTER = 'ToRRouter'
@@ -575,3 +577,30 @@ class TestCfgGenCaseInsensitive(TestCase):
         # TC2: For other minigraph, result should not contain FLEX_COUNTER_TABLE
         result = minigraph.parse_xml(self.sample_graph, port_config_file=self.port_config)
         self.assertNotIn('FLEX_COUNTER_TABLE', result)
+
+
+class TestParseChassisHwsku(TestCase):
+    def build_root(self, devices):
+        ns = minigraph.ns
+        root = ET.Element(QName(ns, "root"))
+        png = ET.SubElement(root, QName(ns, "PngDec"))
+        devices_node = ET.SubElement(png, QName(ns, "Devices"))
+        for hostname, hwsku in devices:
+            device = ET.SubElement(devices_node, QName(ns, "Device"))
+            ET.SubElement(device, QName(ns, "Hostname")).text = hostname
+            ET.SubElement(device, QName(ns, "HwSku")).text = hwsku
+        return root
+
+    def test_parse_chassis_hwsku_matching_hostname(self):
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertEqual(minigraph.parse_chassis_hwsku(root, 'str-sonic'), 'Sonic-chassis-sku')
+
+    def test_parse_chassis_hwsku_no_match(self):
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertIsNone(minigraph.parse_chassis_hwsku(root, 'other-host'))
+
+    def test_parse_chassis_hwsku_none_hostname(self):
+        # VOQ pizzabox: chassis-type minigraph with no ParentRouter, so chassis_hostname is None.
+        # parse_chassis_hwsku must return None instead of raising AttributeError.
+        root = self.build_root([('str-sonic', 'Sonic-chassis-sku')])
+        self.assertIsNone(minigraph.parse_chassis_hwsku(root, None))


### PR DESCRIPTION
Manual cherry-pick of https://github.com/sonic-net/sonic-buildimage/pull/28955

#### Why I did it
chassis_hostname is not defined on voq pizzabox.

parse_chassis_hwsku raised AttributeError on a VOQ pizzabox because a chassis-type minigraph with no ParentRouter yields chassis_hostname=None

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Guard the hostname comparison so it returns None instead of crashing, and add unit tests covering matching, non-matching, and None hostname cases.

#### How to verify it
Added unit test enhancements for this scenario. UT and sonic-cfggen of minigraph which is a voq pizzabox will help verify
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
