### PR TITLE
[redfish]: use unix socket for supervisor-proc-exit-listener CONFIG_DB access

### DIFF
--- a/dockers/docker-sonic-redfish/supervisord.conf
+++ b/dockers/docker-sonic-redfish/supervisord.conf
@@ -13,7 +13,7 @@ events=PROCESS_STATE
 buffer_size=1024
 
 [eventlistener:supervisor-proc-exit-listener]
-command=/usr/local/bin/supervisor-proc-exit-listener --container-name redfish
+command=/usr/local/bin/supervisor-proc-exit-listener --container-name redfish --use-unix-socket-path
 events=PROCESS_STATE_EXITED,PROCESS_STATE_RUNNING,PROCESS_STATE_FATAL
 autostart=true
 autorestart=unexpected


### PR DESCRIPTION
**What I did**

Add `--use-unix-socket-path` to `supervisor-proc-exit-listener` in `dockers/docker-sonic-redfish/supervisord.conf`.

**Why I did it**

Fixes #29245.

The `redfish` container is the only SONiC container that runs with `--net=bridge` (see [`files/build_templates/docker_image_ctl.j2#L699-L704`](https://github.com/sonic-net/sonic-buildimage/blob/master/files/build_templates/docker_image_ctl.j2#L699-L704)), because it uses `-p 0.0.0.0:443:18080` to remap the external HTTPS port.

As a consequence, `127.0.0.1:6379` inside the container does not reach the host redis. `ConfigDBConnector().connect()` (TCP mode) fails with `RuntimeError: Unable to connect to redis - Connection refused`. `supervisor-proc-exit-listener`'s `get_autorestart_state()` catches that and returns `""`. Since `"" != "enabled"`, the listener never sends `SIGTERM` to supervisord when a critical process exits, so container teardown never happens, so container-level autorestart is effectively broken for redfish.

Every other SONiC container using this listener runs on `--net=host` and reaches redis over TCP, so they are unaffected. The `redfish` container already bind-mounts `/var/run/redis:/var/run/redis:rw`, so the unix socket is available; switching the listener to unix-socket mode is a one-line, redfish-only change.

**How I verified it**

Applied the equivalent change on a live SONiC BMC DUT (Chipmunk, `sonic-aspeed-arm64-20260810.06`):

- Before: `docker exec redfish kill -9 <sonic-dbus-bridge pid>` → supervisord respawns in place, container stays up indefinitely.
- After: same kill → container exits within 30s (`systemd[1]: redfish.service: Deactivated successfully`); systemd restarts the service; new container comes up clean and healthy. `autorestart/test_container_autorestart.py::test_containers_autorestart[...-redfish]` now behaves as designed.

**Which release branches to backport (provide reason below if selected)**

- [ ] 202012
- [ ] 202205
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

**Description for the changelog**

`[redfish]: use unix socket for supervisor-proc-exit-listener CONFIG_DB access`
