### PR TITLE
[build]: Support an optional overlay for constants.yml

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -814,7 +814,19 @@ sudo chmod 755 $FILESYSTEM_ROOT/usr/bin/rps.py
 sudo cp $IMAGE_CONFIGS/snmp/snmp.yml $FILESYSTEM_ROOT/etc/sonic/
 
 # Copy ASN configuration files
-j2 files/build_templates/constants.yml.j2 | sudo tee $FILESYSTEM_ROOT/etc/sonic/constants.yml > /dev/null
+# Render constants.yml, applying an optional organization/downstream overlay when
+# present. The overlay carries only its deltas and is deep-merged on top of the
+# base template, so downstreams need not fork the whole file. Without an overlay
+# this is equivalent to rendering the base template directly.
+j2 files/build_templates/constants.yml.j2 > /tmp/constants.yml
+if [ -f files/build_templates/constants.yml.overlay.j2 ]; then
+    j2 files/build_templates/constants.yml.overlay.j2 > /tmp/constants.overlay.yml
+    scripts/deep_merge_yaml.py /tmp/constants.yml /tmp/constants.overlay.yml > /tmp/constants.merged.yml
+    mv /tmp/constants.merged.yml /tmp/constants.yml
+    rm -f /tmp/constants.overlay.yml
+fi
+sudo tee $FILESYSTEM_ROOT/etc/sonic/constants.yml < /tmp/constants.yml > /dev/null
+rm -f /tmp/constants.yml
 
 # Copy BMC network configuration file to share templates
 sudo cp $IMAGE_CONFIGS/constants/bmc.json $FILESYSTEM_ROOT_USR_SHARE_SONIC_TEMPLATES/

--- a/scripts/deep_merge_yaml.py
+++ b/scripts/deep_merge_yaml.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Deep-merge YAML documents and emit the result on stdout.
+
+Usage: deep_merge_yaml.py BASE.yml OVERLAY.yml [OVERLAY2.yml ...]
+
+Merge semantics (each overlay applied in order on top of the accumulated result):
+  * mappings are merged recursively;
+  * a null overlay value deletes the corresponding key;
+  * any other value (scalar or list) replaces the base value.
+
+This lets a downstream/organization overlay carry only its deltas on top of an
+upstream base file, instead of forking the whole file.
+"""
+import sys
+import yaml
+
+
+def deep_merge(base, overlay):
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        return overlay
+    result = dict(base)
+    for key, value in overlay.items():
+        if value is None:
+            result.pop(key, None)
+        elif isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def main(argv):
+    if len(argv) < 3:
+        sys.stderr.write(__doc__)
+        return 2
+    with open(argv[1]) as stream:
+        merged = yaml.safe_load(stream)
+    for path in argv[2:]:
+        with open(path) as stream:
+            merged = deep_merge(merged, yaml.safe_load(stream))
+    yaml.safe_dump(merged, sys.stdout, default_flow_style=False, sort_keys=False)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/src/sonic-bgpcfgd/tests/util.py
+++ b/src/sonic-bgpcfgd/tests/util.py
@@ -9,20 +9,55 @@ from jinja2 import Template
 # the real constants without depending on a separate static copy.
 CONSTANTS_TEMPLATE_PATH = os.path.abspath(
     '../../files/build_templates/constants.yml.j2')
+# Optional organization overlay deep-merged on top of the base at image build
+# time (see files/build_templates/sonic_debian_extension.j2). Apply the same
+# merge here so the tests validate the constants that ship in the real image.
+CONSTANTS_OVERLAY_TEMPLATE_PATH = os.path.abspath(
+    '../../files/build_templates/constants.yml.overlay.j2')
 
 
-def render_constants(template_path=CONSTANTS_TEMPLATE_PATH):
+def _deep_merge(base, overlay):
+    """Deep-merge overlay onto base, matching scripts/deep_merge_yaml.py.
+
+    Mappings merge recursively; a null overlay value deletes the key; any other
+    value (scalar or list) replaces the base value.
+    """
+    if not isinstance(base, dict) or not isinstance(overlay, dict):
+        return overlay
+    result = dict(base)
+    for key, value in overlay.items():
+        if value is None:
+            result.pop(key, None)
+        elif isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _render_template(template_path):
+    with open(template_path) as f:
+        return Template(f.read()).render(
+            ENABLE_FRR_SNMP_AGENT=os.environ.get('ENABLE_FRR_SNMP_AGENT', 'y'))
+
+
+def render_constants(template_path=CONSTANTS_TEMPLATE_PATH,
+                     overlay_path=CONSTANTS_OVERLAY_TEMPLATE_PATH):
     """Render constants.yml.j2 into a temp file and return its path.
 
     The template only references ENABLE_FRR_SNMP_AGENT (defaults to 'y', the
-    same default as rules/config); everything else is static YAML.
+    same default as rules/config); everything else is static YAML. When the
+    optional organization overlay is present it is deep-merged on top of the
+    base, mirroring the image build, so the tests see the shipped constants.
     """
-    with open(template_path) as f:
-        rendered = Template(f.read()).render(
-            ENABLE_FRR_SNMP_AGENT=os.environ.get('ENABLE_FRR_SNMP_AGENT', 'y'))
+    data = yaml.safe_load(_render_template(template_path))
+    if overlay_path and os.path.isfile(overlay_path):
+        overlay = yaml.safe_load(_render_template(overlay_path))
+        if overlay is not None:
+            data = _deep_merge(data, overlay)
     fd, path = tempfile.mkstemp(prefix='constants', suffix='.yml')
     with os.fdopen(fd, 'w') as f:
-        f.write(rendered)
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
     return path
 
 


### PR DESCRIPTION
#### Why I did it

`files/build_templates/constants.yml.j2` is a natural point of divergence for
downstreams/organizations. Today the only way to change these is to
fork the whole template, which produces recurring merge conflicts against upstream
every time this file changes.

This adds an optional overlay so a downstream can carry only its **deltas** and keep
the shared base template identical to upstream.

#### How I did it

- Render `constants.yml.j2` as before, but if an optional
  `files/build_templates/constants.yml.overlay.j2` exists, deep-merge it on top of
  the rendered base before installing `/etc/sonic/constants.yml`.
- Add a small generic `scripts/deep_merge_yaml.py` helper. Merge semantics:
  - mappings are merged recursively;
  - a `null` overlay value deletes the corresponding key (so an overlay can also
    remove/rename upstream keys);
  - any other value (scalar or list) replaces the base value.

When no overlay file is present, behavior is unchanged: the base template is
rendered and installed directly.

#### How to verify it

- Default (no overlay): `/etc/sonic/constants.yml` is byte-for-byte the rendered
  base template (verified: passthrough is identical).
- With an overlay present: the installed file equals the base deep-merged with the
  overlay. `scripts/deep_merge_yaml.py base.yml overlay.yml` can be run standalone to
  inspect the result.

#### Description for the changelog

Support an optional `constants.yml.overlay.j2` that is deep-merged onto the rendered
`constants.yml`, so downstreams can carry only their deltas instead of forking the file.
