### PR TITLE
Update cisco-8000.ini to 202605.1.0.4

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202605.1.0.2
+ref=202605.1.0.4


### PR DESCRIPTION
#### Why I did it

Update the Cisco 8000 platform checkout reference to pick up the latest `202605.1.0.4` release of `platform-cisco-8000`.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Bumped the `ref` in `platform/checkout/cisco-8000.ini` from `202605.1.0.2` to `202605.1.0.4`.

#### How to verify it

Build the Cisco 8000 platform and confirm it checks out the `202605.1.0.4` tag of `platform-cisco-8000`.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

#### Tested branch

- [ ] master
- [ ] N/A

#### Description for the changelog

Update cisco-8000.ini to 202605.1.0.4
