### PR TITLE
[docker-ptf]: Preserve virtualenv versions before removing pip

### DIFF
--- a/dockers/docker-ptf/Dockerfile.j2
+++ b/dockers/docker-ptf/Dockerfile.j2
@@ -463,9 +463,15 @@ RUN PYVER=$(python3 -c 'import sys; print("%d.%d" % sys.version_info[:2])') \
 RUN /root/env-python3/bin/python -c "import switch_sai_thrift.switch_sai_rpc"
 {% endif %}
 
-# pip is only needed to assemble the virtualenv. Remove it after the last
-# package installation to avoid shipping its vulnerable vendored dependencies.
-RUN rm -rf /root/env-python3/lib/python*/site-packages/pip \
+# Record the virtualenv before removing pip. post_run_buildinfo otherwise falls
+# back to the system pip and freezes its version instead of the build version.
+RUN ARCH=$(dpkg --print-architecture) \
+    && mkdir -p /usr/local/share/buildinfo/build-versions \
+    && /root/env-python3/bin/python -m pip freeze --all \
+        | grep -Ev "libsaibcm|libpaibcm|linuxptp|@ file://" \
+        | sort -u \
+        > "/usr/local/share/buildinfo/build-versions/versions-py3-${DISTRO}-${ARCH}" \
+    && rm -rf /root/env-python3/lib/python*/site-packages/pip \
         /root/env-python3/lib/python*/site-packages/pip-*.dist-info \
     && rm -f /root/env-python3/bin/pip*
 


### PR DESCRIPTION
#### Why I did it

The docker-ptf image removes pip from its virtualenv after package installation. The injected `post_run_buildinfo` step subsequently falls back to Debian's system pip, so generated version-update PRs record the system pip version (currently 25.1.1) instead of the virtualenv pip version used to assemble the image (26.2.1).

This is a follow-up to #28835, which routed virtualenv package installation through the SONiC version-control hook.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Snapshot the virtualenv with `python -m pip freeze --all` into the build hook's `build-versions` staging directory immediately before pip is removed. `post_run_buildinfo` copies this staged file over its fallback collection result, preserving the actual build-time package set while keeping pip out of the final image.

#### How to verify it

Run the docker-ptf version-update pipeline and confirm the generated `versions-py3` retains the virtualenv pip version instead of changing it to Debian's system pip version.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result

Static validation only; the docker-ptf pipeline is required to exercise build-info collection.

#### Description for the changelog

Preserve docker-ptf virtualenv versions before removing pip from the final image.

#### Link to config_db schema for YANG module changes

N/A
