### PR TITLE
[ci]: Align pipeline branches with 202605

### DIFF
--- a/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
+++ b/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
@@ -9,7 +9,7 @@ resources:
   - repository: sonic-mgmt
     type: github
     name: sonic-net/sonic-mgmt
-    ref: master
+    ref: 202605
     endpoint: sonic-net
   - repository: buildimage
     type: github

--- a/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
+++ b/.azure-pipelines/azure-pipelines-build-vs-and-test.yml
@@ -15,7 +15,7 @@ resources:
     type: github
     name: sonic-net/sonic-buildimage
     endpoint: sonic-net
-    ref: master
+    ref: 202605
 
 
 variables:
@@ -43,7 +43,7 @@ parameters:
 
   - name: MGMT_BRANCH
     type: string
-    default: 'master'
+    default: '$(BUILD_BRANCH)'
 
   - name: TOPOLOGY
     type: string

--- a/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
@@ -22,7 +22,7 @@ resources:
     type: github
     name: sonic-net/sonic-buildimage
     endpoint: sonic-net
-    ref: master
+    ref: 202605
 
 parameters:
   - name: BUILD_REASON

--- a/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
+++ b/.azure-pipelines/baseline_test/baseline.test.buildimage.yml
@@ -16,7 +16,7 @@ resources:
   - repository: sonic-mgmt
     type: github
     name: sonic-net/sonic-mgmt
-    ref: master
+    ref: 202605
     endpoint: sonic-net
   - repository: buildimage
     type: github

--- a/.azure-pipelines/official-build-vs-with-test.yml
+++ b/.azure-pipelines/official-build-vs-with-test.yml
@@ -33,7 +33,7 @@ resources:
     - repository: sonic-mgmt
       type: github
       name: sonic-net/sonic-mgmt
-      ref: master
+      ref: 202605
       endpoint: sonic-net
     - repository: buildimage
       type: github

--- a/.azure-pipelines/official-build-vs-with-test.yml
+++ b/.azure-pipelines/official-build-vs-with-test.yml
@@ -39,7 +39,7 @@ resources:
       type: github
       name: sonic-net/sonic-buildimage
       endpoint: sonic-net
-      ref: master
+      ref: 202605
 
 variables:
   - template: .azure-pipelines/azure-pipelines-repd-build-variables.yml@buildimage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ resources:
   - repository: sonic-mgmt
     type: github
     name: sonic-net/sonic-mgmt
-    ref: master
+    ref: 202605
     endpoint: sonic-net
   - repository: buildimage
     type: github

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ resources:
     type: github
     name: sonic-net/sonic-buildimage
     endpoint: sonic-net
-    ref: master
+    ref: 202605
 
 parameters:
 - name: TIMEOUT_IN_MINUTES_PR_TEST


### PR DESCRIPTION
#### Why I did it

The `202605` sonic-buildimage pipelines should compile their build and test definitions from the corresponding `202605` branches. Several pipeline entry points instead referenced `sonic-buildimage/master` and `sonic-mgmt/master`, allowing master-only pipeline behavior such as the new `t0-vpp` impacted-area job to appear in `202605` builds.

#### How I did it

Updated both the sonic-buildimage and sonic-mgmt repository resources from `master` to `202605` in the four affected pipeline entry points:

- `azure-pipelines.yml`
- `.azure-pipelines/azure-pipelines-build-vs-and-test.yml`
- `.azure-pipelines/official-build-vs-with-test.yml`
- `.azure-pipelines/baseline_test/baseline.test.buildimage.yml`

The Docker PTF and Docker sonic-mgmt pipeline entry points already referenced `sonic-mgmt/202605` and were left unchanged. The standalone VS-and-test pipeline now also defaults `MGMT_BRANCH` to its computed `BUILD_BRANCH` instead of `master`.

#### How to verify it

Statically verified that the affected pipeline entry points reference `202605` for both buildimage and sonic-mgmt resources, all six sonic-mgmt consumers resolve to `sonic-mgmt/202605`, and the standalone VS-and-test pipeline defaults `MGMT_BRANCH` to `BUILD_BRANCH`. `git diff --check` also passed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A

Failure type: Pipeline configuration regression

#### Tested branch

- [ ] master
- [ ] 202511
- [x] 202605
- [ ] N/A

#### Test result

202605: Build and test template resources were verified to reference `202605`, and runtime management branch selection was verified to follow `BUILD_BRANCH`.

#### Description for the changelog

N/A

#### Link to config_db schema for YANG module changes

N/A
