### PR TITLE
[dhcp_relay] Forbid VSS selection with forward mode

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/test_dhcpv4_relay.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/test_dhcpv4_relay.py
@@ -526,6 +526,62 @@ class TestConfigDhcpv4Relay(object):
 
         db.cfgdb.set_entry.reset_mock()
 
+    def test_config_dhcpv4_relay_rejects_vrf_selection_with_forward_mode(self, mock_cfgdb):
+        runner = CliRunner()
+        db = Db()
+        db.cfgdb = mock_cfgdb
+        expected_error = (
+            "agent-relay-mode forward cannot be used when vrf-selection is enabled"
+        )
+
+        with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+            result = runner.invoke(
+                dhcp_relay.dhcpv4_relay.commands["add"],
+                [
+                    "--dhcpv4-servers", "3.3.3.3",
+                    "--vrf-selection", "enable",
+                    "--agent-relay-mode", "forward",
+                    "Vlan200"
+                ],
+                obj=db
+            )
+            assert result.exit_code != 0
+            assert expected_error in result.output
+            assert mock_run_command.call_count == 0
+            assert mock_cfgdb.set_entry.call_count == 0
+
+        update_cases = [
+            (
+                {
+                    "dhcpv4_servers": ["3.3.3.3"],
+                    "vrf_selection": "enable"
+                },
+                ["--agent-relay-mode", "forward", "Vlan200"]
+            ),
+            (
+                {
+                    "dhcpv4_servers": ["3.3.3.3"],
+                    "agent_relay_mode": "forward"
+                },
+                ["--vrf-selection", "enable", "Vlan200"]
+            )
+        ]
+
+        for existing_entry, arguments in update_cases:
+            mock_cfgdb.set_entry("DHCPV4_RELAY", "Vlan200", existing_entry)
+            mock_cfgdb.set_entry.reset_mock()
+
+            with mock.patch("utilities_common.cli.run_command") as mock_run_command:
+                result = runner.invoke(
+                    dhcp_relay.dhcpv4_relay.commands["update"],
+                    arguments,
+                    obj=db
+                )
+                assert result.exit_code != 0
+                assert expected_error in result.output
+                assert mock_run_command.call_count == 0
+                assert mock_cfgdb.set_entry.call_count == 0
+
     def test_config_dhcpv4_relay_max_hop_count(self, mock_cfgdb):
         """Validating Max Hop Count in DHCPv4 Relay Config"""
         runner = CliRunner()

--- a/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
+++ b/dockers/docker-dhcp-relay/cli/config/plugins/dhcp_relay.py
@@ -190,6 +190,13 @@ def validate_vlan_exists(db, vlan_name):
         return True
     return False
 
+def validate_vrf_selection_agent_relay_mode(relay_entry):
+    if (relay_entry.get("vrf_selection") == "enable" and
+            relay_entry.get("agent_relay_mode") == "forward"):
+        click.get_current_context().fail(
+            "agent-relay-mode forward cannot be used when vrf-selection is enabled"
+        )
+
 def validate_source_interface(vlan_name, source_interface, db):
     config_db = db.cfgdb
     ctx = click.get_current_context()
@@ -302,6 +309,8 @@ def update_dhcpv4_relay(db, vlan_name, dhcpv4_servers, source_interface, link_se
         updated_entry["max_hop_count"] = max_hop_count
         updated_fields.append(f"Max Hop Count as {max_hop_count}")
 
+    validate_vrf_selection_agent_relay_mode(updated_entry)
+
     # Apply updated entry to the database
     config_db.set_entry(DHCPV4_RELAY_TABLE, vlan_name, updated_entry)
 
@@ -380,6 +389,8 @@ def add_dhcpv4_relay(db, dhcpv4_servers, vlan_name, source_interface, link_selec
             ctx.fail("max-hop-count must be between 1 to 16")
         relay_entry["max_hop_count"] = max_hop_count
         added_fields.append(f"Max Hop Count as {max_hop_count}")
+
+    validate_vrf_selection_agent_relay_mode(relay_entry)
 
     config_db.set_entry(DHCPV4_RELAY_TABLE, vlan_name, relay_entry)
     click.echo(f"Added {', '.join(added_fields)} to {vlan_name}")

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/dhcpv4_relay.json
@@ -23,6 +23,12 @@
     "DHCPv4_RELAY_WITH_AGENT_RELAY_MODE_FORWARD": {
         "desc": "Add dhcpv4 relay with agent_relay_mode set to forward."
     },
+    "DHCPv4_RELAY_WITH_VRF_SELECTION_AND_FORWARD_MODE": {
+        "desc": "Reject dhcpv4 relay with VRF selection and forward mode.",
+        "eStr": [
+            "agent-relay-mode forward cannot be used when vrf-selection is enabled"
+        ]
+    },
     "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
         "desc": "Add dhcpv4 relay with valid max_hop_cnt."
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/dhcpv4_relay.json
@@ -150,6 +150,22 @@
             }
         }
     },
+    "DHCPv4_RELAY_WITH_VRF_SELECTION_AND_FORWARD_MODE": {
+        "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
+            "sonic-dhcpv4-relay:DHCPV4_RELAY": {
+                "DHCPV4_RELAY_LIST": [
+                    {
+                        "name": "Vlan777",
+                        "dhcpv4_servers": [
+                            "192.168.20.100"
+                        ],
+                        "vrf_selection": "enable",
+                        "agent_relay_mode": "forward"
+                    }
+                ]
+            }
+        }
+    },
     "DHCPv4_RELAY_WITH_VALID_MAX_HOP_CNT": {
         "sonic-dhcpv4-relay:sonic-dhcpv4-relay": {
             "sonic-dhcpv4-relay:DHCPV4_RELAY": {

--- a/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
+++ b/src/sonic-yang-models/yang-models/sonic-dhcpv4-relay.yang
@@ -43,6 +43,13 @@ module sonic-dhcpv4-relay {
             list DHCPV4_RELAY_LIST {
                 key "name";
 
+                must "not(vrf_selection = 'enable' and agent_relay_mode = 'forward')" {
+                    error-message "agent-relay-mode forward cannot be used when vrf-selection is enabled";
+                    description
+                        "VRF selection requires this relay to add local VSS information,
+                         while forward mode preserves the upstream relay information unchanged";
+                }
+
                 leaf name {
                     description "VLAN ID";
                     type union {


### PR DESCRIPTION
### Description of PR

Summary:

Reject DHCPv4 relay configuration that enables local VRF/VSS selection while
using `agent_relay_mode=forward`.

Completed Xichen review version: `v1.1`, reviewed head
`f6e35bf957e97a15a934121db82591178679211c`.
Current published head: `fcfb2168b158aa5dc8fe0054985c4edbb156497b`,
the patch-identical one-commit form of v1.1.

### Type of change

- [x] Bug fix

### Approach

#### What is the motivation for this PR?

`vrf_selection=enable` makes the local relay responsible for adding RFC 6607
VSS information when the client and server address spaces differ.
`agent_relay_mode=forward` has the opposite contract: a chained request is
forwarded unchanged with the upstream relay's Option 82.

Allowing both settings leaves reply validation unable to distinguish an
upstream relay transaction from a server that ignored or omitted the locally
required VSS. The incompatible configuration must therefore be rejected
instead of relying on stateless reply-side inference.

#### How did you do it?

- Add a YANG `must` constraint rejecting
  `vrf_selection=enable` with `agent_relay_mode=forward`.
- Apply the same validation in the DHCPv4 relay CLI before ConfigDB writes.
- Validate both CLI creation and either update direction.
- Preserve forward mode when VRF selection is disabled and preserve all other
  relay modes when VRF selection is enabled.

This is the configuration prerequisite for
[sonic-dhcp-relay #122](https://github.com/sonic-net/sonic-dhcp-relay/pull/122).
The separate request-side prerequisite,
[sonic-dhcp-relay #146](https://github.com/sonic-net/sonic-dhcp-relay/pull/146),
drops a VSS-required request when its Option 82 VSS information cannot fit.

#### How did you verify/test it?

Focused coverage verifies:

- YANG rejects the incompatible combination;
- CLI add rejects the combination without writing ConfigDB;
- CLI update rejects enabling forward mode on a VSS configuration;
- CLI update rejects enabling VSS on a forward-mode configuration.

Initial Azure build 1197419 proved that the new constraint fired, but the
negative test still expected libyang's generic `must` text instead of the
model's explicit error message. v1.1 corrects that test expectation.
[Azure build 1197468](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1197468)
passed every platform image build and required static check. Its t0 and t2
failures matched documented active flakes. On the patch-identical final head,
[Azure build 1198074](https://dev.azure.com/mssonic/be1b070f-be15-4154-aade-b1d3bfb17054/_build/results?buildId=1198074)
passes all nine platform and virtual-switch image builds, all ten impacted KVM
lanes, and every required static check. The t2 flake passed on its targeted
retry; the t0-vpp packet-count flake repeated once and then passed on the next
targeted retry. All 30 current-head checks are green. Fresh exact-head Copilot
review is clean, there are no review threads, and ordinary discussion contains
no unresolved question.

Validation uses public PR CI only; no local SONiC build was run.

### Backport

Not requested.

##### Work item tracking

- Microsoft ADO (number only): 39058189
