### PR TITLE
[Mellanox] Fix missing error message shield

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/sfp.py
@@ -481,7 +481,7 @@ class SFP(NvidiaSFPCommon):
         try:
             asic_id = self.asic_id
             asic_id_for_file = "asic" + str(int(asic_id.replace("asic", "")) + 1)
-            if utils.read_int_from_file(f'/var/run/hw-management/config/{asic_id_for_file}_ready') == 1:
+            if utils.read_int_from_file(f'/var/run/hw-management/config/{asic_id_for_file}_ready', log_func=None) == 1:
                 if DeviceDataManager.is_module_host_management_mode():
                     if not os.path.exists(get_asic_ready_file_path(asic_id)):
                         return False

--- a/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_sfp.py
@@ -255,7 +255,7 @@ class TestSfp:
         assert not sfp.get_presence()
         mock_read_eeprom.assert_not_called()
         # Verify it checked /var/run/hw-management/config/asic1_ready
-        mock_read_int.assert_called_with('/var/run/hw-management/config/asic1_ready')
+        mock_read_int.assert_called_with('/var/run/hw-management/config/asic1_ready', log_func=None)
 
         # Test case 2: asic_ready config file ready (returns 1), but asic's ready file does not exist
         sfp = SFP(0, asic_id='asic2')


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
On boot, asicN_ready can exist before it contains a value. Reading it as int then logs a spurious thermalctld error for an expected not-ready window.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Pass log_func=None on the asicN_ready read in SFP.get_presence(), consistent with the other presence-sysfs reads. Presence behavior is unchanged; only the error log is suppressed.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->
Reboot a Mellanox platform and confirm syslog has no Failed to read from file .../asic*_ready from thermalctld. Also run tests/test_sfp.py::TestSfp::test_sfp_get_presence.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
Test passed on 202605 image.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
