### PR TITLE
[sonic-py-common] Lazy-import yaml and the natural-sort helper to cut PMON daemon memory

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -5,9 +5,7 @@ import os
 import random
 import re
 import subprocess
-import yaml
 from typing import List, Optional
-from natsort import natsorted
 from sonic_py_common.general import getstatusoutput_noshell_pipe
 from swsscommon.swsscommon import ConfigDBConnector, SonicV2Connector
 
@@ -638,6 +636,7 @@ def get_sonic_version_info():
     if sonic_ver_info:
         return sonic_ver_info
 
+    import yaml  # lazy: keep yaml (~3.2MB) off the module import surface
     with open(SONIC_VERSION_YAML_PATH) as stream:
         if yaml.__version__ >= "5.1":
             sonic_ver_info = yaml.full_load(stream)
@@ -908,6 +907,7 @@ def get_namespaces():
     In a multi NPU platform, each NPU is in a Linux Namespace.
     This method returns list of all the Namespace present on the device
     """
+    from natsort import natsorted  # lazy: keep this ~4.2MB dependency off the module import surface
     ns_list = []
     for path in glob.glob(NAMESPACE_PATH_GLOB):
         ns = os.path.basename(path)
@@ -1325,11 +1325,13 @@ def get_expected_asic_list():
     asic_list = []
 
     asic_list_file = get_expected_asic_list_file_path()
+    if asic_list_file is None or not os.path.exists(asic_list_file):
+        return asic_list
 
+    import yaml  # lazy: keep yaml (~3.2MB) off the module import surface
     try:
-        if asic_list_file is not None and os.path.exists(asic_list_file):
-            with open(asic_list_file, 'r') as file:
-                asic_list = yaml.safe_load(file)
+        with open(asic_list_file) as file:
+            asic_list = yaml.safe_load(file)
 
         # Ensure it's a list
         if not isinstance(asic_list, list):

--- a/src/sonic-py-common/sonic_py_common/multi_asic.py
+++ b/src/sonic-py-common/sonic_py_common/multi_asic.py
@@ -2,7 +2,6 @@ import glob
 import os
 import subprocess
 
-from natsort import natsorted
 from swsscommon import swsscommon
 
 from .device_info import get_asic_conf_file_path, get_expected_asic_list
@@ -212,6 +211,7 @@ def get_namespaces_from_linux():
     if current_ns:
         return [current_ns]
 
+    from natsort import natsorted  # lazy: keep this ~4.2MB dependency off the module import surface
     ns_list = []
     for path in glob.glob(NAMESPACE_PATH_GLOB):
         ns = os.path.basename(path)

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -575,6 +575,50 @@ liquid_cooled=true
         mock_bmc_data.return_value = BMC_DATA
         assert device_info.get_switch_host_address() == "169.254.100.2"
 
+    @mock.patch("sonic_py_common.device_info.get_expected_asic_list_file_path")
+    def test_get_expected_asic_list_no_file(self, mock_path):
+        # No file path resolved -> early return [] (does not import/parse yaml).
+        mock_path.return_value = None
+        assert device_info.get_expected_asic_list() == []
+
+    @mock.patch("os.path.exists")
+    @mock.patch("sonic_py_common.device_info.get_expected_asic_list_file_path")
+    def test_get_expected_asic_list_missing_file(self, mock_path, mock_exists):
+        # Path resolved but file absent -> early return [].
+        mock_path.return_value = "/x/expected_asic_list"
+        mock_exists.return_value = False
+        assert device_info.get_expected_asic_list() == []
+
+    @mock.patch("{}.open".format(BUILTINS), new_callable=mock.mock_open, read_data="[0, 1, 4, 5]")
+    @mock.patch("os.path.exists")
+    @mock.patch("sonic_py_common.device_info.get_expected_asic_list_file_path")
+    def test_get_expected_asic_list_valid(self, mock_path, mock_exists, mock_open):
+        # A valid YAML list is returned as-is.
+        mock_path.return_value = "/x/expected_asic_list"
+        mock_exists.return_value = True
+        assert device_info.get_expected_asic_list() == [0, 1, 4, 5]
+        mock_open.assert_called_once_with("/x/expected_asic_list")
+
+    @mock.patch("{}.open".format(BUILTINS), new_callable=mock.mock_open, read_data="")
+    @mock.patch("os.path.exists")
+    @mock.patch("sonic_py_common.device_info.get_expected_asic_list_file_path")
+    def test_get_expected_asic_list_empty_file(self, mock_path, mock_exists, mock_open):
+        # Empty file -> yaml.safe_load returns None -> normalized to [].
+        mock_path.return_value = "/x/expected_asic_list"
+        mock_exists.return_value = True
+        assert device_info.get_expected_asic_list() == []
+        mock_open.assert_called_once_with("/x/expected_asic_list")
+
+    @mock.patch("{}.open".format(BUILTINS), new_callable=mock.mock_open, read_data="not_a_list: true")
+    @mock.patch("os.path.exists")
+    @mock.patch("sonic_py_common.device_info.get_expected_asic_list_file_path")
+    def test_get_expected_asic_list_non_list(self, mock_path, mock_exists, mock_open):
+        # Non-list YAML content -> normalized to [].
+        mock_path.return_value = "/x/expected_asic_list"
+        mock_exists.return_value = True
+        assert device_info.get_expected_asic_list() == []
+        mock_open.assert_called_once_with("/x/expected_asic_list")
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/src/sonic-py-common/tests/multi_asic_test.py
+++ b/src/sonic-py-common/tests/multi_asic_test.py
@@ -23,3 +23,18 @@ class TestMultiAsic:
                 assert multi_asic.get_asic_sub_role(0) == 'FrontEnd'
                 assert multi_asic.get_asic_sub_role(1) == 'BackEnd'
                 assert multi_asic.get_asic_sub_role(2) == None
+
+    def test_get_namespaces_from_linux_current_ns(self):
+        # When invoked inside an ASIC namespace, return just that namespace
+        # via the early-return path (the sort helper is not needed / not imported here).
+        with mock.patch('sonic_py_common.multi_asic.get_current_namespace', return_value='asic0'):
+            assert multi_asic.get_namespaces_from_linux() == ['asic0']
+
+    def test_get_namespaces_from_linux_global_ns_sorted(self):
+        # In the global namespace, enumerate and naturally-sort all namespaces
+        # (exercises the lazily-imported natural-sort path).
+        with mock.patch('sonic_py_common.multi_asic.get_current_namespace', return_value=''), \
+             mock.patch('glob.glob', return_value=['/run/netns/asic10',
+                                                   '/run/netns/asic2',
+                                                   '/run/netns/asic1']):
+            assert multi_asic.get_namespaces_from_linux() == ['asic1', 'asic2', 'asic10']


### PR DESCRIPTION
#### Why I did it
`sonic_py_common.device_info` and `sonic_py_common.multi_asic` are imported by nearly every PMON daemon (syseepromd, thermalctld, psud, pcied, stormond, xcvrd, ...). Both modules imported `yaml` (~3.2 MB) and `natsort` (~4.2 MB) at module top level, even though most callers never read a YAML file or naturally-sort a namespace list. A top-level import in a shared module is paid by every process that imports it, so this ~3.4 MB import surface was multiplied across every PMON daemon.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
Moved the heavy imports from module top level into the functions that actually use them, so they are loaded lazily on first use instead of at import time:
- `device_info.get_sonic_version_info` / `get_expected_asic_list`: `import yaml`
- `device_info.get_namespaces`: `from natsort import natsorted`
- `multi_asic.get_namespaces_from_linux`: `from natsort import natsorted`

Each relocated import carries a short `# lazy:` marker so a future import cleanup does not hoist it back to module scope. The top-level `import yaml` / `from natsort import natsorted` lines are removed from both modules. Behavior is unchanged; only the import timing moves.

Added unit tests for `get_expected_asic_list` (missing-path, missing-file, valid list, empty file, non-list content) and `get_namespaces_from_linux` (single-namespace early return, global-namespace natural sort).

#### How to verify it
- Import surface: on a running device, confirm `yaml` and `natsort` are no longer loaded in a PMON daemon at startup, and only appear after the relevant function runs.
- Behavior: `show platform syseeprom`, `decode-syseeprom -d`, and namespace enumeration (`get_namespaces` / `get_namespaces_from_linux`) return identical output before and after.
- Unit tests: `pytest src/sonic-py-common/tests/device_info_test.py src/sonic-py-common/tests/multi_asic_test.py`.
- Platform regression tests: all passed.

Per-daemon PSS in the `pmon` container dropped after the change (`pmon` restarted for both measurements to keep the same baseline):

| daemon      | before (MB) | after (MB) | diff        |
|-------------|-------------|------------|-------------|
| syseepromd  | 25.6        | 24.1       | -1.5 (-6%)  |
| thermalctld | 20.9        | 18.7       | -2.2 (-11%) |
| psud        | 18.3        | 16.6       | -1.7 (-9%)  |
| stormond    | 17.0        | 15.1       | -1.9 (-11%) |
| pcied       | 17.1        | 16.3       | -0.7 (-4%)  |
| xcvrd       | 58.8        | 57.8       | -1.0 (-2%)  |

The saving comes purely from not loading `yaml`/`natsort` at import time in every daemon that imports `sonic_py_common`.

#### Which release branch to backport (provide reason below if selected)

#### Tested branch
- [x] master

#### Test result
master_RC: PASSED (unit tests + PSS comparison on switch)

#### Description for the changelog
[sonic-py-common] Lazy-import yaml and natsort to reduce PMON daemon memory footprint (~1-2 MB per daemon, ~5% of the pmon container).
