### PR TITLE
[202605] Backport caclmgrd-owned dhcp_server syslog rule waits

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -41,6 +41,10 @@ get_pmon_device_mounts() {
 }
 {%- endif %}
 
+{%- if docker_container_name == "dhcp_server" %}
+DHCP_SERVER_SYSLOG_CHECK=(iptables -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment dhcp_server_syslog -j ACCEPT)
+{%- endif %}
+
 function updateSyslogConf()
 {
     # On multiNPU platforms, change the syslog target ip to docker0 ip to allow logs from containers
@@ -130,6 +134,23 @@ function preStartAction()
     else
         echo "Cannot fetch system eeprom information. Setting chassis serial number to N/A."
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
+    fi
+{%- elif docker_container_name == "dhcp_server" %}
+    # Wait for caclmgrd to allow dhcp_server syslog before startup.
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "enabled" ]; then
+        local attempt status
+        for attempt in {0..10}; do
+            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+            status=$?
+
+            if [ "$status" -eq 0 ]; then
+                break
+            elif [ "$attempt" -eq 10 ]; then
+                echo "Warning: dhcp_server syslog rule not present after 10 seconds (iptables status $status)."
+            else
+                sleep 1
+            fi
+        done
     fi
 {%- else %}
     : # nothing
@@ -882,6 +903,24 @@ stop() {
         /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}
     fi
+{%- if docker_container_name == "dhcp_server" %}
+    # Wait for caclmgrd to remove the rule after feature disable.
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "disabled" ]; then
+        local attempt status
+        for attempt in {0..10}; do
+            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+            status=$?
+
+            if [ "$status" -eq 1 ]; then
+                break
+            elif [ "$attempt" -eq 10 ]; then
+                echo "Warning: dhcp_server syslog rule not absent after 10 seconds (iptables status $status)."
+            else
+                sleep 1
+            fi
+        done
+    fi
+{%- endif %}
     {%- endif %}
 }
 


### PR DESCRIPTION
#### Why I did it

Manual 202605 backport of https://github.com/sonic-net/sonic-buildimage/pull/28580 (exact root head `60fbc8eeaa3f8fa75675bc6235897dafc13c5557`).

This is step 3 of the coordinated CACL 202605 series:

1. sonic-buildimage #28328 / automated backport #29029 removed the container-owned rule. **Merged.**
2. sonic-host-services #412 / manual backport #426 makes `caclmgrd` own the `dhcp_server` docker0 RELP tcp/2514 INPUT exception. **#426 is open with green CI; its 202605 component must then propagate through a sonic-buildimage submodule-update PR.**
3. **This PR** adds feature-gated bounded waits around the `caclmgrd`-owned rule. It is prepared and running CI concurrently, but **must not merge until #426 is merged and its 202605 sonic-host-services pointer has propagated to sonic-buildimage.**
4. sonic-mgmt #26477 is the final backport.

The release branch already contains #29029, so the old container-side add/delete is gone. This backport restores synchronization without restoring ownership to the container or importing unrelated master changes.

##### Work item tracking
- Microsoft ADO **(number only)**: 39385803

#### How I did it

Applied the squashed root change (`a38b5421646f350bca8dc693f9ca5977620c2bf4`) to current `origin/202605` (`08a1f61c1bba8882ce7aad93828425f2b7ccb2ce`). It applied cleanly because #29029 already provides the release-native template context.

- define the canonical tcp/2514 `iptables -C` probe once;
- when `FEATURE|dhcp_server` is enabled, wait up to 10 seconds for the rule before startup;
- when the feature is disabled, wait up to 10 seconds for rule removal after container stop;
- skip the stop wait for ordinary restarts and when CONFIG_DB is unavailable.

The backport patch-id exactly matches the root merge patch. No conflict resolution or unrelated master change was needed.

#### How to verify it

- `git diff --check origin/202605..HEAD` passed.
- Rendered the `dhcp_server` specialization of `docker_image_ctl.j2` with the repository `j2` tool and passed `bash -n`.
- The focused wait harness passed present/absent transitions, xtables-lock retry, transient-error recovery, and both timeout paths (7 cases).
- The branch contains one signed commit and the worktree is clean.
- The exact root logic was previously hardware-validated on 202605 image `20260510.07` as recorded in #28580. Per release guidance, repository CI is the acceptance gate for this manual backport; no external test plan was triggered.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

This PR already targets 202605; no additional release backport is requested.

#### Tested branch (Please provide the tested image version)

- [x] 202605 (`20260510.07` evidence on #28580; exact-patch source validation above)

#### Description for the changelog

[dhcp_server] Backport feature-gated bounded waits for the caclmgrd-owned docker0 RELP tcp/2514 rule.

#### Link to config_db schema for YANG module changes

Not applicable.

#### A picture of a cute animal (not mandatory but encouraged)

Not included.