### PR TITLE
Fix host rsyslog service config script for unconditional restart

### DIFF
--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -40,40 +40,11 @@ if [ -z "$syslog_counter" ]; then
     syslog_counter="false"
 fi
 
-# Generate config to a temp file so we can compare before restarting.
-# On Debian 13 (Trixie), rsyslog.service has systemd sandboxing directives
-# (PrivateTmp, ProtectSystem, etc.) that add ~4 seconds of overhead per
-# restart due to namespace setup/teardown.  Skipping the restart when the
-# config is unchanged avoids this delay on warm/fast reboot and config_reload
-# where nothing actually changed.
-#
-# When the config IS unchanged we still send SIGHUP so rsyslog re-opens its
-# log files (needed after log rotation or /var/log remounts).
-#
-# See: https://github.com/sonic-net/sonic-buildimage/issues/25382
-
-TMPFILE=$(mktemp /tmp/rsyslog.conf.XXXXXX)
-trap 'rm -f "$TMPFILE"' EXIT
-
+# With RELP, https://github.com/sonic-net/sonic-buildimage/pull/18113, the
+# logs from containers will be queued during host rsyslog restart.
+# To restart rsyslog unconditionally when system reboots or rsyslog config
+# is updated allows the rsyslog service to rebind correctly.
 sonic-cfggen -d -t /usr/share/sonic/templates/rsyslog.conf.j2 \
     -a "{\"udp_server_ip\": \"$udp_server_ip\", \"hostname\": \"$hostname\", \"docker0_ip\": \"$docker0_ip\", \"forward_with_osversion\": \"$syslog_with_osversion\", \"os_version\": \"$os_version\", \"syslog_counter\": \"$syslog_counter\"}" \
-    > "$TMPFILE"
-
-if [ ! -f /etc/rsyslog.conf ] || ! cmp -s "$TMPFILE" /etc/rsyslog.conf; then
-    # Config changed (or first boot) — install and restart
-    if cp "$TMPFILE" /etc/rsyslog.conf; then
-        systemctl restart rsyslog
-    else
-        echo "Failed to update /etc/rsyslog.conf; not restarting rsyslog" >&2
-        exit 1
-    fi
-else
-    if [[ ($NUM_ASIC -gt 1) ]]; then
-        # multi-asic, docker0 IP interface may not be present when rsyslog.service was started.
-        # restart the rsyslog for TCP port socket binding.
-        systemctl restart rsyslog
-    else
-        # Config unchanged — just signal rsyslog to re-open log files
-        systemctl kill -s HUP rsyslog
-    fi
-fi
+    > /etc/rsyslog.conf
+systemctl restart rsyslog


### PR DESCRIPTION
This PR is to replace the gating rsyslog approach in the #28307 with unconditional restart approach.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
The gating rsyslog approach in #28307 has the drawbacks of losing host-side logs if docker service is stuck, which prevents the troubleshooting based on syslog.

With RELP support being merged by #18113, the rsyslog is able to queue the container logs and flush to the host syslog. Also the host journald in can cache the host-side logs when host rsyslog service is unavailable and flush to the syslog when it turns to active. Therefore, the rsyslog-config.sh can be simplified by unconditionally restarting rsyslog whenever system reboots or rsyslog configuration is updated.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Replace the conditional checking of restart in rsyslog-config.sh with simple rsyslog.conf generation and service restart.

#### How to verify it
Restart device and check the syslog after system is up and running,
- The host rsyslog service can start successfully
- The journald can flush the cached host-side logs into syslog
- The container rsyslog can establish connection to host RELP port successfully


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
3. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [X] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [X] 202605
- [X] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

Tested with 202605, msft-202608 and master on multi-asic platform.  Even there are still some transient errors of host rsyslog binding failure and container rsyslog connection failure, the rsyslog can resume properly with retry.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
To unconditionally restart host rsyslog when system reboots or rsyslog configuration changes.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
