### PR TITLE
docker-sonic-mgmt: retain snappi resource group mode

### DIFF
--- a/dockers/docker-sonic-mgmt/0002-Fix-resource-group.patch
+++ b/dockers/docker-sonic-mgmt/0002-Fix-resource-group.patch
@@ -1,0 +1,26 @@
+From 9c84d7ff4d1f03053653cf42873f84e3d7d4e475 Mon Sep 17 00:00:00 2001
+From: Vinod <vkjammala@arista.com>
+Date: Fri, 1 Aug 2025 12:51:51 +0000
+Subject: [PATCH] [PATCH 1/2] Fix snappi api to retain group mode based on a
+ flag.
+
+---
+ snappi_ixnetwork/resourcegroup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/snappi_ixnetwork/resourcegroup.py b/snappi_ixnetwork/resourcegroup.py
+index 0b57f493..87ddb655 100644
+--- a/snappi_ixnetwork/resourcegroup.py
++++ b/snappi_ixnetwork/resourcegroup.py
+@@ -190,7 +190,7 @@ class ResourceGroup(object):
+                                 card,
+                                 group_id,
+                                 current_mode,
+-                                group_mode,
++                                group_mode if self._api._retain_group_mode is False else current_mode,
+                             )
+                             if l1_name is not None:
+                                 if l1_name not in self.layer1_check:
+-- 
+2.47.3
+

--- a/dockers/docker-sonic-mgmt/0003-Fix-snappi-api.patch
+++ b/dockers/docker-sonic-mgmt/0003-Fix-snappi-api.patch
@@ -1,0 +1,25 @@
+From 483f88b865b2eae3ac363aebce361b6b4cbc5b4f Mon Sep 17 00:00:00 2001
+From: Vinod <vkjammala@arista.com>
+Date: Fri, 1 Aug 2025 12:56:22 +0000
+Subject: [PATCH] [PATCH 2/2]Fix snappi api to retain group mode based on a
+ flag.
+
+---
+ snappi_ixnetwork/snappi_api.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/snappi_ixnetwork/snappi_api.py b/snappi_ixnetwork/snappi_api.py
+index fbc66718..ff093b90 100644
+--- a/snappi_ixnetwork/snappi_api.py
++++ b/snappi_ixnetwork/snappi_api.py
+@@ -78,6 +78,7 @@ class Api(snappi.Api):
+         self._address, self._port = self._get_addr_port(location)
+         self._username = "admin" if username is None else username
+         self._password = "admin" if password is None else password
++        self._retain_group_mode = kwargs.get("retain_group_mode", False)
+         self._license_servers = (
+             [] if license_servers is None else license_servers
+         )
+-- 
+2.47.3
+

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -201,16 +201,20 @@ RUN uv pip install --no-cache {% for whl in docker_sonic_mgmt_whls.split() %}/py
 RUN /opt/venv/bin/python3 -B -c "from sonic_grpc.gnoi import GnoiClient, file_pb2, file_pb2_grpc, system_pb2"
 {% endif %}
 
-# Apply patches to ansible and ptf
+# Apply patches to ansible, ptf, and snappi-ixnetwork
 COPY \
     0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch \
     0002-extend-dataplane-poll-method-to-support-multi-ptf-nn.patch \
     0003-add-dataplane-mask-counters-to-avoid-dataplane-noise.patch \
+    0002-Fix-resource-group.patch \
+    0003-Fix-snappi-api.patch \
     /tmp/
 RUN site_packages_dir=$(/opt/venv/bin/python3 -c "import site; print(site.getsitepackages()[0])") \
     && patch -u -b "$site_packages_dir/ansible/plugins/loader.py" -i /tmp/0001-Fix-getattr-AttributeError-in-multi-thread-scenario.patch \
     && patch -u -b "$site_packages_dir/ptf/dataplane.py"  -i /tmp/0002-extend-dataplane-poll-method-to-support-multi-ptf-nn.patch \
     && patch -u -b "$site_packages_dir/ptf/dataplane.py"  -i /tmp/0003-add-dataplane-mask-counters-to-avoid-dataplane-noise.patch \
+    && patch -u -b "$site_packages_dir/snappi_ixnetwork/resourcegroup.py" -i /tmp/0002-Fix-resource-group.patch \
+    && patch -u -b "$site_packages_dir/snappi_ixnetwork/snappi_api.py" -i /tmp/0003-Fix-snappi-api.patch \
     && rm -f /tmp/*.patch
 
 RUN mkdir /var/run/sshd


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
snappi-ixnetwork selects the first resource group mode matching a port display name. Port display names can overlap between supported resource group modes, so this can reconfigure the traffic generator to an unintended speed or breakout mode.

SONiC needs an opt-in mechanism to retain the existing compatible resource group mode for Keysight IxNetwork test sessions.

Related to sonic-net/sonic-mgmt#27195.

The underlying bug was reported in open-traffic-generator/snappi-ixnetwork#607 and was closed after being redirected to SONiC Snappi.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added two patches to docker-sonic-mgmt:

1. Add a retain_group_mode option to snappi-ixnetwork. The option defaults to false so existing behavior remains unchanged.
2. When retain_group_mode is enabled, use the current compatible resource group mode instead of selecting another mode from overlapping port display names.

Updated Dockerfile.j2 to apply both patches to the snappi-ixnetwork package installed under the docker-sonic-mgmt virtual environment.
 
#### How to verify it
Validated against snappi-ixnetwork v1.59.1:
- Confirmed both embedded patches apply cleanly with git apply --check.
- Applied both patches to a clean v1.59.1 checkout.
- Confirmed the resulting source diff contains only the intended two changes.
- Confirmed git diff --check passes on the patched Python source.
- Confirmed both modified Python files compile successfully with `python3 -m py_compile`.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
4. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): https://github.com/sonic-net/sonic-mgmt/issues/27195
Failure type: day-one issue

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
- 202605: `branch.202605-ars.58a15ff2-buildimage.0b2faef94668aef37278566e8d6277200de7a807-nightly-2026.08.13.13.47`
    - Image ID: `sha256:2e21e00b18dec0e40d338a29d4ebd6623b9bfeb5102344b82e694581f942870b`
    - Repository digest: `sha256:33523d3f472f521aeb74da754010a0f4122999caf192d343ed6587ecf119367c`
    - The image contains both the sonic-buildimage resource-group retention patches and the corresponding sonic-mgmt change that enables retention.
    - Snappi tests have been running successfully on internal T0 and T1 testbeds using this combined patch set.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
docker-sonic-mgmt: add opt-in support for retaining the existing snappi resource group mode.
<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
