### PR TITLE
Fix xcvrd restart during swss start to support mellanox media_settings path

### DIFF
--- a/files/scripts/swss.sh
+++ b/files/scripts/swss.sh
@@ -453,8 +453,9 @@ start() {
         fi
         clean_up_chassis_db_tables
         rm -rf /tmp/cache
-        MEDIA_SETTINGS="/usr/share/sonic/device/$PLATFORM/media_settings.json"
-        if [ -f $MEDIA_SETTINGS ]; then
+        MEDIA_SETTINGS_PLATFORM_PATH="/usr/share/sonic/device/$PLATFORM/media_settings.json"
+        MEDIA_SETTINGS_HWSKU_PATH="/usr/share/sonic/device/$PLATFORM/$HWSKU/media_settings.json"
+        if [ -f $MEDIA_SETTINGS_PLATFORM_PATH ] || [ -f $MEDIA_SETTINGS_HWSKU_PATH ]; then
             if [ "$( docker inspect -f '{{.State.Running}}' pmon )" != "true" ]; then
                 debug "pmon not running so skip restarting xcvrd"
             else


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The `xcvrd `restart added in [22240](https://github.com/sonic-net/sonic-buildimage/pull/22240) gates on media_settings.json in the platform directory. Mellanox keeps that file in the HWSKU directory, so the gate never matches, and the workaround isn't being applied on NVIDIA platforms. 

#### How I did it
Also check the HWSKU path for MEDIA_SETTINGS.


#### How to verify it

1. systemctl restart swss on a Mellanox SKU that ships media_settings.json
2. Verify "Restarting xcvrd service..." in syslog, and xcvrd's PID in pmon changes.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] 202605

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [x] 202605

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)