### PR TITLE
[Aspeed][Nexthop]: Add cold-boot init service for reset-tolerant GPIO cpe_ctrl

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -441,6 +441,13 @@ install_deb_package $debs_path/openssh-server_${OPENSSH_VERSION_FULL}_*.deb $deb
 install_deb_package $debs_path/flashrom_*.deb
 {% endif %}
 
+{% if sonic_asic_platform == "aspeed" %}
+# libgpiod tools (gpioset/gpioget/gpioinfo), required by GPIO init scripts in
+# aspeed platform packages. Trixie ships libgpiod v2, where lines are
+# addressed by name and gpiofind no longer exists.
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install gpiod
+{% endif %}
+
 # Copy crontabs
 sudo cp -f $IMAGE_CONFIGS/cron.d/* $FILESYSTEM_ROOT/etc/cron.d/
 

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/gpio-cold-init.sh
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/gpio-cold-init.sh
@@ -63,6 +63,16 @@ if ! before=$(busybox devmem "${CTRL_REG}" 32); then
     exit 1
 fi
 
+# The line is addressed by its device-tree gpio-line-names entry, so a DTB that
+# predates those names exposes nothing to request. That DTB also predates the
+# gpio-hog this script replaces, so the pin is left exactly as the boot loader
+# configured it -- the behaviour from before this script existed. Skip rather
+# than fail the unit on that kernel/userspace skew.
+if ! gpioinfo "${LINE}" >/dev/null 2>&1; then
+    log "no GPIO line named ${LINE} in this kernel; skipping, ${CTRL_REG}=${before}"
+    exit 0
+fi
+
 if ! wdt_reset; then
     value=${COLD_VALUE}
     log "cold boot (no WDT reset): applying default ${value}, ${CTRL_REG}=${before}"
@@ -80,9 +90,14 @@ fi
 # chip/offset lookup is needed. Requesting the line muxes the pad to GPIO
 # (pinctrl gpio_request_enable) and arms reset tolerance (gpiolib requests
 # PIN_CONFIG_PERSIST_STATE for a non-transitory line); gpioset then drives the
-# level and exits. The aspeed pinctrl implements no gpio_disable_free, so
-# releasing the line does not undo the mux and the pin keeps driving.
-if ! gpioset --strict --consumer gpio-cold-init "${LINE}=${value}"; then
+# level. The aspeed pinctrl implements no gpio_disable_free, so releasing the
+# line does not undo the mux and the pin keeps driving.
+#
+# --toggle 0 is required: a v2 gpioset with no toggle period never exits, it
+# holds the request open until it is killed. Without it this script blocks
+# forever and cpe-ctrl-init.service is stuck in "activating", which wedges
+# every unit ordered after it.
+if ! gpioset --strict --toggle 0 --consumer gpio-cold-init "${LINE}=${value}"; then
     log "gpioset failed for ${LINE}=${value}"
     exit 1
 fi

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/gpio-cold-init.sh
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/scripts/gpio-cold-init.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+# Copyright 2026 Nexthop Systems Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Cold-boot initializer for reset-tolerant GPIOs.
+#
+# Reset tolerance (per-pin control register bit6) keeps the direction (bit1) and
+# output data (bit0) bits from being cleared by a WDT_SOC/EXTRSTN reset, so an
+# output can hold its level across a BMC reboot. It does not stop software from
+# rewriting the pin after the reset, which is why these lines must not be
+# gpio-hogged in the device tree: a hog is applied unconditionally when the
+# gpiochip probes and would clobber the level that survived the reset.
+#
+# So apply the power-on default only when this boot was not a watchdog-caused
+# reset; on a warm reset re-drive the level the pin came up with, which is a
+# no-op on the pad but re-arms reset tolerance and re-muxes the pad to GPIO for
+# the next reset.
+#
+# Boot cause comes from the watchdog bootstatus, which the aspeed_wdt driver
+# derives from the SCU WDT reset log. Note that U-Boot clears the power-on and
+# EXTRST flags before Linux runs, so a reset that is not attributable to a WDT
+# is treated as a cold boot here.
+#
+# The per-pin control register is passed in rather than derived: libgpiod v2
+# dropped gpiofind, and gpioinfo's output is not a stable parsing target. For
+# AST2700 the address is <controller base> + 0x180 + <line offset> * 4, e.g.
+# cpe_ctrl is GPIOE2, offset 34 on gpio1 (0x14c0b000), giving
+# 0x14c0b000 + 0x180 + 34 * 4 = 0x14c0b208.
+#
+# Usage: gpio-cold-init.sh <gpio-line-name> <ctrl-reg> <cold-boot-value>
+
+set -u
+
+if [ $# -ne 3 ]; then
+    echo "usage: $(basename "$0") <gpio-line-name> <ctrl-reg> <cold-boot-value>" >&2
+    exit 1
+fi
+
+LINE=$1
+CTRL_REG=$2
+COLD_VALUE=$3
+
+WDIOF_CARDRESET=32      # 0x0020, linux/watchdog.h: card previously reset the CPU
+CTRL_DATA=1             # per-pin control bit0: output data
+CTRL_TOLERANT_OUT=66    # bit6 reset tolerance | bit1 direction=output
+
+log() {
+    echo "gpio-cold-init[${LINE}]: $*"
+}
+
+wdt_reset() {
+    for f in /sys/class/watchdog/*/bootstatus; do
+        [ -r "${f}" ] || continue
+        if [ $(( $(cat "${f}" 2>/dev/null || echo 0) & WDIOF_CARDRESET )) -ne 0 ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+if ! before=$(busybox devmem "${CTRL_REG}" 32); then
+    log "cannot read ${CTRL_REG}"
+    exit 1
+fi
+
+if ! wdt_reset; then
+    value=${COLD_VALUE}
+    log "cold boot (no WDT reset): applying default ${value}, ${CTRL_REG}=${before}"
+elif [ $(( before & CTRL_TOLERANT_OUT )) -ne "${CTRL_TOLERANT_OUT}" ]; then
+    # Tolerance and/or direction did not survive, so the data bit is not
+    # meaningful either. Fall back to the default rather than drive a guess.
+    value=${COLD_VALUE}
+    log "warm reset but ${CTRL_REG}=${before} is not a tolerant output: applying default ${value}"
+else
+    value=$(( before & CTRL_DATA ))
+    log "warm reset: preserving level ${value}, ${CTRL_REG}=${before}"
+fi
+
+# libgpiod v2 addresses lines by name, so neither gpiofind (removed in v2) nor a
+# chip/offset lookup is needed. Requesting the line muxes the pad to GPIO
+# (pinctrl gpio_request_enable) and arms reset tolerance (gpiolib requests
+# PIN_CONFIG_PERSIST_STATE for a non-transitory line); gpioset then drives the
+# level and exits. The aspeed pinctrl implements no gpio_disable_free, so
+# releasing the line does not undo the mux and the pin keeps driving.
+if ! gpioset --strict --consumer gpio-cold-init "${LINE}=${value}"; then
+    log "gpioset failed for ${LINE}=${value}"
+    exit 1
+fi
+
+log "${CTRL_REG}: ${before} -> $(busybox devmem "${CTRL_REG}" 32)"

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/switch_host_module.py
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/sonic_platform/switch_host_module.py
@@ -27,8 +27,9 @@ class SwitchHostModule(ModuleBase):
 
     # Hardware register constants
     CPE_CTRL_REG = "0x14C0B208"      # CPU reset control register
-    RESET_VALUE_ASSERT = "2"         # Write 2 => drive low (into reset)
-    RESET_VALUE_DEASSERT = "3"       # Write 3 => drive high (out of reset)
+    RESET_VALUE_MASK = 0x3           # Reset control occupies bits [1:0]
+    RESET_VALUE_ASSERT = 0x2         # Bits [1:0] = 2 => drive low (into reset)
+    RESET_VALUE_DEASSERT = 0x3       # Bits [1:0] = 3 => drive high (out of reset)
 
     def __init__(self, module_index=0):
         """
@@ -42,16 +43,25 @@ class SwitchHostModule(ModuleBase):
 
     def _write_reset_register(self, value):
         """
-        Write to the switch CPU reset register using devmem.
+        Set the reset control bits of the switch CPU reset register using devmem.
+
+        Read-modify-write: only bits [1:0] are updated, every other bit in the
+        register is preserved.
 
         Args:
-            value: Register value to write (str)
+            value: Reset control value (int); only bits [1:0] are used
 
         Returns:
             bool: True if operation succeeded, False otherwise
         """
+        current = self._read_reset_register()
+        if current == -1:
+            sys.stderr.write("Failed to read reset register before write\n")
+            return False
+
+        new_value = (current & ~self.RESET_VALUE_MASK) | (value & self.RESET_VALUE_MASK)
         try:
-            cmd = ["busybox", "devmem", self.CPE_CTRL_REG, "32", value]
+            cmd = ["busybox", "devmem", self.CPE_CTRL_REG, "32", f"0x{new_value:08X}"]
             result = subprocess.run(cmd, capture_output=True, timeout=5)
             if result.returncode != 0:
                 sys.stderr.write(f"devmem write failed: {result.stderr}\n")
@@ -66,15 +76,14 @@ class SwitchHostModule(ModuleBase):
         Read current value from switch CPU reset register.
 
         Returns:
-            int: 0 or 1 (CPU in reset or out of reset), -1 on error
+            int: Full 32-bit register value, -1 on error
         """
         try:
             cmd = ["busybox", "devmem", self.CPE_CTRL_REG, "32"]
             result = subprocess.run(cmd, capture_output=True, timeout=5, text=True)
             if result.returncode == 0:
                 # Parse hex value (e.g., "0x00000001")
-                value = int(result.stdout.strip(), 16)
-                return value & 0x1  # Extract bit 0: 0=in reset, 1=out of reset
+                return int(result.stdout.strip(), 16)
         except Exception as e:
             sys.stderr.write(f"Failed to read reset register: {e}\n")
         return -1

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/cpe-ctrl-init.service
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/cpe-ctrl-init.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Cold-boot init for reset-tolerant GPIO cpe_ctrl
+# cpe_ctrl is not a gpio-hog: a hog would be re-applied at every gpiochip probe
+# and clobber the level carried across a warm reset by the GPIO reset-tolerance
+# bit. Run before anything that reads or drives cpe_ctrl.
+# sonic.target pulls in pmon/redfish, which reach cpe_ctrl through sonic_platform;
+# order against it explicitly rather than relying on target sequencing.
+After=basic.target
+Before=multi-user.target sonic.target
+ConditionPathExists=/usr/local/bin/gpio-cold-init.sh
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# <gpio-line-name> <per-pin control register> <cold-boot value>
+# cpe_ctrl is GPIOE2: gpio1 (0x14c0b000) + 0x180 + 34 * 4 = 0x14c0b208
+ExecStart=/usr/local/bin/gpio-cold-init.sh cpe_ctrl 0x14C0B208 0
+
+[Install]
+WantedBy=multi-user.target

--- a/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/cpe-ctrl-init.service
+++ b/platform/aspeed/sonic-platform-modules-nexthop/common/systemd/cpe-ctrl-init.service
@@ -12,6 +12,9 @@ ConditionPathExists=/usr/local/bin/gpio-cold-init.sh
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+# Type=oneshot disables the start timeout by default; cap it so a hung
+# ExecStart fails the unit instead of blocking every unit ordered after it.
+TimeoutStartSec=30s
 # <gpio-line-name> <per-pin control register> <cold-boot value>
 # cpe_ctrl is GPIOE2: gpio1 (0x14c0b000) + 0x180 + 34 * 4 = 0x14c0b208
 ExecStart=/usr/local/bin/gpio-cold-init.sh cpe_ctrl 0x14C0B208 0

--- a/platform/aspeed/sonic-platform-modules-nexthop/debian/control
+++ b/platform/aspeed/sonic-platform-modules-nexthop/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.6
 
 Package: sonic-platform-aspeed-nexthop-common
 Architecture: arm64
-Depends: ${misc:Depends}, ${python3:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, gpiod
 Description: Common modules, USB network gadget configuration and initialization scripts
  shared across all NextHop Aspeed-based BMC cards.
 

--- a/platform/aspeed/sonic-platform-modules-nexthop/debian/sonic-platform-aspeed-nexthop-common.postinst
+++ b/platform/aspeed/sonic-platform-modules-nexthop/debian/sonic-platform-aspeed-nexthop-common.postinst
@@ -31,6 +31,11 @@ case "$1" in
         # Enable USB network service
         echo "Enabling USB network service..."
         systemctl enable --now usb-network-init.service 2>/dev/null || true
+
+        # Enable cpe_ctrl cold-boot init service at boot-time init
+        # (ordered before sonic.target)
+        echo "Enabling cpe_ctrl cold-boot init service..."
+        systemctl enable cpe-ctrl-init.service 2>/dev/null || true
         ;;
 esac
 


### PR DESCRIPTION
#### Why I did it

On NextHop Aspeed (AST2700) BMC cards, the `cpe_ctrl` GPIO drives the
switch-host CPU reset and must hold its level across BMC warm reboots. This
requires setting a tolerance bit in the startup/shutdown commands as well as 
a boot-time init service to reset GPIO direction and mux bits instead of a 
device-tree gpio-hog, plus read-modify-write of the reset register so the 
reset-tolerance bit is preserved.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- New `gpio-cold-init.sh` + `cpe-ctrl-init.service` in the NextHop platform
  package, enabled in postinst, ordered before `sonic.target`.
- `switch_host_module.py`: reset register writes are now read-modify-write of
  bits [1:0] only.
- Install `gpiod` (libgpiod v2 tools) into aspeed images via
  `sonic_debian_extension.j2`, guarded by `sonic_asic_platform == "aspeed"`.
- `gpioset --toggle 0` so the tool sets the values and exits: libgpiod v2
  changed the default to holding the line request open until killed, which
  left this `Type=oneshot` unit in `activating` forever and blocked every
  unit ordered after it. Also cap the unit with `TimeoutStartSec=30s`
  (`Type=oneshot` disables the start timeout by default) so any future hang
  fails the unit instead of wedging boot.
- Probe the line name with `gpioinfo` and skip cleanly on kernels whose DTB
  predates the `gpio-line-names` entry; such a DTB also predates the gpio-hog
  this script replaces, so the pin is left as the boot loader configured it.

#### How to verify it

Verified on a NextHop Aspeed BMC card: cold boot applies the default (CPU in
reset); after releasing the CPU from reset, a BMC reboot preserves the level
and the switch-host CPU stays out of reset.

#### Tested branch

- [x] master

#### Test result

- master: <image version> - verified on hardware per steps above

