### PR TITLE
Bump up queue limits for rsyslog

### DIFF
--- a/dockers/docker-base-bookworm/etc/rsyslog.conf
+++ b/dockers/docker-base-bookworm/etc/rsyslog.conf
@@ -36,13 +36,13 @@ set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 # the action queue. Dropping at queue saturation is safer than stalling service
 # initialization in syslog()/sendto().
 #
-# Also bump up window size from 128 to 256 to have the client side send more
+# Also bump up window size from 128 to 512 to have the client side send more
 # messages in each batch before waiting for an ACK. This increases performance
 # at the potential risk of duplicated messages, but considering the
 # destination is this device, this shouldn't be an issue.
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="150000" queue.discardMark="120000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="256" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="100000" queue.discardMark="80000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="512" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-base-bookworm/etc/rsyslog.conf
+++ b/dockers/docker-base-bookworm/etc/rsyslog.conf
@@ -35,9 +35,14 @@ set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 # Keep container syslog writers non-blocking if host-side RELP backpressure fills
 # the action queue. Dropping at queue saturation is safer than stalling service
 # initialization in syslog()/sendto().
+#
+# Also bump up window size from 128 to 256 to have the client side send more
+# messages in each batch before waiting for an ACK. This increases performance
+# at the potential risk of duplicated messages, but considering the
+# destination is this device, this shouldn't be an issue.
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="150000" queue.discardMark="120000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="256" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-base-trixie/etc/rsyslog.conf
+++ b/dockers/docker-base-trixie/etc/rsyslog.conf
@@ -36,13 +36,13 @@ set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 # the action queue. Dropping at queue saturation is safer than stalling service
 # initialization in syslog()/sendto().
 #
-# Also bump up window size from 128 to 256 to have the client side send more
+# Also bump up window size from 128 to 512 to have the client side send more
 # messages in each batch before waiting for an ACK. This increases performance
 # at the potential risk of duplicated messages, but considering the
 # destination is this device, this shouldn't be an issue.
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="150000" queue.discardMark="120000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="256" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="100000" queue.discardMark="80000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="512" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.

--- a/dockers/docker-base-trixie/etc/rsyslog.conf
+++ b/dockers/docker-base-trixie/etc/rsyslog.conf
@@ -35,9 +35,14 @@ set $.CONTAINER_NAME=getenv("CONTAINER_NAME");
 # Keep container syslog writers non-blocking if host-side RELP backpressure fills
 # the action queue. Dropping at queue saturation is safer than stalling service
 # initialization in syslog()/sendto().
+#
+# Also bump up window size from 128 to 256 to have the client side send more
+# messages in each batch before waiting for an ACK. This increases performance
+# at the potential risk of duplicated messages, but considering the
+# destination is this device, this shouldn't be an issue.
 template (name="ForwardFormatInContainer" type="string" string="<%PRI%>%TIMESTAMP:::date-rfc3339% %HOSTNAME% %$.CONTAINER_NAME%#%syslogtag%%msg:::sp-if-no-1st-sp%%msg%")
 module(load="omrelp")
-*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="20000" queue.timeoutEnqueue="0" Template="ForwardFormatInContainer")
+*.* action(type="omrelp" target=`echo $SYSLOG_TARGET_IP` port="2514" action.resumeRetryCount="60" queue.type="LinkedList" queue.size="150000" queue.discardMark="120000" queue.discardSeverity="6" queue.timeoutEnqueue="0" windowSize="256" Template="ForwardFormatInContainer")
 
 #
 # Use traditional timestamp format.


### PR DESCRIPTION


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Some applications at some points of time may generate a ton of logging output, more than the 20000 limit currently configured as the max queue limit. If rsyslog can't confirm the delivery of these messages to the host rsyslog fast enough, then the queue will be filled, and messages will get dropped.

Fixes: #28810

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

To alleviate that, bump up the queue limit to 150k messages, with INFO and DEBUG messages being capped at 120k messages and being dropped if it crosses that threshold. Additionally, increase the message window size from the default of 128 up to 256. This increases the number of messages that might get duplicated (in the worst case in case of some network or application issue), but increases performance as it allows the container rsyslog to send more messages before waiting for an ACK.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
