### PR TITLE
[pmon]: Recreate the container when a mapped device node is gone

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -58,6 +58,22 @@ get_pmon_device_cgroup_rules() {
         [ "${major:-0}" -gt 0 ] 2>/dev/null && echo "c $major:* rwm"
     done
 }
+
+# Whole disks are still passed to 'docker create' by name, and docker resolves that
+# set again on every start. A disk that went away while the container was down, a USB
+# stick for example, makes the start fail. Report those paths so the container can be
+# recreated against the devices the host currently has.
+get_pmon_stale_devices() {
+    local inspect_format={{"'{{range .HostConfig.Devices}}{{.PathOnHost}} {{end}}{{range .Mounts}}{{.Source}} {{end}}'"}}
+    local path
+    for path in $(docker inspect --format "$inspect_format" "${DOCKERNAME}" 2>/dev/null); do
+        case "$path" in
+        /dev/*)
+            [ -e "$path" ] || echo "$path"
+            ;;
+        esac
+    done
+}
 {%- endif %}
 
 {%- if docker_container_name == "dhcp_server" %}
@@ -602,7 +618,10 @@ start() {
         {%- else %}
         DOCKERMOUNT=`getMountPoint "$DOCKERCHECK"`
         {%- endif %}
-        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]; then
+        {%- if docker_container_name == "pmon" %}
+        STALE_DEVICES=`get_pmon_stale_devices`
+        {%- endif %}
+        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ]{% if docker_container_name == "pmon" %} && [ -z "$STALE_DEVICES" ]{% endif %}; then
             CONTAINER_EXISTS="yes"
             preStartAction
             {%- if docker_container_name == "database" %}
@@ -616,8 +635,20 @@ start() {
             exit $?
         fi
 
+        {%- if docker_container_name == "pmon" %}
+
+        if [ -n "$STALE_DEVICES" ]; then
+            # a mapped device node was hot-unplugged, recreate against the current set
+            echo "Removing ${DOCKERNAME} container, host no longer has:" $STALE_DEVICES
+        else
+            # docker created with a different HWSKU, remove and recreate
+            echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        fi
+        {%- else %}
+
         # docker created with a different HWSKU, remove and recreate
         echo "Removing obsolete ${DOCKERNAME} container with HWSKU $DOCKERMOUNT"
+        {%- endif %}
         docker rm -f ${DOCKERNAME}
     fi
 


### PR DESCRIPTION
Fixes #29137

#### Why I did it

`get_pmon_device_mounts()` in `docker_image_ctl.j2` scans `/dev` and turns what it finds into `--device` / `--mount` arguments for `docker create`. That scan happens **once**, when the pmon container is created, and the resulting mappings are stored in the container config. Docker re-resolves them on every subsequent start.

So when a node that was present at creation time is later unplugged, pmon stops coming up:

```
Error: error gathering device information while adding custom device "/dev/sda1": no such file or directory
```

The regex already matches `sd[a-z]+`, `mmcblk[0-9].*` and `nvme[0-9].*`, so any attached USB or SD storage is picked up. The realistic path to this is a plain install:

1. Install SONiC from a USB drive.
2. pmon is created while the drive is still attached and records `/dev/sda1`.
3. The drive is removed once the box is up.
4. Anything that restarts pmon or the system — `systemctl restart pmon`, a reboot, a warm/fast reboot — leaves pmon down, and the device sits in a degraded state with no platform monitoring.

Nothing recovers on its own: the mapping is only recomputed when the container is recreated, and a restart alone never recreates it.

#### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Two changes, both confined to the `pmon` branches of `files/build_templates/docker_image_ctl.j2`:

**1. Recreate the container when a recorded device node has gone away.**

New `get_pmon_stale_devices()` inspects the existing container and reports the `/dev` paths it maps that the host no longer has:

```sh
get_pmon_stale_devices() {
    local inspect_format='{{range .HostConfig.Devices}}{{.PathOnHost}} {{end}}{{range .Mounts}}{{.Source}} {{end}}'
    local path
    for path in $(docker inspect --format "$inspect_format" ${DOCKERNAME} 2>/dev/null); do
        case "$path" in
        /dev/*)
            [ -e "$path" ] || echo "$path"
            ;;
        esac
    done
}
```

It covers both shapes `get_pmon_device_mounts()` emits — `--device` entries land in `.HostConfig.Devices`, and the bind-mount fallback used for symlinks lands in `.Mounts`. Non-`/dev` mounts are filtered out so unrelated bind mounts can never trigger a recreate.

`start()` then refuses to reuse a container that has stale mappings, and falls through to the existing remove-and-recreate path — the same one already used when the HWSKU changes:

```sh
        STALE_DEVICES=`get_pmon_stale_devices`
        if [ x"$DOCKERMOUNT" == x"$MOUNTPATH" ] && [ -z "$STALE_DEVICES" ]; then
```

The rescan on recreate produces a device list matching the current host, so this converges after a single recreate rather than looping.

**2. Skip unresolvable entries during the scan itself.**

`[ -e "$device" ] || continue` in `get_pmon_device_mounts()`, so a dangling symlink under `/dev`, or a node unplugged between `find` and `docker create`, can't fail container *creation* either. On a host where everything resolves, the emitted arguments are unchanged.

The net effect is what the issue asks for: a missing hot-pluggable node no longer takes pmon down, and the recreate is logged rather than silent:

```
Removing pmon container, host no longer has: /dev/sda1
```

#### How to verify it

Reproduction from the issue:

1. Plug a USB drive in.
2. `docker rm -f pmon`
3. `sudo systemctl restart pmon` — pmon runs, and `docker inspect pmon` shows the drive under `.HostConfig.Devices`.
4. Unplug the drive.
5. `sudo systemctl restart pmon`

Before: pmon fails with `error gathering device information ... no such file or directory`.
After: pmon logs `Removing pmon container, host no longer has: /dev/sda1`, recreates without the stale mapping, and starts normally. A further restart reuses the container as usual.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

No backport requested in this PR. The issue is filed as Critical and the fix is small and self-contained, so backporting looks reasonable to me — but the template asks for test evidence from each target branch, and I don't have hardware to produce it. Happy to open backports if a maintainer wants them.

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Being upfront: I do not have a SONiC switch to run the reproduction on, so no image version is claimed. What I did verify, against `master` at be8fb5473:

- Rendered `docker_image_ctl.j2` for `pmon`, `database`, `swss`, `syncd`, `bgp`, `teamd` and `dhcp_server` across the `broadcom`, `mellanox`, `vs`, `nvidia-bluefield` and `aspeed` platforms. Every generated script passes `bash -n`.
- Diffed every rendered non-pmon script against the same render from unmodified `master`: **byte-identical**. The change cannot affect any other container.
- Exercised `get_pmon_stale_devices()` as rendered, with `docker inspect` mocked: all devices present → empty (container reused); a missing `--device` node → reported; a missing bind-mounted node → reported; absent non-`/dev` mounts → ignored; no mappings at all → empty; several missing at once → all reported; `docker inspect` failing → empty, so a lost container falls back to the previous behaviour instead of erroring.
- Checked the three-way branch selection in `start()`: reuse when nothing changed, recreate on a stale device, recreate on a HWSKU change.
- Ran `get_pmon_device_mounts()` before and after the `[ -e ]` guard on a live Linux host with 29 matching nodes — identical output.

On-hardware validation of the USB reproduction is the gap. I'd appreciate a maintainer or the issue reporter (@RayWang-micas) confirming it on a real device.

#### Description for the changelog

Recreate the pmon container when a device node recorded at creation time is no longer present on the host, so removable storage does not block pmon startup.

#### Related

#26953 filters removable block devices out of the scan so they are never mapped in the first place. That is complementary and I have deliberately not duplicated it — it prevents new stale mappings, while this PR recovers containers that already carry one (including systems already in the field, where the mapping was recorded by an older image). The two can merge independently.
