### PR TITLE
Fix audisp-tacplus: mask all password args in multi-wildcard PASSWD_CMDS

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -46,6 +46,10 @@ Cmnd_Alias      READ_ONLY_CMDS = /bin/cat /var/log/syslog, /bin/cat /var/log/sys
                                  /usr/local/bin/sfputil show *
 
 
+# PASSWD_CMDS: commands whose password arguments must not appear in audit logs.
+# Each pattern uses wildcards (*) for secret arguments; the pattern with the most
+# wildcards is 'replace * *' (2 subexpressions), so REGEX_MATCH_GROUP_COUNT=6
+# (1 full match + up to 5 subexpressions) is sufficient for all current patterns.
 Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
                               /usr/local/bin/config radius passkey *, \
                               /usr/local/bin/config snmp community add *, \

--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -809,6 +809,9 @@ index 0000000..536f17a
 +#endif
 +
 +#endif /* MOCK_H */
+diff --git a/unittest/mock_helper.c b/unittest/mock_helper.c
+new file mode 100644
+index 0000000..3fdf325
 --- /dev/null
 +++ b/unittest/mock_helper.c
 @@ -0,0 +1,68 @@
@@ -1168,6 +1171,9 @@ index 0000000..606ecc5
 +    // use failed UT count as return value
 +    return CU_get_number_of_failure_records();
 +}
+diff --git a/unittest/sudoers b/unittest/sudoers
+new file mode 100644
+index 0000000..3ce61a7
 --- /dev/null
 +++ b/unittest/sudoers
 @@ -0,0 +1,9 @@

--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -296,7 +296,7 @@ new file mode 100644
 index 0000000..1edea94
 --- /dev/null
 +++ b/regex_helper.c
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,96 @@
 +#include <ctype.h>
 +#include <stdarg.h>
 +#include <stdio.h>
@@ -318,8 +318,8 @@ index 0000000..1edea94
 +#define REGEX_WHITESPACES              "[[:space:]]*"
 +#define REGEX_TOKEN                   "\\([^[:space:]]*\\)"
 +
-+/* Regex match group count, 2 because only have 1 subexpression for password */
-+#define REGEX_MATCH_GROUP_COUNT      2
++/* Regex match group count: support up to 5 password subexpressions (e.g. 'replace * *') */
++#define REGEX_MATCH_GROUP_COUNT      6
 +
 +/* The password mask */
 +#define PASSWORD_MASK                   '*'
@@ -338,14 +338,18 @@ index 0000000..1edea94
 +        return PASSWORD_NOT_FOUND;
 +    }
 +
-+    /* Found password between pmatch[1].rm_so to pmatch[1].rm_eo, replace it. */
-+    trace("Found password between: %d -- %d\n", pmatch[1].rm_so, pmatch[1].rm_eo);
-+
-+    /* Replace password with mask. */
++    /* Mask all matched password subexpressions (handles patterns like 'replace * *'). */
 +    size_t command_length = strlen(command);
-+    int password_start_pos = min(pmatch[1].rm_so, command_length);
-+    int password_count = min(pmatch[1].rm_eo, command_length) - password_start_pos;
-+    memset(command + password_start_pos, PASSWORD_MASK, password_count);
++    int i;
++    for (i = 1; i < REGEX_MATCH_GROUP_COUNT; i++) {
++        if (pmatch[i].rm_so < 0) {
++            break;
++        }
++        trace("Found password between: %d -- %d\n", pmatch[i].rm_so, pmatch[i].rm_eo);
++        int password_start_pos = min(pmatch[i].rm_so, command_length);
++        int password_count = min(pmatch[i].rm_eo, command_length) - password_start_pos;
++        memset(command + password_start_pos, PASSWORD_MASK, password_count);
++    }
 +
 +    return PASSWORD_REMOVED;
 +}
@@ -389,10 +393,6 @@ index 0000000..1edea94
 +        src_idx++;
 +    }
 +}
-\ No newline at end of file
-diff --git a/regex_helper.h b/regex_helper.h
-new file mode 100644
-index 0000000..33c1916
 --- /dev/null
 +++ b/regex_helper.h
 @@ -0,0 +1,17 @@
@@ -782,7 +782,7 @@ new file mode 100644
 index 0000000..536f17a
 --- /dev/null
 +++ b/unittest/mock.h
-@@ -0,0 +1,17 @@
+@@ -0,0 +1,22 @@
 +#ifndef MOCK_H
 +#define MOCK_H
 +
@@ -796,13 +796,15 @@ index 0000000..536f17a
 +#define malloc  mock_malloc
 +#define realloc  mock_realloc
 +#define free    mock_free
++
++/* Stub out PAM/libtac dependencies for unit test builds */
++#define PAM_TAC_DEBUG 0x01
++/* Prevent libtac/support.h from being processed (it pulls in PAM headers) */
++#define PAM_TACPLUS_SUPPORT_H
 +#else
 +#endif
 +
 +#endif /* MOCK_H */
-diff --git a/unittest/mock_helper.c b/unittest/mock_helper.c
-new file mode 100644
-index 0000000..cd6433d
 --- /dev/null
 +++ b/unittest/mock_helper.c
 @@ -0,0 +1,68 @@
@@ -935,7 +937,7 @@ new file mode 100644
 index 0000000..606ecc5
 --- /dev/null
 +++ b/unittest/password_test.c
-@@ -0,0 +1,213 @@
+@@ -0,0 +1,226 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <string.h>
@@ -977,7 +979,7 @@ index 0000000..606ecc5
 +
 +    release_password_setting();
 +
-+    CU_ASSERT_EQUAL(loaded_regex_count, 6);
++    CU_ASSERT_EQUAL(loaded_regex_count, 8);
 +}
 +
 +/* Test convert setting string to regex string*/
@@ -1059,6 +1061,19 @@ index 0000000..606ecc5
 +
 +    debug_printf("Fixed command: %s\n", result_buffer);
 +    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/bin/sudo /usr/local/bin/config tacacs passkey **********");
++
++    /* snmp community replace: both secrets must be masked */
++    snprintf(result_buffer, sizeof(result_buffer), "%s", "/usr/local/bin/config snmp community replace oldsecret newsecret");
++    remove_password(result_buffer);
++
++    debug_printf("Fixed command: %s\n", result_buffer);
++    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/local/bin/config snmp community replace ********* *********");
++
++    snprintf(result_buffer, sizeof(result_buffer), "%s", "/usr/bin/sudo config snmp community replace oldsecret newsecret");
++    remove_password(result_buffer);
++
++    debug_printf("Fixed command: %s\n", result_buffer);
++    CU_ASSERT_STRING_EQUAL(result_buffer, "/usr/bin/sudo config snmp community replace ********* *********");
 +
 +    /* Regular command not change */
 +    snprintf(result_buffer, sizeof(result_buffer), "%s", "command no password");
@@ -1149,20 +1164,15 @@ index 0000000..606ecc5
 +    // use failed UT count as return value
 +    return CU_get_number_of_failure_records();
 +}
-diff --git a/unittest/sudoers b/unittest/sudoers
-new file mode 100644
-index 0000000..4e36873
 --- /dev/null
 +++ b/unittest/sudoers
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,9 @@
 +# test file for read user secret setting
 +
 +Cmnd_Alias      PASSWD_CMDS = /usr/local/bin/config tacacs passkey *, \
 +                              /usr/sbin/unfinished\
 +command * \, ,/usr/sbin/chpasswd *   , /usr/sbin/setpasswd *, \
++                              /usr/local/bin/config snmp community replace * *, \
 +                              /usr/bin/sudo config tacacs passkey *, \
-+                              /usr/bin/sudo /usr/local/bin/config tacacs passkey *
-\ No newline at end of file
--- 
-2.17.1.windows.2
-
++                              /usr/bin/sudo /usr/local/bin/config tacacs passkey *, \
++                              /usr/bin/sudo config snmp community replace * *

--- a/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
+++ b/src/tacacs/audisp/patches/0002-Remove-user-secret-from-accounting-log.patch
@@ -393,6 +393,10 @@ index 0000000..1edea94
 +        src_idx++;
 +    }
 +}
+\ No newline at end of file
+diff --git a/regex_helper.h b/regex_helper.h
+new file mode 100644
+index 0000000..33c1916
 --- /dev/null
 +++ b/regex_helper.h
 @@ -0,0 +1,17 @@


### PR DESCRIPTION
#### Why I did it

Fix a bug in audisp-tacplus where `snmp community replace <old> <new>` only masked the first secret argument in TACACS+ accounting records. The second argument was sent in plaintext.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

`regex_helper.c` built a BRE regex with one capture group per `*` wildcard in the sudoers `PASSWD_CMDS` pattern. For `replace * *`, this produces two capture groups, but `remove_password_by_regex()` only read `pmatch[1]` (the first group) and stopped, leaving the second argument unmasked.

Increased `REGEX_MATCH_GROUP_COUNT` from 2 to 6 and replaced the single-group mask with a loop that iterates over all matched capture groups, masking each one. Also added unit tests and test sudoers patterns to cover the two-argument case.

#### How to verify it

Unit tests in `src/tacacs/audisp/audisp-tacplus/unittest/` pass with the updated code. Run `make && ./password_test` in that directory; all 6 tests pass including the new `snmp community replace` cases.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: bug

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

master: unit tests 6/6 pass

#### Description for the changelog

Fix audisp-tacplus masking to cover all password arguments in multi-wildcard PASSWD_CMDS patterns.

#### Link to config_db schema for YANG module changes

N/A