### PR TITLE
Load psample kernel module for sFlow

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -919,11 +919,17 @@ fi
 ## copy blacklist file
 sudo cp $IMAGE_CONFIGS/platform/linux_kernel_bde.conf $FILESYSTEM_ROOT/etc/modprobe.d/
 
-# Enable psample drivers to support sFlow on vs
+# Enable psample drivers to support sFlow 
+# vpp samples in its own dataplane and needs only the psample netlink channel
+# vs additional needs act_sample for the kernel tc(1) sampler.
 {% if sonic_asic_platform == "vs" %}
 sudo tee -a $FILESYSTEM_ROOT/etc/modules-load.d/modules.conf > /dev/null <<EOF
 psample
 act_sample
+EOF
+{% elif sonic_asic_platform == "vpp" %}
+sudo tee -a $FILESYSTEM_ROOT/etc/modules-load.d/modules.conf > /dev/null <<EOF
+psample
 EOF
 {% endif %}
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

VPP's sFlow plugin exports packet samples to hsflowd over the kernel psample netlink channel, which requires the psample module to be loaded. The image loads it explicitly for the `vs` platform but not for `vpp`, where it was only ever loaded as a side effect of the kernel tc(1) sampler that sonic-sairedis installed per port. That sampler was removed in the [sFlow phase three](https://github.com/sonic-net/sonic-sairedis/pull/2004) PR to fix duplicated ingress samples, so on a fresh boot nothing loads psample and sFlow produces no flow samples at all.

The failure is silent: VPP reports a healthy `packet samples sent` with `packet samples dropped: 0` while nothing reaches the collector, because the plugin resolves the psample netlink family once at plugin init.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Extended the existing psample module-load block in `files/build_templates/sonic_debian_extension.j2` to cover the `vpp` platform, which previously only handled `vs`. This appends `psample` to `/etc/modules-load.d/modules.conf` so systemd loads it at boot, before anycontainer starts.

Only `psample` is loaded for `vpp`, not `act_sample`: VPP samples in its own dataplane and does not use the kernel tc(1) sampler that `act_sample` provides.

#### How to verify it

Boot a sonic-vpp image built with this change and confirm the module loaded with no manual intervention:

```
  lsmod | grep psample
  psample                16384  0
```

Configured sFlow on a two-node VPP topology (collector on 127.0.0.1:6344,
per-port sample rates and directions) and sent 100,000 packets per link from the
peer:

```
  Ethernet4, 1-in-1000, direction rx    -> 103 ingress samples, 0 egress
  Ethernet8, 1-in-5000, direction both  ->  25 ingress samples, 18 egress
```

Both match the configured rates, and each port is labelled with its own rate at the collector.

Without this change the same test yields zero flow samples, while vppctl show sflow reports packet samples sent incrementing normally.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
