### PR TITLE
Fix the error message in post-build hook

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1983,7 +1983,7 @@ $(addprefix $(TARGET_PATH)/, $(SONIC_INSTALLERS)) : $(TARGET_PATH)/% : \
 
 	# Provide a hook that modules may use for post-build activities
 	$(if $($*_POST_BUILD_HOOK), \
-		$($*_POST_BUILD_HOOK) $(LOG) || echo WARNING: Hook for module $* failed, continuing ... \
+		$($*_POST_BUILD_HOOK) $(LOG) || echo WARNING: Hook for module $* failed \
 	)
 
 	chmod a+x $@


### PR DESCRIPTION
#### Why I did it

Fix the issue https://github.com/sonic-net/sonic-buildimage/issues/29119 that was caused by the changes in https://github.com/sonic-net/sonic-buildimage/pull/29038

The comma in the echo statement caused the rest of the message to be interpreted as a command in the case of a failure.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Trimmed the log to remove the comma and some text

#### How to verify it

1. Went through the logs of nvidia and vs in the pipebuild build of this PR and confirmed that the error message is no longer present
2. Downloaded the Alpine artifact from this PR and ran sanity on it.

```
root@sonic:/home/admin# show ver

SONiC Software Version: SONiC.master-29123.1198073-0bf142b48
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 0bf142b48
Build date: Thu Aug 20 13:20:33 UTC 2026
Built by: azureuser@bf0157c7c000002

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs

```

#### Description for the changelog

Fix the error log that is printed when the hook returns an error