### PR TITLE
[Nokia vs] update syncd to trixie and update default platform mac addr for a special sku

### DIFF
--- a/platform/nokia-vs/docker-syncd-vs.mk
+++ b/platform/nokia-vs/docker-syncd-vs.mk
@@ -1,7 +1,7 @@
 # docker image for vs syncd
 
 DOCKER_SYNCD_PLATFORM_CODE = vs
-include $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
+include $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 
 $(DOCKER_SYNCD_BASE)_DEPENDS += $(SYNCD_VS) \
                               $(LIBNL3_DEV) \

--- a/platform/nokia-vs/docker-syncd-vs/Dockerfile.j2
+++ b/platform/nokia-vs/docker-syncd-vs/Dockerfile.j2
@@ -1,5 +1,5 @@
-{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files %}
-ARG BASE=docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+{% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, rsync_from_builder_stage %}
+ARG BASE=docker-config-engine-trixie-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 FROM $BASE AS base
 
@@ -10,14 +10,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -f -y iproute2 libcap2-bin
+RUN apt-get install -f -y libcap2-bin
 
 # For DASH engine
 
 COPY debs/libnl-3-dev_{{ LIBNL3_VERSION_SONIC }}_{{ CONFIGURED_ARCH }}.deb debs/libnl-route-3-dev_{{ LIBNL3_VERSION_SONIC }}_{{ CONFIGURED_ARCH }}.deb debs/
 RUN dpkg -i debs/libnl-3-dev_{{ LIBNL3_VERSION_SONIC }}_{{ CONFIGURED_ARCH }}.deb debs/libnl-route-3-dev_{{ LIBNL3_VERSION_SONIC }}_{{ CONFIGURED_ARCH }}.deb
 
-RUN apt-get install -f -y libabsl20220623 libc-ares2 python3-six libboost-thread1.74.0 libboost-dev libboost-system-dev libboost-thread-dev libboost-filesystem1.74.0 libboost-program-options1.74.0 libboost-thread1.74.0 libnanomsg5 libpcap0.8 libthrift-0.17.0 libboost-dev libboost-filesystem-dev libboost-program-options-dev libgmp-dev libnanomsg-dev libpcap-dev libtool pkg-config libthrift-dev python3-thrift thrift-compiler libboost-iostreams1.74.0 libgc1 cpp libboost-dev libboost-all-dev libboost-graph-dev libboost-iostreams-dev libfl-dev libgc-dev libgmp-dev libbpf-dev tcpdump libelf-dev llvm clang python3-pyroute2 python3-ply python3-scapy python3-setuptools python3-thrift libthrift-0.17.0 libgrpc++1.51 libgrpc29 libprotobuf32 libboost-dev libboost-system-dev libboost-thread-dev libprotoc-dev protobuf-compiler python3-protobuf libgrpc++-dev libgrpc-dev protobuf-compiler-grpc python3-grpcio 
+RUN apt-get install -f -y libc-ares2 python3-six libnanomsg5 libpcap0.8 libgmp-dev libnanomsg-dev libpcap-dev libtool pkg-config libthrift-dev python3-thrift thrift-compiler libgc1 cpp libfl-dev libgc-dev libgmp-dev libbpf-dev tcpdump libelf-dev llvm clang python3-pyroute2 python3-ply python3-scapy python3-setuptools python3-thrift libgrpc++1.51 libgrpc29 libprotobuf32 libprotoc-dev protobuf-compiler python3-protobuf libgrpc++-dev libgrpc-dev protobuf-compiler-grpc python3-grpcio
 
 {% if docker_syncd_vs_debs.strip() -%}
 # Copy built Debian packages
@@ -34,7 +34,7 @@ COPY ["critical_processes", "/etc/supervisor/"]
 
 FROM $BASE
 
-RUN --mount=type=bind,from=base,target=/changes-to-image rsync -axAX --no-D --exclude=/sys --exclude=/proc --exclude=/dev --exclude=resolv.conf /changes-to-image/ /
+{{ rsync_from_builder_stage() }}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENTRYPOINT ["/usr/local/bin/supervisord"]

--- a/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-init.sh
+++ b/platform/nokia-vs/sonic-platform-nokia/7215-c1/scripts/nokia-7215-init.sh
@@ -384,6 +384,7 @@ if [ "$HWSKU" = "Nokia-7215-C1-mp" ]; then
     echo "[nokia-7215-init] HWSKU='$HWSKU'"
     SWAP_SRC=eth0
     ETH_LAST=2
+    sudo ifconfig eth2 hw ether $MAC_ADDR
 else
     echo "[nokia-7215-init] HWSKU='${HWSKU:-<unknown>}'"
     rotate_usb_to_eth0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
bring nokia vs platform syncd up to trixie
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
update make files
#### How to verify it
use cat /etc/os-release
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
dockers up, port up.
```
admin@right-twix-c1-1:~$ show version

SONiC Software Version: SONiC.nokia-master.0-f2f95b43d
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-arm64
Build commit: f2f95b43d
Build date: Wed Jul 29 19:36:48 UTC 2026
Built by: hehuang@sonic-armv19

Platform: arm64-nokia_ixs7215_c1xa-r0
HwSKU: Nokia-7215-C1
ASIC: nokia-vs
ASIC Count: 1
Serial Number: UN255000006
Model Number: 3HE22118AARA01
Hardware Revision: 0
Uptime: 18:47:56 up 19 days,  3:33,  1 user,  load average: 1.49, 1.35, 1.50
Date: Tue 18 Aug 2026 18:47:56

Docker images:
REPOSITORY                    TAG                        IMAGE ID       SIZE
docker-sonic-otel             latest                     8c8bb33a1a08   654MB
docker-sonic-otel             nokia-master.0-f2f95b43d   8c8bb33a1a08   654MB
docker-database               latest                     db9fca298c4a   347MB
docker-database               nokia-master.0-f2f95b43d   db9fca298c4a   347MB
docker-fpm-frr                latest                     e63c9a58eb82   448MB
docker-fpm-frr                nokia-master.0-f2f95b43d   e63c9a58eb82   448MB
docker-mux                    latest                     c5ff2af16672   353MB
docker-mux                    nokia-master.0-f2f95b43d   c5ff2af16672   353MB
docker-eventd                 latest                     1ec880e30ee0   340MB
docker-eventd                 nokia-master.0-f2f95b43d   1ec880e30ee0   340MB
docker-bmp-watchdog           latest                     bae2d79820c8   340MB
docker-bmp-watchdog           nokia-master.0-f2f95b43d   bae2d79820c8   340MB
docker-sonic-gnmi             latest                     59e63b825348   479MB
docker-sonic-gnmi             nokia-master.0-f2f95b43d   59e63b825348   479MB
docker-gnmi-watchdog          latest                     7a67a34b7f22   347MB
docker-gnmi-watchdog          nokia-master.0-f2f95b43d   7a67a34b7f22   347MB
docker-sonic-mgmt-framework   latest                     a57bc426b981   399MB
docker-sonic-mgmt-framework   nokia-master.0-f2f95b43d   a57bc426b981   399MB
docker-lldp                   latest                     d5f67214b67a   348MB
docker-lldp                   nokia-master.0-f2f95b43d   d5f67214b67a   348MB
docker-teamd                  latest                     1a6840666f52   377MB
docker-teamd                  nokia-master.0-f2f95b43d   1a6840666f52   377MB
docker-gnmi-sidecar           latest                     3068608e91f2   340MB
docker-gnmi-sidecar           nokia-master.0-f2f95b43d   3068608e91f2   340MB
docker-nat                    latest                     cc31327ee830   386MB
docker-nat                    nokia-master.0-f2f95b43d   cc31327ee830   386MB
docker-restapi-sidecar        latest                     546963677f2f   340MB
docker-restapi-sidecar        nokia-master.0-f2f95b43d   546963677f2f   340MB
docker-platform-monitor       latest                     ac73e07382fe   463MB
docker-platform-monitor       nokia-master.0-f2f95b43d   ac73e07382fe   463MB
docker-sysmgr                 latest                     e845d7c91710   345MB
docker-sysmgr                 nokia-master.0-f2f95b43d   e845d7c91710   345MB
docker-orchagent              latest                     f84db1f99c31   394MB
docker-orchagent              nokia-master.0-f2f95b43d   f84db1f99c31   394MB
docker-sonic-bmp              latest                     fd8b41b1acb8   342MB
docker-sonic-bmp              nokia-master.0-f2f95b43d   fd8b41b1acb8   342MB
docker-syncd-vs               latest                     00e3ca97af12   1.12GB
docker-syncd-vs               nokia-master.0-f2f95b43d   00e3ca97af12   1.12GB
docker-sflow                  latest                     65719c62bdab   379MB
docker-sflow                  nokia-master.0-f2f95b43d   65719c62bdab   379MB
docker-dash-ha                latest                     cc71abedaa93   395MB
docker-dash-ha                nokia-master.0-f2f95b43d   cc71abedaa93   395MB
docker-snmp                   latest                     8f6ad0a67844   367MB
docker-snmp                   nokia-master.0-f2f95b43d   8f6ad0a67844   367MB
docker-dhcp-server            latest                     296da96d1eb3   366MB
docker-dhcp-server            nokia-master.0-f2f95b43d   296da96d1eb3   366MB
docker-dhcp-relay             latest                     3ee6d85f51cb   363MB
docker-dhcp-relay             nokia-master.0-f2f95b43d   3ee6d85f51cb   363MB
docker-router-advertiser      latest                     628ef613b9da   340MB
docker-router-advertiser      nokia-master.0-f2f95b43d   628ef613b9da   340MB
docker-macsec                 latest                     4744c9df4da4   380MB
docker-macsec                 nokia-master.0-f2f95b43d   4744c9df4da4   380MB

admin@right-twix-c1-1:~$
admin@right-twix-c1-1:~$
admin@right-twix-c1-1:~$ docker exec -it syncd bash
root@right-twix-c1-1:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
NAME="Debian GNU/Linux"
VERSION_ID="13"
VERSION="13 (trixie)"
VERSION_CODENAME=trixie
DEBIAN_VERSION_FULL=13.6
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
root@right-twix-c1-1:/#
exit
admin@right-twix-c1-1:~$ show interface sta
  Interface    Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin            Type    Asym PFC
-----------  -------  -------  -----  -----  -------  ------  ------  -------  --------------  ----------
  Ethernet0        1       1G   9100    N/A     etp1   trunk      up       up  SFP/SFP+/SFP28         N/A
  Ethernet1        2       1G   9100    N/A     etp2   trunk    down       up             N/A         N/A
  Ethernet2        3       1G   9100    N/A     etp3   trunk    down       up             N/A         N/A

admin@right-twix-c1-1:~$ docker ps -a
CONTAINER ID   IMAGE                                COMMAND                  CREATED       STATUS       PORTS     NAMES
042e739a65ee   docker-snmp:latest                   "/usr/bin/docker-snm…"   2 weeks ago   Up 2 weeks             snmp
9a9d1bf828b1   docker-sonic-mgmt-framework:latest   "/usr/local/bin/supe…"   2 weeks ago   Up 2 weeks             mgmt-framework
724bd1eb3349   docker-lldp:latest                   "/usr/bin/docker-lld…"   2 weeks ago   Up 2 weeks             lldp
1bc5908a3015   docker-dhcp-relay:latest             "/usr/bin/docker_ini…"   2 weeks ago   Up 2 weeks             dhcp_relay
352d5908e66e   docker-eventd:latest                 "/usr/local/bin/supe…"   2 weeks ago   Up 2 weeks             eventd
39ee4fcf2a04   docker-fpm-frr:latest                "/usr/bin/docker_ini…"   2 weeks ago   Up 2 weeks             bgp
b1831bd080cc   docker-sonic-gnmi:latest             "/usr/local/bin/supe…"   2 weeks ago   Up 2 weeks             gnmi
b1f06da39f95   docker-router-advertiser:latest      "/usr/bin/docker-ini…"   2 weeks ago   Up 2 weeks             radv
9d38e00409d7   docker-syncd-vs:latest               "/usr/local/bin/supe…"   2 weeks ago   Up 2 weeks             syncd
a3b3beedaf31   docker-teamd:latest                  "/usr/bin/docker-tea…"   2 weeks ago   Up 2 weeks             teamd
a38ee32821a6   docker-sysmgr:latest                 "/usr/local/bin/supe…"   2 weeks ago   Up 2 weeks             sysmgr
c5382c10beb1   docker-orchagent:latest              "/usr/bin/docker-ini…"   2 weeks ago   Up 2 weeks             swss
46b41e999366   docker-platform-monitor:latest       "/usr/bin/docker_ini…"   2 weeks ago   Up 2 weeks             pmon
3aea9383ae24   docker-database:latest               "/usr/local/bin/dock…"   2 weeks ago   Up 2 weeks             database
admin@right-twix-c1-1:~$
```
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
