### PR TITLE
[Mellanox]: Drop TTY flags from get_component_versions docker exec

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_component_versions/main.py
+++ b/platform/mellanox/platform-utils/mellanox_component_versions/main.py
@@ -119,12 +119,12 @@ def process_rule(rule: ComponentRule) -> tuple[bool, str | list[str]]:
     cmd_args = shlex.split(cmd)
     if asic_count > 1 and rule.is_from_syncd:
         for asic in range(asic_count):
-            asic_cmd = ["docker", "exec", "-it", f"syncd{asic}"] + cmd_args
+            asic_cmd = ["docker", "exec", f"syncd{asic}"] + cmd_args
             version = subprocess.run(asic_cmd, shell=False, stdout=subprocess.PIPE, text=True).stdout
             versions.append(version)
     else:
         if rule.is_from_syncd:
-            run_cmd = ["docker", "exec", "-it", "syncd"] + cmd_args
+            run_cmd = ["docker", "exec", "syncd"] + cmd_args
         else:
             run_cmd = cmd_args
         version = subprocess.run(run_cmd, shell=False, stdout=subprocess.PIPE, text=True).stdout


### PR DESCRIPTION
#### Why I did it

`get_component_versions.py` uses `docker exec -it` for rules executed inside the syncd container. Without a terminal on stdin, Docker reports `the input device is not a TTY`; the empty output is then reported as `N/A` for SDK, SAI, and SAI_API_HEADERS. This affects non-interactively generated techsupport dumps on single-ASIC and multi-ASIC systems.

##### Work item tracking

- Microsoft ADO **(number only)**: N/A

#### How I did it

Removed the unnecessary `-it` flags from the single-ASIC and multi-ASIC
`docker exec` invocations.

#### How to verify it

Run the utility without allocating a terminal:

```text
ssh admin@sonic 'sudo get_component_versions.py'
```

Confirm SDK, SAI, and SAI_API_HEADERS contain their actual versions. Running the
same utility interactively must continue producing the same values.

Before:

```
with no tty
$ ssh admin@sonic 'sudo get_component_versions.py' 

the input device is not a TTY
the input device is not a TTY
the input device is not a TTY
COMPONENT        COMPILATION           ACTUAL
---------------  --------------------  ---------------------
MFT              4.36.0-1033           4.36.0-1033
HW_MANAGEMENT    7.0070.1013           7.0070.1013
SDK              4.10.1090             N/A
SAI              SAIBuild2605.37.0.31  N/A
SAI_API_HEADERS  1.18.1                N/A


with a pseudo tty:
$ssh admin@sonic "sudo script -qec get_component_versions.py"

COMPONENT        COMPILATION           ACTUAL
---------------  --------------------  ---------------------
MFT              4.36.0-1033           4.36.0-1033
HW_MANAGEMENT    7.0070.1013           7.0070.1013
SDK              4.10.1090             4.10.1090
SAI              SAIBuild2605.37.0.31  SAIBuild2605.37.0.31
SAI_API_HEADERS  1.18.1                1.18.1


```

After:

```
Always:

SDK              4.10.1090             4.10.1090
SAI              SAIBuild2605.37.0.31  SAIBuild2605.37.0.31
SAI_API_HEADERS  1.18.1                1.18.1
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

The same bug affects 202605.

Tracking issue/work item for backport/cherry-pick request: N/A
Failure type: day-one issue

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- 202605: verified with and without a pseudo-terminal. All three component
  versions were populated after the change; interactive behavior was unchanged.
- master: the change applies cleanly and build succeeded

#### Description for the changelog

[Mellanox] Fix SDK, SAI, and SAI_API_HEADERS reporting N/A in non-interactive
`get_component_versions.py` runs
