### PR TITLE
[docker-ptf][202605] make external package versions reproducible and refreshable

### DIFF
--- a/.azure-pipelines/docker-ptf.yml
+++ b/.azure-pipelines/docker-ptf.yml
@@ -13,6 +13,7 @@ pr:
   paths:
     include:
     - .azure-pipelines/docker-ptf.yml
+    - dockers/docker-ptf
 
 resources:
   repositories:

--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -134,29 +134,25 @@ RUN WIRESHARK_VERSION=4.6.6 \
     && rm -rf /tmp/wireshark.tar.xz "/tmp/wireshark-${WIRESHARK_VERSION}" /tmp/wireshark-build /var/lib/apt/lists/*
 {% endif %}
 
-# Install Go toolchain for building grpcurl and gnmic from source
-# to ensure they use a patched Go stdlib (GO-2026-4970, GO-2026-5856)
-{% if CONFIGURED_ARCH == "armhf" %}
-RUN GO_ARCH=armv6l \
-    && GO_SHA256=6cd7311c02c73ba0b482a1cf8c885268edf23519261bf4b5cef3353ad934d1f1 \
-{% elif CONFIGURED_ARCH == "arm64" %}
-RUN GO_ARCH=arm64 \
-    && GO_SHA256=8b5884aef89600aef5b0b051fb971f11f49bb996521e911f30f02a66884f7bd2 \
-{% else %}
+# Install the latest stable Go toolchain for building grpcurl and gnmic. The
+# hooked metadata and archive downloads are recorded in versions-web, allowing
+# version-controlled builds to reproduce the selected release.
 RUN GO_ARCH=amd64 \
-    && GO_SHA256=234828b7a89e0e303d2556310ee549fbcf253d28de937bac3da13d6294262ac1 \
-{% endif %}
-    && GO_VERSION=1.25.12 \
-    && curl -L "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz \
+    && curl --fail --show-error --location -o /tmp/go-downloads.json "https://go.dev/dl/?mode=json" \
+    && GO_FILE_INFO=$(python3 -c 'import json, sys; release = next(item for item in json.load(open(sys.argv[1])) if item["stable"]); archive = next(item for item in release["files"] if item["os"] == "linux" and item["arch"] == sys.argv[2] and item["kind"] == "archive"); print(archive["filename"], archive["sha256"])' /tmp/go-downloads.json "${GO_ARCH}") \
+    && GO_FILENAME=${GO_FILE_INFO%% *} \
+    && GO_SHA256=${GO_FILE_INFO##* } \
+    && curl --fail --show-error --location -o /tmp/go.tar.gz "https://go.dev/dl/${GO_FILENAME}" \
     && echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
-    && rm /tmp/go.tar.gz
+    && rm /tmp/go.tar.gz /tmp/go-downloads.json
 
 ENV PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
 
 # Build grpcurl from source with patched Go and golang.org/x/* deps
 # upgraded to latest to address current and future golang.org/x/* CVEs.
-RUN GRPCURL_VERSION=v1.9.3 \
+RUN curl --fail --show-error --location -o /tmp/grpcurl-release.json "https://api.github.com/repos/fullstorydev/grpcurl/releases/latest" \
+    && GRPCURL_VERSION=$(python3 -c 'import json; print(json.load(open("/tmp/grpcurl-release.json"))["tag_name"])') \
     && git clone --depth 1 --branch "${GRPCURL_VERSION}" https://github.com/fullstorydev/grpcurl.git /tmp/grpcurl \
     && cd /tmp/grpcurl \
     && go get google.golang.org/grpc@v1.82.1 \
@@ -165,21 +161,17 @@ RUN GRPCURL_VERSION=v1.9.3 \
     && go mod tidy \
     && go build -o /usr/local/bin/grpcurl ./cmd/grpcurl \
     && chmod +x /usr/local/bin/grpcurl \
-    && rm -rf /tmp/grpcurl /root/go/pkg/mod /root/.cache/go-build
+    && rm -rf /tmp/grpcurl /tmp/grpcurl-release.json /root/go/pkg/mod /root/.cache/go-build
 # Security fixes: upgrade all vulnerable system packages (S360 scan remediation)
 # Covers CVE-2026-33416 and CVE-2026-33636 (libpng16-16) among others
 RUN apt-get update && apt-get upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Install InfluxDB 3 Core for HFT E2E tests (not available for armhf)
-{% if CONFIGURED_ARCH != "armhf" %}
+# Install InfluxDB 3 Core for HFT E2E tests
 RUN set -eux \
-{% if CONFIGURED_ARCH == "arm64" %}
-    && INFLUXDB_ARCH=linux_arm64 \
-{% else %}
     && INFLUXDB_ARCH=linux_amd64 \
-{% endif %}
-    && INFLUXDB_VERSION=3.9.0 \
+    && curl --fail --show-error --location -o /tmp/influxdb-release.json "https://api.github.com/repos/influxdata/influxdb/releases/latest" \
+    && INFLUXDB_VERSION=$(python3 -c 'import json; tag = json.load(open("/tmp/influxdb-release.json"))["tag_name"]; print(tag[1:] if tag.startswith("v") else tag)') \
     && cd /tmp \
     && curl --fail --show-error --location --retry 3 --retry-delay 5 -O "https://dl.influxdata.com/influxdb/releases/influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && tar xzf "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
@@ -191,10 +183,10 @@ RUN set -eux \
     && ln -sf /usr/local/bin/influxdb3 /usr/local/bin/influxd \
     && rm -f "influxdb3-core-${INFLUXDB_VERSION}_${INFLUXDB_ARCH}.tar.gz" \
     && rm -rf "/tmp/influxdb3-core-${INFLUXDB_VERSION}" \
+    && rm -f /tmp/influxdb-release.json \
     && rm -rf /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip \
         /usr/local/lib/influxdb3-python/lib/python3.13/site-packages/pip-*.dist-info \
     && rm -f /usr/local/lib/influxdb3-python/bin/pip*
-{% endif %}
 
 {% if PTF_ENV_PY_VER == "py3" %}
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
@@ -242,15 +234,16 @@ RUN rm -rf /debs \
     && cd .. \
     && rm -fr scapy-vxlan \
 {% endif %}
-    && git clone https://github.com/sflow/sflowtool \
+    && curl --fail --show-error --location -o /tmp/sflowtool-release.json "https://api.github.com/repos/sflow/sflowtool/releases/latest" \
+    && SFLOWTOOL_VERSION=$(python3 -c 'import json; print(json.load(open("/tmp/sflowtool-release.json"))["tag_name"])') \
+    && git clone --depth 1 --branch "${SFLOWTOOL_VERSION}" https://github.com/sflow/sflowtool \
     && cd sflowtool \
-    && git checkout v6.09 \
     && ./boot.sh \
     && ./configure \
     && make \
     && make install \
     && cd  .. \
-    && rm -fr sflowtool \
+    && rm -fr sflowtool /tmp/sflowtool-release.json \
     && git clone https://github.com/dyninc/OpenBFDD.git \
     && cd OpenBFDD \
     && git apply /root/openbfdd-patches/broken-build-bookworm.patch \
@@ -260,17 +253,20 @@ RUN rm -rf /debs \
     && make install \
     && cd  .. \
     && rm -fr OpenBFDD \
-    && wget https://github.com/nanomsg/nanomsg/archive/1.2.2.tar.gz \
-    && tar xvfz 1.2.2.tar.gz \
-    && cd nanomsg-1.2.2    \
+    && curl --fail --show-error --location -o /tmp/nanomsg-release.json "https://api.github.com/repos/nanomsg/nanomsg/releases/latest" \
+    && NANOMSG_VERSION=$(python3 -c 'import json; print(json.load(open("/tmp/nanomsg-release.json"))["tag_name"])') \
+    && curl --fail --show-error --location -o nanomsg.tar.gz "https://github.com/nanomsg/nanomsg/archive/refs/tags/${NANOMSG_VERSION}.tar.gz" \
+    && mkdir nanomsg-src \
+    && tar xvfz nanomsg.tar.gz --strip-components=1 -C nanomsg-src \
+    && cd nanomsg-src \
     && mkdir -p build      \
     && cd build            \
     && cmake ..            \
     && make install        \
     && ldconfig            \
     && cd ../..            \
-    && rm -fr nanomsg-1.2.2 \
-    && rm -f 1.2.2.tar.gz  \
+    && rm -fr nanomsg-src \
+    && rm -f nanomsg.tar.gz /tmp/nanomsg-release.json \
 {% if PTF_ENV_PY_VER == "mixed" %}
     && pip install cffi    \
     && pip install nnpy    \
@@ -318,19 +314,21 @@ COPY ["tacacs+", "/etc/default"]
 
 RUN python3 -m venv env-python3
 # Activating a virtualenv. The virtualenv automatically works for RUN, ENV and CMD.
-# Python 3 reproducible build hooks are not used after this point in docker-ptf.
-# Once PATH is switched to the virtualenv, pip3 resolves to the venv binary
-# instead of the host pip3 wrapper, so run_pip_command is bypassed.
+# Keep Python 3 package installation behind the reproducible build hooks while
+# using the virtualenv's interpreter and site-packages.
 ENV VIRTUAL_ENV=/root/env-python3
 ARG BACKUP_OF_PATH="$PATH"
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# Keep the build hook ahead of the virtualenv. The hook's get_command helper
+# removes /usr/local/sbin before resolving the real command, so it delegates
+# to the virtualenv pip without recursing.
+ENV PATH="/usr/local/sbin:$VIRTUAL_ENV/bin:/usr/local/go/bin:/root/go/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONIOENCODING=UTF-8
 
 # Upgrade pip to address CVE vulnerabilities in older pip versions
 RUN pip3 install --upgrade pip
 
 {% if PTF_ENV_PY_VER == "mixed" %}
-RUN python3 -m pip install --upgrade --ignore-installed pip
+RUN pip3 install --upgrade --ignore-installed pip
 {% endif %}
 
 # For py3 image the following offending packages below do not use the updated
@@ -381,9 +379,9 @@ RUN pip3 install Flask   \
 RUN set -e; \
     . /etc/os-release; \
     if [ "$VERSION_CODENAME" = "bookworm" ]; then \
-        pip install protobuf==7.35.1; \
+        pip3 install protobuf==7.35.1; \
     else \
-        pip install protobuf; \
+        pip3 install protobuf; \
     fi
 
 {% if docker_ptf_whls.strip() -%}
@@ -485,7 +483,7 @@ RUN set -eux; \
   for f in /root/env-python3/bin/*; do \
     base="$(basename "$f")"; \
     case "$base" in \
-      python*|pip*) continue ;; \
+      python*) continue ;; \
     esac; \
     ln -sf "$f" "/usr/local/bin/$base"; \
   done

--- a/files/build/versions-public/dockers/docker-ptf/versions-py3
+++ b/files/build/versions-public/dockers/docker-ptf/versions-py3
@@ -49,7 +49,7 @@ parso==0.8.3
 pexpect==4.8.0
 pickleshare==0.7.5
 pillow==9.4.0
-pip==23.0.1
+pip==26.2.1
 plumbum==2.0.1
 ply==3.11
 prompt-toolkit==3.0.36


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->
cherry-pick: https://github.com/sonic-net/sonic-buildimage/pull/28835
#### Why I did it
docker-ptf contained hard-coded versions for several external tools, requiring manual updates for new releases and security fixes. Python packages installed inside the virtual environment also bypassed the SONiC version-control hook, so they were not reliably constrained or recorded.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Resolve the latest stable releases of Go, grpcurl, InfluxDB, sflowtool, and nanomsg from upstream release metadata.
- Download release metadata and artifacts through the SONiC web hook so unfrozen builds discover updates and frozen builds reproduce recorded inputs.
- Continue verifying the Go archive with its upstream SHA-256 checksum.
- Route virtualenv pip installs through the SONiC build hook.
- Expose virtualenv pip binaries for final Python version collection.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
202605: The stdlib package can be upgraded
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
