### PR TITLE
[device/arista]: Restore sai_tunnel_support on Arista-7060X6-64PE-B-C512S2

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm
@@ -40,7 +40,7 @@ bcm_device:
             #l3_intf_vlan_split_egress for MTU at L3IF
             l3_intf_vlan_split_egress : 1
             pfc_deadlock_seq_control : 1
-            sai_tunnel_support: 0x12
+            sai_tunnel_support: 2
             bcm_tunnel_term_compatible_mode: 1
             l3_ecmp_member_first_lkup_mem_size: 0
             l3_ecmp_member_secondary_mem_size: 0


### PR DESCRIPTION
#### Why I did it

VXLAN tunnels do not come up on `Arista-7060X6-64PE-B-C512S2`. The SAI profile
for this HwSKU sets `sai_tunnel_support: 0x12`, and the SAI adapter decodes that
bitmask with VXLAN disabled. The `BCMSAI MPTnl Global` capability line reports:

```
VxLAN:No  IPinIP/GRE:Yes  VxLAN_Decap_Only:No  VxLAN_L3VNI_Only:No
```

so the platform offers only IPinIP/GRE and no VXLAN encap or decap at all.
Setting bit 0 on its own (`0x13`) is not sufficient either: it flips
`VxLAN_L3VNI_Only` to Yes, which restricts the platform to L3VNI and still does
not give a usable L2VNI.

This file carried `sai_tunnel_support: 2` until `Enable srv6 on TH5` (#23018)
changed it to `0x12` on 2025-06-27. `Arista-7060X6-64PE-B-P28O72` and
`Arista-7060X6-64PE-B-O128/th5-a7060x6-64pe-lt2.config.bcm` still carry `2`
today.

#### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Restore `sai_tunnel_support: 2` in
`device/arista/x86_64-arista_7060x6_64pe_b/Arista-7060X6-64PE-B-C512S2/th5-a7060x6-64pe.config.bcm`.

Scope is deliberately limited to this one HwSKU. The other profiles in the same
directory are also `0x12`, but no hardware was available to verify them, so they
are left unchanged.

#### How to verify it

On a pair of 7060X6-64PE-B C512S2 units running an L2VNI (VNI 10100) between
VTEPs 172.30.255.11 and 172.30.255.12:

```
# tunnel object reaches the ASIC
redis-cli -n 1 --scan --pattern 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL:*' | wc -l
# -> 1

redis-cli -n 1 --scan --pattern 'ASIC_STATE:SAI_OBJECT_TYPE_TUNNEL_TERM_TABLE_ENTRY:*' | wc -l
# -> 2

# no SAI rejection of tunnel creation
grep -c 'SAI_STATUS_ATTR_NOT_IMPLEMENTED.*[Tt]unnel' /var/log/syslog
# -> 0

show vxlan remotevtep
show vxlan vlanvnimap
```

Without this change no VXLAN packets are produced at all and no
`SAI_OBJECT_TYPE_TUNNEL` object appears in ASIC_DB.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

- [x] Verified on an image built from this change on a 7060X6-64PE-B C512S2 pair
      (`SONiC-OS-tahmed_fpm-mac-learning-master.0-427f611889`).

#### Description for the changelog

Restore `sai_tunnel_support` on Arista-7060X6-64PE-B-C512S2 so VXLAN tunnels come up.

#### Link to config_db schema for YANG module changes

N/A, no YANG or config_db schema change.
