### PR TITLE
[docker-dash-engine]: Remove vulnerable python3-pip package

### DIFF
--- a/platform/vs/docker-dash-engine/Dockerfile.j2
+++ b/platform/vs/docker-dash-engine/Dockerfile.j2
@@ -13,7 +13,8 @@ RUN sed -i 's|http://.*.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/s
 RUN apt-get update
 
 RUN apt-get install -f -y net-tools supervisor rsyslog  python3-pip
-RUN pip3 install --break-system-packages supervisord-dependent-startup || pip3 install supervisord-dependent-startup
+RUN pip3 install --break-system-packages supervisord-dependent-startup
+RUN apt-get purge -y python3-pip && rm -rf /var/lib/apt/lists/*
 
 COPY ["start.sh", "/usr/bin/"]
 


### PR DESCRIPTION
#### Why I did it

A vulnerability scan of `docker-dash-engine` reports `python3-pip` version `24.0+dfsg-1ubuntu1.3`, with `24.0+dfsg-1ubuntu1.3+esm1` required by [Ubuntu security advisory USN-8344-1](https://ubuntu.com/security/notices/USN-8344-1).

`python3-pip` is only required while installing `supervisord-dependent-startup`; it does not need to remain in the final container image. The fixed `esm1` package is only available in ubuntu pro.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Kept the supported `pip3 install --break-system-packages` invocation, then purged `python3-pip` and removed the apt package lists after the Python package installation completes.

#### How to verify it

Rebuild `docker-dash-engine`, confirm `supervisord-dependent-startup` remains installed and functional, and rescan the image to verify that the vulnerable `python3-pip` package is absent.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result

N/A

#### Description for the changelog

Remove the vulnerable build-time `python3-pip` package from the `docker-dash-engine` image.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)