### PR TITLE
bgpcfgd: Validate allow-list keys and prefixes

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_allow_list.py
@@ -5,7 +5,6 @@ import re
 import ipaddress
 
 from .log import log_debug, log_info, log_err, log_warn
-from .template import TemplateFabric
 from .manager import Manager
 
 
@@ -41,7 +40,12 @@ class BGPAllowListMgr(Manager):
             db,
             table,
         )
-        self.key_re = re.compile(r"^DEPLOYMENT_ID\|\d+\|\S+$|^DEPLOYMENT_ID\|\d+$|^DEPLOYMENT_ID\|\d+\|\S+\|NEIGHBOR_TYPE\|\S+$|^DEPLOYMENT_ID\|\d+\|NEIGHBOR_TYPE\|\S+")
+        key_value = r"[A-Za-z0-9_.:-]+"
+        self.key_re = re.compile(
+            r"DEPLOYMENT_ID\|(?P<deployment_id>[0-9]{1,10})"
+            r"(?:\|(?:%s|NEIGHBOR_TYPE\|%s(?:\|%s)?))?" %
+            (key_value, key_value, key_value)
+        )
         self.enabled = self.__get_enabled()
         self.prefix_match_tag = self.__get_routemap_tag()
         self.__load_constant_lists()
@@ -87,20 +91,21 @@ class BGPAllowListMgr(Manager):
         if data is None:
             log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message without data")
             return False
-        if not self.key_re.match(key):
-            log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid key: '%s'" % key)
+        key_match = self.key_re.fullmatch(key)
+        if not key_match or int(key_match.group("deployment_id")) > 0xffffffff:
+            log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid key: %r" % key)
             return False
         prefixes_v4 = []
         prefixes_v6 = []
         if "prefixes_v4" in data:
             prefixes_v4 = str(data["prefixes_v4"]).split(",")
-            if not all(TemplateFabric.is_ipv4(re.split('ge|le', prefix)[0]) for prefix in prefixes_v4):
+            if not all(self.__parse_prefix(prefix, 4) for prefix in prefixes_v4):
                 arguments = "prefixes_v4", str(data["prefixes_v4"])
                 log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[%s]:'%s'" % arguments)
                 return False
         if "prefixes_v6" in data:
             prefixes_v6 = str(data["prefixes_v6"]).split(",")
-            if not all(TemplateFabric.is_ipv6(re.split('ge|le', prefix)[0]) for prefix in prefixes_v6):
+            if not all(self.__parse_prefix(prefix, 6) for prefix in prefixes_v6):
                 arguments = "prefixes_v6", str(data["prefixes_v6"])
                 log_err("BGPAllowListMgr::Received BGP ALLOWED 'SET' message with invalid input[%s]:'%s'" % arguments)
                 return False
@@ -141,10 +146,36 @@ class BGPAllowListMgr(Manager):
         :param key: a key of "DEL" message
         :return: True if parameters are valid, False if parameters are invalid
         """
-        if not self.key_re.match(key):
-            log_err("BGPAllowListMgr::Received BGP ALLOWED 'DEL' message with invalid key: '$s'" % key)
+        key_match = self.key_re.fullmatch(key)
+        if not key_match or int(key_match.group("deployment_id")) > 0xffffffff:
+            log_err("BGPAllowListMgr::Received BGP ALLOWED 'DEL' message with invalid key: %r" % key)
             return False
         return True
+
+    @staticmethod
+    def __parse_prefix(prefix, version):
+        match = re.fullmatch(
+            r"(?P<prefix>\S+)(?: (?P<operator>le|ge) (?P<length>[0-9]+))?",
+            prefix
+        )
+        if not match or "/" not in match.group("prefix"):
+            return None
+
+        try:
+            network = ipaddress.ip_network(match.group("prefix"), strict=False)
+        except ValueError:
+            return None
+
+        if network.version != version:
+            return None
+
+        length = match.group("length")
+        if length is not None:
+            length = int(length)
+            if not network.prefixlen <= length <= network.max_prefixlen:
+                return None
+
+        return match.group("prefix"), match.group("operator"), length, network.prefixlen
 
     def __update_policy(self, deployment_id, community_value, prefixes_v4, prefixes_v6, default_action, neighbor_type):
         """
@@ -743,10 +774,14 @@ class BGPAllowListMgr(Manager):
         res = []
         prefix_mask_default = 32 if af == self.V4 else 128
         for prefix in allow_list:
-            if 'le' in prefix or 'ge' in prefix:
-                res.append("permit %s" % prefix)
+            parsed = self.__parse_prefix(prefix, 4 if af == self.V4 else 6)
+            if parsed is None:
+                log_err("BGPAllowListMgr::Ignoring invalid prefix-list entry: %r" % prefix)
+                continue
+            prefix, operator, length, prefix_mask = parsed
+            if operator:
+                res.append("permit %s %s %d" % (prefix, operator, length))
             else:
-                prefix_mask = int(prefix.split("/")[1])
                 if prefix_mask == prefix_mask_default:
                     res.append("permit %s" % prefix)
                 else:

--- a/src/sonic-bgpcfgd/tests/test_allow_list.py
+++ b/src/sonic-bgpcfgd/tests/test_allow_list.py
@@ -1006,9 +1006,24 @@ def test___set_handler_validate():
         "prefixes_v4": "20.20.30.0/24,40.50.0.0/16",
         "prefixes_v6": "fc01:20::/64,fc01:30::/64",
     }
+    assert mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|5|1010:2020", data)
+    assert mgr._BGPAllowListMgr__set_handler_validate(
+        "DEPLOYMENT_ID|5|NEIGHBOR_TYPE|OpticalLonghaulTerminal|1010:2020", data
+    )
     assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|5|1010:2020", None)
     assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID1|5|1010:2020", data)
     assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|z|1010:2020", data)
+    assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|4294967296", data)
+    assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|99999999999", data)
+    assert not mgr._BGPAllowListMgr__set_handler_validate(
+        "DEPLOYMENT_ID|5|NEIGHBOR_TYPE|leaf\nroute-map injected", data
+    )
+    assert not mgr._BGPAllowListMgr__set_handler_validate(
+        "DEPLOYMENT_ID|5|NEIGHBOR_TYPE|leaf|1010:2020\n", data
+    )
+    assert not mgr._BGPAllowListMgr__set_handler_validate(
+        "DEPLOYMENT_ID|5|NEIGHBOR_TYPE|leaf;exit", data
+    )
     assert not mgr._BGPAllowListMgr__set_handler_validate("DEPLOYMENT_ID|5|1010:2020", {
         "prefixes_v4": "20.20.30.0/24,40.50.0.0/16",
         "prefixes_v6": "20.20.30.0/24,40.50.0.0/16",
@@ -1017,6 +1032,23 @@ def test___set_handler_validate():
         "prefixes_v4": "fc01:20::/64,fc01:30::/64",
         "prefixes_v6": "fc01:20::/64,fc01:30::/64",
     })
+    for prefixes_v4 in (
+        "1.2.3.4/x",
+        "1.2.3.4",
+        "10.0.0.0/24 ge 33",
+        "10.0.0.0/24 le 20",
+        "10.0.0.0/24\nroute-map injected",
+    ):
+        assert not mgr._BGPAllowListMgr__set_handler_validate(
+            "DEPLOYMENT_ID|5|1010:2020", {"prefixes_v4": prefixes_v4}
+        )
+
+
+def test_set_del_handlers_reject_unsafe_keys():
+    data = {"prefixes_v4": "20.20.30.0/24"}
+    key = "DEPLOYMENT_ID|5|NEIGHBOR_TYPE|leaf\nroute-map injected"
+    set_del_test("SET", (key, data), [], [])
+    set_del_test("DEL", (key,), [], [])
 
 @patch.dict("sys.modules", swsscommon=swsscommon_module_mock)
 def test___find_peer_group():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

BGPAllowListMgr currently accepts partially matched keys and loosely parsed prefix rules. Trailing key data can be incorporated into generated FRR identifiers, while malformed prefixes can raise an exception during conversion.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Validate complete documented allow-list key layouts.
- Restrict neighbor and community fields to safe identifier characters.
- Bound deployment IDs to the unsigned 32-bit range.
- Parse IPv4 and IPv6 networks with `ipaddress`.
- Accept only complete optional `le` or `ge` modifiers whose lengths are valid for the prefix.
- Add regression tests for malformed keys, prefixes, masks, modifiers, and trailing data.

#### How to verify it

Run:

`pytest -q src/sonic-bgpcfgd/tests/test_allow_list.py`

Result: `41 passed`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: `41 passed` in `src/sonic-bgpcfgd/tests/test_allow_list.py`

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Validate BGP allow-list keys and prefix rules before generating configuration.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A

#### A picture of a cute animal (not mandatory but encouraged)
