### PR TITLE
[sonic-py-common] Add interface name validation helper

### DIFF
--- a/src/sonic-py-common/sonic_py_common/interface.py
+++ b/src/sonic-py-common/sonic_py_common/interface.py
@@ -2,6 +2,8 @@
 SONiC interface types and access functions.
 """
 
+import re
+
 """
  Dictionary of SONIC interface name prefixes. Each entry in the format
  "Human readable interface string":"Sonic interface prefix"
@@ -21,6 +23,21 @@ SONIC_INTERFACE_PREFIXES = {
 }
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
+
+# This validates interface-name syntax only. Category semantics remain in the
+# YANG models and port utilities. The 15-character limit matches
+# sonic-types:interface_name and Linux IFNAMSIZ minus its NUL.
+INTERFACE_NAME_RE = re.compile(r"[A-Za-z0-9_.][A-Za-z0-9_.-]{0,14}")
+
+
+def is_valid_interface_name(value):
+    """Return whether value matches the interface-name syntax."""
+    return (
+        isinstance(value, str) and
+        value not in (".", "..") and
+        INTERFACE_NAME_RE.fullmatch(value) is not None
+    )
+
 
 def front_panel_prefix():
     """

--- a/src/sonic-py-common/tests/interface_test.py
+++ b/src/sonic-py-common/tests/interface_test.py
@@ -5,6 +5,35 @@ from sonic_py_common import interface
 from sonic_py_common.multi_asic import is_front_panel_port
 
 class TestInterface(object):
+    def test_valid_interface_name(self):
+        for name in (
+            "Ethernet0",
+            "PortChannel1",
+            "Eth0.100",
+            "Ethernet-BP0",
+            "1Ethernet",
+            "_eth0",
+            ".eth0",
+        ):
+            assert interface.is_valid_interface_name(name)
+
+    def test_invalid_interface_name(self):
+        for name in (
+            "",
+            ".",
+            "..",
+            "-Ethernet0",
+            "Port Channel",
+            "Ethernet0/1",
+            "Ethernet0:1",
+            "Ethernet0@1",
+            "PortChannel1.100",
+            "InterfaceNameTooLong",
+        ):
+            assert not interface.is_valid_interface_name(name)
+
+        assert not interface.is_valid_interface_name(None)
+
     def test_get_interface_table_name(self):
         result = interface.get_interface_table_name("Ethernet0")
         assert result == "INTERFACE"


### PR DESCRIPTION
#### Why I did it

Add one shared interface-name syntax check so callers use the same accepted format.

The accepted format is a string from 1 through 15 characters. The first character must match `[A-Za-z0-9_.]`; each remaining character must match `[A-Za-z0-9_.-]`. The complete values `.` and `..` are not accepted.

Dependent PRs [#29172](https://github.com/sonic-net/sonic-buildimage/pull/29172) and [#29175](https://github.com/sonic-net/sonic-buildimage/pull/29175) are explicitly paused until this helper merges; they will then be rebuilt from `master`.

##### Work item tracking

#### How I did it

Added `is_valid_interface_name()` to `sonic_py_common.interface` with the format above and focused unit coverage for accepted and rejected names. Existing prefix, interface-type, and YANG validation remains unchanged.

#### How to verify it

Build the Trixie `sonic_py_common` wheel and run its unit tests.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Trixie `sonic_py_common` wheel build and 118 tests passed.

#### Description for the changelog

Add shared interface-name syntax validation.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
