### PR TITLE
[build] Extend Make to support the SONIC_BAZEL_DOCKER_IMAGES target type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ ifeq ($(NOTRIXIE),0)
 BUILD_TRIXIE=1
 endif
 
+# Bazel dockers (SONIC_BAZEL_DOCKER_IMAGES) only support the trixie base today,
+# so fail fast whenever anything else is requested.
+ifeq ($(BUILD_WITH_BAZEL_WHEN_AVAILABLE),y)
+BAZEL_NON_TRIXIE_BUILDS := $(strip $(BUILD_JESSIE) $(BUILD_STRETCH) $(BUILD_BUSTER) $(BUILD_BULLSEYE) $(BUILD_BOOKWORM))
+ifneq ($(BAZEL_NON_TRIXIE_BUILDS),)
+$(error BUILD_WITH_BAZEL_WHEN_AVAILABLE=y only supports trixie builds: Bazel dockers require the trixie base. Re-run with trixie only, e.g. NOJESSIE=1 NOSTRETCH=1 NOBUSTER=1 NOBULLSEYE=1 NOBOOKWORM=1 NOTRIXIE=0.)
+endif
+endif
+
 PLATFORM_PATH := platform/$(if $(PLATFORM),$(PLATFORM),$(CONFIGURED_PLATFORM))
 PLATFORM_CHECKOUT := platform/checkout
 PLATFORM_CHECKOUT_FILE := $(PLATFORM_CHECKOUT)/$(PLATFORM).ini

--- a/Makefile.work
+++ b/Makefile.work
@@ -68,6 +68,12 @@
 #  * ENABLE_VRF_STRICT: Enable VRF strict mode.
 #  *                 Default: unset
 #  *                 Values: y
+#  * BUILD_WITH_BAZEL_WHEN_AVAILABLE: Build targets registered in
+#  *                 SONIC_BAZEL_DOCKER_IMAGES with Bazel instead of the legacy
+#  *                 `docker build` flow.
+#  *                 When disabled they fall back to the normal Make docker build.
+#  *                 Default: n
+#  *                 Values: y,n
 ###############################################################################
 
 SHELL = /bin/bash
@@ -197,6 +203,9 @@ SONIC_OVERRIDE_BUILD_VARS += SONIC_VERSION_CACHE_SOURCE=$(SONIC_VERSION_CACHE_SO
 export SONIC_VERSION_CACHE SONIC_VERSION_CACHE_SOURCE
 $(shell test -d $(SONIC_VERSION_CACHE_SOURCE) || \
     mkdir -p $(SONIC_VERSION_CACHE_SOURCE) && chmod -f 777 $(SONIC_VERSION_CACHE_SOURCE) 2>/dev/null )
+
+$(shell test -d $(SONIC_BAZEL_CACHE_SOURCE) || \
+    mkdir -p $(SONIC_BAZEL_CACHE_SOURCE) && chmod -f 777 $(SONIC_BAZEL_CACHE_SOURCE) 2>/dev/null )
 
 # Generate the version control build info
 $(shell \
@@ -436,6 +445,21 @@ endif
 
 ifneq ($(SONIC_VERSION_CACHE_SOURCE),)
 	DOCKER_RUN += -v "$(SONIC_VERSION_CACHE_SOURCE):/vcache:rw"
+endif
+
+# Create a volume to store Bazel caches into
+# See the documentation in rules/config for more information
+#
+# Only mount it if the host directory actually exists:
+# SONIC_BAZEL_CACHE_SOURCE can be non-empty even when the mkdir silently failed
+# (e.g. an unwritable parent on some CI agents), and passing that to Docker has unintended consequences.
+ifneq ($(wildcard $(SONIC_BAZEL_CACHE_SOURCE)),)
+	DOCKER_RUN += -v "$(SONIC_BAZEL_CACHE_SOURCE):/bazel_cache:rw"
+	# Persist bazelisk downloads in the cache
+	DOCKER_RUN += -e "BAZELISK_HOME=/bazel_cache/bazelisk"
+	# Apply the slave Bazel cache config as a system RC file, which Bazel reads regardless of cwd.
+	# Ref: https://bazel.build/run/bazelrc#bazelrc-file-locations
+	DOCKER_RUN += -v "$(PWD)/tools/bazel/slave.bazelrc:/etc/bazel.bazelrc:ro"
 endif
 
 # User name and tag for "docker-*" images created by native dockerd mode.
@@ -683,6 +707,7 @@ SONIC_BUILD_INSTRUCTION :=  $(MAKE) \
 						   SBOM_INCLUDE_LICENSES=$(SBOM_INCLUDE_LICENSES) \
 						   SBOM_STRICT=$(SBOM_STRICT) \
 						   SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) \
+						   BUILD_WITH_BAZEL_WHEN_AVAILABLE=$(BUILD_WITH_BAZEL_WHEN_AVAILABLE) \
                            $(SONIC_OVERRIDE_BUILD_VARS)
 
 .PHONY: sonic-slave-build sonic-slave-bash sonic-slave-run init reset

--- a/README.buildsystem.md
+++ b/README.buildsystem.md
@@ -189,6 +189,33 @@ $(SOME_DOCKER)_LOAD_DOCKERS += $(SOME_OTHER_DOCkER) # docker image from which th
 SONIC_DOCKER_IMAGES += $(SOME_DOCKER) # add docker to this group
 ```
 
+<a id="sonic-bazel-docker-images"></a>
+**SONIC_BAZEL_DOCKER_IMAGES**
+Target group for docker images that are built with [Bazel](https://bazel.build/) instead of the legacy `docker build` flow.
+A docker in this group is built by running `bazel run //dockers/<name>:write_<name>.gz`, which produces the same `target/<name>.gz` artifact as the normal docker rule.
+This is opt-in: a recipe only registers the image here when `BUILD_WITH_BAZEL_WHEN_AVAILABLE=y` (see **rules/config**).
+
+The image is still registered in `SONIC_DOCKER_IMAGES` / `SONIC_INSTALL_DOCKER_IMAGES`, and still carries `_PATH`, `_VERSION` and `_PACKAGE_NAME`, so it is installed and listed in the sonic-package-manager catalog exactly as a Make-built one.
+
+Bazel currently only supports trixie-based images.
+
+Define:
+
+```make
+SOME_DOCKER = some_docker.gz # name of your docker (must match dockers/<name>/BUILD.bazel)
+$(SOME_DOCKER)_PATH = path/to/your/docker # path to the docker's directory
+$(SOME_DOCKER)_VERSION = 1.0.0 # version recorded in the package catalog
+$(SOME_DOCKER)_PACKAGE_NAME = some_package # sonic-package-manager package name
+$(SOME_DOCKER)_BAZEL_BASE += $(SOME_BASE_DOCKER) # base docker(s) the Bazel build depends on
+SONIC_BAZEL_DOCKER_IMAGES += $(SOME_DOCKER) # build this docker with Bazel
+SONIC_DOCKER_IMAGES += $(SOME_DOCKER) # still a regular docker image downstream of the .gz
+SONIC_INSTALL_DOCKER_IMAGES += $(SOME_DOCKER) # install it into the final image
+```
+
+Two configuration knobs in **rules/config** control this flow:
+* **BUILD_WITH_BAZEL_WHEN_AVAILABLE** (default `n`): When set to `y`, eligible dockers are built with Bazel rather than the legacy `docker build` flow.
+* **SONIC_BAZEL_CACHE_SOURCE** (default `$(SONIC_DPKG_CACHE_SOURCE)/bazel`): Host directory used to persist Bazel's disk and repository caches across slave container runs. Will be mounted into the slave as a volume.
+
 ## Tips & Tricks
 Although every target is built inside a sonic-slave container, which exits at the end of build, you can enter bash of sonic-slave using this command:
 ```

--- a/rules/config
+++ b/rules/config
@@ -161,6 +161,21 @@ ENABLE_FRR_SNMP_AGENT ?= y
 SONIC_DPKG_CACHE_METHOD ?= none
 SONIC_DPKG_CACHE_SOURCE ?= /var/cache/sonic/artifacts
 
+# Allow setting Bazel disk and repository caches in the host machine when building inside the container.
+# That way, Bazel caches are preserved across slave container runs.
+# Bazel will create two directories:
+#   - $(SONIC_BAZEL_CACHE_SOURCE)/disk_cache will hold the disk cache
+#   - $(SONIC_BAZEL_CACHE_SOURCE)/repository_cache will hold the repository cache
+#
+# Ref:
+#   - Disk cache: https://bazel.build/remote/caching#disk-cache
+SONIC_BAZEL_CACHE_SOURCE ?= $(SONIC_DPKG_CACHE_SOURCE)/bazel
+
+# Build eligible dockers (those registered in SONIC_BAZEL_DOCKER_IMAGES) with
+# Bazel instead of the legacy `docker build` flow.
+# When disabled, fall back to the normal Make docker build.
+BUILD_WITH_BAZEL_WHEN_AVAILABLE ?= n
+
 # Default VS build memory preparation
 DEFAULT_VS_PREPARE_MEM = yes
 

--- a/slave.mk
+++ b/slave.mk
@@ -1350,6 +1350,14 @@ endif
 endif
 endif
 
+# Bazel dockers (opted in via SONIC_BAZEL_DOCKER_IMAGES in their recipe) are
+# built by the Bazel rule further below, not the normal `docker build` rule.
+# Drop them from DOCKER_IMAGES so they don't also get the normal recipe.
+# When Bazel is disabled, SONIC_BAZEL_DOCKER_IMAGES will be empty.
+# Same applies for `DOCKER_DBG_IMAGES`
+DOCKER_IMAGES := $(filter-out $(SONIC_BAZEL_DOCKER_IMAGES),$(DOCKER_IMAGES))
+DOCKER_DBG_IMAGES := $(filter-out $(SONIC_BAZEL_DBG_DOCKER_IMAGES),$(DOCKER_DBG_IMAGES))
+
 $(foreach IMAGE,$(DOCKER_IMAGES), $(eval $(IMAGE)_DEBS_PATH := $(DEBS_PATH)))
 $(foreach IMAGE,$(DOCKER_IMAGES), $(eval $(IMAGE)_FILES_PATH := $(FILES_PATH)))
 $(foreach IMAGE,$(DOCKER_DBG_IMAGES), $(eval $(IMAGE)_DEBS_PATH := $(DEBS_PATH)))
@@ -1477,6 +1485,22 @@ $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform
 	$(FOOTER)
 
 SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(DOCKER_IMAGES))
+
+# Targets for building docker images (and debug images) with Bazel.
+$(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES)) : $(TARGET_PATH)/%.gz : .platform \
+		$$(addprefix $(TARGET_PATH)/,$$($$*.gz_BAZEL_BASE))
+	$(HEADER)
+	bazel run //dockers/$*:write_$*.gz $(LOG)
+	$(FOOTER)
+
+$(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DBG_DOCKER_IMAGES)) : $(TARGET_PATH)/%-$(DBG_IMAGE_MARK).gz : .platform \
+		$$(addprefix $(TARGET_PATH)/,$$($$*.gz_BAZEL_BASE))
+	$(HEADER)
+	bazel run //dockers/$*:write_$*-$(DBG_IMAGE_MARK).gz $(LOG)
+	$(FOOTER)
+
+SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DOCKER_IMAGES))
+SONIC_TARGET_LIST += $(addprefix $(TARGET_PATH)/, $(SONIC_BAZEL_DBG_DOCKER_IMAGES))
 
 # Targets for building docker debug images
 $(addprefix $(TARGET_PATH)/, $(DOCKER_DBG_IMAGES)) : $(TARGET_PATH)/%-$(DBG_IMAGE_MARK).gz : .platform docker-start \

--- a/src/sonic-p4rt/Makefile
+++ b/src/sonic-p4rt/Makefile
@@ -18,18 +18,17 @@ BAZEL_BUILD_OPTS += --copt=-Wno-stringop-overflow
 # Build optimized, stripped binaries.
 BAZEL_BUILD_OPTS += -c opt
 
-# Use a host directory to store Bazel cache, if mounted. This will speed up
-# incremental rebuilds on the same system for developers that makes changes
-# to sonic-pins code.
+# Use a host directory to store Bazel cache, to speed up incremental rebuilds
+# on the same system for developers that make changes to sonic-pins code.
 #
-# To build with Bazel cache, add DOCKER_BUILDER_USER_MOUNT:
+# /bazel_cache is the shared Bazel cache mount every slave container gets
+# (see SONIC_BAZEL_CACHE_SOURCE in rules/config), so this works out of the box.
+# To point it elsewhere instead, override BAZEL_CACHE and mount it yourself via
+# DOCKER_BUILDER_USER_MOUNT:
 #   DOCKER_BUILDER_USER_MOUNT=<directory on host system>:$BAZEL_CACHE:rw
 #
-# For example:
-#   DOCKER_BUILDER_USER_MOUNT=/tmp/bazel_cache:/bazel:rw make target/...
-#
-BAZEL_CACHE ?= /bazel
-BAZEL_OPTS += $(shell test -d $(BAZEL_CACHE) && echo --output_user_root=$(BAZEL_CACHE)/cache)
+BAZEL_CACHE ?= /bazel_cache
+BAZEL_OPTS += $(shell test -d $(BAZEL_CACHE) && echo --output_user_root=$(BAZEL_CACHE)/output_user_root)
 
 MAIN_TARGET = $(SONIC_P4RT)
 DERIVED_TARGETS = $(SONIC_P4RT_DBG)

--- a/tools/bazel/slave.bazelrc
+++ b/tools/bazel/slave.bazelrc
@@ -1,0 +1,27 @@
+##
+## Slave-specific config
+##
+# Mounted into the slave container as /etc/bazel.bazelrc,
+# which means it'll be picked up automatically by anything that builds on that container.
+#  Ref: https://bazel.build/run/bazelrc#bazelrc-file-locations
+#
+# Usually, this wouldn't be necessary, and we could just gate everything on a configuration
+# (e.g. bazel build --config=slave ...).
+# However, startup options cannot be gated by configuration, so we must resort to composing bazelrc files.
+
+startup --output_user_root=/bazel_cache/output_user_root
+
+# Caches for the slave
+#
+# Set the disk and repository caches to a mounted volume in the slave.
+#
+# Without persistent caches, every build re-downloads and re-extracts all external dependencies,
+# as well as re-build every artifact.
+#
+# /bazel_cache is expected to be bind-mounted from a host directory by
+# Makefile.work's DOCKER_RUN (alongside /dpkg_cache and /vcache).
+#
+# Please see the documentation of `SONIC_BAZEL_CACHE_SOURCE` in `rules/config` for more information.
+common --repository_cache=/bazel_cache/repository_cache
+common --disk_cache=/bazel_cache/disk_cache
+


### PR DESCRIPTION
Implements infrastructure as per the [Bazel Migration HLD](https://github.com/sonic-net/SONiC/blob/master/doc/bazel/bazel_migration_hld.md).

#### Why I did it

This is splintered off from #28005 . It encapsulates just the changes to the Make-based build system, to make them easier to review.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

Should not be backported.

#### Description for the changelog

Extend Make to support the SONIC_BAZEL_DOCKER_IMAGES target type

#### A picture of a cute animal (not mandatory but encouraged)
