### PR TITLE
[macsec]: Fix show command key parsing

### DIFF
--- a/dockers/docker-macsec/cli-plugin-tests/appl_db.json
+++ b/dockers/docker-macsec/cli-plugin-tests/appl_db.json
@@ -1,4 +1,10 @@
 {
+  "MACSEC_PORT_TABLE_KEY_SET": {
+    "pending": "Ethernet8"
+  },
+  "MACSEC_PORT_TABLE_DEL_SET": {
+    "pending": "Ethernet32"
+  },
   "MACSEC_EGRESS_SA_TABLE:Ethernet1:5254008f4f1c0001:1": {
     "type": "hash",
     "value": {

--- a/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
+++ b/dockers/docker-macsec/cli-plugin-tests/test_show_macsec.py
@@ -19,6 +19,9 @@ class TestShowMACsec(object):
         runner = CliRunner()
         result = runner.invoke(show_macsec.macsec,[])
         assert result.exit_code == 0, "exit code: {}, Exception: {}, Traceback: {}".format(result.exit_code, result.exception, result.exc_info)
+        assert "MACsec port(Ethernet1)" in result.output
+        assert "MACSEC_PORT_TABLE_KEY_SET" not in result.output
+        assert "MACSEC_PORT_TABLE_DEL_SET" not in result.output
 
     def test_show_one_port(self):
         runner = CliRunner()

--- a/dockers/docker-macsec/cli/show/plugins/show_macsec.py
+++ b/dockers/docker-macsec/cli/show/plugins/show_macsec.py
@@ -305,7 +305,12 @@ class MacsecContext(object):
         if not profile:
             COUNTER_TABLE = CounterTable(self.db.get_redis_client(self.db.COUNTERS_DB))
 
-            interface_names = [name.split(":")[1] for name in self.db.keys(self.db.APPL_DB, "MACSEC_PORT*")]
+            separator = self.db.get_db_separator(self.db.APPL_DB)
+            port_key_prefix = MACsecPort.get_appl_table_name() + separator
+            interface_names = [
+                name[len(port_key_prefix):]
+                for name in self.db.keys(self.db.APPL_DB, port_key_prefix + "*")
+            ]
             if interface_name is not None:
                 if interface_name not in interface_names:
                     return
@@ -315,7 +320,12 @@ class MacsecContext(object):
             for interface_name in natsorted(interface_names):
                 objs += create_macsec_objs(interface_name)
         else:
-            profile_names = [name.split("|")[1] for name in self.db.keys(self.db.CONFIG_DB, "MACSEC_PROFILE*")]
+            separator = self.db.get_db_separator(self.db.CONFIG_DB)
+            profile_key_prefix = MACsecProfile.get_cfg_table_name() + separator
+            profile_names = [
+                name[len(profile_key_prefix):]
+                for name in self.db.keys(self.db.CONFIG_DB, profile_key_prefix + "*")
+            ]
             objs = []
 
             for profile_name in natsorted(profile_names):


### PR DESCRIPTION
Restrict MACsec port and profile lookups to exact table prefixes so ConsumerStateTable bookkeeping keys are not parsed as interfaces.

If show macsec would run when these keys are there, it would throw a backtrace : 

admin@str2-7804-lc5-1:~$ show macsec
Traceback (most recent call last):
  File "/usr/local/bin/show", line 8, in <module>
    sys.exit(cli())
             ~~~^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3/dist-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.13/dist-packages/show/plugins/macsec.py", line 289, in macsec
    MacsecContext(namespace, display).show(interface_name, dump_file, profile)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/utilities_common/multi_asic.py", line 204, in wrapped_run_on_all_asics
    func(self,  *args, **kwargs)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/dist-packages/show/plugins/macsec.py", line 308, in show
    interface_names = [name.split(":")[1] for name in self.db.keys(self.db.APPL_DB, "MACSEC_PORT*")]
                       ~~~~~~~~~~~~~~~^^^
IndexError: list index out of range


<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md
     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
