### PR TITLE
[slave.mk]: Fix post-build hook conditional

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1983,7 +1983,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 
 	# Provide a hook that modules may use for post-build activities
 	$(if $($*_POST_BUILD_HOOK), \
-		$($*_POST_BUILD_HOOK) $(LOG) || echo WARNING: Hook for module $* failed, continuing ... \
+		$($*_POST_BUILD_HOOK) $(LOG) || echo WARNING: Hook for module $* failed - continuing ... \
 	)
 
 	chmod a+x $@


### PR DESCRIPTION
#### Why I did it

Image builds without a post-build hook fail with `/bin/bash: continuing: command not found`. The comma in the GNU Make `if` expression is parsed as the separator before its else argument, causing `continuing ...` to be emitted as a shell command.
```
[ building ] [ target/sonic-broadcom.bin ] 
/bin/bash: line 1244: continuing: command not found
make: *** [slave.mk:1705: target/sonic-broadcom.bin] Error 127
make[1]: *** [Makefile.work:721: target/sonic-broadcom.bin] Error 2
```
##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Replaced the comma in the hook failure message with a hyphen so GNU Make keeps the entire command in the true branch of the conditional.

#### How to verify it

Build an image target without a post-build hook, such as `target/sonic-broadcom.bin`, and confirm the recipe no longer attempts to execute a `continuing` command.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: regression

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Validated GNU Make expansion for both an empty hook and a failing configured hook.

#### Description for the changelog

Fix image builds failing with an unintended `continuing` shell command.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)