### PR TITLE
Adding new ram2disk service

### DIFF
--- a/files/build_templates/sonic_debian_extension.j2
+++ b/files/build_templates/sonic_debian_extension.j2
@@ -511,6 +511,21 @@ sudo mkdir -p $FILESYSTEM_ROOT/etc/systemd/system/logrotate.timer.d
 sudo cp $IMAGE_CONFIGS/logrotate/timerOverride.conf $FILESYSTEM_ROOT/etc/systemd/system/logrotate.timer.d/
 echo "logrotate-config.service" | sudo tee -a $GENERATED_SERVICE_FILE
 
+# Copy ram2disk and install rsync as a dependency
+sudo LANG=C DEBIAN_FRONTEND=noninteractive chroot $FILESYSTEM_ROOT apt-get -y install rsync
+sudo cp $IMAGE_CONFIGS/ram2disk/ram2disk.sh $FILESYSTEM_ROOT/usr/local/bin/ram2disk.sh
+sudo cp $IMAGE_CONFIGS/ram2disk/logrotate-counter-functions.sh $FILESYSTEM_ROOT/usr/local/bin/logrotate-counter-functions.sh
+sudo chmod 755 $FILESYSTEM_ROOT/usr/local/bin/ram2disk.sh $FILESYSTEM_ROOT/usr/local/bin/logrotate-counter-functions.sh
+# Divert the stock logrotate binary and install the counting wrapper in its place
+sudo LANG=C chroot $FILESYSTEM_ROOT dpkg-divert --divert /usr/sbin/logrotate.real --rename --add /usr/sbin/logrotate
+sudo cp $IMAGE_CONFIGS/ram2disk/logrotate-wrapper.sh $FILESYSTEM_ROOT/usr/sbin/logrotate
+sudo chmod 755 $FILESYSTEM_ROOT/usr/sbin/logrotate
+sudo cp $IMAGE_CONFIGS/ram2disk/ram2disk.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/ram2disk/ram2disk.timer $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo cp $IMAGE_CONFIGS/ram2disk/ram2disk-restore.service $FILESYSTEM_ROOT_USR_LIB_SYSTEMD_SYSTEM
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ram2disk.timer
+sudo LANG=C chroot $FILESYSTEM_ROOT systemctl enable ram2disk-restore.service
+
 # Copy systemd-journald configuration files
 sudo cp -f $IMAGE_CONFIGS/systemd/journald.conf $FILESYSTEM_ROOT/etc/systemd/
 

--- a/files/image_config/ram2disk/logrotate-counter-functions.sh
+++ b/files/image_config/ram2disk/logrotate-counter-functions.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# logrotate-counter-functions.sh - sourced library functions for logrotate rotation counters.
+#
+# Per-file counters:     /dev/shm/logrotate/rotation_counts
+#   One "<file-path> <count>" line per rotated file.
+#
+# A consuming application reads these and resets them to zero; the logrotate
+# service increments them.
+#
+# Public functions:
+#   lrc_file_increment <path> [<path>...]   +1 for each existing path or adds new one
+
+#   lrc_file_get [<path>]                    print one path's count, or whole file
+#   lrc_file_read_reset [<path>]             print then zero one path, or print
+#                                            whole file then clear it
+#   lrc_file_reset [<path>]                  zero one path, or clear whole file
+
+: "${LRC_DIR:=/dev/shm/logrotate}"
+: "${LRC_COUNTS_FILE:=$LRC_DIR/rotation_counts}"
+: "${LRC_LOCK:=$LRC_DIR/rotation_count.lock}"
+
+_lrc_ensure() {
+    mkdir -p "$LRC_DIR"
+    [ -f "$LRC_COUNTS_FILE" ] || : > "$LRC_COUNTS_FILE"
+    [ -f "$LRC_LOCK" ]   || : > "$LRC_LOCK"
+}
+
+lrc_file_increment() {
+    (( $# )) || return 0
+    _lrc_ensure
+    local lockfd
+    exec {lockfd}>"$LRC_LOCK"; flock "$lockfd"
+    printf '%s\n' "$@" | awk '
+        NR==FNR { inc[$0]++; next }
+        { if ($1 in inc) { $2=$2+inc[$1]; delete inc[$1] } print }
+        END { for (p in inc) print p" "inc[p] }
+    ' - "$LRC_COUNTS_FILE" > "$LRC_COUNTS_FILE.tmp" && mv "$LRC_COUNTS_FILE.tmp" "$LRC_COUNTS_FILE"
+    exec {lockfd}>&-
+}
+
+lrc_file_get() {
+    local path=${1:-}
+    _lrc_ensure
+    if [ -n "$path" ]; then
+        awk -v p="$path" '$1==p{print $2; f=1} END{if(!f) print 0}' "$LRC_COUNTS_FILE"
+    else
+        cat "$LRC_COUNTS_FILE"
+    fi
+}
+
+lrc_file_read_reset() {
+    local path=${1:-} lockfd
+    _lrc_ensure
+    exec {lockfd}>"$LRC_LOCK"; flock "$lockfd"
+    if [ -n "$path" ]; then
+        awk -v p="$path" '$1==p{print $2; f=1} END{if(!f) print 0}' "$LRC_COUNTS_FILE"
+        awk -v p="$path" '$1==p{$2=0} {print}' "$LRC_COUNTS_FILE" > "$LRC_COUNTS_FILE.tmp" && mv "$LRC_COUNTS_FILE.tmp" "$LRC_COUNTS_FILE"
+    else
+        cat "$LRC_COUNTS_FILE"; : > "$LRC_COUNTS_FILE"
+    fi
+    exec {lockfd}>&-
+}
+
+lrc_file_reset() {
+    local path=${1:-} lockfd
+    _lrc_ensure
+    exec {lockfd}>"$LRC_LOCK"; flock "$lockfd"
+    if [ -n "$path" ]; then
+        awk -v p="$path" '$1==p{$2=0} {print}' "$LRC_COUNTS_FILE" > "$LRC_COUNTS_FILE.tmp" && mv "$LRC_COUNTS_FILE.tmp" "$LRC_COUNTS_FILE"
+    else
+        : > "$LRC_COUNTS_FILE"
+    fi
+    exec {lockfd}>&-
+}

--- a/files/image_config/ram2disk/logrotate-wrapper.sh
+++ b/files/image_config/ram2disk/logrotate-wrapper.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# /usr/sbin/logrotate-wrapper.sh - counting wrapper around the real logrotate binary.
+#
+# Installed via dpkg-divert so it transparently replaces the stock binary:
+#   dpkg-divert --divert /usr/sbin/logrotate.real --rename --add /usr/sbin/logrotate
+#   cp logrotate-wrapper.sh /usr/sbin/logrotate && chmod 755 /usr/sbin/logrotate
+#
+
+set -u
+set -o pipefail
+
+ORIG_LOGROTATE=/usr/sbin/logrotate.real
+COUNTER_FUNCS=/usr/local/bin/logrotate-counter-functions.sh
+
+[ -x "$ORIG_LOGROTATE" ] || { echo "logrotate : $ORIG_LOGROTATE not found" >&2; exit 127; }
+
+# In debug/dry-run mode logrotate PRINTS "rotating log ..." without actually
+# rotating, so we must never count it -- just pass straight through.
+debug=0
+verbose=0
+for a in "$@"; do
+    case "$a" in
+        -d|--debug)   debug=1 ;;
+        -v|--verbose) verbose=1 ;;
+    esac
+done
+
+if [ "$debug" -eq 1 ]; then
+    exec "$ORIG_LOGROTATE" "$@"
+fi
+
+# Force verbose so we can detect which files actually rotated. logrotate writes
+# verbose diagnostics to stderr; stdout is left untouched for the caller.
+args=("$@")
+[ "$verbose" -eq 1 ] || args=(-v "${args[@]}")
+
+TMP_STATUS_FILE=$(mktemp)
+trap 'rm -f "$TMP_STATUS_FILE"' EXIT
+
+"$ORIG_LOGROTATE" "${args[@]}" 2>"$TMP_STATUS_FILE"
+RC=$?
+
+# Re-emit stderr to the caller when they asked for -v (preserve requested
+# output) or when logrotate failed (never hide real errors). Otherwise stay
+# quiet, matching plain non-verbose logrotate behaviour.
+if [ "$verbose" -eq 1 ] || [ "$RC" -ne 0 ]; then
+    cat "$TMP_STATUS_FILE" >&2
+fi
+
+# Count the rotations that actually happened. Source the counter library and
+# increment all rotated files.
+mapfile -t ROTATED < <(sed -n 's/^rotating log \(.*\), log->rotateCount.*/\1/p' "$TMP_STATUS_FILE")
+if [ "${#ROTATED[@]}" -gt 0 ] && [ -r "$COUNTER_FUNCS" ]; then
+    . "$COUNTER_FUNCS"
+    lrc_file_increment "${ROTATED[@]}"
+fi
+
+exit "$RC"

--- a/files/image_config/ram2disk/ram2disk-restore.service
+++ b/files/image_config/ram2disk/ram2disk-restore.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Ram2disk boot-time restore of active logs from /var/log.disk
+# Must run after /var/log (tmpfs) and /var/log.disk are mounted, but before
+# rsyslog starts writing fresh logs into the empty tmpfs.
+# Normal service dependencies add After=sysinit.target, which cycles with
+# journald's syslog.socket ordering when this unit is ordered before syslog.
+DefaultDependencies=no
+RequiresMountsFor=/var/log
+# Skip cleanly (condition not met) when /var/log is not on tmpfs, i.e. when
+# /var/log.disk is not mounted. Avoids failed units on non-tmpfs boots.
+# The mount is created in initramfs, so it is already present when systemd runs.
+ConditionPathIsMountPoint=/var/log.disk
+Before=systemd-journald.service rsyslog.service syslog.socket
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/ram2disk.sh restore
+
+[Install]
+WantedBy=multi-user.target

--- a/files/image_config/ram2disk/ram2disk.service
+++ b/files/image_config/ram2disk/ram2disk.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ram2disk periodic sync of /var/log (tmpfs) to /var/log.disk
+After=logrotate.service
+RequiresMountsFor=/var/log
+# Skip cleanly (condition not met) when /var/log is not on tmpfs, i.e. when
+# /var/log.disk is not mounted. Avoids failed units on non-tmpfs boots.
+ConditionPathIsMountPoint=/var/log.disk
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/ram2disk.sh sync

--- a/files/image_config/ram2disk/ram2disk.sh
+++ b/files/image_config/ram2disk/ram2disk.sh
@@ -1,0 +1,324 @@
+#!/bin/bash
+# =============================================================================
+# ram2disk.sh — Sequential write of /var/log (tmpfs) to /var/log.disk
+#                 (disk) backup using rsync
+#
+# Usage:
+#   ram2disk.sh sync        — Periodic tmpfs to Disk sync with rename detection
+#   ram2disk.sh restore     — Boot-time: archive previous session, restore
+#                                active logs to tmpfs
+#   ram2disk.sh pre-shutdown — Final sync before shutdown/reboot
+#
+# Design:
+#   Disk layout Example:
+#     /var/log.disk/
+#     ├── current/                     live mirror of this boot's /var/log
+#     │   ├── syslog
+#     │   ├── syslog.1
+#     │   ├── syslog.2.gz ...
+#     │   └── frr/bgpd.log ...
+#     ├── session_20260619_065000/     previous boot (immutable, compressed)
+#     ├── session_20260618_120000/     older boot (immutable, compressed)
+#     └── .boot_id
+#
+#   Cleanup:
+#     - Oldest session_* directories are rm -rf'd when Disk free space is low
+#
+# =============================================================================
+
+MODE="${1:-sync}"    # sync | restore | pre-shutdown
+
+: "${SRC_RAM_DIR:=/var/log}"
+: "${DST_DISK_DIR:=/var/log.disk}"
+: "${CURRENT_MIRROR_DIR:=${DST_DISK_DIR}/current}"
+: "${BOOT_ID_FILE:=${DST_DISK_DIR}/.boot_id}"
+
+# Counter library that maintains per-file rotation counters in /dev/shm/logrotate.
+COUNTER_FUNCS="/usr/local/bin/logrotate-counter-functions.sh"
+[ -r "$COUNTER_FUNCS" ] && . "$COUNTER_FUNCS"
+
+# Disk cleanup kicks in once disk usage of the DST_DISK_DIR filesystem exceeds this
+# percentage
+DISK_USED_MAX_PCT=80
+
+# --- Logging ---
+log_info()  { logger -p syslog.info -t "ram2disk" "$*" 2>/dev/null || printf 'ram2disk: %s\n' "$*" >&2; }
+log_err()   { logger -p syslog.err -t "ram2disk" "$*" 2>/dev/null || printf 'ram2disk: ERROR: %s\n' "$*" >&2; }
+
+# =============================================================================
+# is_new_boot
+#
+# Compares current boot_id with stored one. Returns 0 (true) if new boot.
+# =============================================================================
+is_new_boot() {
+    local current_boot_id stored_boot_id
+    current_boot_id=$(cat /proc/sys/kernel/random/boot_id 2>/dev/null)
+
+    if [ ! -f "$BOOT_ID_FILE" ]; then
+        return 0
+    fi
+
+    stored_boot_id=$(cat "$BOOT_ID_FILE" 2>/dev/null)
+    [ "$current_boot_id" != "$stored_boot_id" ]
+}
+
+save_boot_id() {
+    cat /proc/sys/kernel/random/boot_id > "$BOOT_ID_FILE"
+}
+
+# =============================================================================
+# archive_current_session
+#
+# Renames current/ to session_<timestamp>/
+#
+# Uses .boot_id mtime as the session timestamp (represents when that boot
+# session started). Falls back to current time if unavailable.
+#
+# =============================================================================
+archive_current_session() {
+    [ -d "$CURRENT_MIRROR_DIR" ] || return 0
+
+    # Use .boot_id mtime as session start timestamp
+    local timestamp
+    if [ -f "$BOOT_ID_FILE" ]; then
+        timestamp=$(stat -c '%Y' "$BOOT_ID_FILE" \
+                    | xargs -I{} date -d @{} '+%Y%m%d_%H%M%S' 2>/dev/null)
+    fi
+    [ -z "$timestamp" ] && timestamp=$(date '+%Y%m%d_%H%M%S')
+
+    local session_dir="${DST_DISK_DIR}/session_${timestamp}"
+
+    mv "$CURRENT_MIRROR_DIR" "$session_dir"
+
+    log_info "Archived previous session → $(basename "$session_dir")"
+}
+
+# =============================================================================
+# ensure_current_dir
+#
+# Creates current/ with necessary subdirectories if it doesn't exist.
+# =============================================================================
+ensure_current_dir() {
+    if [ ! -d "$CURRENT_MIRROR_DIR" ]; then
+        mkdir -p "$CURRENT_MIRROR_DIR"
+    fi
+}
+
+# =============================================================================
+# =============================================================================
+# replay_rotations
+#
+# Replays, on current/, every logrotate cycle that happened since the last run.
+#
+# The set of files to replay and their counts come entirely from
+# /dev/shm/logrotate/rotation_counts (maintained by the logrotate-wrapper). We
+# consume it with lrc_file_read_reset, which atomically
+# fetches every "<path> <count>" line and clears the file, so the next run only
+# sees rotations that occur after this one.
+# =============================================================================
+replay_rotations() {
+    declare -F lrc_file_read_reset >/dev/null || return 0
+
+    local path count base
+    while read -r path count; do
+        [ -n "$path" ] || continue
+        [[ "$count" =~ ^[0-9]+$ ]] || continue
+        [ "$count" -gt 0 ] || continue
+
+        # Only mirror files that live under ${SRC_RAM_DIR} (what current/ mirrors)
+	# Consider adding a warning for files not under SRC_RAM_DIR to understand other files managed by logrotate
+	[[ "$path" == "${SRC_RAM_DIR}/"* ]] || continue
+	base="${path#"${SRC_RAM_DIR}/"}"
+
+        mirror_renames "$base" "$count"
+    done < <(lrc_file_read_reset 2>/dev/null)
+}
+
+# =============================================================================
+# mirror_renames <base> <shift>
+#
+# Performs the same rename chain on disk's current/ that logrotate did on tmpfs.
+# =============================================================================
+mirror_renames() {
+    local base="$1"
+    local shift="$2"
+    local dst_base="${CURRENT_MIRROR_DIR}/${base}"
+
+    [ "$shift" -eq 0 ] && return
+
+    log_info "${base}: mirroring ${shift} rotation(s) on disk"
+
+    # Find highest archive number in current/
+    local max_n=0
+    for f in "${dst_base}".*.gz; do
+        [ -f "$f" ] || continue
+        local n
+        n=$(echo "$f" | grep -oP '\.\K[0-9]+(?=\.gz$)')
+        [ -n "$n" ] && [ "$n" -gt "$max_n" ] && max_n=$n
+    done
+    [ -f "${dst_base}.1" ] && [ "$max_n" -lt 1 ] && max_n=1
+
+    # Start the rename shifting
+    for s in $(seq 1 "$shift"); do
+        # Shift .gz archives up by 1 (highest first to avoid collision)
+        for i in $(seq "$max_n" -1 2); do
+            [ -f "${dst_base}.${i}.gz" ] && \
+                mv "${dst_base}.${i}.gz" "${dst_base}.$((i + 1)).gz"
+        done
+        max_n=$((max_n + 1))
+
+        # delaycompress: .1 to .2.gz (one gzip write)
+        if [ -f "${dst_base}.1" ]; then
+            gzip -c "${dst_base}.1" > "${dst_base}.2.gz"
+            rm -f "${dst_base}.1"
+        fi
+
+        # active to .1
+        if [ "$s" -eq 1 ] && [ -f "${dst_base}" ]; then
+            mv "${dst_base}" "${dst_base}.1"
+        fi
+    done
+}
+
+# =============================================================================
+# cleanup_disk
+#
+# Manages disk space based on actual filesystem usage of the DST_DISK_DIR mount. While
+# usage exceeds DISK_USED_MAX_PCT, it first removes the oldest session_*
+# directory, then falls back to removing individual archives from
+# current/ if needed.
+# =============================================================================
+cleanup_disk() {
+    local use_pct
+    use_pct=$(df -P "$DST_DISK_DIR" 2>/dev/null | awk 'NR==2 {gsub("%","",$5); print $5}')
+    [[ "$use_pct" =~ ^[0-9]+$ ]] || return
+
+    while [ "$use_pct" -gt "$DISK_USED_MAX_PCT" ]; do
+        # First: remove oldest session directory (entire previous boot)
+        local oldest_session
+        oldest_session=$(find "$DST_DISK_DIR" -maxdepth 1 -type d -name 'session_*' \
+                         | sort | head -1)
+
+        if [ -n "$oldest_session" ]; then
+            log_info "Cleanup: removing $(basename "$oldest_session")"
+            rm -rf "$oldest_session"
+            use_pct=$(df -P "$DST_DISK_DIR" | awk 'NR==2 {gsub("%","",$5); print $5}')
+            continue
+        fi
+
+        # Fallback: remove oldest archive from current/
+        local oldest_archive
+        oldest_archive=$(find "$CURRENT_MIRROR_DIR" -type f -name '*.gz' -printf '%T+ %p\n' \
+                         | sort | awk 'NR==1 {print $2}')
+
+        if [ -z "$oldest_archive" ]; then
+            log_info "No archives to delete — disk may fill up"
+            break
+        fi
+
+        log_info "Cleanup: deleting $oldest_archive"
+        rm -f "$oldest_archive"
+        use_pct=$(df -P "$DST_DISK_DIR" | awk 'NR==2 {gsub("%","",$5); print $5}')
+    done
+}
+
+# =============================================================================
+# do_sync — Periodic sync (default mode)
+# =============================================================================
+do_sync() {
+    # --- Step 1: Handle reboot if restore wasn't called ---
+    if is_new_boot; then
+        archive_current_session
+        ensure_current_dir
+        save_boot_id
+    fi
+
+    ensure_current_dir
+
+    # --- Step 2: Replay logrotate rotations on current/ ---
+    replay_rotations
+
+    # --- Step 3: rsync into disk's current/ ---
+    rsync -a --inplace --no-whole-file "${SRC_RAM_DIR}/" "${CURRENT_MIRROR_DIR}/"
+
+    # --- Step 4: Disk space management ---
+    cleanup_disk
+
+    log_info "Sync complete"
+}
+
+# =============================================================================
+# do_restore — Boot-time: restore active logs from disk back to tmpfs,
+# then archive previous session
+#
+# Called early in boot before rsyslogd starts.
+# 1. Restores active log files from the previous boot's current/ to tmpfs
+# 2. Archives previous boot's current/ → session_<timestamp>/
+# 3. Creates fresh current/ for this boot
+#
+# Archives stay on disk only — tmpfs starts clean except for active files.
+# =============================================================================
+do_restore() {
+	log_info "Boot-time restore active logs to /var/log (tmpfs)"
+
+    if [ -d "$CURRENT_MIRROR_DIR" ]; then
+        log_info "Restoring active logs from current/"
+        rsync -a \
+            --exclude='*.[0-9]' \
+            --exclude='*.[0-9][0-9]' \
+            --exclude='*.[0-9][0-9][0-9]' \
+            --exclude='*.[0-9].gz' \
+            --exclude='*.[0-9][0-9].gz' \
+            --exclude='*.[0-9][0-9][0-9].gz' \
+            "${CURRENT_MIRROR_DIR}/" "${SRC_RAM_DIR}/"
+    else
+        log_info "No previous current/ to restore from"
+    fi
+
+    # Archive previous boot's data (mv current/ → session_<timestamp>/)
+    archive_current_session
+
+    # Create fresh current/ for this boot
+    ensure_current_dir
+    save_boot_id
+
+    log_info "Restore complete"
+}
+
+# =============================================================================
+# do_pre_shutdown — Final sync before shutdown/reboot
+#
+# Same as sync but skips cleanup
+# Ensures disk's current/ has the latest data before it gets archived on next boot.
+# =============================================================================
+do_pre_shutdown() {
+    log_info "Pre-reboot: final sync"
+
+    ensure_current_dir
+
+    # Replay logrotate rotations + rsync
+    replay_rotations
+
+    rsync -a --inplace --no-whole-file "${SRC_RAM_DIR}/" "${CURRENT_MIRROR_DIR}/"
+    save_boot_id
+    log_info "Pre-reboot sync complete"
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+# checking if DST_DISK_DIR is present or mounted
+if ! mountpoint -q "$DST_DISK_DIR" 2>/dev/null; then
+    log_err "$DST_DISK_DIR is not mounted, skipping"
+    exit 1
+fi
+
+case "$MODE" in
+    sync)       do_sync ;;
+    restore)    do_restore ;;
+    pre-shutdown) do_pre_shutdown ;;
+    *)
+        echo "Usage: $0 {sync|restore|pre-shutdown}"
+        exit 1
+        ;;
+esac

--- a/files/image_config/ram2disk/ram2disk.timer
+++ b/files/image_config/ram2disk/ram2disk.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Periodic ram2disk sync of /var/log to /var/log.disk
+
+[Timer]
+OnCalendar=*:05/10:00
+AccuracySec=1min
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/files/image_config/syslog/host_umount.sh
+++ b/files/image_config/syslog/host_umount.sh
@@ -7,11 +7,25 @@ journal_stop() {
     systemctl stop systemd-journald.service
 }
 
+# When /var/log is on tmpfs, the persistent copy lives on the
+# disk-backed /var/log.disk mount maintained by ram2disk. Flush the latest
+# tmpfs contents to disk after journald stops and before the mounts are torn down.
+ram2disk_preshutdown() {
+    if mountpoint -q /var/log.disk; then
+        /usr/local/bin/ram2disk.sh pre-shutdown
+    fi
+}
+
 delete_loop_device() {
     umount /var/log
     if [[ $? -ne 0 ]]
     then
         exit 0
+    fi
+    # When /var/log is on tmpfs, the loop device backs /var/log.disk
+    # instead of /var/log, so unmount it too before detaching the loop device.
+    if mountpoint -q /var/log.disk; then
+        umount /var/log.disk
     fi
     loop_exist=$(losetup -a | grep loop1 | wc -l)
     if [ $loop_exist -ne 0 ]; then
@@ -20,11 +34,11 @@ delete_loop_device() {
 }
 
 case "$1" in
-    journal_stop|delete_loop_device)
+    journal_stop|delete_loop_device|ram2disk_preshutdown)
         $1
         ;;
     *)
-        echo "Usage: $0 {journal_stop|delete_loop_device}" >&2
+        echo "Usage: $0 {journal_stop|delete_loop_device|ram2disk_preshutdown}" >&2
         exit 1
         ;;
 esac

--- a/files/image_config/syslog/override.conf
+++ b/files/image_config/syslog/override.conf
@@ -3,4 +3,5 @@ After=var-log.mount host.mount local-fs.target
 
 [Socket]
 ExecStopPre=/usr/bin/host_umount.sh journal_stop
+ExecStopPost=/usr/bin/host_umount.sh ram2disk_preshutdown
 ExecStopPost=/usr/bin/host_umount.sh delete_loop_device

--- a/files/initramfs-tools/union-mount.j2
+++ b/files/initramfs-tools/union-mount.j2
@@ -240,8 +240,12 @@ if $logs_inram; then
     #       SONiC image growth before being bottlenecked.
     set_tmpfs_log_partition_size
     mount -t tmpfs -o rw,nosuid,nodev,size=${varlogsize}M tmpfs ${rootmnt}/var/log
+    # Keep the disk-backed var-log.ext4 and mount it on /var/log.disk so that
+    # ram2disk can persist the in-memory /var/log contents to disk.
     if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then
-        rm -rf ${rootmnt}/host/disk-img/var-log.ext4
+        fsck.ext4 -v -p ${rootmnt}/host/disk-img/var-log.ext4 2>&1 | gzip -c >> /tmp/fsck.log.gz
+        mkdir -p ${rootmnt}/var/log.disk
+        mount -t ext4 -o loop,rw ${rootmnt}/host/disk-img/var-log.ext4 ${rootmnt}/var/log.disk
     fi
 else
     if [ -f ${rootmnt}/host/disk-img/var-log.ext4 ]; then

--- a/files/initramfs-tools/varlog
+++ b/files/initramfs-tools/varlog
@@ -28,9 +28,6 @@ done
 
 [ -z "$varlog_size" ] && exit 0
 
-# If logs are being stored in memory, then don't bother
-# creating the log file just to have it deleted afterwards.
-$logs_inram && exit 0
 
 # exit when the var_log.ext4 exists and the size matches
 if [ -e "${rootmnt}/host/disk-img/var-log.ext4" ]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

The `ram2disk` service is used for devices which have `/var/log` in `tmpfs` but since tmpfs is volatile and logs are lost when the system shuts down, reboots, or loses power but logs are required for debugging, post-incident analysis and understanding failures across boot sessions. Therefore, need a service, called `ram2disk` (also known as `LogKeeper`), that:
   - Periodically copies logs from the tmpfs-backed /var/log to persistent disk in batches and in a sequential manner by using `rsync` as the utility for copying/backing up the logs. 
   - Performs a final synchronization during an orderly shutdown or reboot
   - Restores active logs early during boot so logging can continue across sessions
   - Retains previous boot sessions for later analysis

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Devices which currently have `/var/log` under `tmpfs` will have a new new disk based mountpoint under `/var/log.disk` where periodically, we sync the logs from the tmpfs to this disk location and persist it across system boots.

| File | Responsibility |
|---|---|
| `logrotate-wrapper.sh` | Producer that detects completed rotations and records per-file counts |
| `logrotate-counter-functions.sh` | Shared counter and locking library used by the producer and consumer |
| `ram2disk.sh` | Consumer that reads rotation counts, replays renames, synchronizes logs, restores logs, and performs cleanup |
| `ram2disk.service` | Runs the periodic `ram2disk.sh sync` operation |
| `ram2disk.timer` | Schedules the periodic service |
| `ram2disk-restore.service` | Runs boot-time restore before rsyslog begins writing |

More detaills in [HLD for ram2disk](https://github.com/sonic-net/SONiC/pull/2527) 
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
Applied the following changes and built a virtual image and tested its functionality on it.

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
