### PR TITLE
Fixed BGPMON for IPv6 not enabled in UpperSpine role

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/monitors/peer-group.conf.j2
@@ -20,7 +20,7 @@
     neighbor BGPMON maximum-prefix 1
   exit-address-family
 
-{% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'voq' or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' %}
+{% if CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'voq' or CONFIG_DB__DEVICE_METADATA['localhost']['switch_type'] == 'chassis-packet' or CONFIG_DB__DEVICE_METADATA['localhost']['type'] == 'UpperSpineRouter' %}
   address-family ipv6
     neighbor BGPMON activate
     neighbor BGPMON route-map FROM_BGPMON in


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
BGP Monitor Sonic Mgmt test was not passing for IPv6 family in UpperSpine role because the FRR config was rejecting enabling the config if the type is not voq or chassis-packet. Added the check for UpperSpineRouter.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verified with Sonic Mgmt run:
TEST CASE DETAILS

Test Name: test_bgpmon_v6
Classname: bgp.test_bgpmon_v6
Time: 43.483s
Status: Passed
Message: N/A

Test Name: test_bgpmon_no_ipv6_resolve_via_default
Classname: bgp.test_bgpmon_v6
Time: 5.786s
Status: Skipped
Message: Not applicable for passive bgpmon_v6
[test_bgpmon_v6_2026-03-24-05-03-27.log](https://wwwin-github.cisco.com/whitebox/sonic-buildimage/files/39494/test_bgpmon_v6_2026-03-24-05-03-27.log)

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
