### PR TITLE
Disable debugfs on Nokia 7215 IXS-A1 and 7215-C1 devices

### DIFF
--- a/device/nokia/arm64-nokia_ixs7215_52xb-r0/installer.conf
+++ b/device/nokia/arm64-nokia_ixs7215_52xb-r0/installer.conf
@@ -1,2 +1,2 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1 debugfs=off"
 GRUB_SERIAL_COMMAND="set timeout_style=hidden"

--- a/device/nokia/arm64-nokia_ixs7215_c1xa-r0/installer.conf
+++ b/device/nokia/arm64-nokia_ixs7215_c1xa-r0/installer.conf
@@ -1,2 +1,2 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="default_hugepagesz=32M hugepages=4 loglevel=4 efi_pstore.pstore_disable=1 debugfs=off"
 GRUB_SERIAL_COMMAND="set timeout_style=hidden"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
This prevents kernel panics when `grep -r traverses /sys/kernel/debug` is executed inside the pmon container, which is covered by the new sonic-mgmt test `test_pmon_grep_no_kernel_panic` in `test_pmon_grep_safe.py`.
Fixes [sonic-net/sonic-mgmt#18394](https://github.com/sonic-net/sonic-mgmt/issues/18394)

#####   Type of change

- [x] Platform-specific fix
- [ ] Bug fix (generic)
- [ ] New feature

#### How I did it
Use the existing platform boot-parameter mechanism (ONIE_PLATFORM_EXTRA_CMDLINE_LINUX -> U-Boot linuxargs on Marvell Prestera arm64) to pass `debugfs=off` to the kernel at boot. Updated `device/nokia/arm64-nokia_ixs7215_52xb-r0/installer.conf` and `device/nokia/arm64-nokia_ixs7215_c1xa-r0/installer.conf` by appending `debugfs=off`.

#### How to verify it

- Verified /sys/kernel/debug is not available
- Ran `docker exec pmon grep -r "PMON_GREP_SAFE_TEST" /sys/kernel/debug/` without kernel panic
- Ran `tests/platform_tests/test_pmon_grep_safe.py::test_pmon_grep_no_kernel_panic`
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] 202605

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Kusto ids for Nokia-7215-A1 (202605 branch):
- M0: 71fba884-11dc-4d90-a07f-2f3cee18cb6d
- MX: 515c8847-43c8-4e68-b1e0-01023f7edfd4

Tests (as described in `How to verify it` section) PASSED for the Nokia-7215-C1 device.
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
