### PR TITLE
[vpp] Load the mpls_router kernel module on sonic-vpp

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -938,6 +938,15 @@ psample
 EOF
 {% endif %}
 
+# Enable the MPLS dataplane on vpp. Enabling MPLS on an interface makes intfmgrd
+# run "sysctl -w net.mpls.conf.<intf>.input=1", which fails unless the
+# mpls_router module is loaded. The module ships in the image already.
+{% if sonic_asic_platform == "vpp" %}
+sudo tee -a $FILESYSTEM_ROOT/etc/modules-load.d/modules.conf > /dev/null <<EOF
+mpls_router
+EOF
+{% endif %}
+
 ## Bind docker path
 if [[ $MULTIARCH_QEMU_ENVIRON == y || $CROSS_BUILD_ENVIRON == y ]]; then
     sudo mkdir -p $FILESYSTEM_ROOT/dockerfs


### PR DESCRIPTION
#### Why I did it

Enabling MPLS on an interface does not work on sonic-vpp because the `mpls_router` kernel module is never loaded.

`config interface mpls add <intf>` writes the `INTERFACE` table, which makes `intfmgrd` run:

```
sysctl -w net.mpls.conf.<intf>.input=1
```

(`sonic-swss`, `cfgmgr/intfmgr.cpp`, `IntfMgr::setIntfMpls`)

That sysctl needs `/proc/sys/net/mpls`, which only appears once `mpls_router` is loaded. The module ships in the image, but nothing loads it, so the sysctl fails and `intfmgr` logs

```
Command 'sysctl -w net.mpls.conf.<intf>.input=1' failed with rc 255
```

and continues. The failure is non-fatal, so MPLS silently does not work in the kernel and the only trace is a syslog error.

This came up while enabling the MPLS data-plane tests for sonic-vpp ([sonic-mgmt#26619](https://github.com/sonic-net/sonic-mgmt/pull/26619)), where the tests currently have to `modprobe mpls_router` themselves. As reviewer feedback rightly pointed out, for a deployable product the image should load this, not the test.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Load `mpls_router` via `modules-load.d` on the vpp platform, following the same pattern used for `psample` in #29080.

```jinja
{% if sonic_asic_platform == "vpp" %}
sudo tee -a $FILESYSTEM_ROOT/etc/modules-load.d/modules.conf > /dev/null <<EOF
mpls_router
EOF
{% endif %}
```

I kept it as its own block rather than appending to the existing `psample` list, since that block is specifically documented as being for sFlow.

#### How to verify it

On a sonic-vpp DUT, after boot and with no manual `modprobe`:

```bash
lsmod | grep mpls_router          # module is loaded
ls /proc/sys/net/mpls             # sysctl path exists

config interface mpls add Ethernet0
# no "failed with rc 255" for net.mpls.conf.Ethernet0.input in syslog
cat /proc/sys/net/mpls/conf/Ethernet0/input   # 1
```

The MPLS data-plane tests in [sonic-mgmt#26619](https://github.com/sonic-net/sonic-mgmt/pull/26619) (`tests/mpls/test_mpls.py`) exercise this end to end on `t1-lag-vpp`.

I verified the loading mechanism itself on a running sonic-vpp image rather than only by inspection: `/etc/modules-load.d/modules.conf` is present (a symlink to `/etc/modules`) and `systemd-modules-load` is active, so an entry appended there is processed at boot.

To be transparent about scope: I have not yet built a full image from this change, so the end-to-end confirmation above is the mechanism plus the existing test coverage, not a from-scratch image build. Happy to add that evidence if you'd like it before merge.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

No backport requested: MPLS support for sonic-vpp is only being enabled on master.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

#### Tested branch

- [x] master

#### Test result

master: mechanism verified on a running sonic-vpp DUT (see "How to verify it"). MPLS data-plane tests pass on `t1-lag-vpp` with the module loaded (3 passed, 1 skipped).

#### Description for the changelog

[vpp] Load the mpls_router kernel module so MPLS can be enabled on interfaces