### PR TITLE
bgpcfgd: Validate DEVICE_METADATA BGP ASN

### DIFF
--- a/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
@@ -1,3 +1,6 @@
+from swsscommon import swsscommon
+
+from .log import log_err
 from .manager import Manager
 
 
@@ -19,6 +22,12 @@ class BGPDataBaseMgr(Manager):
 
     def set_handler(self, key, data):
         """ Implementation of 'SET' command for this class """
+        if (self.table_name == swsscommon.CFG_DEVICE_METADATA_TABLE_NAME
+                and key == "localhost" and data and "bgp_asn" in data
+                and not self.__is_valid_asn(data["bgp_asn"])):
+            log_err("BGPDataBaseMgr::Invalid bgp_asn value: %r. Row ignored" % data["bgp_asn"])
+            return True
+
         self.directory.put(self.db_name, self.table_name, key, data)
 
         return True
@@ -26,3 +35,11 @@ class BGPDataBaseMgr(Manager):
     def del_handler(self, key):
         """ Implementation of 'DEL' command for this class """
         self.directory.remove(self.db_name, self.table_name, key)
+
+    @staticmethod
+    def __is_valid_asn(value):
+        """Return True when value is a decimal BGP autonomous system number."""
+        if not isinstance(value, str) or not value.isascii() or not value.isdigit():
+            return False
+
+        return 0 < int(value) <= 0xffffffff

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
@@ -39,7 +39,8 @@ class BGPDataBaseMgr(Manager):
     @staticmethod
     def __is_valid_asn(value):
         """Return True when value is a decimal BGP autonomous system number."""
-        if not isinstance(value, str) or not value.isascii() or not value.isdigit():
+        if (not isinstance(value, str) or not value.isascii()
+                or not value.isdigit() or len(value) > 10):
             return False
 
         return 0 < int(value) <= 0xffffffff

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_db.py
@@ -1,4 +1,5 @@
 from swsscommon import swsscommon
+from sonic_py_common.bgp import validate_asn
 
 from .log import log_err
 from .manager import Manager
@@ -38,9 +39,14 @@ class BGPDataBaseMgr(Manager):
 
     @staticmethod
     def __is_valid_asn(value):
-        """Return True when value is a decimal BGP autonomous system number."""
-        if (not isinstance(value, str) or not value.isascii()
-                or not value.isdigit() or len(value) > 10):
+        """Return True when the common BGP ASN validator accepts *value*."""
+        # CONFIG_DB values are strings. Keep rejecting non-string values here
+        # while sharing the syntax and range checks with other callers that
+        # legitimately receive integers (for example, template rendering).
+        if not isinstance(value, str):
             return False
-
-        return 0 < int(value) <= 0xffffffff
+        try:
+            validate_asn(value)
+        except ValueError:
+            return False
+        return True

--- a/src/sonic-bgpcfgd/tests/test_db.py
+++ b/src/sonic-bgpcfgd/tests/test_db.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock, patch
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
 from . import swsscommon_test
-from swsscommon import swsscommon
 
 with patch.dict("sys.modules", swsscommon=swsscommon_test):
+    from swsscommon import swsscommon
     from bgpcfgd.managers_db import BGPDataBaseMgr
 
 def test_set_del_handler():
@@ -38,3 +38,49 @@ def test_set_del_handler():
 
     m.del_handler("test_key2")
     assert "test_key2" not in m.directory.get_slot(m.db_name, m.table_name)
+
+
+def test_device_metadata_bgp_asn_validation():
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr': MagicMock(),
+        'tf': TemplateFabric(),
+        'constants': {},
+    }
+    m = BGPDataBaseMgr(common_objs, "CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME)
+
+    for bgp_asn in ("1", "65100", "4294967295"):
+        assert m.set_handler("localhost", {"bgp_asn": bgp_asn})
+        assert m.directory.get(m.db_name, m.table_name, "localhost") == {"bgp_asn": bgp_asn}
+
+    for bgp_asn in (
+        "0", "4294967296", "-1", "+1", " 65100", "65100 ", "65.100",
+        "65100\ninvalid", "１２３", 65100, None,
+    ):
+        assert m.set_handler("localhost", {"bgp_asn": bgp_asn})
+        assert m.directory.get(m.db_name, m.table_name, "localhost") == {"bgp_asn": "4294967295"}
+
+
+def test_bgp_asn_validation_scope():
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr': MagicMock(),
+        'tf': TemplateFabric(),
+        'constants': {},
+    }
+    metadata_mgr = BGPDataBaseMgr(
+        common_objs, "CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME
+    )
+    neighbor_mgr = BGPDataBaseMgr(
+        common_objs, "CONFIG_DB", "DEVICE_NEIGHBOR_METADATA"
+    )
+
+    assert metadata_mgr.set_handler("other-host", {"bgp_asn": "not-an-asn"})
+    assert metadata_mgr.directory.get(
+        metadata_mgr.db_name, metadata_mgr.table_name, "other-host"
+    ) == {"bgp_asn": "not-an-asn"}
+
+    assert neighbor_mgr.set_handler("localhost", {"bgp_asn": "not-an-asn"})
+    assert neighbor_mgr.directory.get(
+        neighbor_mgr.db_name, neighbor_mgr.table_name, "localhost"
+    ) == {"bgp_asn": "not-an-asn"}

--- a/src/sonic-bgpcfgd/tests/test_db.py
+++ b/src/sonic-bgpcfgd/tests/test_db.py
@@ -55,7 +55,7 @@ def test_device_metadata_bgp_asn_validation():
 
     for bgp_asn in (
         "0", "4294967296", "-1", "+1", " 65100", "65100 ", "65.100",
-        "65100\ninvalid", "１２３", 65100, None,
+        "65100\ninvalid", "１２３", "0" * 10 + "1", "9" * 5000, 65100, None,
     ):
         assert m.set_handler("localhost", {"bgp_asn": bgp_asn})
         assert m.directory.get(m.db_name, m.table_name, "localhost") == {"bgp_asn": "4294967295"}

--- a/src/sonic-py-common/sonic_py_common/bgp.py
+++ b/src/sonic-py-common/sonic_py_common/bgp.py
@@ -1,0 +1,47 @@
+"""Helpers for validating BGP configuration values."""
+
+from __future__ import print_function
+
+import re
+from numbers import Integral
+
+
+try:
+    STRING_TYPES = (basestring,)
+except NameError:
+    STRING_TYPES = (str,)
+
+
+_ASN_PATTERN = re.compile(r'\A[0-9]{1,10}\Z')
+_MAX_ASN = 0xffffffff
+
+
+def validate_asn(value):
+    """Return *value* in its configuration representation when it is valid.
+
+    BGP ASNs are represented as decimal strings in CONFIG_DB, while callers
+    such as template filters may receive an integer. Both representations are
+    accepted, but booleans are deliberately excluded even though ``bool`` is a
+    subclass of ``int`` in Python.
+
+    ``None`` and other sentinel values are not interpreted here. A caller that
+    supports disabling BGP should handle that policy before invoking this
+    validator.
+
+    :raises ValueError: if *value* is not a decimal ASN in the 32-bit range.
+    :return: the original decimal string, or the rendered integer string.
+    """
+    if isinstance(value, Integral) and not isinstance(value, bool):
+        asn = int(value)
+        rendered_value = str(value)
+    elif (isinstance(value, STRING_TYPES)
+          and _ASN_PATTERN.match(value) is not None):
+        asn = int(value)
+        rendered_value = value
+    else:
+        raise ValueError("Invalid BGP ASN")
+
+    if not 0 < asn <= _MAX_ASN:
+        raise ValueError("Invalid BGP ASN")
+
+    return rendered_value

--- a/src/sonic-py-common/tests/test_bgp.py
+++ b/src/sonic-py-common/tests/test_bgp.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sonic_py_common.bgp import validate_asn
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("1", "1"),
+    ("0001", "0001"),
+    ("4294967295", "4294967295"),
+    (1, "1"),
+    (4294967295, "4294967295"),
+])
+def test_validate_asn_accepts_valid_values(value, expected):
+    assert validate_asn(value) == expected
+
+
+@pytest.mark.parametrize("value", [
+    None,
+    True,
+    False,
+    "",
+    "0",
+    "4294967296",
+    "1.0",
+    "+1",
+    " 1",
+    "1 ",
+    "1e3",
+    "12345678901",
+    "\u0661",
+    b"1",
+    -1,
+    4294967296,
+    1.0,
+])
+def test_validate_asn_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        validate_asn(value)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

BGPDataBaseMgr publishes the localhost BGP ASN to several dependent managers without verifying its format or range. Those managers expect a decimal ASN when generating `router bgp` configuration. Validate the shared input before publishing it so invalid values cannot produce malformed configuration.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Validate `DEVICE_METADATA|localhost` when `bgp_asn` is present.
- Require an ASCII decimal string in the range 1 through 4294967295.
- Ignore invalid updates while retaining the last valid value.
- Preserve unrelated metadata keys and tables.
- Add boundary, invalid-input, retained-state, and scope tests.
- Correct the test mock import order so the test does not require a host-installed native `swsscommon` module.

#### How to verify it

`pytest -q src/sonic-bgpcfgd/tests/test_db.py`

Result: `3 passed`. The changed manager has 100% statement coverage in this focused run.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: other

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: `3 passed` in `src/sonic-bgpcfgd/tests/test_db.py`

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Validate the DEVICE_METADATA BGP ASN before generating routing configuration.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

N/A - no YANG or CONFIG_DB schema change.

#### A picture of a cute animal (not mandatory but encouraged)
