### PR TITLE
[gnmi] Raise gNMI server max send size to 32MB for all platforms

### DIFF
--- a/dockers/docker-ptf/gnxi-patches/0011-Lift-grpc-4MiB-receive-limit-in-py_gnmicli.patch
+++ b/dockers/docker-ptf/gnxi-patches/0011-Lift-grpc-4MiB-receive-limit-in-py_gnmicli.patch
@@ -1,0 +1,28 @@
+diff --git a/gnmi_cli_py/py_gnmicli.py b/gnmi_cli_py/py_gnmicli.py
+--- a/gnmi_cli_py/py_gnmicli.py
++++ b/gnmi_cli_py/py_gnmicli.py
+@@ -293,14 +293,20 @@
+   if ':' in target:
+     target = '[' + target + ']'
+ 
++  # Raise grpc's 4MiB receive limit to the server's 32MB send cap: a
++  # whole-table subscribe (e.g. COUNTERS) can exceed the default (NOS-11426).
++  options = (('grpc.max_receive_message_length', 32*1024*1024),)
+   if creds:
+     if host_override:
+-      channel = gnmi_pb2_grpc.grpc.secure_channel(target + ':' + port, creds, ((
+-          'grpc.ssl_target_name_override', host_override,),))
++      channel = gnmi_pb2_grpc.grpc.secure_channel(
++          target + ':' + port, creds,
++          (('grpc.ssl_target_name_override', host_override,),) + options)
+     else:
+-      channel = gnmi_pb2_grpc.grpc.secure_channel(target + ':' + port, creds)
++      channel = gnmi_pb2_grpc.grpc.secure_channel(target + ':' + port, creds,
++                                                  options)
+   else:
+-      channel = gnmi_pb2_grpc.grpc.insecure_channel(target + ':' + port)
++      channel = gnmi_pb2_grpc.grpc.insecure_channel(target + ':' + port,
++                                                    options)
+   return gnmi_pb2_grpc.gNMIStub(channel)
+ 
+ 

--- a/dockers/docker-ptf/gnxi-patches/series
+++ b/dockers/docker-ptf/gnxi-patches/series
@@ -8,3 +8,4 @@
 0008-Fix-ipv6-addr-port-format-for-grpc.patch
 0009-chore-remove-deprecated-use_aliases-field-and-fix-syntax.patch
 0010-Fix-regex-to-allow-hyphen-character-in-key-name.patch
+0011-Lift-grpc-4MiB-receive-limit-in-py_gnmicli.patch

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -104,10 +104,14 @@ else
     TELEMETRY_ARGS+=" -v=2"
 fi
 
+# A whole-table subscribe (e.g. COUNTERS on a 128-port system) is sent as a
+# single SubscribeResponse that can exceed the 4MiB default send limit (NOS-11426).
+TELEMETRY_ARGS+=" -max_send_msg_size=$((32*1024*1024))"
+
 # Enable ZMQ for SmartSwitch
 LOCALHOST_SUBTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "subtype"`
 if [[ x"${LOCALHOST_SUBTYPE}" == x"SmartSwitch" ]]; then
-    TELEMETRY_ARGS+=" -zmq_port=8100 -max_recv_msg_size=$((32*1024*1024)) -max_send_msg_size=$((32*1024*1024))"
+    TELEMETRY_ARGS+=" -zmq_port=8100 -max_recv_msg_size=$((32*1024*1024))"
 fi
 
 GNMI_VRF=$(extract_field "$GNMI" '.vrf')


### PR DESCRIPTION
#### Why I did it

Non-SmartSwitch platforms silently regressed from "gNMI server can send responses of any size" to "server refuses anything over 4 MiB" after https://github.com/sonic-net/sonic-gnmi/pull/643.

Before that PR, grpc-go's server **send** limit was `math.MaxInt32` (grpc-go's deliberate default — only the receive side defaults to 4 MiB). #643's stated goal was to raise the *receive* limit for 32 MB SmartSwitch DASH configs, and its description says "Defaults are unchanged" — its own before/after table documents send = `math.MaxInt32`. The implementation didn't match that intent: the follow-up commit ("Correctly set default to 4MB") set **both** new flags to `4*1024*1024`. Correct for receive; a regression for send. The companion https://github.com/sonic-net/sonic-buildimage/pull/26679 compensates with `-max_send_msg_size=32MB` — but only under the `SmartSwitch` subtype check in `gnmi-native.sh`.

The visible breakage: the sonic-db subscribe handler (`sonic_data_client/db_client.go`, `dbTableKeySubscribe`) serializes the entire subscribed table into a single `SubscribeResponse` — for the initial sync and on every SAMPLE tick. A whole-table subscribe to `COUNTERS_DB/localhost/COUNTERS` on a 128-port system is ~5.6 MB in one message, so the stream aborts on the very first (sync) message with:

```
rpc error: code = ResourceExhausted desc = trying to send message larger than max (5591743 vs. 4194304)
```

`gnmi/test_gnmi.py::test_gnmi_subscribe_sample` fails with `AssertionError: expected 6 responses, got 0`, and any production gNMI collector doing a whole-table COUNTERS subscribe on a high-port-count platform hits the same abort.

There is a second, latent 4 MiB cap behind the first: the PTF test client `py_gnmicli` (google/gnxi + `dockers/docker-ptf/gnxi-patches/`) never sets `grpc.max_receive_message_length`, and grpcio's receive default is also 4 MiB — so fixing only the server just moves the same failure to the client side.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Two changes, one per side of the connection:

1. **`dockers/docker-sonic-gnmi/gnmi-native.sh`** — pass `-max_send_msg_size=$((32*1024*1024))` unconditionally instead of only for SmartSwitch, matching the value #26679 chose. `-max_recv_msg_size` stays at the 4 MiB default for regular switches (the receive limit is what bounds per-message server memory against clients; the send limit only caps the server's own responses, which grpc-go deliberately ships unlimited).
2. **`dockers/docker-ptf/gnxi-patches/0011-Lift-grpc-4MiB-receive-limit-in-py_gnmicli.patch`** — new patch (added to `series`) setting `('grpc.max_receive_message_length', 32*1024*1024)` on all three channel creations in `py_gnmicli.py`'s `_create_stub`. 32 MB rather than unlimited, to stay symmetric with the server's send cap so an outgrown table fails with a legible `RESOURCE_EXHAUSTED` instead of being absorbed unbounded.

The arguably more correct fix is restoring the `max_send_msg_size` flag *default* to `math.MaxInt32` in sonic-gnmi's `telemetry.go` (the behavior #643 claimed to preserve); this PR takes the config-side route so it needs no sonic-gnmi change and mirrors the existing SmartSwitch precedent in this repo.

#### How to verify it

A/B/C verification of the mechanism (telemetry server built from sonic-gnmi master, redis with a synthetic `COUNTERS_DB` `COUNTERS` table of 128 keys serializing to 6,326,485 bytes, real docker-ptf `py_gnmicli` subscribing SAMPLE mode to `/COUNTERS_DB/localhost/COUNTERS` — the exact call `test_gnmi_subscribe_sample` makes):

| Phase | Server | Client | Result |
|---|---|---|---|
| A — status quo | no flag (4 MiB default) | stock | `RESOURCE_EXHAUSTED: trying to send message larger than max (6326485 vs. 4194304)`, 0 responses |
| B — server half only | `-max_send_msg_size=33554432` | stock | `RESOURCE_EXHAUSTED: CLIENT: Received message larger than max (6326485 vs. 4194304)` — proves the client patch is required |
| C — both halves | `-max_send_msg_size=33554432` | with patch 0011 | 3 updates + sync_response received at the expected SAMPLE cadence |

Static checks: `bash -n dockers/docker-sonic-gnmi/gnmi-native.sh`; all 11 gnxi patches apply cleanly on the pinned gnxi commit (`208acfa`) and the patched `py_gnmicli.py` parses.

To reproduce the original failure: on any switch whose `COUNTERS` table serializes above 4 MiB (≈128 ports), run `gnmi/test_gnmi.py::test_gnmi_subscribe_sample` — the sonic-db subscribe step returns 0 responses without this change and all responses with it.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression (only affects branches whose sonic-gnmi contains sonic-net/sonic-gnmi#643's `max_send_msg_size` flag; on older sonic-gnmi the flag does not exist and passing it would fail startup)

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: A/B/C container verification above (server built from sonic-gnmi master + real docker-ptf client); static validation of `gnmi-native.sh` and the gnxi patch series.

#### Description for the changelog

Raise the gNMI server gRPC max send message size to 32MB on all platforms so whole-table subscribes (e.g. COUNTERS on 128-port systems) are not rejected.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
