### PR TITLE
[pensando]: Upgrade syncd container to Debian Trixie

### DIFF
--- a/platform/pensando/docker-syncd-pensando.mk
+++ b/platform/pensando/docker-syncd-pensando.mk
@@ -1,7 +1,7 @@
 # docker image for centec syncd
 
 DOCKER_SYNCD_PLATFORM_CODE = pensando
-include $(PLATFORM_PATH)/../template/docker-syncd-bookworm.mk
+include $(PLATFORM_PATH)/../template/docker-syncd-trixie.mk
 
 $(DOCKER_SYNCD_BASE)_DEPENDS += $(SYNCD)
 

--- a/platform/pensando/docker-syncd-pensando/Dockerfile.j2
+++ b/platform/pensando/docker-syncd-pensando/Dockerfile.j2
@@ -1,4 +1,4 @@
-FROM docker-config-engine-bookworm-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
+FROM docker-config-engine-trixie-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
 ARG docker_container_name
 


### PR DESCRIPTION
#### Why I did it

Migrate the Pensando `syncd` container from Debian Bookworm to Debian Trixie so it uses the current Trixie-based SONiC container stack.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Updated the Pensando syncd build rule to use `docker-syncd-trixie.mk` and changed its Dockerfile base image from `docker-config-engine-bookworm` to `docker-config-engine-trixie`.

#### How to verify it

Configure a Pensando build and build `target/docker-syncd-pensando.gz`. Confirm the image uses the Trixie config-engine base and starts the syncd service successfully.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

#### Test result

N/A

#### Description for the changelog

Upgrade the Pensando syncd container from Debian Bookworm to Debian Trixie.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)