### PR TITLE
[Arista] Update thermal policy for arista_7280dr3a[k|m]_36[s] SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/arista-platform.yaml
+++ b/device/arista/x86_64-arista_7280dr3a_36/arista-platform.yaml
@@ -1,0 +1,3 @@
+cooling_loop_interval: 5
+cooling_rpm_slope: 1.177
+cooling_rpm_offset: -17.67

--- a/device/arista/x86_64-arista_7280dr3a_36/thermal_policy.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/thermal_policy.json
@@ -1,1 +1,153 @@
-../x86_64-arista_common/thermal_policy.json
+{
+    "thermal_control_algorithm": {
+        "run_at_boot_up": "true",
+        "fan_speed_when_suspend": "100"
+    },
+    "info_types": [
+        {
+            "type": "control_info"
+        },
+        {
+            "type": "fan_info"
+        },
+        {
+            "type": "thermal_info"
+        }
+    ],
+    "policies": [
+        {
+            "name": "any thermal critical",
+            "conditions": [
+                {
+                    "type": "thermal.any.critical"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "100"
+                }
+            ]
+        },
+        {
+            "name": "any thermal overheat",
+            "conditions": [
+                {
+                    "type": "thermal.any.overheat"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "100"
+                }
+            ]
+        },
+        {
+            "name": "any fan fault",
+            "conditions": [
+                {
+                    "type": "fan.any.fault"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.all.set_speed",
+                    "speed": "100"
+                }
+            ]
+        },
+        {
+            "name": "normal operations",
+            "conditions": [
+                {
+                    "type": "normal"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "thermal_control.control",
+                    "version": 1,
+                    "profiles": {
+                        "default": {
+                            "thermals": {
+                                "CPU( board)?": {
+                                    "kp": 0,
+                                    "ki": 0,
+                                    "kd": 0,
+                                    "zone": "system_zone"
+                                },
+                                "JE\\d_C Diode": {
+                                    "kp": 0.1,
+                                    "ki": 0,
+                                    "kd": 11.031,
+                                    "zone": "system_zone"
+                                },
+                                "JE0 Front Side": {
+                                    "kp": 0.214,
+                                    "ki": 0.00059,
+                                    "kd": 19.39375,
+                                    "zone": "system_zone"
+                                },
+                                "(Air Inlet|Board Temp|Back-panel)": {
+                                    "kp": 0,
+                                    "ki": 0,
+                                    "kd": 0,
+                                    "zone": "system_zone"
+                                },
+                                "(Outlet|Management Card)": {
+                                    "kp": 0,
+                                    "ki": 0,
+                                    "kd": 0,
+                                    "zone": "system_zone"
+                                },
+                                "(PCB Temp Near Q3D|POS[013]V.+)": {
+                                    "kp": 0,
+                                    "ki": 0,
+                                    "kd": 0,
+                                    "zone": "system_zone"
+                                },
+                                "Ethernet.*": {
+                                    "kp": 0.033,
+                                    "ki": 0,
+                                    "kd": 6.11,
+                                    "zone": "system_zone"
+                                },
+                                "Power supply \\d+ inlet sensor": {
+                                    "kp": 0.0,
+                                    "ki": 0,
+                                    "kd": 0.0,
+                                    "zone": "psu_zone"
+                                },
+                                "Power supply \\d+ secondary hotspot sensor": {
+                                    "kp": 0.0,
+                                    "ki": 0,
+                                    "kd": 0.0,
+                                    "zone": "psu_zone"
+                                },
+                                "Power supply \\d+ primary hotspot sensor": {
+                                    "kp": 0.0,
+                                    "ki": 0,
+                                    "kd": 0.0,
+                                    "zone": "psu_zone"
+                                }
+                            },
+                            "fans": {
+                                "fan[1-4]": { "zone": "system_zone" },
+                                "psu\\d+/\\d+": { "zone": "system_zone" }
+                            },
+                            "zones": {
+                                "system_zone": {
+                                    "logic": "classicpid"
+                                },
+                                "psu_zone": {
+                                    "logic": "classicpid"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/device/arista/x86_64-arista_7280dr3ak_36/arista-platform.yaml
+++ b/device/arista/x86_64-arista_7280dr3ak_36/arista-platform.yaml
@@ -1,0 +1,1 @@
+./../x86_64-arista_7280dr3a_36/arista-platform.yaml

--- a/device/arista/x86_64-arista_7280dr3ak_36/thermal_policy.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_7280dr3a_36/thermal_policy.json

--- a/device/arista/x86_64-arista_7280dr3ak_36s/arista-platform.yaml
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/arista-platform.yaml
@@ -1,0 +1,1 @@
+./../x86_64-arista_7280dr3a_36/arista-platform.yaml

--- a/device/arista/x86_64-arista_7280dr3ak_36s/thermal_policy.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_7280dr3a_36/thermal_policy.json

--- a/device/arista/x86_64-arista_7280dr3am_36/arista-platform.yaml
+++ b/device/arista/x86_64-arista_7280dr3am_36/arista-platform.yaml
@@ -1,0 +1,1 @@
+./../x86_64-arista_7280dr3a_36/arista-platform.yaml

--- a/device/arista/x86_64-arista_7280dr3am_36/thermal_policy.json
+++ b/device/arista/x86_64-arista_7280dr3am_36/thermal_policy.json
@@ -1,1 +1,1 @@
-../x86_64-arista_common/thermal_policy.json
+../x86_64-arista_7280dr3a_36/thermal_policy.json


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This PR adds a new thermal policy with per sensor PID values
for better cooling performance on arista_7280dr3a[k|m]_36[s] SKUs

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Modify files in the SKU folder for the related platform

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

202511: Sanitization passes on internal builds
202605: Sanitization passes on internal builds

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->


<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->


<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->


