### PR TITLE
[SONiC BMC] Create BMC OS configuration value for choosing the communication path

### DIFF
--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/eeprom.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/eeprom.py
@@ -39,6 +39,7 @@ class IpmiFru:
         "FRU Board Serial Number:": TlvInfoDecoder._TLV_CODE_SERIAL_NUMBER,
         "FRU Board Custom Info: MAC:": TlvInfoDecoder._TLV_CODE_MAC_BASE,
         "FRU Product Version:": TlvInfoDecoder._TLV_CODE_LABEL_REVISION,
+        "FRU Board Manufacturer:": TlvInfoDecoder._TLV_CODE_MANUF_NAME,
     }
 
     IPMI_FRU_BIN = "ipmi-fru"
@@ -162,6 +163,9 @@ class Eeprom(TlvInfoDecoder):
 
     def get_revision(self):
         return self._get_eeprom_value(self._TLV_CODE_LABEL_REVISION)
+
+    def get_manufacturer(self):
+        return self._get_eeprom_value(self._TLV_CODE_MANUF_NAME)
 
 
 class EepromBMC(Eeprom):

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_eeprom.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_eeprom.py
@@ -41,6 +41,7 @@ IPMI_FRU_OUTPUT = (
     "FRU Board Serial Number: SN1234567\n"
     "FRU Board Custom Info: MAC: aa:bb:cc:dd:ee:ff\n"
     "FRU Product Version: A0\n"
+    "FRU Board Manufacturer: NVIDIA\n"
 )
 
 
@@ -94,6 +95,7 @@ class TestIpmiFru:
         assert Eeprom._TLV_CODE_SERIAL_NUMBER in tlv_list
         assert Eeprom._TLV_CODE_MAC_BASE in tlv_list
         assert Eeprom._TLV_CODE_LABEL_REVISION in tlv_list
+        assert Eeprom._TLV_CODE_MANUF_NAME in tlv_list
 
     def test_get_tlv_dict_parses_output(self):
         fru = IpmiFru("/dev/null")
@@ -104,6 +106,7 @@ class TestIpmiFru:
         assert tlvs[Eeprom._TLV_CODE_SERIAL_NUMBER] == "SN1234567"
         assert tlvs[Eeprom._TLV_CODE_MAC_BASE] == "aa:bb:cc:dd:ee:ff"
         assert tlvs[Eeprom._TLV_CODE_LABEL_REVISION] == "A0"
+        assert tlvs[Eeprom._TLV_CODE_MANUF_NAME] == "NVIDIA"
 
     def test_get_tlv_dict_ignores_unknown_lines(self):
         fru = IpmiFru("/dev/null")
@@ -169,6 +172,7 @@ class TestEeprom:
             hex(Eeprom._TLV_CODE_SERIAL_NUMBER): "serial",
             hex(Eeprom._TLV_CODE_MAC_BASE): "11:22:33:44:55:66",
             hex(Eeprom._TLV_CODE_LABEL_REVISION): "A0",
+            hex(Eeprom._TLV_CODE_MANUF_NAME): "NVIDIA",
         }
         eeprom._eeprom_info_dict = info
 
@@ -177,6 +181,7 @@ class TestEeprom:
         assert eeprom.get_serial_number() == "serial"
         assert eeprom.get_base_mac() == "11:22:33:44:55:66"
         assert eeprom.get_revision() == "A0"
+        assert eeprom.get_manufacturer() == "NVIDIA"
 
     def test_getters_return_none_when_code_missing(self):
         eeprom = self._make_eeprom()
@@ -186,6 +191,7 @@ class TestEeprom:
         assert eeprom.get_serial_number() is None
         assert eeprom.get_base_mac() is None
         assert eeprom.get_revision() is None
+        assert eeprom.get_manufacturer() is None
 
     def test_read_eeprom_caches_raw_buffer(self):
         eeprom = self._make_eeprom()

--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1021,6 +1021,8 @@ class ComponentBMC(Component):
         """
         if self.bmc is None:
             return 'N/A'
+        if device_info.get_bmc_os() == device_info.BMC_OS_SONIC:
+            return 'N/A'
         return self.bmc.get_version()
 
     def get_available_firmware_version(self, image_path):
@@ -1056,6 +1058,9 @@ class ComponentBMC(Component):
         Returns:
             A boolean, True if the BMC firmware is installed successfully, False otherwise.
         """
+        if device_info.get_bmc_os() == device_info.BMC_OS_SONIC:
+            print('BMC firmware install not supported when BMC OS is sonic')
+            return False
         if not self._check_file_validity(image_path):
             print(f"Invalid firmware image path: {image_path}")
             return False

--- a/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_bmc.py
@@ -44,6 +44,8 @@ class MockBMCComponent:
 
 @mock.patch('sonic_platform.device_data.DeviceDataManager.is_platform_with_bmc',
             mock.MagicMock(return_value=True))
+@mock.patch('sonic_py_common.device_info.get_bmc_os',
+            mock.MagicMock(return_value='openbmc'))
 class TestBMC:
     @mock.patch('sonic_py_common.device_info.get_bmc_build_config', \
                 mock.MagicMock(return_value={'bmc_nos_account_username': 'testuser', 'bmc_root_account_default_password': 'testpass'}))

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -656,13 +656,15 @@ class TestComponent:
         c.image_ext_name = '.txt'
         assert not c._check_file_validity(os.path.abspath(__file__))
 
-    @mock.patch('sonic_py_common.device_info.get_bmc_build_config', 
+    @mock.patch('sonic_py_common.device_info.get_bmc_build_config',
                 mock.MagicMock(return_value={'bmc_nos_account_username': 'testuser'}))
-    @mock.patch('sonic_py_common.device_info.get_bmc_data', 
+    @mock.patch('sonic_py_common.device_info.get_bmc_data',
                 mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_py_common.device_info.get_bmc_os',
+                mock.MagicMock(return_value='openbmc'))
     @mock.patch('sonic_platform.bmc.BMC._get_tpm_password', mock.MagicMock(return_value=''))
     @mock.patch('sonic_platform.component.subprocess.check_call')
-    @mock.patch('sonic_platform.component.ComponentBMC._check_file_validity', 
+    @mock.patch('sonic_platform.component.ComponentBMC._check_file_validity',
                 mock.MagicMock(return_value=True))
     def test_bmc_update_firmware(self, mock_check_call):
         mock_check_call.return_value = None
@@ -674,3 +676,45 @@ class TestComponent:
             start_new_session=True
         )
         assert ret == True
+
+    @mock.patch('sonic_py_common.device_info.get_bmc_build_config',
+                mock.MagicMock(return_value={'bmc_nos_account_username': 'testuser'}))
+    @mock.patch('sonic_py_common.device_info.get_bmc_data',
+                mock.MagicMock(return_value={'bmc_addr': '169.254.0.1'}))
+    @mock.patch('sonic_py_common.device_info.get_bmc_os',
+                mock.MagicMock(return_value='sonic'))
+    @mock.patch('sonic_platform.component.subprocess.check_call')
+    @mock.patch('sonic_platform.component.ComponentBMC._check_file_validity')
+    def test_bmc_update_firmware_rejected_when_sonic_bmc(self, mock_check_validity,
+                                                         mock_check_call, capsys):
+        mock_check_validity.return_value = True
+        component = ComponentBMC()
+        ret = component.install_firmware('fake_image.fwpkg')
+        assert ret is False
+        mock_check_validity.assert_not_called()
+        mock_check_call.assert_not_called()
+        captured = capsys.readouterr()
+        assert 'BMC firmware install not supported when BMC OS is sonic' in captured.out
+
+    @mock.patch('sonic_py_common.device_info.get_bmc_os', mock.MagicMock(return_value='sonic'))
+    @mock.patch('sonic_platform.bmc.BMC.get_instance')
+    def test_bmc_get_firmware_version_sonic_bmc(self, mock_get_instance):
+        mock_get_instance.return_value = mock.MagicMock()
+        component = ComponentBMC()
+        assert component.get_firmware_version() == 'N/A'
+        component.bmc.get_version.assert_not_called()
+
+    @mock.patch('sonic_py_common.device_info.get_bmc_os', mock.MagicMock(return_value='openbmc'))
+    @mock.patch('sonic_platform.bmc.BMC.get_instance')
+    def test_bmc_get_firmware_version_openbmc(self, mock_get_instance):
+        mock_bmc = mock.MagicMock()
+        mock_bmc.get_version.return_value = '1.2.3'
+        mock_get_instance.return_value = mock_bmc
+        component = ComponentBMC()
+        assert component.get_firmware_version() == '1.2.3'
+        mock_bmc.get_version.assert_called_once()
+
+    @mock.patch('sonic_platform.bmc.BMC.get_instance', mock.MagicMock(return_value=None))
+    def test_bmc_get_firmware_version_no_bmc(self):
+        component = ComponentBMC()
+        assert component.get_firmware_version() == 'N/A'

--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -29,6 +29,11 @@ CPO_FILE = "cpo.json"
 BMC_BUILD_CONFIG_FILE = '/etc/sonic/bmc_config.json'
 GLOBAL_BMC_DATA_FILE = '/etc/sonic/bmc.json'
 
+BMC_OS_OPENBMC = 'openbmc'
+BMC_OS_SONIC = 'sonic'
+BMC_OS_DEFAULT = BMC_OS_SONIC
+_VALID_BMC_OS_VALUES = frozenset({BMC_OS_OPENBMC, BMC_OS_SONIC})
+
 # Fabric port configuration file names
 FABRIC_MONITOR_CONFIG_FILE = "fabric_monitor_config.json"
 
@@ -1168,6 +1173,29 @@ def get_bmc_address():
     if not bmc_data:
         return None
     return bmc_data.get('bmc_addr')
+
+
+def get_bmc_os():
+    """
+    Return the configured BMC operating system for Switch-Host communication.
+
+    Reads 'os' from CONFIG_DB DEVICE_METADATA|bmc. When unset or invalid,
+    returns BMC_OS_DEFAULT (sonic).
+
+    Returns:
+        BMC_OS_OPENBMC or BMC_OS_SONIC.
+    """
+    try:
+        config_db = ConfigDBConnector()
+        config_db.connect()
+        entry = config_db.get_entry('DEVICE_METADATA', 'bmc')
+        if entry:
+            bmc_os = entry.get('os')
+            if bmc_os in _VALID_BMC_OS_VALUES:
+                return bmc_os
+    except Exception:
+        pass
+    return BMC_OS_DEFAULT
 
 
 def get_switch_host_address():

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -575,6 +575,25 @@ liquid_cooled=true
         mock_bmc_data.return_value = BMC_DATA
         assert device_info.get_switch_host_address() == "169.254.100.2"
 
+    @mock.patch("sonic_py_common.device_info.ConfigDBConnector", autospec=True)
+    def test_get_bmc_os(self, mock_cfg_db):
+        mock_cfg_inst = mock_cfg_db.return_value
+
+        mock_cfg_inst.get_entry.return_value = None
+        assert device_info.get_bmc_os() == device_info.BMC_OS_DEFAULT
+
+        mock_cfg_inst.get_entry.return_value = {'os': device_info.BMC_OS_SONIC}
+        assert device_info.get_bmc_os() == device_info.BMC_OS_SONIC
+
+        mock_cfg_inst.get_entry.return_value = {'os': device_info.BMC_OS_OPENBMC}
+        assert device_info.get_bmc_os() == device_info.BMC_OS_OPENBMC
+
+        mock_cfg_inst.get_entry.return_value = {'os': 'linux'}
+        assert device_info.get_bmc_os() == device_info.BMC_OS_DEFAULT
+
+        mock_cfg_db.return_value.connect.side_effect = Exception("connect failed")
+        assert device_info.get_bmc_os() == device_info.BMC_OS_DEFAULT
+
     @classmethod
     def teardown_class(cls):
         print("TEARDOWN")

--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1151,6 +1151,26 @@ instance is supported in SONiC.
 
 ```
 
+The **DEVICE_METADATA** table also has a `bmc` object on Switch-Host platforms with a BMC.
+It stores the BMC link addressing (populated from `bmc.json`) and the configured BMC
+operating system, which selects how the Switch-Host talks to the BMC: `openbmc` uses
+Redfish, `sonic` uses Redis over the host-BMC link. Default is `sonic`.
+
+```
+{
+"DEVICE_METADATA": {
+        "bmc": {
+        "bmc_if_name": "usb0",
+        "bmc_if_addr": "169.254.100.2",
+        "bmc_addr": "169.254.100.1",
+        "bmc_net_mask": "255.255.255.252",
+        "os": "sonic"
+    }
+  }
+}
+
+```
+
 
 ### Device neighbor metada
 

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -296,5 +296,24 @@
             "key": "sonic-device_metadata:dpu_auto_recovery",
             "value": "disable"
         }
+    },
+    "DEVICE_METADATA_BMC_OS_VALID_OPENBMC": {
+        "desc": "DEVICE_METADATA valid value 'openbmc' for bmc os field."
+    },
+    "DEVICE_METADATA_BMC_OS_VALID_SONIC": {
+        "desc": "DEVICE_METADATA valid value 'sonic' for bmc os field."
+    },
+    "DEVICE_METADATA_BMC_OS_INVALID": {
+        "desc": "DEVICE_METADATA invalid value for bmc os field.",
+        "eStrKey": "InvalidValue"
+    },
+    "DEVICE_METADATA_BMC_OS_DEFAULT": {
+        "desc": "DEVICE_METADATA DEFAULT VALUE FOR BMC OS FIELD.",
+        "eStrKey" : "Verify",
+        "verify": {
+            "xpath": "/sonic-device_metadata:sonic-device_metadata/DEVICE_METADATA/bmc/bmc_if_name",
+            "key": "sonic-device_metadata:os",
+            "value": "sonic"
+        }
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -892,5 +892,41 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_BMC_OS_VALID_OPENBMC": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:bmc": {
+                    "os": "openbmc"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_BMC_OS_VALID_SONIC": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:bmc": {
+                    "os": "sonic"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_BMC_OS_INVALID": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:bmc": {
+                    "os": "linux"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_BMC_OS_DEFAULT": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:bmc": {
+                    "bmc_if_name": "usb0"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -19,6 +19,10 @@ module sonic-device_metadata {
 
     description "DEVICE_METADATA YANG Module for SONiC OS";
 
+    revision 2026-06-16 {
+        description "Added os leaf under bmc container to select BMC OS (openbmc or sonic).";
+    }
+
     revision 2026-06-05 {
         description "Added dpu_auto_recovery to enable/disable automatic DPU recovery on SmartSwitch.";
     }
@@ -420,6 +424,15 @@ module sonic-device_metadata {
                 leaf bmc_net_mask {
                     type inet:ipv4-address;
                     description "BMC network mask";
+                }
+
+                leaf os {
+                    type enumeration {
+                        enum openbmc;
+                        enum sonic;
+                    }
+                    default sonic;
+                    description "BMC operating system on the Switch-Host link. openbmc uses Redfish; sonic uses Redis.";
                 }
             }
             /* end of container bmc */


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Switch-Host platforms need to distinguish OpenBMC BMCs from SONiC-on-BMC peers when
choosing how to talk to the BMC (Redfish vs Redis). This change introduces a
CONFIG_DB setting under `DEVICE_METADATA|bmc` so callers can read the configured BMC
OS type and behave accordingly. The first consumer blocks BMC firmware install when
the BMC OS is `sonic`, since that path is OpenBMC-specific.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Added `os` leaf to `DEVICE_METADATA|bmc` in `sonic-device_metadata.yang`
  (`openbmc` | `sonic`, default `sonic`).
- Added `get_bmc_os()` and related constants in `sonic_py_common.device_info`; reads
  CONFIG_DB and falls back to `sonic` when unset, invalid, or on error.
- Guarded Mellanox `ComponentBMC.install_firmware()` to reject updates when BMC OS is
  `sonic`.
- Added unit tests for `get_bmc_os()` and the firmware-install guard.

#### How to verify it
- Run unit tests:
  ```bash
  cd src/sonic-py-common
  pytest tests/device_info_test.py::TestDeviceInfo::test_get_bmc_os -v

  cd platform/mellanox/mlnx-platform-api
  pytest tests/test_component.py -k bmc_update_firmware -v
  ```
- Manual (optional, on a Switch-Host image with this build):
  ```bash
  # Default when unset
  sonic-db-cli CONFIG_DB HGET "DEVICE_METADATA|bmc" os

  sonic-db-cli CONFIG_DB HSET "DEVICE_METADATA|bmc" os openbmc

  # Confirm firmware install is rejected (Mellanox platform API)
  config platform firmware install chassis component BMC fw PATH
  # expect False and message about sonic BMC OS
  ```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
