### PR TITLE
[Mellanox] Use an explicit syslog identifier in mlnx-platform-api loggers

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/inotify_helper.py
@@ -30,7 +30,7 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + '- required module not found') from e
 
-logger = SysLogger()
+logger = SysLogger("mlnx-platform-api")
 
 
 class InotifyHelper():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
No INFO or DEBUG message from xcvrd is ever emitted on Mellanox platforms, no matter what config syslog level is set to.

inotify_helper.py and module.py create their loggers as SysLogger() with no identifier. SysLogger then falls back to sys.argv[0], so inside a daemon it becomes SysLogger("xcvrd") and takes over the daemon's own process-wide logging.Logger. Its constructor sets the level unconditionally, and with enable_runtime_config=False it applies the hardcoded NOTICE default instead of the value in CONFIG_DB. So import sonic_platform.platform — the first line of xcvrd's init() — silently wipes the configured log level.

A shared library shouldn't name its logger after whichever binary imported it. dpuctlplat.py already passes an explicit identifier.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
`logger = SysLogger("mlnx-platform-api")`
'enable_runtime_config' is left False on purpose: enabling it would keep the argv[0]-derived name and create CONFIG_DB rows for every binary that imports the platform API.

#### How to verify it
Manual testing

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
