### PR TITLE
Ship /etc/resolv.conf as a regular file for installer compatibility

### DIFF
--- a/build_debian.sh
+++ b/build_debian.sh
@@ -915,7 +915,17 @@ sudo mkdir -p $FILESYSTEM_ROOT/var/lib/docker
 
 ## Clear DNS configuration inherited from the build server
 sudo rm -f $FILESYSTEM_ROOT/etc/resolvconf/resolv.conf.d/original
+sudo rm -f $FILESYSTEM_ROOT/run/resolvconf/resolv.conf
 sudo cp files/image_config/resolv-config/resolv.conf.head $FILESYSTEM_ROOT/etc/resolvconf/resolv.conf.d/head
+
+## sonic-installer package migration runs the deployed image's installer
+## against this rootfs, and a symlinked /etc/resolv.conf breaks one installer
+## generation or another (absolute targets alias the host's own resolv.conf,
+## relative targets escape the image mount). Ship a regular file, which
+## every generation handles; resolv-symlink.conf restores the symlink at boot.
+sudo rm -f $FILESYSTEM_ROOT/etc/resolv.conf
+sudo touch $FILESYSTEM_ROOT/etc/resolv.conf
+sudo cp files/image_config/resolv-config/resolv-symlink.conf $FILESYSTEM_ROOT/usr/lib/tmpfiles.d/
 
 ## Optimize filesystem size
 if [ "$BUILD_REDUCE_IMAGE_SIZE" = "y" ]; then

--- a/files/image_config/resolv-config/resolv-symlink.conf
+++ b/files/image_config/resolv-config/resolv-symlink.conf
@@ -1,0 +1,5 @@
+# /etc/resolv.conf is shipped as a regular file so that every
+# sonic-installer generation can inject DNS into it during package
+# migration. Restore the resolvconf-managed symlink early each boot,
+# before docker or networking can propagate stale content.
+L+ /etc/resolv.conf - - - - /run/resolvconf/resolv.conf


### PR DESCRIPTION
#### Why I did it

`sonic-installer install` runs the **currently-installed image's** installer against the new image's rootfs during package migration, and different installer generations disagree about how to handle a **symlinked** `/etc/resolv.conf` in that rootfs. The generation boundaries are two sonic-utilities PRs: sonic-net/sonic-utilities#4365 made the migration copy symlink-aware, and sonic-net/sonic-utilities#4732 added target normalization on top of it.

Because the two older generations fail in opposite ways, no single symlink spelling satisfies both at once — only a regular file, which has nothing to resolve, works for every generation. This is what was actually exercised, upgrading from each source branch's image into a target image built with the change:

| source branch (installer generation) | → regular file (this PR) | → relative symlink (previous default) | → absolute symlink |
|---|---|---|---|
| 202311 / 202411 / 202505 (pre-[#4365](https://github.com/sonic-net/sonic-utilities/pull/4365)) | PASS | PASS | **FAIL** — `cp: '/etc/resolv.conf' and '.../etc/resolv.conf' are the same file`; install aborts |
| 202511 ([#4365](https://github.com/sonic-net/sonic-utilities/pull/4365)) | PASS | **FAIL** — the literal target joined below the image mount escapes it; migration silently falls back to a stale resolver | PASS |
| 202605 (#4732) | PASS | PASS | PASS |

Measured upgrade paths: 202311 → 202605, 202411 → 202605, 202505 → 202605, 202511 → 202605, 202605 → 202605 (self-upgrade), and downgrades 202605 → 202511 and 202605 → 202505. Every path into a regular-file target passed; the relative- and absolute-symlink columns show the two pre-existing, mutually-exclusive failure modes this PR removes.

A regular file was avoided previously because resolvconf's `update.d/libc` notify gate only propagates DNS updates into containers once `/etc/resolv.conf` is the resolvconf-managed symlink (sonic-net/sonic-buildimage#25991) — but that only constrains the *runtime* shape, not what the squashfs ships. Restoring the symlink at boot, before it's needed, satisfies both requirements at once.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- `build_debian.sh`: ship `/etc/resolv.conf` as an empty regular file, install the tmpfiles.d rule described below, and drop the build server's `/run/resolvconf/resolv.conf` snapshot — it's shadowed by tmpfs at runtime, but older installer generations' migration step reads it while it's still reachable through the pre-fix symlink, which made migration success depend on the *build server's* DNS rather than the target device's.
- New `files/image_config/resolv-config/resolv-symlink.conf`: a systemd-tmpfiles `L+` rule (`L+ /etc/resolv.conf - - - - /run/resolvconf/resolv.conf`) that restores the resolvconf-managed symlink during `sysinit.target`, before `docker.service` or networking start. This is the same link `resolv-config.sh` already creates later, at `sonic.target` — just early enough that containers never see the placeholder file.

The read-write overlay persists the restored symlink after first boot, so the regular file only exists inside the squashfs, where the installer reads it — a running system never sees it.

#### How to verify it

1. Build the image and inspect its contents: `/etc/resolv.conf` is a regular file, `/run/resolvconf/resolv.conf` is absent, and `resolv-symlink.conf` is present under `/usr/lib/tmpfiles.d/`.
2. Boot the image and confirm `/etc/resolv.conf` is now a symlink to `/run/resolvconf/resolv.conf`, `systemd-tmpfiles-setup.service` completed before `docker.service` started, and every running container has a populated `/etc/resolv.conf`.
3. Install this image over a system running a release predating sonic-net/sonic-utilities#4365, with package migration enabled, and confirm migration no longer aborts with `cp: ... are the same file`.
4. Install this image over a system running a sonic-net/sonic-utilities#4365-era release, and confirm the migrated `/etc/resolv.conf` content is no longer silently dropped.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] 202311
- [x] 202411
- [x] 202505
- [x] 202511
- [x] 202605

#### Test result

Package-migration upgrade paths validated: 202311 → 202605, 202411 → 202605, 202505 → 202605, 202511 → 202605, 202605 → 202605, and downgrades 202605 → 202511 and 202605 → 202505. All completed without the `cp: ... are the same file` abort and without the migrated `/etc/resolv.conf` content being silently dropped; see the table above for the corresponding pass/fail-by-shape breakdown.

#### Description for the changelog

Ship `/etc/resolv.conf` as a regular file so `sonic-installer` package migration works across all installer generations; restore the resolvconf-managed symlink at boot via `systemd-tmpfiles`.

#### Link to config_db schema for YANG module changes

N/A
