### PR TITLE
[yang-models]: Allow tunnel src_ip to be optional in the case of IPv6 AF

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/tunnel.json
@@ -5,6 +5,9 @@
     "TUNNEL_LOAD_IPV6": {
         "desc": "Load TUNNEL with IPv6 source and destination addresses."
     },
+    "TUNNEL_LOAD_IPV6_NO_SRC": {
+        "desc": "Load TUNNEL with an IPv6 destination and no source address."
+    },
     "TUNNEL_INVALID_ADDR": {
         "desc": "Load TUNNEL with invalid IP address.",
         "eStrKey": "InvalidValue"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/tunnel.json
@@ -86,6 +86,24 @@
         }
     },
 
+    "TUNNEL_LOAD_IPV6_NO_SRC": {
+        "sonic-tunnel:sonic-tunnel": {
+            "sonic-tunnel:TUNNEL": {
+                "TUNNEL_LIST": [
+                    {
+                        "tunnel_name": "MyIPv6TunnelWithoutSource",
+                        "dscp_mode": "pipe",
+                        "dst_ip": "fc00:1::32",
+                        "ecn_mode": "standard",
+                        "encap_ecn_mode": "standard",
+                        "ttl_mode": "pipe",
+                        "tunnel_type": "IPINIP"
+                    }
+                ]
+            }
+        }
+    },
+
     "TUNNEL_MIXED_AF": {
         "sonic-tunnel:sonic-tunnel": {
             "sonic-tunnel:TUNNEL": {

--- a/src/sonic-yang-models/yang-models/sonic-tunnel.yang
+++ b/src/sonic-yang-models/yang-models/sonic-tunnel.yang
@@ -32,8 +32,8 @@ module sonic-tunnel {
 			list TUNNEL_LIST {
 				key "tunnel_name";
 
-				must "(contains(src_ip, ':') and contains(dst_ip, ':')) or " +
-				     "(not(contains(src_ip, ':')) and not(contains(dst_ip, ':')))";
+				must "not(src_ip) or not(dst_ip) or " +
+				     "(contains(src_ip, ':') = contains(dst_ip, ':'))";
 
 				leaf tunnel_name {
 					description "Name of Tunnel";


### PR DESCRIPTION
#### Why I did it

The TUNNEL must condition constraint did not allow src_ip to be empty when the dst_ip is in IPv6. As a result, configuring an IPv6 `dst_ip` without `src_ip` incorrectly failed validation.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Guarded the address-family comparison when either endpoint is absent while preserving rejection of mismatched IPv4 and IPv6 addresses when both endpoints are present. Added a positive YANG model test for an IPv6 destination without a source address.

#### How to verify it

Run a SONiC config apply-patch command with the new YANG model suite and the following GCU patch:
[
  {
    "op": "add",
    "path": "/TUNNEL/Tunnel",
    "value": {
      "tunnel_type": "IPINIP",
      "dst_ip": "fcbb:bbbb:1::",
      "dscp_mode": "pipe",
      "ecn_mode": "standard",
      "ttl_mode": "pipe"
    }
  }
]

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: other

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Meet the expectation.

#### Description for the changelog

Allow TUNNEL configurations to omit `src_ip` when using an IPv6 destination.

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#tunnel