### PR TITLE
[bgpcfgd] Validate static route identifiers before rendering

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -3,6 +3,7 @@ import socket
 import traceback
 
 from ipaddress import ip_network, IPv4Network
+from sonic_py_common.interface import is_valid_interface_name
 from swsscommon import swsscommon
 
 from .log import log_crit, log_err, log_debug
@@ -10,15 +11,7 @@ from .manager import Manager
 from .template import TemplateFabric
 
 
-INTERFACE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
 VRF_NAME_RE = re.compile(r"(?:default|mgmt|Vrf[A-Za-z0-9_-]+)")
-
-
-def _valid_interface_name(value):
-    return (
-        isinstance(value, str) and
-        INTERFACE_NAME_RE.fullmatch(value) is not None
-    )
 
 
 def _valid_vrf_name(value):
@@ -40,7 +33,7 @@ def _valid_nexthops(values):
         values is None or
         all(
             not value.startswith("PortChannel") or
-            _valid_interface_name(value)
+            is_valid_interface_name(value)
             for value in values
         )
     )
@@ -101,7 +94,7 @@ class StaticRouteMgr(Manager):
 
         if (
             not _valid_nexthops(nh_list) or
-            not _valid_optional_values(intf_list, _valid_interface_name) or
+            not _valid_optional_values(intf_list, is_valid_interface_name) or
             not _valid_optional_values(nh_vrf_list, _valid_vrf_name)
         ):
             log_err("Invalid name in static route data")

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -10,24 +10,39 @@ from .manager import Manager
 from .template import TemplateFabric
 
 
-STATIC_ROUTE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
+INTERFACE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
+VRF_NAME_RE = re.compile(r"(?:default|mgmt|Vrf[A-Za-z0-9_-]+)")
 
 
-def _valid_optional_names(values):
-    return values is None or all(
-        value == "" or (
-            isinstance(value, str) and
-            STATIC_ROUTE_NAME_RE.fullmatch(value)
-        )
-        for value in values
+def _valid_interface_name(value):
+    return (
+        isinstance(value, str) and
+        INTERFACE_NAME_RE.fullmatch(value) is not None
+    )
+
+
+def _valid_vrf_name(value):
+    return (
+        isinstance(value, str) and
+        VRF_NAME_RE.fullmatch(value) is not None
+    )
+
+
+def _valid_optional_values(values, validator):
+    return (
+        values is None or
+        all(value == "" or validator(value) for value in values)
     )
 
 
 def _valid_nexthops(values):
-    return values is None or all(
-        not value.startswith("PortChannel") or
-        STATIC_ROUTE_NAME_RE.fullmatch(value)
-        for value in values
+    return (
+        values is None or
+        all(
+            not value.startswith("PortChannel") or
+            _valid_interface_name(value)
+            for value in values
+        )
     )
 
 class StaticRouteMgr(Manager):
@@ -74,8 +89,8 @@ class StaticRouteMgr(Manager):
 
         if (
             not _valid_nexthops(nh_list) or
-            not _valid_optional_names(intf_list) or
-            not _valid_optional_names(nh_vrf_list)
+            not _valid_optional_values(intf_list, _valid_interface_name) or
+            not _valid_optional_values(nh_vrf_list, _valid_vrf_name)
         ):
             log_err("Invalid name in static route data")
             return True
@@ -216,10 +231,7 @@ class StaticRouteMgr(Manager):
                 vrf = output[0]
                 prefix = key[len(vrf)+1:]
 
-        if vrf != 'default' and not (
-            isinstance(vrf, str) and
-            STATIC_ROUTE_NAME_RE.fullmatch(vrf)
-        ):
+        if not _valid_vrf_name(vrf):
             log_err("Invalid name in static route key")
             return None
 

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -45,6 +45,18 @@ def _valid_nexthops(values):
         )
     )
 
+
+def _canonical_prefix(value):
+    if (
+        not isinstance(value, str) or
+        "%" in value or
+        any(not "\x21" <= character <= "\x7e" for character in value)
+    ):
+        raise ValueError("Invalid characters in prefix")
+
+    return str(ip_network(value, strict=False))
+
+
 class StaticRouteMgr(Manager):
     """ This class updates static routes when STATIC_ROUTE table is updated """
     def __init__(self, common_objs, db, table):
@@ -219,8 +231,8 @@ class StaticRouteMgr(Manager):
             vrf, prefix = key.split('|', 1)
         else:
             try:
-                ip_network(key, strict=False)
-                vrf, prefix = 'default', key
+                prefix = _canonical_prefix(key)
+                vrf = 'default'
             except ValueError:
                 # key in APPL_DB
                 log_debug("static route key {} is not prefix only formart, split with ':'".format(key))
@@ -236,7 +248,7 @@ class StaticRouteMgr(Manager):
             return None
 
         try:
-            ip_network(prefix, strict=False)
+            prefix = _canonical_prefix(prefix)
         except (TypeError, ValueError):
             log_err("Invalid prefix in static route key")
             return None

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -1,10 +1,26 @@
+import re
+import socket
 import traceback
+
+from ipaddress import ip_network, IPv4Network
+from swsscommon import swsscommon
+
 from .log import log_crit, log_err, log_debug
 from .manager import Manager
 from .template import TemplateFabric
-import socket
-from swsscommon import swsscommon
-from ipaddress import ip_network, IPv4Network
+
+
+STATIC_ROUTE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
+
+
+def _valid_optional_names(values):
+    return values is None or all(
+        value == "" or (
+            isinstance(value, str) and
+            STATIC_ROUTE_NAME_RE.fullmatch(value)
+        )
+        for value in values
+    )
 
 class StaticRouteMgr(Manager):
     """ This class updates static routes when STATIC_ROUTE table is updated """
@@ -33,7 +49,10 @@ class StaticRouteMgr(Manager):
     ROUTE_ADVERTISE_DISABLE_TAG = '2'
 
     def set_handler(self, key, data):
-        vrf, ip_prefix = self.split_key(key)
+        key_parts = self.split_key(key)
+        if key_parts is None:
+            return True
+        vrf, ip_prefix = key_parts
         is_ipv6 = TemplateFabric.is_ipv6(ip_prefix)
 
         arg_list    = lambda v: v.split(',') if len(v.strip()) != 0 else None
@@ -44,6 +63,10 @@ class StaticRouteMgr(Manager):
         nh_vrf_list = arg_list(data['nexthop-vrf']) if 'nexthop-vrf' in data else None
         bfd_enable  = arg_list(data['bfd']) if 'bfd' in data else None
         route_tag   = self.ROUTE_ADVERTISE_DISABLE_TAG if 'advertise' in data and data['advertise'] == "false" else self.ROUTE_ADVERTISE_ENABLE_TAG
+
+        if not _valid_optional_names(intf_list) or not _valid_optional_names(nh_vrf_list):
+            log_err("Invalid name in static route data")
+            return True
 
         # bfd enabled route would be handled in staticroutebfd, skip here
         if bfd_enable and bfd_enable[0].lower() == "true":
@@ -128,7 +151,10 @@ class StaticRouteMgr(Manager):
         return False
 
     def del_handler(self, key):
-        vrf, ip_prefix = self.split_key(key)
+        key_parts = self.split_key(key)
+        if key_parts is None:
+            return
+        vrf, ip_prefix = key_parts
         is_ipv6 = TemplateFabric.is_ipv6(ip_prefix)
 
         if self.skip_appl_del(vrf, ip_prefix):
@@ -162,24 +188,35 @@ class StaticRouteMgr(Manager):
         key example: APPL_DB   vrf:5.5.5.0/24, 5.5.5.0/24, vrf:2001::0/64, 2001::0/64
                      CONFIG_DB vrf|5.5.5.0/24, 5.5.5.0/24, vrf|2001::0/64, 2001::0/64
         """
-        vrf = ""
-        prefix = ""
-
         if '|' in key:
-            return tuple(key.split('|', 1))
+            vrf, prefix = key.split('|', 1)
         else:
             try:
-                _ = ip_network(key)
+                ip_network(key, strict=False)
                 vrf, prefix = 'default', key
             except ValueError:
                 # key in APPL_DB
                 log_debug("static route key {} is not prefix only formart, split with ':'".format(key))
                 output = key.split(':', 1)
                 if len(output) < 2:
-                    log_debug("invalid input in APPL_DB {}".format(key))
-                    raise ValueError
+                    log_err("Invalid static route key")
+                    return None
                 vrf = output[0]
                 prefix = key[len(vrf)+1:]
+
+        if vrf != 'default' and not (
+            isinstance(vrf, str) and
+            STATIC_ROUTE_NAME_RE.fullmatch(vrf)
+        ):
+            log_err("Invalid name in static route key")
+            return None
+
+        try:
+            ip_network(prefix, strict=False)
+        except (TypeError, ValueError):
+            log_err("Invalid prefix in static route key")
+            return None
+
         return vrf, prefix
 
     def static_route_commands(self, ip_nh_set, cur_nh_set, ip_prefix, vrf, route_tag, cur_route_tag):

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_static_rt.py
@@ -22,6 +22,14 @@ def _valid_optional_names(values):
         for value in values
     )
 
+
+def _valid_nexthops(values):
+    return values is None or all(
+        not value.startswith("PortChannel") or
+        STATIC_ROUTE_NAME_RE.fullmatch(value)
+        for value in values
+    )
+
 class StaticRouteMgr(Manager):
     """ This class updates static routes when STATIC_ROUTE table is updated """
     def __init__(self, common_objs, db, table):
@@ -64,7 +72,11 @@ class StaticRouteMgr(Manager):
         bfd_enable  = arg_list(data['bfd']) if 'bfd' in data else None
         route_tag   = self.ROUTE_ADVERTISE_DISABLE_TAG if 'advertise' in data and data['advertise'] == "false" else self.ROUTE_ADVERTISE_ENABLE_TAG
 
-        if not _valid_optional_names(intf_list) or not _valid_optional_names(nh_vrf_list):
+        if (
+            not _valid_nexthops(nh_list) or
+            not _valid_optional_names(intf_list) or
+            not _valid_optional_names(nh_vrf_list)
+        ):
             log_err("Invalid name in static route data")
             return True
 

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bgpcfgd.directory import Directory
-from bgpcfgd.managers_static_rt import StaticRouteMgr
+from bgpcfgd.managers_static_rt import (
+    StaticRouteMgr,
+    _valid_interface_name,
+    _valid_vrf_name,
+)
 from bgpcfgd.template import TemplateFabric
 from swsscommon import swsscommon
 
@@ -58,8 +62,9 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
 @pytest.mark.parametrize("key", [
     "not-a-key",
     "vrf name|10.1.0.0/24",
-    "vrfRED|not-a-prefix",
-    "vrfRED|10.1.0.0/24|extra",
+    "vrfRED|10.1.0.0/24",
+    "VrfRED|not-a-prefix",
+    "VrfRED|10.1.0.0/24|extra",
 ])
 def test_invalid_key_is_rejected(key):
     mgr = constructor()
@@ -81,11 +86,11 @@ def test_invalid_key_is_rejected(key):
 
 
 @pytest.mark.parametrize(("field", "value"), [
-    ("nexthop", "PortChannelNameTooLong"),
+    ("nexthop", "PortChannel 1"),
     ("ifname", "Port Channel"),
-    ("ifname", "InterfaceNameTooLong"),
+    ("ifname", "Ethernet0/1"),
     ("nexthop-vrf", "vrf name"),
-    ("nexthop-vrf", "VrfNameThatIsTooLong"),
+    ("nexthop-vrf", "nh_vrf"),
 ])
 def test_invalid_name_field_is_rejected(field, value):
     mgr = constructor()
@@ -100,6 +105,38 @@ def test_invalid_name_field_is_rejected(field, value):
         True,
         []
     )
+
+
+@pytest.mark.parametrize("name", [
+    "default",
+    "mgmt",
+    "VrfRED",
+    "VrfNameLongerThanAnInterface",
+])
+def test_valid_vrf_name(name):
+    assert _valid_vrf_name(name)
+
+
+@pytest.mark.parametrize("name", [
+    "",
+    "vrfRED",
+    "Vrf.RED",
+    "Vrf RED",
+])
+def test_invalid_vrf_name(name):
+    assert not _valid_vrf_name(name)
+
+
+@pytest.mark.parametrize(("name", "expected"), [
+    ("Ethernet0", True),
+    ("PortChannel0001", True),
+    ("PortChannel1.100", False),
+    ("Ethernet999.4094", False),
+    ("Port Channel", False),
+    ("Ethernet0/1", False),
+])
+def test_interface_name_policy(name, expected):
+    assert _valid_interface_name(name) is expected
 
 
 def test_set():
@@ -379,12 +416,12 @@ def test_set_nhvrf():
             "nexthop": "10.0.0.57",
             "ifname": "PortChannel0001",
             "distance": "10",
-            "nexthop-vrf": "nh_vrf",
+            "nexthop-vrf": "VrfNH",
             "blackhole": "false",
         }),
         True,
         [
-            "ip route 10.1.1.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf tag 1",
+            "ip route 10.1.1.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
             "router bgp 65100",
@@ -407,7 +444,7 @@ def test_set_blackhole():
             "nexthop": "10.0.0.57",
             "ifname": "PortChannel0001",
             "distance": "10",
-            "nexthop-vrf": "nh_vrf",
+            "nexthop-vrf": "VrfNH",
             "blackhole": "true",
         }),
         True,
@@ -431,19 +468,19 @@ def test_set_vrf():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57",
             "ifname": "PortChannel0001",
             "distance": "10",
-            "nexthop-vrf": "nh_vrf",
+            "nexthop-vrf": "VrfNH",
             "blackhole": "false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -487,20 +524,20 @@ def test_set_nh_only():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -516,20 +553,20 @@ def test_set_ifname_only():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -545,21 +582,21 @@ def test_set_with_empty_ifname():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -575,21 +612,21 @@ def test_set_with_empty_nh():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,,",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -605,21 +642,21 @@ def test_set_del():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -632,13 +669,13 @@ def test_set_del():
     set_del_test(
         mgr,
         "DEL",
-        ("vrfRED|10.1.3.0/24",),
+        ("VrfRED|10.1.3.0/24",),
         True,
         [
-            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  no redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -652,21 +689,21 @@ def test_set_del():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -682,21 +719,21 @@ def test_set_same_route():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -709,21 +746,21 @@ def test_set_same_route():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "40,50,60",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 40 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 50 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 60 nexthop-vrf default vrf vrfRED tag 1"
+            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 40 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 50 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 60 nexthop-vrf default vrf VrfRED tag 1"
         ]
     )
 
@@ -732,21 +769,21 @@ def test_set_add_del_nh():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
             "route-map STATIC_ROUTE_FILTER permit 10",
             " match tag 1",
-            "router bgp 65100 vrf vrfRED",
+            "router bgp 65100 vrf VrfRED",
             " address-family ipv4",
             "  redistribute static route-map STATIC_ROUTE_FILTER",
             " exit-address-family",
@@ -759,32 +796,32 @@ def test_set_add_del_nh():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61,10.0.0.63",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003,PortChannel0004",
             "distance": "10,20,30,30",
-            "nexthop-vrf": "nh_vrf,,default,",
+            "nexthop-vrf": "VrfNH,,default,",
             "blackhole": "false,false,false,",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.63 PortChannel0004 30 vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.63 PortChannel0004 30 vrf VrfRED tag 1",
         ]
     )
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59",
             "ifname": "PortChannel0001,PortChannel0002",
             "distance": "10,20",
-            "nexthop-vrf": "nh_vrf,",
+            "nexthop-vrf": "VrfNH,",
             "blackhole": "false,false",
         }),
         True,
         [
-            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.63 PortChannel0004 30 vrf vrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.63 PortChannel0004 30 vrf VrfRED tag 1",
         ]
     )
 
@@ -958,29 +995,29 @@ def test_set_del_no_bgp_asn():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
         ]
     )
     set_del_test(
         mgr,
         "DEL",
-        ("vrfRED|10.1.3.0/24",),
+        ("VrfRED|10.1.3.0/24",),
         True,
         [
-            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "no ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
         ]
     )
 
@@ -989,27 +1026,27 @@ def test_set_del_bgp_asn_change():
     set_del_test(
         mgr,
         "SET",
-        ("vrfRED|10.1.3.0/24", {
+        ("VrfRED|10.1.3.0/24", {
             "nexthop": "10.0.0.57,10.0.0.59,10.0.0.61",
             "ifname": "PortChannel0001,PortChannel0002,PortChannel0003",
             "distance": "10,20,30",
-            "nexthop-vrf": "nh_vrf,,default",
+            "nexthop-vrf": "VrfNH,,default",
             "blackhole": "false,false,false",
         }),
         True,
         [
-            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf nh_vrf vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf vrfRED tag 1",
-            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf vrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.57 PortChannel0001 10 nexthop-vrf VrfNH vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.59 PortChannel0002 20 vrf VrfRED tag 1",
+            "ip route 10.1.3.0/24 10.0.0.61 PortChannel0003 30 nexthop-vrf default vrf VrfRED tag 1",
         ]
     )
 
-    assert mgr.vrf_pending_redistribution == {"vrfRED"}
+    assert mgr.vrf_pending_redistribution == {"VrfRED"}
 
     expected_cmds = [
         "route-map STATIC_ROUTE_FILTER permit 10",
         " match tag 1",
-        "router bgp 65100 vrf vrfRED",
+        "router bgp 65100 vrf VrfRED",
         " address-family ipv4",
         "  redistribute static route-map STATIC_ROUTE_FILTER",
         " exit-address-family",

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -81,6 +81,7 @@ def test_invalid_key_is_rejected(key):
 
 
 @pytest.mark.parametrize(("field", "value"), [
+    ("nexthop", "PortChannelNameTooLong"),
     ("ifname", "Port Channel"),
     ("ifname", "InterfaceNameTooLong"),
     ("nexthop-vrf", "vrf name"),

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -1,9 +1,11 @@
+from collections import Counter
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from bgpcfgd.directory import Directory
-from bgpcfgd.template import TemplateFabric
 from bgpcfgd.managers_static_rt import StaticRouteMgr
-from collections import Counter
+from bgpcfgd.template import TemplateFabric
 from swsscommon import swsscommon
 
 def constructor(skip_bgp_asn=False):
@@ -51,6 +53,53 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
         assert set_del_test.push_list_called, "cfg_mgr.push_list wasn't called"
     else:
         assert not set_del_test.push_list_called, "cfg_mgr.push_list was called"
+
+
+@pytest.mark.parametrize("key", [
+    "not-a-key",
+    "vrf name|10.1.0.0/24",
+    "vrfRED|not-a-prefix",
+    "vrfRED|10.1.0.0/24|extra",
+])
+def test_invalid_key_is_rejected(key):
+    mgr = constructor()
+
+    set_del_test(
+        mgr,
+        "SET",
+        (key, {"nexthop": "10.0.0.57"}),
+        True,
+        []
+    )
+    set_del_test(
+        mgr,
+        "DEL",
+        (key,),
+        True,
+        []
+    )
+
+
+@pytest.mark.parametrize(("field", "value"), [
+    ("ifname", "Port Channel"),
+    ("ifname", "InterfaceNameTooLong"),
+    ("nexthop-vrf", "vrf name"),
+    ("nexthop-vrf", "VrfNameThatIsTooLong"),
+])
+def test_invalid_name_field_is_rejected(field, value):
+    mgr = constructor()
+
+    set_del_test(
+        mgr,
+        "SET",
+        ("10.1.0.0/24", {
+            "nexthop": "10.0.0.57",
+            field: value,
+        }),
+        True,
+        []
+    )
+
 
 def test_set():
     mgr = constructor()

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -65,6 +65,8 @@ def set_del_test(mgr, op, args, expected_ret, expected_cmds):
     "vrfRED|10.1.0.0/24",
     "VrfRED|not-a-prefix",
     "VrfRED|10.1.0.0/24|extra",
+    "VrfRED|fe80::%scope\nname/64",
+    "VrfRED|10.1.0.0/24\t",
 ])
 def test_invalid_key_is_rejected(key):
     mgr = constructor()
@@ -83,6 +85,11 @@ def test_invalid_key_is_rejected(key):
         True,
         []
     )
+
+
+def test_split_key_canonicalizes_prefix():
+    assert StaticRouteMgr.split_key("10.1.0.1/24") == ("default", "10.1.0.0/24")
+    assert StaticRouteMgr.split_key("VrfRED|2001:db8::1/64") == ("VrfRED", "2001:db8::/64")
 
 
 @pytest.mark.parametrize(("field", "value"), [

--- a/src/sonic-bgpcfgd/tests/test_static_rt.py
+++ b/src/sonic-bgpcfgd/tests/test_static_rt.py
@@ -6,10 +6,10 @@ import pytest
 from bgpcfgd.directory import Directory
 from bgpcfgd.managers_static_rt import (
     StaticRouteMgr,
-    _valid_interface_name,
     _valid_vrf_name,
 )
 from bgpcfgd.template import TemplateFabric
+from sonic_py_common.interface import is_valid_interface_name
 from swsscommon import swsscommon
 
 def constructor(skip_bgp_asn=False):
@@ -143,7 +143,7 @@ def test_invalid_vrf_name(name):
     ("Ethernet0/1", False),
 ])
 def test_interface_name_policy(name, expected):
-    assert _valid_interface_name(name) is expected
+    assert is_valid_interface_name(name) is expected
 
 
 def test_set():

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -2,6 +2,8 @@
 SONiC interface types and access functions.
 """
 
+import re
+
 """
  Dictionary of SONIC interface name prefixes. Each entry in the format
  "Human readable interface string":"Sonic interface prefix"
@@ -21,6 +23,16 @@ SONIC_INTERFACE_PREFIXES = {
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+INTERFACE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
+
+
+def is_valid_interface_name(value):
+    """Return whether value is a valid SONiC kernel interface name."""
+    return (
+        isinstance(value, str) and
+        INTERFACE_NAME_RE.fullmatch(value) is not None
+    )
+
 
 def front_panel_prefix():
     """

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -23,13 +23,14 @@ SONIC_INTERFACE_PREFIXES = {
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
-INTERFACE_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_.-]{0,14}")
+INTERFACE_NAME_RE = re.compile(r"[A-Za-z0-9_.][A-Za-z0-9_.-]{0,14}")
 
 
 def is_valid_interface_name(value):
-    """Return whether value is a valid SONiC kernel interface name."""
+    """Return whether value is safe to use as a kernel interface name."""
     return (
         isinstance(value, str) and
+        value not in (".", "..") and
         INTERFACE_NAME_RE.fullmatch(value) is not None
     )
 

--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -23,6 +23,13 @@ SONIC_INTERFACE_PREFIXES = {
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+
+# Security-only syntax guard, not SONiC interface-type validation. Category
+# semantics remain in the YANG models and port utilities. The 15-character
+# limit matches sonic-types:interface_name and Linux IFNAMSIZ minus its NUL.
+# The ASCII allowlist is intentional because names can reach shell commands
+# and generated configuration; a leading '-' is excluded to prevent option
+# injection.
 INTERFACE_NAME_RE = re.compile(r"[A-Za-z0-9_.][A-Za-z0-9_.-]{0,14}")
 
 

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -5,6 +5,22 @@ from sonic_py_common import interface
 from sonic_py_common.multi_asic import is_front_panel_port
 
 class TestInterface(object):
+    def test_valid_interface_name(self):
+        for name in ("Ethernet0", "PortChannel1", "Loopback0", "Eth0.100"):
+            assert interface.is_valid_interface_name(name)
+
+    def test_invalid_interface_name(self):
+        for name in (
+            "",
+            "Port Channel",
+            "Ethernet0/1",
+            "PortChannel1.100",
+            "InterfaceNameTooLong",
+        ):
+            assert not interface.is_valid_interface_name(name)
+
+        assert not interface.is_valid_interface_name(None)
+
     def test_get_interface_table_name(self):
         result = interface.get_interface_table_name("Ethernet0")
         assert result == "INTERFACE"

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -6,14 +6,27 @@ from sonic_py_common.multi_asic import is_front_panel_port
 
 class TestInterface(object):
     def test_valid_interface_name(self):
-        for name in ("Ethernet0", "PortChannel1", "Loopback0", "Eth0.100"):
+        for name in (
+            "Ethernet0",
+            "PortChannel1",
+            "Eth0.100",
+            "Ethernet-BP0",
+            "1Ethernet",
+            "_eth0",
+            ".eth0",
+        ):
             assert interface.is_valid_interface_name(name)
 
     def test_invalid_interface_name(self):
         for name in (
             "",
+            ".",
+            "..",
+            "-Ethernet0",
             "Port Channel",
             "Ethernet0/1",
+            "Ethernet0:1",
+            "Ethernet0;id",
             "PortChannel1.100",
             "InterfaceNameTooLong",
         ):


### PR DESCRIPTION
#### Why I did it

Use the shared interface-name syntax check consistently for static-route interface fields and canonicalize route prefixes before processing.

The accepted interface-name format is a string from 1 through 15 characters. The first character must match `[A-Za-z0-9_.]`; each remaining character must match `[A-Za-z0-9_.-]`. The complete values `.` and `..` are not accepted.

##### Work item tracking

#### How I did it

Applied the shared interface-name check to static-route interface fields, made set and delete handling consistent for route keys and name fields, and canonicalized IPv4 and IPv6 prefixes to network form. Added unit coverage for accepted and rejected names and keys, canonical prefixes, and existing route behavior.

#### How to verify it

Unit coverage was added for accepted and rejected static-route keys and name fields and for prefix canonicalization. Upstream CI will verify the change.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Upstream CI.

#### Description for the changelog

Apply shared interface-name syntax validation and canonicalize static-route prefixes.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
