### PR TITLE
marvell-prestera: P8.0.1 sai-1.18.1-11

### DIFF
--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 else
-MRVL_SAI_VERSION = 1.17.1-13
+MRVL_SAI_VERSION = 1.18.1-1
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/

--- a/platform/marvell-prestera/sai.mk
+++ b/platform/marvell-prestera/sai.mk
@@ -2,11 +2,11 @@
 
 BRANCH = master
 ifeq ($(CONFIGURED_ARCH),arm64)
-MRVL_SAI_VERSION = 1.18.1-1
+MRVL_SAI_VERSION = 1.18.1-11
 else ifeq ($(CONFIGURED_ARCH),armhf)
-MRVL_SAI_VERSION = 1.18.1-1
+MRVL_SAI_VERSION = 1.18.1-11
 else
-MRVL_SAI_VERSION = 1.18.1-1
+MRVL_SAI_VERSION = 1.18.1-11
 endif
 
 MRVL_SAI_URL_PREFIX = https://github.com/Marvell-switching/sonic-marvell-binaries/raw/master/$(CONFIGURED_ARCH)/sai-plugin/$(BRANCH)/


### PR DESCRIPTION
#### Why I did it
Update marvell-prestera SAI version from 1.18.1-1 onto 1.18.1-11

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update the version index in the
platform/marvell-prestera/sai.mk

#### How to verify it
Build marvell-prestera
Check
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb.log
sonic-buildimage/target/debs/bookworm/mrvllibsai_1.18.1-1*.deb-install.log

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

- [X] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [ ] 202608
- [ ] N/A

#### Test result

[202605] tested OK on top of the
63f17ae50 -  2026-07-14 14:02:29 -0700, Deepak Singhal : [frr]: Fix zebra NB RIB route lookup_next route_node lock under-run (#28260)

[master] tested OK on top


#### Description for the changelog

#### Link to config_db schema for YANG module changes

#### A picture of a cute animal (not mandatory but encouraged)
