### PR TITLE
[H6-128] Bringup bmc0 interface

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7220_h6_128-r0/platform_env.conf
+++ b/device/nokia/x86_64-nokia_ixr7220_h6_128-r0/platform_env.conf
@@ -1,3 +1,3 @@
 SYNCD_SHM_SIZE=512m
 is_ltsw_chip=1
-
+switch_host=1


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
To bring up bmc0 interface for communication between SwitchHost and BMC. This has dependency with platform changes which renames usb0 to bmc0 before assigning IP address
PR: https://github.com/sonic-net/sonic-buildimage/pull/28977

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

Build image with the changes included. interface is renamed to bmc0 and assigned IP 169.254.100.2 successfully.

```
admin@sonic:~$ sudo ifconfig bmc0
bmc0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 169.254.100.2  netmask 255.255.255.252  broadcast 0.0.0.0
        inet6 fe80::ff:fe00:2  prefixlen 64  scopeid 0x20<link>
        ether 02:00:00:00:00:02  txqueuelen 1000  (Ethernet)
        RX packets 2427  bytes 135827 (132.6 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 2926  bytes 1125669 (1.0 MiB)
        TX errors 0  dropped 1 overruns 0  carrier 0  collisions 0

```

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

202605: Tested
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Tested with the changes and interface is renamed to bmc0 and assigned successfully.
```
admin@sonic:~$ sudo ifconfig bmc0
bmc0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 169.254.100.2  netmask 255.255.255.252  broadcast 0.0.0.0
        inet6 fe80::ff:fe00:2  prefixlen 64  scopeid 0x20<link>
        ether 02:00:00:00:00:02  txqueuelen 1000  (Ethernet)
        RX packets 2427  bytes 135827 (132.6 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 2926  bytes 1125669 (1.0 MiB)
        TX errors 0  dropped 1 overruns 0  carrier 0  collisions 0
```



#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
