### PR TITLE
Enable translib write for gNMI

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -867,6 +867,14 @@ start() {
     $(get_pmon_device_mounts) \
     "${PMON_DEVICE_CGROUP_RULES[@]}" \
 {%- endif %}
+
+{%- if docker_container_name == "telemetry" or docker_container_name == "gnmi" %}
+    -v /etc/passwd:/etc/passwd:ro \
+    -v /etc/shadow:/etc/shadow:ro \
+    -v /etc/group:/etc/group:ro \
+    -v /etc/pam.d:/etc/pam.d:ro \
+{%- endif %}
+
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \
 {%- endif -%}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -867,14 +867,6 @@ start() {
     $(get_pmon_device_mounts) \
     "${PMON_DEVICE_CGROUP_RULES[@]}" \
 {%- endif %}
-
-{%- if docker_container_name == "telemetry" or docker_container_name == "gnmi" %}
-    -v /etc/passwd:/etc/passwd:ro \
-    -v /etc/shadow:/etc/shadow:ro \
-    -v /etc/group:/etc/group:ro \
-    -v /etc/pam.d:/etc/pam.d:ro \
-{%- endif %}
-
 {%- if docker_container_name == "swss" %}
         -e ASIC_VENDOR={{ sonic_asic_platform }} \
 {%- endif -%}

--- a/rules/config
+++ b/rules/config
@@ -227,8 +227,7 @@ INCLUDE_VS_DASH_SAI ?= y
 ENABLE_AUTO_TECH_SUPPORT = y
 
 # ENABLE_TRANSLIB_WRITE - Enable translib write/config operations via the gNMI interface.
-# Uncomment to enable:
-# ENABLE_TRANSLIB_WRITE = y
+ENABLE_TRANSLIB_WRITE = y
 
 # ENABLE_NATIVE_WRITE - Enable native write/config operations via the gNMI interface.
 ENABLE_NATIVE_WRITE = y


### PR DESCRIPTION
#### Why I did it

Enable translib_write by default. This is required for set operations through gNMI to work

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

ENABLE_TRANSLIB_WRITE to y by default

#### How to verify it

Tested together with [authentication](https://github.com/sonic-net/sonic-buildimage/pull/29506) and [unit tests](https://github.com/sonic-net/sonic-mgmt/pull/27282)

#### Description for the changelog

Enable translib_write by default

