### PR TITLE
[minigraph]: parse KubernetesServerPort into KUBERNETES_MASTER SERVER

### DIFF
--- a/src/sonic-config-engine/minigraph.py
+++ b/src/sonic-config-engine/minigraph.py
@@ -1533,6 +1533,8 @@ def parse_meta(meta, hname):
                     kube_data["enable"] = value
                 elif name == "KubernetesServerIp":
                     kube_data["ip"] = value
+                elif name == "KubernetesServerPort":
+                    kube_data["port"] = value
                 elif name == 'MacSecProfile':
                     macsec_profile = parse_macsec_profile(value)
                 elif name == "RedundancyType":
@@ -2182,6 +2184,8 @@ def parse_xml(filename, platform=None, port_config_file=None, asic_name=None, hw
                 'ip': kube_data.get('ip', '')
             }
         }
+        if kube_data.get('port'):
+            results['KUBERNETES_MASTER']['SERVER']['port'] = kube_data['port']
 
     results['PEER_SWITCH'], mux_tunnel_name, peer_switch_ip = get_peer_switch_info(linkmetas, devices)
 

--- a/src/sonic-config-engine/tests/simple-sample-graph-case.xml
+++ b/src/sonic-config-engine/tests/simple-sample-graph-case.xml
@@ -536,6 +536,11 @@
      <a:Value>10.10.10.10</a:Value>
     </a:DeviceProperty>
     <a:DeviceProperty>
+     <a:Name>KubernetesServerPort</a:Name>
+     <a:Reference i:nil="true"/>
+     <a:Value>18443</a:Value>
+    </a:DeviceProperty>
+    <a:DeviceProperty>
      <a:Name>ResourceType</a:Name>
      <a:Reference i:nil="true"/>
      <a:Value>Storage</a:Value>

--- a/src/sonic-config-engine/tests/test_minigraph_case.py
+++ b/src/sonic-config-engine/tests/test_minigraph_case.py
@@ -277,7 +277,7 @@ class TestCfgGenCaseInsensitive(TestCase):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "KUBERNETES_MASTER[\'SERVER\']"]
         output = self.run_script(argument)
         self.assertEqual(json.loads(output.strip().replace("'", "\"")),
-                json.loads('{"ip": "10.10.10.10", "disable": "True"}'))
+                json.loads('{"ip": "10.10.10.10", "disable": "True", "port": "18443"}'))
 
     def test_minigraph_mgmt_port(self):
         argument = ['-m', self.sample_graph, '-p', self.port_config, '-v', "MGMT_PORT"]


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Modify minigraph.py to render Kubernetes Server Port into CONFIG_DB. Currently ctrmgrd hardcodes port, but it is better to refactor such that port is configurable through CONFIG_DB.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added KubernetesServerPort to the DeviceMetadata property parsing in minigraph.py, alongside the existing KubernetesEnabled and KubernetesServerIp cases, storing it in kube_data["port"].

The KUBERNETES_MASTER|SERVER table already supports a port field (it is in the YANG model as inet:port-number, and consumers default it to 6443 when absent), but the minigraph parser had no way to populate it — so a device whose minigraph specifies a non-default Kubernetes server port could not express that in CONFIG_DB.

The field is emitted only when the property is present, so a minigraph without KubernetesServerPort produces byte-identical output to before

#### How to verify it

Pytest


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
