### PR TITLE
[bgpcfgd]: Fix FRR daemon poll log level and Python 3.13 SyntaxWarning

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/frr.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/frr.py
@@ -26,7 +26,7 @@ class FRR(object):
                 log_info("All required daemons have connected to vtysh: %s" % str(datetime.datetime.now()))
                 return
             else:
-                log_warn("Can't read daemon status from FRR: %s" % str(err))
+                log_info("Can't read daemon status from FRR: %s" % str(err))
             time.sleep(0.1)  # sleep 100 ms
         raise RuntimeError("FRR daemons hasn't been started in %d seconds" % seconds)
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_rm.py
@@ -86,7 +86,7 @@ class RouteMapMgr(Manager):
         if rm in ROUTE_MAPS :
             cmds.append("route-map %s permit 100" % ("%s_RM" % rm))
             bgp_asn = self.__read_asn()
-            if bgp_asn is None or bgp_asn is '':
+            if bgp_asn is None or bgp_asn == '':
                 log_debug("BGPRouteMapMgr:: update route-map %s, but asn is not found in constants" % ("%s_RM" % rm))
                 return
             cmds.append(" set as-path prepend %s %s" % (bgp_asn, bgp_asn))


### PR DESCRIPTION
#### Why I did it
Fixed two issues in bgpcfgd:

bgpcfgd/frr.py — Changed log_warn to log_info in wait_for_daemons() poll loop (line 29)

bgpcfgd/managers_rm.py — Fixed Python 3.13 SyntaxWarning: replaced bgp_asn is '' with bgp_asn == '' (line 89)

##### Work item tracking
- Microsoft ADO **(number only)**:  (N/A — community fix)

#### How I did it
frr.py: wait_for_daemons() polls vtysh -c "show daemons" every 100ms until all required FRR daemons connect. Each failed poll logs log_warn("Can't read daemon status from FRR"). FRR typically takes 10–100+ seconds to start on hardware, generating 100–1000+ WARNING messages per boot. This is expected behavior — not a warning condition. The actual failure (FRR never starts) still raises RuntimeError at line 31.

managers_rm.py: In Python 3.12+, is with a string literal (bgp_asn is '') raises SyntaxWarning: "is" with 'str' literal. The correct equality check is ==. This warning appears in syslog on every bgpcfgd startup.

#### How to verify it
Tested on sonic-vs (SONiC master, Build date: Wed Aug 20 17:04:35 UTC 2026):

managers_rm.py — Before fix:
INFO bgp#supervisord: bgpcfgd managers_rm.py:89: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?

After fix:

$ show logging | grep "SyntaxWarning" | wc -l
0

frr.py — FRR starts in <200ms on VS (no WARNING generated). On hardware with BGP configured, FRR takes 10–100+ seconds → 100–1000 WARNING messages per boot eliminated.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [X] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

master: SONiC.master.0-dirty-20260820.165606 — SyntaxWarning absent after fix (sonic-vs)

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Fix FRR daemon poll log level from WARNING to INFO and fix Python 3.13 SyntaxWarning in managers_rm.py

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
