### PR TITLE
sudoers: remove unnecessary VTYSH_PAGER from env_keep

### DIFF
--- a/files/image_config/sudoers/sudoers
+++ b/files/image_config/sudoers/sudoers
@@ -10,7 +10,6 @@ Defaults        env_reset
 #Defaults        mail_badpass
 Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 Defaults        env_keep += "SONIC_CLI_IFACE_MODE"
-Defaults        env_keep += "VTYSH_PAGER"
 Defaults        lecture = once
 Defaults        lecture_file = /etc/sudoers.lecture
 


### PR DESCRIPTION
#### Why I did it

`VTYSH_PAGER` is not needed in `env_keep`. All NOPASSWD `vtysh` entries in `READ_ONLY_CMDS` use the `-c` flag, which calls `vtysh_execute_no_pager()` and never invokes the pager. Keeping this variable in `env_keep` is unnecessary and reduces the sudoers attack surface.

##### Work item tracking
- Microsoft ADO:

#### How I did it

Removed `Defaults env_keep += "VTYSH_PAGER"` from `files/image_config/sudoers/sudoers`.

#### How to verify it

Confirm that `sudo vtysh -c 'show version'` continues to work normally. `VTYSH_PAGER` is only used by vtysh's interactive readline path, which is not granted via NOPASSWD rules.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request:
Failure type:

#### Tested branch

- [ ] N/A

#### Test result

#### Description for the changelog

sudoers: remove unnecessary VTYSH_PAGER from env_keep

#### Link to config_db schema for YANG module changes

N/A