### PR TITLE
docker-sonic-gnmi: select DPU ephemeral TLS mode

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -54,7 +54,7 @@ TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
 if [[ "$DPU_EPHEMERAL_TLS" == "true" ]]; then
-    TELEMETRY_ARGS+=" --insecure"
+    TELEMETRY_ARGS+=" --dpu_ephemeral_tls"
 elif [ -n "$CERTS" ]; then
     SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
     SERVER_KEY=$(extract_field "$CERTS" '.server_key')

--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -54,7 +54,11 @@ TELEMETRY_ARGS=" -logtostderr"
 export CVL_SCHEMA_PATH=/usr/sbin/schema
 
 if [[ "$DPU_EPHEMERAL_TLS" == "true" ]]; then
-    TELEMETRY_ARGS+=" --dpu_ephemeral_tls"
+    if /usr/sbin/telemetry -h 2>&1 | grep -q -- '-dpu_ephemeral_tls'; then
+        TELEMETRY_ARGS+=" --dpu_ephemeral_tls"
+    else
+        TELEMETRY_ARGS+=" --insecure"
+    fi
 elif [ -n "$CERTS" ]; then
     SERVER_CRT=$(extract_field "$CERTS" '.server_crt')
     SERVER_KEY=$(extract_field "$CERTS" '.server_key')


### PR DESCRIPTION
## Why

When no server certificate is configured, the SmartSwitch DPU fallback selects generic `--insecure`. The launcher should select `--dpu_ephemeral_tls`, the DPU-specific certificate mode required by sonic-net/sonic-host-services#427.

## References

- Uses: sonic-net/sonic-gnmi#772
- Related: sonic-net/sonic-buildimage#29188
- ADO: 39456784

## What

- The `DPU_EPHEMERAL_TLS` path selects `--dpu_ephemeral_tls` when the telemetry binary supports it.
- The path falls back to `--insecure` with an older telemetry binary.
- The path keeps `--allow_no_client_auth` for clients that do not present certificates.
- The change does not affect configured certificates or explicit application authentication.
- The change does not affect UDS-only or non-DPU behavior.

## Validation

- `bash -n dockers/docker-sonic-gnmi/gnmi-native.sh`
- `git diff --check`
- The compatibility check selects the existing fallback for a telemetry binary without `--dpu_ephemeral_tls`.

## Rollout

Merge sonic-net/sonic-gnmi#772 and update the buildimage source pointer to enable the new mode. Until then, this launcher preserves the existing `--insecure` fallback.
