### PR TITLE
[frrcfgd] Add prefix-set description support

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -44,6 +44,12 @@ class CachedDataWithOp:
 
 bgpd_client = None
 
+
+def is_valid_prefix_set_description(value):
+    if not isinstance(value, str) or not 1 <= len(value) <= 255:
+        return False
+    return all(ord(char) >= 0x20 and ord(char) != 0x7f for char in value)
+
 def g_run_command(table, command, use_bgpd_client, daemons, ignore_fail = False):
     syslog.syslog(syslog.LOG_DEBUG, "execute command {} for table {}.".format(command, table))
     if not (len(command) > 0 and command[0] == 'vtysh'):
@@ -2234,6 +2240,8 @@ class BGPConfigDaemon:
             if 'mode' in entry:
                 syslog.syslog(syslog.LOG_DEBUG, 'Init Config DB Data: Prefix_Set %s mode %s' % (key, entry['mode']))
                 self.prefix_set_list[key] = MatchPrefixList(entry['mode'].lower())
+                if 'description' in entry and is_valid_prefix_set_description(entry['description']):
+                    self.prefix_set_list[key].description = entry['description']
         pfx_table = self.config_db.get_table('PREFIX')
         for key, entry in pfx_table.items():
             if len(key) == 4:
@@ -2897,21 +2905,70 @@ class BGPConfigDaemon:
                         comm_set.db_data_to_attr(dkey, upd_val)
             elif table == 'PREFIX_SET':
                 pfx_set_name = prefix
-                if not del_table:
-                    if pfx_set_name in self.prefix_set_list:
-                        syslog.syslog(syslog.LOG_DEBUG, 'prefix-set %s exists with af %d' %
-                                (pfx_set_name, self.prefix_set_list[pfx_set_name].af))
-                        continue
+                prefix_set = self.prefix_set_list.get(pfx_set_name)
+                if del_table:
+                    description_removed = True
+                    if prefix_set is not None and hasattr(prefix_set, 'description'):
+                        af_type = 'ip' if prefix_set.af == socket.AF_INET else 'ipv6'
+                        command = ['vtysh', '-c', 'configure terminal',
+                                   '-c', 'no {} prefix-list {} description'.format(af_type, pfx_set_name)]
+                        if not self.__run_command(table, command):
+                            description_removed = False
+                            syslog.syslog(syslog.LOG_ERR,
+                                          'failed to remove description while deleting prefix-set %s' % pfx_set_name)
+                    if description_removed:
+                        self.prefix_set_list.pop(pfx_set_name, None)
+                    for dkey, dval in data.items():
+                        dval.status = (CachedDataWithOp.STAT_FAIL
+                                      if dkey == 'description' and not description_removed
+                                      else CachedDataWithOp.STAT_SUCC)
+                    continue
+
+                if prefix_set is None:
                     if 'mode' not in data:
                         syslog.syslog(syslog.LOG_ERR, 'no mode given for prefix-set %s' % pfx_set_name)
                         continue
                     set_mode = data['mode'].data.lower()
-                    self.prefix_set_list[pfx_set_name] = MatchPrefixList(set_mode)
+                    prefix_set = MatchPrefixList(set_mode)
+                    self.prefix_set_list[pfx_set_name] = prefix_set
                 else:
-                    if pfx_set_name in self.prefix_set_list:
-                        del(self.prefix_set_list[pfx_set_name])
-                for _, dval in data.items():
-                    dval.status = CachedDataWithOp.STAT_SUCC
+                    syslog.syslog(syslog.LOG_DEBUG, 'prefix-set %s exists with af %d' %
+                            (pfx_set_name, prefix_set.af))
+
+                desc_op = data.get('description')
+                if desc_op is not None:
+                    af_type = 'ip' if prefix_set.af == socket.AF_INET else 'ipv6'
+                    if desc_op.op == CachedDataWithOp.OP_DELETE:
+                        if hasattr(prefix_set, 'description'):
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', 'no {} prefix-list {} description'.format(af_type, pfx_set_name)]
+                            if self.__run_command(table, command):
+                                delattr(prefix_set, 'description')
+                                desc_op.status = CachedDataWithOp.STAT_SUCC
+                            else:
+                                desc_op.status = CachedDataWithOp.STAT_FAIL
+                        else:
+                            desc_op.status = CachedDataWithOp.STAT_SUCC
+                    elif desc_op.op in (CachedDataWithOp.OP_ADD, CachedDataWithOp.OP_UPDATE):
+                        if not is_valid_prefix_set_description(desc_op.data):
+                            syslog.syslog(syslog.LOG_ERR,
+                                          'invalid description for prefix-set %s' % pfx_set_name)
+                            desc_op.status = CachedDataWithOp.STAT_FAIL
+                        else:
+                            command = ['vtysh', '-c', 'configure terminal',
+                                       '-c', '{} prefix-list {} description {}'.format(
+                                           af_type, pfx_set_name, desc_op.data)]
+                            if self.__run_command(table, command):
+                                prefix_set.description = desc_op.data
+                                desc_op.status = CachedDataWithOp.STAT_SUCC
+                            else:
+                                desc_op.status = CachedDataWithOp.STAT_FAIL
+                    else:
+                        desc_op.status = CachedDataWithOp.STAT_SUCC
+
+                for dkey, dval in data.items():
+                    if dkey != 'description':
+                        dval.status = CachedDataWithOp.STAT_SUCC
             elif table == 'PREFIX' or table == 'NEIGHBOR_SET' or table == 'NEXTHOP_SET':
                 pfx_set_name = self.get_prefix_set_name(prefix, table)
                 if table == 'PREFIX':

--- a/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.pref_list.j2
+++ b/src/sonic-frr-mgmt-framework/templates/bgpd/bgpd.conf.db.pref_list.j2
@@ -1,12 +1,15 @@
 {# ------------------------------------------------------------------------------------ #}
-{% if (PREFIX_SET is defined and PREFIX_SET|length > 0) and
-      (PREFIX is defined and PREFIX|length > 0) %}
+{% if PREFIX_SET is defined and PREFIX_SET|length > 0 %}
 {% set modes = ['IPv4', 'IPv6'] %}
 {% set ip_str = {'IPv4':'ip', 'IPv6':'ipv6' } %}
 {% for md in modes %}
 !
 {% for key, val in PREFIX_SET.items() %}
 {% if 'mode' in val %}
+{% if md == val['mode'] and 'description' in val and 0 < val['description']|length <= 255 and '\n' not in val['description'] and '\r' not in val['description'] %}
+{{ip_str[md]}} prefix-list {{key}} description {{val['description']}}
+{% endif %}
+{% if PREFIX is defined %}
 {% for pf_key, pf_val in PREFIX.items() %}
 {# Support both PREFIX_LIST and PREFIX_NOSEQ_LIST #}
 {% if pf_key|count == 4 %}
@@ -35,6 +38,7 @@
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% endfor %}

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -1,6 +1,9 @@
 import copy
 import re
+from pathlib import Path
 from unittest.mock import MagicMock, NonCallableMagicMock, patch
+
+from jinja2 import Environment, FileSystemLoader
 
 swsscommon_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
 # because can’t use dotted names directly in a call, have to create a dictionary and unpack it using **:
@@ -222,6 +225,16 @@ neighbor_shutdown_data = [
                   conf_bgp_cmd('default', 100) + ['{}no neighbor 10.1.1.5 shutdown'])
 ]
 
+prefix_set_description_data = [
+    CmdMapTestInfo(
+        'PREFIX_SET', 'PL_EDGE',
+        {'mode': 'IPv4', 'description': "Branch office's preferred routes"},
+        [conf_cmd, "ip prefix-list PL_EDGE description Branch office's preferred routes"],
+        False,
+        [conf_cmd, 'no ip prefix-list PL_EDGE description'],
+        ignore_tail=None)
+]
+
 @patch.dict('sys.modules', **mockmapping)
 @patch('frrcfgd.frrcfgd.g_run_command')
 def data_set_del_test(test_data, run_cmd, skip_del=False):
@@ -268,6 +281,32 @@ def test_bgp_neighbor_shutdown():
     # The neighbor shutdown msg test cases explicitly verify delete behavior, so skip the delete
     # verification data_set_del_test (else it would try the del of 'no ' commands as well and fail)
     data_set_del_test(neighbor_shutdown_data, skip_del=True)
+
+def test_prefix_set_description():
+    data_set_del_test(prefix_set_description_data)
+
+@patch.dict('sys.modules', **mockmapping)
+def test_prefix_set_description_validation():
+    from frrcfgd.frrcfgd import is_valid_prefix_set_description
+
+    assert is_valid_prefix_set_description("Branch office's preferred routes")
+    assert not is_valid_prefix_set_description('')
+    assert not is_valid_prefix_set_description('line one\nline two')
+    assert not is_valid_prefix_set_description('x' * 256)
+
+def test_prefix_set_description_template():
+    template_dir = Path(__file__).parents[1] / 'templates' / 'bgpd'
+    template = Environment(loader=FileSystemLoader(template_dir)).get_template(
+        'bgpd.conf.db.pref_list.j2')
+    rendered = template.render(PREFIX_SET={
+        'PL_V4': {'mode': 'IPv4', 'description': "Branch office's preferred routes"},
+        'PL_V6': {'mode': 'IPv6', 'description': 'IPv6 edge routes'},
+    })
+
+    assert "ip prefix-list PL_V4 description Branch office's preferred routes" in rendered
+    assert 'ipv6 prefix-list PL_V6 description IPv6 edge routes' in rendered
+    assert 'ipv6 prefix-list PL_V4 description' not in rendered
+    assert 'ip prefix-list PL_V6 description' not in rendered
 
 
 @patch.dict('sys.modules', **mockmapping)

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/route_filter.json
@@ -74,6 +74,10 @@
     "ROUTE_PREFIX_VALID": {
         "desc": "Configure prefix table."
     },
+    "ROUTE_PREFIX_INVALID_DESCRIPTION": {
+        "desc": "Configure a prefix set with an invalid multiline description.",
+        "eStrKey": "Pattern"
+    },
     "ROUTE_PREFIX_INVALID_MODE_ENUM": {
         "desc": "Referring invalid Mode",
         "eStrKey": "InvalidValue"
@@ -112,4 +116,3 @@
     }
 
 }
-

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/route_filter.json
@@ -392,7 +392,8 @@
                 "PREFIX_SET_LIST": [
                 {
                     "name": "prefix1",
-                    "mode": "IPv4"
+                    "mode": "IPv4",
+                    "description": "Branch office preferred routes"
                 },
                 {
                     "name": "prefix2",
@@ -429,6 +430,19 @@
                     "ip_prefix": "21.0.0.0/8",
                     "masklength_range": "exact",
                     "action": "permit"
+                }
+                ]
+            }
+        }
+    },
+    "ROUTE_PREFIX_INVALID_DESCRIPTION": {
+        "sonic-routing-policy-sets:sonic-routing-policy-sets":{
+            "sonic-routing-policy-sets:PREFIX_SET": {
+                "PREFIX_SET_LIST": [
+                {
+                    "name": "prefix1",
+                    "mode": "IPv4",
+                    "description": "line one\nline two"
                 }
                 ]
             }
@@ -637,6 +651,5 @@
         }
     }
 }
-
 
 

--- a/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
+++ b/src/sonic-yang-models/yang-models/sonic-routing-policy-sets.yang
@@ -99,6 +99,14 @@ module sonic-routing-policy-sets {
                     description "Address family of the prefix";
                     default "IPv4";
                 }
+
+                leaf description {
+                    type string {
+                        length "1..255";
+                        pattern '[^\n\r]+';
+                    }
+                    description "Prefix-list description";
+                }
             }
         }
 


### PR DESCRIPTION
#### Why I did it

PREFIX_SET entries cannot currently preserve and apply an operational
description consistently during startup and runtime configuration updates.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Added an optional PREFIX_SET description field to the YANG model.
- Rendered IPv4 and IPv6 prefix-list descriptions during startup.
- Added runtime handling for description creation, update, and deletion.
- Validated descriptions before applying them.
- Added unit and YANG model test cases.

#### How to verify it

Run the frrcfgd unit tests and validate the updated YANG model.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- `PYTHONPATH=src/sonic-frr-mgmt-framework python3 -m pytest -q src/sonic-frr-mgmt-framework/tests`
  - Result: 20 passed
- `pyang` validation of `sonic-routing-policy-sets.yang`
  - Result: passed using the generated SONiC YANG dependency paths

#### Description for the changelog

Add PREFIX_SET description support to frrcfgd.

#### Link to config_db schema for YANG module changes

N/A — PREFIX_SET is not currently documented in Configuration.md.

#### A picture of a cute animal (not mandatory but encouraged)

N/A
