### PR TITLE
[yang-models] Add gRPC authorization policy YANG model

### DIFF
--- a/dockers/docker-gnmi-sidecar/cli-plugin-tests/test_systemd_stub.py
+++ b/dockers/docker-gnmi-sidecar/cli-plugin-tests/test_systemd_stub.py
@@ -253,6 +253,26 @@ def test_sync_missing_src_returns_false(ss):
     assert ok is False
 
 
+def test_sync_installs_grpc_authz_yang(ss):
+    ss, container_fs, host_fs, commands = ss
+    schema_path = "/usr/local/yang-models/sonic-grpc-authz.yang"
+
+    for item in ss.SYNC_ITEMS:
+        container_fs[item.src_in_container] = b"current"
+        host_fs[item.dst_on_host] = b"current"
+    container_fs[schema_path] = b"new schema"
+    host_fs[schema_path] = b"old schema"
+    container_fs["/usr/share/sonic/systemd_scripts/container_checker_202311"] = b"chk"
+    host_fs["/bin/container_checker"] = b"chk"
+
+    assert ss.ensure_sync() is True
+    assert host_fs[schema_path] == b"new schema"
+
+    schema_item = next(item for item in ss.SYNC_ITEMS if item.dst_on_host == schema_path)
+    assert schema_item.src_in_container == schema_path
+    assert schema_item.mode == 0o644
+
+
 def test_main_once_exits_zero_and_disables_post_actions(monkeypatch):
     if "systemd_stub" in sys.modules:
         del sys.modules["systemd_stub"]

--- a/dockers/docker-gnmi-sidecar/systemd_stub.py
+++ b/dockers/docker-gnmi-sidecar/systemd_stub.py
@@ -151,6 +151,7 @@ logger.log_notice(f"gnmi source set to {_GNMI_SRC}")
 # post-copy action (systemctl restart gnmi) would fail with "No such file or
 # directory".
 SYNC_ITEMS: List[SyncItem] = [
+    SyncItem("/usr/local/yang-models/sonic-grpc-authz.yang", "/usr/local/yang-models/sonic-grpc-authz.yang", mode=0o644),
     SyncItem("/usr/share/sonic/scripts/k8s_pod_control.sh", "/usr/share/sonic/scripts/docker-gnmi-sidecar/k8s_pod_control.sh"),
     SyncItem(_GNMI_SRC, "/usr/local/bin/gnmi.sh"),
 ]

--- a/src/sonic-yang-models/setup.py
+++ b/src/sonic-yang-models/setup.py
@@ -138,6 +138,7 @@ yang_files = [
     'sonic-fips.yang',
     'sonic-flex_counter.yang',
     'sonic-gnmi.yang',
+    'sonic-grpc-authz.yang',
     'sonic-grpcclient.yang',
     'sonic-hash.yang',
     'sonic-heartbeat.yang',

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1461,6 +1461,39 @@
                 ]
             }
         },
+        "GRPC_AUTHZ_PRINCIPAL": {
+            "client.example.com": {
+                "roles": [
+                    "reader"
+                ]
+            }
+        },
+        "GRPC_AUTHZ_RULE": {
+            "allow-gnmi-get": {
+                "roles": [
+                    "reader"
+                ],
+                "rpc": "/gnmi.gNMI/Get",
+                "effect": "allow",
+                "priority": "100"
+            }
+        },
+        "GNMI_PATHZ_RULE": {
+            "allow-interface-read": {
+                "role": "reader",
+                "target": "default",
+                "origin": "openconfig",
+                "path": "/interfaces/interface[name=*]",
+                "mode": "READ",
+                "action": "PERMIT"
+            },
+            "deny-interface-write": {
+                "principal": "client.example.com",
+                "path": "/interfaces/interface[name=Ethernet1/2/3]",
+                "mode": "WRITE",
+                "action": "DENY"
+            }
+        },
         "TUNNEL": {
             "MuxTunnel0": {
                 "dscp_mode": "uniform",

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1474,8 +1474,7 @@
                     "reader"
                 ],
                 "rpc": "/gnmi.gNMI/Get",
-                "effect": "allow",
-                "priority": "100"
+                "effect": "allow"
             }
         },
         "GNMI_PATHZ_RULE": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
@@ -44,13 +44,14 @@
         "desc": "gNMI Pathz rule without a principal or role fails.",
         "eStr": [
             "Mandatory choice",
-            "missing a case branch"
+            "subject"
         ]
     },
     "GNMI_PATHZ_RULE_WITH_MULTIPLE_SUBJECTS": {
         "desc": "gNMI Pathz rule cannot select both a principal and a role.",
         "eStr": [
-            "more than one case branch"
+            "Data for",
+            "principal"
         ]
     },
     "GRPC_AUTHZ_RULE_WITH_PATH_FIELD": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
@@ -1,0 +1,33 @@
+{
+    "GRPC_AUTHZ_POLICY_WITH_VALID_CONFIG": {
+        "desc": "Shared gRPC authorization policy with valid configuration."
+    },
+    "GRPC_AUTHZ_METADATA_WITH_MISSING_POLICY_VERSION": {
+        "desc": "gRPC authorization metadata without a policy version fails.",
+        "eStrKey": "Mandatory"
+    },
+    "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
+        "desc": "gRPC authorization principal without roles fails.",
+        "eStrKey": "MinElements"
+    },
+    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_ROLE": {
+        "desc": "gRPC authorization rule with an unknown role fails.",
+        "eStrKey": "LeafRef"
+    },
+    "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
+        "desc": "gRPC authorization rule with an invalid method name fails.",
+        "eStrKey": "Pattern"
+    },
+    "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
+        "desc": "gRPC authorization path rule without operations fails.",
+        "eStrKey": "MinElements"
+    },
+    "GRPC_AUTHZ_RULE_WITH_OPERATIONS_AND_NO_PATH": {
+        "desc": "gRPC authorization method rule cannot contain path operations.",
+        "eStrKey": "When"
+    },
+    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_FIELD": {
+        "desc": "gRPC authorization rule with an unknown field fails.",
+        "eStrKey": "UnknownElement"
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
@@ -6,6 +6,16 @@
         "desc": "gRPC authorization metadata without a policy version fails.",
         "eStrKey": "Mandatory"
     },
+    "GRPC_AUTHZ_POLICY_WITH_MISSING_METADATA": {
+        "desc": "gRPC authorization policy without metadata fails.",
+        "eStr": [
+            "requires one metadata entry"
+        ]
+    },
+    "GRPC_AUTHZ_POLICY_WITH_UNSUPPORTED_SCHEMA_VERSION": {
+        "desc": "gRPC authorization policy with an unsupported schema version fails.",
+        "eStrKey": "Range"
+    },
     "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
         "desc": "gRPC authorization principal without roles fails.",
         "eStrKey": "MinElements"
@@ -17,6 +27,12 @@
     "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
         "desc": "gRPC authorization rule with an invalid method name fails.",
         "eStrKey": "Pattern"
+    },
+    "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
+        "desc": "gRPC authorization rules with duplicate priorities fail.",
+        "eStr": [
+            "Unique data leaf(s)"
+        ]
     },
     "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
         "desc": "gRPC authorization path rule without operations fails.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
@@ -14,11 +14,9 @@
         "desc": "gRPC method rule with an invalid method name fails.",
         "eStrKey": "Pattern"
     },
-    "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
-        "desc": "gRPC method rules with duplicate priorities fail.",
-        "eStr": [
-            "Unique data leaf(s)"
-        ]
+    "GRPC_AUTHZ_RULE_WITH_PRIORITY": {
+        "desc": "gRPC method rule cannot override A43 conflict handling.",
+        "eStrKey": "UnknownElement"
     },
     "GNMI_PATHZ_RULE_WITH_UNKNOWN_ROLE": {
         "desc": "gNMI Pathz rule with an unknown role fails.",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/grpc_authz.json
@@ -1,49 +1,64 @@
 {
     "GRPC_AUTHZ_POLICY_WITH_VALID_CONFIG": {
-        "desc": "Shared gRPC authorization policy with valid configuration."
-    },
-    "GRPC_AUTHZ_METADATA_WITH_MISSING_POLICY_VERSION": {
-        "desc": "gRPC authorization metadata without a policy version fails.",
-        "eStrKey": "Mandatory"
-    },
-    "GRPC_AUTHZ_POLICY_WITH_MISSING_METADATA": {
-        "desc": "gRPC authorization policy without metadata fails.",
-        "eStr": [
-            "requires one metadata entry"
-        ]
-    },
-    "GRPC_AUTHZ_POLICY_WITH_UNSUPPORTED_SCHEMA_VERSION": {
-        "desc": "gRPC authorization policy with an unsupported schema version fails.",
-        "eStrKey": "Range"
+        "desc": "Shared method and Pathz policy with valid configuration."
     },
     "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
         "desc": "gRPC authorization principal without roles fails.",
         "eStrKey": "MinElements"
     },
     "GRPC_AUTHZ_RULE_WITH_UNKNOWN_ROLE": {
-        "desc": "gRPC authorization rule with an unknown role fails.",
+        "desc": "gRPC method rule with an unknown role fails.",
         "eStrKey": "LeafRef"
     },
     "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
-        "desc": "gRPC authorization rule with an invalid method name fails.",
+        "desc": "gRPC method rule with an invalid method name fails.",
         "eStrKey": "Pattern"
     },
     "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
-        "desc": "gRPC authorization rules with duplicate priorities fail.",
+        "desc": "gRPC method rules with duplicate priorities fail.",
         "eStr": [
             "Unique data leaf(s)"
         ]
     },
-    "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
-        "desc": "gRPC authorization path rule without operations fails.",
-        "eStrKey": "MinElements"
+    "GNMI_PATHZ_RULE_WITH_UNKNOWN_ROLE": {
+        "desc": "gNMI Pathz rule with an unknown role fails.",
+        "eStrKey": "LeafRef"
     },
-    "GRPC_AUTHZ_RULE_WITH_OPERATIONS_AND_NO_PATH": {
-        "desc": "gRPC authorization method rule cannot contain path operations.",
-        "eStrKey": "When"
+    "GNMI_PATHZ_RULE_WITH_UNKNOWN_PRINCIPAL": {
+        "desc": "gNMI Pathz rule with an unknown principal fails.",
+        "eStrKey": "LeafRef"
     },
-    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_FIELD": {
-        "desc": "gRPC authorization rule with an unknown field fails.",
+    "GNMI_PATHZ_RULE_WITH_INVALID_PATH": {
+        "desc": "gNMI Pathz rule with a non-canonical path fails.",
+        "eStrKey": "Pattern"
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_MODE": {
+        "desc": "gNMI Pathz rule without an access mode fails.",
+        "eStrKey": "Mandatory"
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_PATH": {
+        "desc": "gNMI Pathz rule without a resource path fails.",
+        "eStrKey": "Mandatory"
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_SUBJECT": {
+        "desc": "gNMI Pathz rule without a principal or role fails.",
+        "eStr": [
+            "Mandatory choice",
+            "missing a case branch"
+        ]
+    },
+    "GNMI_PATHZ_RULE_WITH_MULTIPLE_SUBJECTS": {
+        "desc": "gNMI Pathz rule cannot select both a principal and a role.",
+        "eStr": [
+            "more than one case branch"
+        ]
+    },
+    "GRPC_AUTHZ_RULE_WITH_PATH_FIELD": {
+        "desc": "gRPC method rule cannot contain a Pathz field.",
+        "eStrKey": "UnknownElement"
+    },
+    "GNMI_PATHZ_RULE_WITH_RPC_FIELD": {
+        "desc": "gNMI Pathz rule cannot contain a gRPC method field.",
         "eStrKey": "UnknownElement"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
@@ -19,8 +19,15 @@
                             "reader"
                         ],
                         "rpc": "/gnmi.gNMI/Get",
-                        "effect": "allow",
-                        "priority": "100"
+                        "effect": "allow"
+                    },
+                    {
+                        "name": "deny-gnmi-get",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "effect": "deny"
                     }
                 ]
             },
@@ -77,8 +84,7 @@
                             "administrator"
                         ],
                         "rpc": "/gnmi.gNMI/Get",
-                        "effect": "deny",
-                        "priority": "100"
+                        "effect": "deny"
                     }
                 ]
             }
@@ -104,14 +110,13 @@
                             "reader"
                         ],
                         "rpc": "gnmi.gNMI.Get",
-                        "effect": "allow",
-                        "priority": "100"
+                        "effect": "allow"
                     }
                 ]
             }
         }
     },
-    "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
+    "GRPC_AUTHZ_RULE_WITH_PRIORITY": {
         "sonic-grpc-authz:sonic-grpc-authz": {
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
@@ -126,21 +131,12 @@
             "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
                 "GRPC_AUTHZ_RULE_LIST": [
                     {
-                        "name": "allow-get",
+                        "name": "priority-override",
                         "roles": [
                             "reader"
                         ],
                         "rpc": "/gnmi.gNMI/Get",
                         "effect": "allow",
-                        "priority": "100"
-                    },
-                    {
-                        "name": "deny-set",
-                        "roles": [
-                            "reader"
-                        ],
-                        "rpc": "/gnmi.gNMI/Set",
-                        "effect": "deny",
                         "priority": "100"
                     }
                 ]
@@ -331,8 +327,7 @@
                         ],
                         "rpc": "/gnmi.gNMI/Get",
                         "path": "/interfaces",
-                        "effect": "allow",
-                        "priority": "100"
+                        "effect": "allow"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
@@ -1,0 +1,209 @@
+{
+    "GRPC_AUTHZ_POLICY_WITH_VALID_CONFIG": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "allow-gnmi-get",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "effect": "allow",
+                        "priority": "100"
+                    },
+                    {
+                        "name": "allow-interface-read",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "path": "/interfaces",
+                        "operations": [
+                            "READ"
+                        ],
+                        "effect": "allow",
+                        "priority": "200"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_METADATA_WITH_MISSING_POLICY_VERSION": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_ROLE": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "unknown-role",
+                        "roles": [
+                            "administrator"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "effect": "deny"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "invalid-method",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "gnmi.gNMI.Get",
+                        "effect": "allow"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "missing-operations",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "path": "/interfaces",
+                        "effect": "allow"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_OPERATIONS_AND_NO_PATH": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "operations-without-path",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "operations": [
+                            "READ"
+                        ],
+                        "effect": "allow"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_FIELD": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "unknown-field",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "effect": "allow",
+                        "unsupported": "value"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
@@ -1,15 +1,6 @@
 {
     "GRPC_AUTHZ_POLICY_WITH_VALID_CONFIG": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -30,58 +21,26 @@
                         "rpc": "/gnmi.gNMI/Get",
                         "effect": "allow",
                         "priority": "100"
-                    },
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
                     {
                         "name": "allow-interface-read",
-                        "roles": [
-                            "reader"
-                        ],
-                        "rpc": "/gnmi.gNMI/Get",
-                        "path": "/interfaces",
-                        "operations": [
-                            "READ"
-                        ],
-                        "effect": "allow",
-                        "priority": "200"
-                    }
-                ]
-            }
-        }
-    },
-    "GRPC_AUTHZ_METADATA_WITH_MISSING_POLICY_VERSION": {
-        "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
+                        "role": "reader",
+                        "target": "default",
+                        "origin": "openconfig",
+                        "path": "/interfaces/interface[name=*]",
+                        "mode": "READ",
+                        "action": "PERMIT"
+                    },
                     {
-                        "name": "GLOBAL",
-                        "schema_version": "1"
-                    }
-                ]
-            }
-        }
-    },
-    "GRPC_AUTHZ_POLICY_WITH_MISSING_METADATA": {
-        "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
-                "GRPC_AUTHZ_PRINCIPAL_LIST": [
-                    {
-                        "name": "client.example.com",
-                        "roles": [
-                            "reader"
-                        ]
-                    }
-                ]
-            }
-        }
-    },
-    "GRPC_AUTHZ_POLICY_WITH_UNSUPPORTED_SCHEMA_VERSION": {
-        "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "2",
-                        "policy_version": "2026-08-18"
+                        "name": "deny-system-write",
+                        "principal": "client.example.com",
+                        "path": "/interfaces/interface[name=Ethernet1/2/3]",
+                        "mode": "WRITE",
+                        "action": "DENY"
                     }
                 ]
             }
@@ -89,15 +48,6 @@
     },
     "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -109,15 +59,6 @@
     },
     "GRPC_AUTHZ_RULE_WITH_UNKNOWN_ROLE": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -145,15 +86,6 @@
     },
     "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -181,15 +113,6 @@
     },
     "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -224,17 +147,171 @@
             }
         }
     },
-    "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
+    "GNMI_PATHZ_RULE_WITH_UNKNOWN_ROLE": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
                     }
                 ]
             },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "unknown-role",
+                        "role": "administrator",
+                        "path": "/interfaces",
+                        "mode": "READ",
+                        "action": "DENY"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_UNKNOWN_PRINCIPAL": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "unknown-principal",
+                        "principal": "unknown.example.com",
+                        "path": "/interfaces",
+                        "mode": "READ",
+                        "action": "DENY"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_INVALID_PATH": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "invalid-path",
+                        "role": "reader",
+                        "path": "interfaces",
+                        "mode": "READ",
+                        "action": "PERMIT"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_MODE": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "missing-mode",
+                        "role": "reader",
+                        "path": "/interfaces",
+                        "action": "PERMIT"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_PATH": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "missing-path",
+                        "role": "reader",
+                        "mode": "READ",
+                        "action": "PERMIT"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_MISSING_SUBJECT": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "missing-subject",
+                        "path": "/interfaces",
+                        "mode": "READ",
+                        "action": "PERMIT"
+                    }
+                ]
+            }
+        }
+    },
+    "GNMI_PATHZ_RULE_WITH_MULTIPLE_SUBJECTS": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
+                    {
+                        "name": "multiple-subjects",
+                        "principal": "client.example.com",
+                        "role": "reader",
+                        "path": "/interfaces",
+                        "mode": "READ",
+                        "action": "PERMIT"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_PATH_FIELD": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -248,7 +325,7 @@
             "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
                 "GRPC_AUTHZ_RULE_LIST": [
                     {
-                        "name": "missing-operations",
+                        "name": "path-in-method-rule",
                         "roles": [
                             "reader"
                         ],
@@ -261,17 +338,8 @@
             }
         }
     },
-    "GRPC_AUTHZ_RULE_WITH_OPERATIONS_AND_NO_PATH": {
+    "GNMI_PATHZ_RULE_WITH_RPC_FIELD": {
         "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -282,56 +350,15 @@
                     }
                 ]
             },
-            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
-                "GRPC_AUTHZ_RULE_LIST": [
+            "sonic-grpc-authz:GNMI_PATHZ_RULE": {
+                "GNMI_PATHZ_RULE_LIST": [
                     {
-                        "name": "operations-without-path",
-                        "roles": [
-                            "reader"
-                        ],
+                        "name": "method-in-path-rule",
+                        "role": "reader",
                         "rpc": "/gnmi.gNMI/Get",
-                        "operations": [
-                            "READ"
-                        ],
-                        "effect": "allow",
-                        "priority": "100"
-                    }
-                ]
-            }
-        }
-    },
-    "GRPC_AUTHZ_RULE_WITH_UNKNOWN_FIELD": {
-        "sonic-grpc-authz:sonic-grpc-authz": {
-            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
-                "GRPC_AUTHZ_METADATA_LIST": [
-                    {
-                        "name": "GLOBAL",
-                        "schema_version": "1",
-                        "policy_version": "2026-08-18"
-                    }
-                ]
-            },
-            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
-                "GRPC_AUTHZ_PRINCIPAL_LIST": [
-                    {
-                        "name": "client.example.com",
-                        "roles": [
-                            "reader"
-                        ]
-                    }
-                ]
-            },
-            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
-                "GRPC_AUTHZ_RULE_LIST": [
-                    {
-                        "name": "unknown-field",
-                        "roles": [
-                            "reader"
-                        ],
-                        "rpc": "/gnmi.gNMI/Get",
-                        "effect": "allow",
-                        "priority": "100",
-                        "unsupported": "value"
+                        "path": "/interfaces",
+                        "mode": "READ",
+                        "action": "PERMIT"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/grpc_authz.json
@@ -60,8 +60,44 @@
             }
         }
     },
+    "GRPC_AUTHZ_POLICY_WITH_MISSING_METADATA": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_POLICY_WITH_UNSUPPORTED_SCHEMA_VERSION": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "2",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            }
+        }
+    },
     "GRPC_AUTHZ_PRINCIPAL_WITH_MISSING_ROLES": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -73,6 +109,15 @@
     },
     "GRPC_AUTHZ_RULE_WITH_UNKNOWN_ROLE": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -91,7 +136,8 @@
                             "administrator"
                         ],
                         "rpc": "/gnmi.gNMI/Get",
-                        "effect": "deny"
+                        "effect": "deny",
+                        "priority": "100"
                     }
                 ]
             }
@@ -99,6 +145,15 @@
     },
     "GRPC_AUTHZ_RULE_WITH_INVALID_RPC": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -117,7 +172,53 @@
                             "reader"
                         ],
                         "rpc": "gnmi.gNMI.Get",
-                        "effect": "allow"
+                        "effect": "allow",
+                        "priority": "100"
+                    }
+                ]
+            }
+        }
+    },
+    "GRPC_AUTHZ_RULE_WITH_DUPLICATE_PRIORITY": {
+        "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
+                "GRPC_AUTHZ_PRINCIPAL_LIST": [
+                    {
+                        "name": "client.example.com",
+                        "roles": [
+                            "reader"
+                        ]
+                    }
+                ]
+            },
+            "sonic-grpc-authz:GRPC_AUTHZ_RULE": {
+                "GRPC_AUTHZ_RULE_LIST": [
+                    {
+                        "name": "allow-get",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Get",
+                        "effect": "allow",
+                        "priority": "100"
+                    },
+                    {
+                        "name": "deny-set",
+                        "roles": [
+                            "reader"
+                        ],
+                        "rpc": "/gnmi.gNMI/Set",
+                        "effect": "deny",
+                        "priority": "100"
                     }
                 ]
             }
@@ -125,6 +226,15 @@
     },
     "GRPC_AUTHZ_RULE_WITH_PATH_AND_NO_OPERATIONS": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -144,7 +254,8 @@
                         ],
                         "rpc": "/gnmi.gNMI/Get",
                         "path": "/interfaces",
-                        "effect": "allow"
+                        "effect": "allow",
+                        "priority": "100"
                     }
                 ]
             }
@@ -152,6 +263,15 @@
     },
     "GRPC_AUTHZ_RULE_WITH_OPERATIONS_AND_NO_PATH": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -173,7 +293,8 @@
                         "operations": [
                             "READ"
                         ],
-                        "effect": "allow"
+                        "effect": "allow",
+                        "priority": "100"
                     }
                 ]
             }
@@ -181,6 +302,15 @@
     },
     "GRPC_AUTHZ_RULE_WITH_UNKNOWN_FIELD": {
         "sonic-grpc-authz:sonic-grpc-authz": {
+            "sonic-grpc-authz:GRPC_AUTHZ_METADATA": {
+                "GRPC_AUTHZ_METADATA_LIST": [
+                    {
+                        "name": "GLOBAL",
+                        "schema_version": "1",
+                        "policy_version": "2026-08-18"
+                    }
+                ]
+            },
             "sonic-grpc-authz:GRPC_AUTHZ_PRINCIPAL": {
                 "GRPC_AUTHZ_PRINCIPAL_LIST": [
                     {
@@ -200,6 +330,7 @@
                         ],
                         "rpc": "/gnmi.gNMI/Get",
                         "effect": "allow",
+                        "priority": "100",
                         "unsupported": "value"
                     }
                 ]

--- a/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
@@ -28,45 +28,6 @@ module sonic-grpc-authz {
     }
 
     container sonic-grpc-authz {
-        must "count(GRPC_AUTHZ_METADATA/GRPC_AUTHZ_METADATA_LIST) = 1" {
-            error-message
-                "A gRPC authorization policy requires one metadata entry.";
-        }
-
-        container GRPC_AUTHZ_METADATA {
-            description
-                "Version metadata for the active authorization policy.";
-
-            list GRPC_AUTHZ_METADATA_LIST {
-                key "name";
-                max-elements 1;
-
-                leaf name {
-                    type string {
-                        pattern "GLOBAL";
-                    }
-                    description
-                        "Singleton metadata entry name.";
-                }
-
-                leaf schema_version {
-                    type uint32 {
-                        range "1";
-                    }
-                    mandatory true;
-                    description
-                        "Version of the CONFIG_DB authorization schema contract.";
-                }
-
-                leaf policy_version {
-                    type identifier;
-                    mandatory true;
-                    description
-                        "Version of the active authorization policy.";
-                }
-            }
-        }
-
         container GRPC_AUTHZ_PRINCIPAL {
             description
                 "Authenticated principals and their assigned roles.";
@@ -91,7 +52,7 @@ module sonic-grpc-authz {
 
         container GRPC_AUTHZ_RULE {
             description
-                "Method rules and optional resource rules shared by gRPC servers.";
+                "Method authorization rules shared by gRPC servers.";
 
             list GRPC_AUTHZ_RULE_LIST {
                 key "name";
@@ -121,27 +82,6 @@ module sonic-grpc-authz {
                         "Exact full gRPC method name in /package.Service/Method form.";
                 }
 
-                leaf path {
-                    type string {
-                        length 1..4096;
-                        pattern '/.*';
-                    }
-                    description
-                        "Optional resource path selector within the RPC.";
-                }
-
-                leaf-list operations {
-                    when "../path";
-                    type enumeration {
-                        enum READ;
-                        enum WRITE;
-                    }
-                    min-elements 1;
-                    max-elements 2;
-                    description
-                        "Resource operations controlled by a path rule.";
-                }
-
                 leaf effect {
                     type enumeration {
                         enum allow;
@@ -157,6 +97,85 @@ module sonic-grpc-authz {
                     mandatory true;
                     description
                         "Rule priority used by the policy consumer.";
+                }
+            }
+        }
+
+        container GNMI_PATHZ_RULE {
+            description
+                "Path authorization rules for gNMI resources.";
+
+            list GNMI_PATHZ_RULE_LIST {
+                key "name";
+
+                leaf name {
+                    type identifier;
+                    description
+                        "Stable Pathz rule identifier.";
+                }
+
+                choice subject {
+                    mandatory true;
+                    description
+                        "Principal or role to which this Pathz rule applies.";
+
+                    leaf principal {
+                        type leafref {
+                            path "/grpc-authz:sonic-grpc-authz/grpc-authz:GRPC_AUTHZ_PRINCIPAL/grpc-authz:GRPC_AUTHZ_PRINCIPAL_LIST/grpc-authz:name";
+                        }
+                        description
+                            "Authenticated principal to which this rule applies.";
+                    }
+
+                    leaf role {
+                        type leafref {
+                            path "/grpc-authz:sonic-grpc-authz/grpc-authz:GRPC_AUTHZ_PRINCIPAL/grpc-authz:GRPC_AUTHZ_PRINCIPAL_LIST/grpc-authz:roles";
+                        }
+                        description
+                            "Role to which this rule applies.";
+                    }
+                }
+
+                leaf target {
+                    type identifier;
+                    description
+                        "Optional gNMI target selector.";
+                }
+
+                leaf origin {
+                    type identifier;
+                    description
+                        "Optional gNMI origin selector.";
+                }
+
+                leaf path {
+                    type string {
+                        length 1..4096;
+                        pattern '/|(/[A-Za-z_][A-Za-z0-9_.:-]*(\[[A-Za-z_][A-Za-z0-9_.:-]*=[^\[\]=]+\])*)+';
+                    }
+                    mandatory true;
+                    description
+                        "Canonical gNMI resource path, including path-element keys.";
+                }
+
+                leaf mode {
+                    type enumeration {
+                        enum READ;
+                        enum WRITE;
+                    }
+                    mandatory true;
+                    description
+                        "gNMI resource access mode.";
+                }
+
+                leaf action {
+                    type enumeration {
+                        enum PERMIT;
+                        enum DENY;
+                    }
+                    mandatory true;
+                    description
+                        "Pathz result when this rule matches.";
                 }
             }
         }

--- a/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
@@ -1,0 +1,159 @@
+module sonic-grpc-authz {
+
+    yang-version 1.1;
+
+    namespace "http://github.com/sonic-net/sonic-grpc-authz";
+    prefix grpc-authz;
+
+    organization
+        "SONiC";
+
+    contact
+        "SONiC";
+
+    description
+        "Shared authorization policy registry for gRPC servers in SONiC.";
+
+    revision 2026-08-18 {
+        description
+            "Initial revision.";
+    }
+
+    typedef identifier {
+        type string {
+            length 1..255;
+        }
+        description
+            "Non-empty identifier in the authorization policy registry.";
+    }
+
+    container sonic-grpc-authz {
+
+        container GRPC_AUTHZ_METADATA {
+            description
+                "Version metadata for the active authorization policy.";
+
+            list GRPC_AUTHZ_METADATA_LIST {
+                key "name";
+                max-elements 1;
+
+                leaf name {
+                    type string {
+                        pattern "GLOBAL";
+                    }
+                    description
+                        "Singleton metadata entry name.";
+                }
+
+                leaf schema_version {
+                    type uint32 {
+                        range 1..max;
+                    }
+                    mandatory true;
+                    description
+                        "Version of the CONFIG_DB authorization schema contract.";
+                }
+
+                leaf policy_version {
+                    type identifier;
+                    mandatory true;
+                    description
+                        "Version of the active authorization policy.";
+                }
+            }
+        }
+
+        container GRPC_AUTHZ_PRINCIPAL {
+            description
+                "Authenticated principals and their assigned roles.";
+
+            list GRPC_AUTHZ_PRINCIPAL_LIST {
+                key "name";
+
+                leaf name {
+                    type identifier;
+                    description
+                        "Principal derived from authenticated transport identity.";
+                }
+
+                leaf-list roles {
+                    type identifier;
+                    min-elements 1;
+                    description
+                        "Authorization roles assigned to this principal.";
+                }
+            }
+        }
+
+        container GRPC_AUTHZ_RULE {
+            description
+                "Method rules and optional resource rules shared by gRPC servers.";
+
+            list GRPC_AUTHZ_RULE_LIST {
+                key "name";
+
+                leaf name {
+                    type identifier;
+                    description
+                        "Stable rule identifier.";
+                }
+
+                leaf-list roles {
+                    type leafref {
+                        path "/grpc-authz:sonic-grpc-authz/grpc-authz:GRPC_AUTHZ_PRINCIPAL/grpc-authz:GRPC_AUTHZ_PRINCIPAL_LIST/grpc-authz:roles";
+                    }
+                    min-elements 1;
+                    description
+                        "Roles to which this rule applies.";
+                }
+
+                leaf rpc {
+                    type string {
+                        pattern '/[A-Za-z_][A-Za-z0-9_.]*/[A-Za-z_][A-Za-z0-9_]*';
+                    }
+                    mandatory true;
+                    description
+                        "Exact full gRPC method name in /package.Service/Method form.";
+                }
+
+                leaf path {
+                    type string {
+                        length 1..4096;
+                        pattern '/.*';
+                    }
+                    description
+                        "Optional resource path selector within the RPC.";
+                }
+
+                leaf-list operations {
+                    when "../path";
+                    type enumeration {
+                        enum READ;
+                        enum WRITE;
+                    }
+                    min-elements 1;
+                    max-elements 2;
+                    description
+                        "Resource operations controlled by a path rule.";
+                }
+
+                leaf effect {
+                    type enumeration {
+                        enum allow;
+                        enum deny;
+                    }
+                    mandatory true;
+                    description
+                        "Authorization result when this rule matches.";
+                }
+
+                leaf priority {
+                    type uint32;
+                    default 0;
+                    description
+                        "Rule priority used by the policy consumer.";
+                }
+            }
+        }
+    }
+}

--- a/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
@@ -28,6 +28,10 @@ module sonic-grpc-authz {
     }
 
     container sonic-grpc-authz {
+        must "count(GRPC_AUTHZ_METADATA/GRPC_AUTHZ_METADATA_LIST) = 1" {
+            error-message
+                "A gRPC authorization policy requires one metadata entry.";
+        }
 
         container GRPC_AUTHZ_METADATA {
             description
@@ -47,7 +51,7 @@ module sonic-grpc-authz {
 
                 leaf schema_version {
                     type uint32 {
-                        range 1..max;
+                        range "1";
                     }
                     mandatory true;
                     description
@@ -91,6 +95,7 @@ module sonic-grpc-authz {
 
             list GRPC_AUTHZ_RULE_LIST {
                 key "name";
+                unique "priority";
 
                 leaf name {
                     type identifier;
@@ -109,7 +114,7 @@ module sonic-grpc-authz {
 
                 leaf rpc {
                     type string {
-                        pattern '/[A-Za-z_][A-Za-z0-9_.]*/[A-Za-z_][A-Za-z0-9_]*';
+                        pattern '/([A-Za-z_][A-Za-z0-9_]*\.)*[A-Za-z_][A-Za-z0-9_]*/[A-Za-z_][A-Za-z0-9_]*';
                     }
                     mandatory true;
                     description
@@ -149,7 +154,7 @@ module sonic-grpc-authz {
 
                 leaf priority {
                     type uint32;
-                    default 0;
+                    mandatory true;
                     description
                         "Rule priority used by the policy consumer.";
                 }

--- a/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
+++ b/src/sonic-yang-models/yang-models/sonic-grpc-authz.yang
@@ -52,11 +52,12 @@ module sonic-grpc-authz {
 
         container GRPC_AUTHZ_RULE {
             description
-                "Method authorization rules shared by gRPC servers.";
+                "Method authorization rules shared by gRPC servers. Consumers
+                 evaluate matching deny rules before allow rules and deny when
+                 no allow rule matches.";
 
             list GRPC_AUTHZ_RULE_LIST {
                 key "name";
-                unique "priority";
 
                 leaf name {
                     type identifier;
@@ -90,13 +91,6 @@ module sonic-grpc-authz {
                     mandatory true;
                     description
                         "Authorization result when this rule matches.";
-                }
-
-                leaf priority {
-                    type uint32;
-                    mandatory true;
-                    description
-                        "Rule priority used by the policy consumer.";
                 }
             }
         }


### PR DESCRIPTION
## Purpose

This change adds a CONFIG_DB schema for certificate principals, shared gRPC method authorization, and separate gNMI Pathz authorization.

The gNMI sidecar installs the packaged model in `/usr/local/yang-models` on the host.

## Changes

### Schema

- `GRPC_AUTHZ_PRINCIPAL` assigns roles to authenticated principals.
- `GRPC_AUTHZ_RULE` selects exact gRPC methods and defines allow or deny effects. Consumers apply deny rules first. Otherwise, consumers apply matching allow rules. Consumers deny access if no rule matches.
- `GNMI_PATHZ_RULE` selects one principal or role and a gNMI path. Each rule specifies a `READ` or `WRITE` mode. Each rule specifies a `PERMIT` or `DENY` action.
- Pathz target and origin selectors are optional.
- The model has no policy metadata table.

### Packaging and installation

- The `sonic-yang-models` wheel includes the model.
- `docker-gnmi-sidecar` atomically synchronizes the packaged model to `/usr/local/yang-models` on the host.

## Validation

- `pyang` and `yanglint` accepted the model.
- `yanglint` accepted the valid registry fixture and rejected 13 invalid fixtures.
- `cd dockers/docker-gnmi-sidecar/cli-plugin-tests && python3 -m pytest -q` reported `40 passed`.
- A local wheel build without build isolation included the model in `yang-models` and `cvlyang-models`.
- The libyang 3 integration validated and reverse-translated 201 sample CONFIG_DB tables across 147 models.
- The local validation did not include a full SONiC image build or on-device validation.

## Remaining design work

- Define how a policy publisher verifies schema compatibility before publication.
- Define the rollback order for policy data and schema removal.
- Confirm whether roles need independent declarations instead of principal-owned assignments.

## Tracking

Azure DevOps work item `39316091`