### PR TITLE
[202511][docker-sonic-mgmt]: Add frozen versions

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -36,9 +36,40 @@ parameters:
 - name: registry_conn
   type: string
   default: sonicdev
+- name: use_frozen_versions
+  type: boolean
+  default: false
+  displayName: 'Use pinned versions from dockers/docker-sonic-mgmt/files'
 
 stages:
+- stage: Prepare
+  jobs:
+  - job: Prepare
+    steps:
+    - script: |
+        DEFAULT_MIRROR_URL_PREFIX=http://packages.trafficmanager.net
+        DEBIAN_TIMESTAMP=$(curl $DEFAULT_MIRROR_URL_PREFIX/debian-snapshot/debian/latest)
+        DEBIAN_SECURITY_TIMESTAMP=$(curl $DEFAULT_MIRROR_URL_PREFIX/debian-snapshot/debian-security/latest)
+        echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
+        echo "##vso[task.setvariable variable=DEBIAN_TIMESTAMP;isOutput=true]$DEBIAN_TIMESTAMP"
+        echo "##vso[task.setvariable variable=DEBIAN_SECURITY_TIMESTAMP;isOutput=true]$DEBIAN_SECURITY_TIMESTAMP"
+      name: SetVersions
+      displayName: 'Set snapshot versions'
+
 - stage: Build
+  dependsOn: Prepare
+  variables:
+  - name: DEBIAN_TIMESTAMP
+    value: $[ stageDependencies.Prepare.Prepare.outputs['SetVersions.DEBIAN_TIMESTAMP'] ]
+  - name: DEBIAN_SECURITY_TIMESTAMP
+    value: $[ stageDependencies.Prepare.Prepare.outputs['SetVersions.DEBIAN_SECURITY_TIMESTAMP'] ]
+  - name: MIRROR_SNAPSHOT
+    value: 'y'
+  - name: VERSION_CONTROL_OPTIONS
+    ${{ if parameters.use_frozen_versions }}:
+      value: 'SONIC_VERSION_CONTROL_COMPONENTS=py2,py3,web,git,docker'
+    ${{ else }}:
+      value: 'SONIC_VERSION_CONTROL_COMPONENTS='
   jobs:
   - job: Build
     pool: sonicso1ES-amd64
@@ -52,12 +83,36 @@ stages:
         sudo setfacl -R -b $(Agent.BuildDirectory)
       displayName: 'setfacl'
 
+    - ${{ if not(parameters.use_frozen_versions) }}:
+      - script: |
+          echo "DEBIAN_TIMESTAMP=$DEBIAN_TIMESTAMP, DEBIAN_SECURITY_TIMESTAMP=$DEBIAN_SECURITY_TIMESTAMP"
+          if [ "$MIRROR_SNAPSHOT" == y ]; then
+            mkdir -p target/versions/default/
+            echo "debian==$DEBIAN_TIMESTAMP" > target/versions/default/versions-mirror
+            echo "debian-security==$DEBIAN_SECURITY_TIMESTAMP" >> target/versions/default/versions-mirror
+            cat target/versions/default/versions-mirror
+          fi
+        displayName: 'Set snapshot versions'
+
+    - ${{ if parameters.use_frozen_versions }}:
+      - bash: |
+          set -ex
+          if [ ! -d dockers/docker-sonic-mgmt/files ] || [ -z "$(ls -A dockers/docker-sonic-mgmt/files)" ]; then
+            echo "No frozen versions are available under dockers/docker-sonic-mgmt/files."
+            echo "Run this pipeline once with use_frozen_versions disabled and merge the version update pull request it opens, then retry."
+            exit 1
+          fi
+          rsync -av dockers/docker-sonic-mgmt/files/ files/build/versions/
+        displayName: 'Apply frozen versions for docker-sonic-mgmt'
+
     - bash: |
         set -xe
         git submodule update --init --recursive -- src/sonic-platform-daemons src/sonic-genl-packet src/sonic-sairedis src/ptf src/sonic-device-data src/sonic-dash-api
 
-        make NOBUSTER=1 NOBULLSEYE=1 SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y configure PLATFORM=generic DOCKER_BUILDKIT=0
-        make -f Makefile.work BLDENV=bookworm SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y target/docker-sonic-mgmt.gz
+        BUILD_OPTIONS="SONIC_BUILD_JOBS=$(nproc) DEFAULT_CONTAINER_REGISTRY=publicmirror.azurecr.io ENABLE_DOCKER_BASE_PULL=y \
+                DOCKER_BUILDKIT=0 MIRROR_SNAPSHOT=$MIRROR_SNAPSHOT $(VERSION_CONTROL_OPTIONS)"
+        make NOBUSTER=1 NOBULLSEYE=1 $BUILD_OPTIONS configure PLATFORM=generic
+        make -f Makefile.work BLDENV=bookworm $BUILD_OPTIONS target/docker-sonic-mgmt.gz
         cp -r target $(Build.ArtifactStagingDirectory)/target
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
@@ -145,7 +200,7 @@ stages:
 
 - stage: Publish
   dependsOn: Test
-  condition: and(not(canceled()), in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues'))
+  condition: and(not(canceled()), ne(variables['Build.Reason'], 'PullRequest'), in(dependencies.Test.result, 'Succeeded', 'SucceededWithIssues'))
   jobs:
   - job: PublishAsLatest
     pool: sonicso1ES-amd64
@@ -157,18 +212,110 @@ stages:
 
     - bash: |
         set -ex
+        BRANCH=$(Build.SourceBranchName)
+        [[ "$BRANCH" == "master" ]] && TAG="latest" || TAG="$BRANCH"
+        echo "Docker tag: $TAG"
+        echo "##vso[task.setvariable variable=DOCKER_TAG]$TAG"
+      displayName: 'Compute Docker tag'
+
+    - bash: |
+        set -ex
         docker load -i $(Pipeline.Workspace)/docker-sonic-mgmt/target/docker-sonic-mgmt.gz
-        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202511
+        docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:$(DOCKER_TAG)
         docker images
       env:
         REGISTRY_SERVER: ${{ parameters.registry_url }}
-      displayName: 'Load and tag docker-sonic-mgmt as 202511'
+      displayName: 'Load and tag docker-sonic-mgmt'
 
     - task: Docker@2
-      displayName: 'Push docker-sonic-mgmt:202511 to registry'
+      displayName: 'Push docker-sonic-mgmt to registry'
       condition: succeeded()
       inputs:
         containerRegistry: ${{ parameters.registry_conn }}
         repository: docker-sonic-mgmt
         command: push
-        tags: 202511
+        tags: $(DOCKER_TAG)
+
+- stage: UpdateVersions
+  dependsOn: Publish
+  condition: and(not(canceled()), ne(variables['Build.Reason'], 'PullRequest'), in(dependencies.Publish.result, 'Succeeded'))
+  jobs:
+  - job: UpdateVersions
+    pool:
+      vmImage: 'ubuntu-22.04'
+    variables:
+      - group: sonicbld
+    steps:
+    - script: |
+        if [ -z "$(which gh)" ]; then
+          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
+          sudo apt-add-repository -y https://cli.github.com/packages
+          sudo apt update
+          sudo apt install -y gh
+        fi
+
+        echo $TOKEN | gh auth login --with-token
+      env:
+        TOKEN: $(GITHUB-TOKEN)
+      displayName: 'Install gh'
+
+    - checkout: self
+      displayName: 'Checkout code'
+
+    - download: current
+      artifact: 'docker-sonic-mgmt'
+      patterns: '**/versions-*'
+      displayName: 'Download build artifact'
+
+    - script: |
+        set -ex
+        mkdir -p target
+        cp -r $(Pipeline.Workspace)/docker-sonic-mgmt/target/versions target/
+        FREEZE_TMPDIR=$(mktemp -d)
+        make freeze FREEZE_VERSION_OPTIONS="-r -s $FREEZE_TMPDIR"
+
+        mkdir -p dockers/docker-sonic-mgmt/files
+        rsync -av --delete "$FREEZE_TMPDIR/files/build/versions/" dockers/docker-sonic-mgmt/files/
+        rm -rf "$FREEZE_TMPDIR"
+        git diff dockers/docker-sonic-mgmt/files
+      displayName: 'Update docker-sonic-mgmt version files'
+
+    - script: |
+        GIT_STATUS=$(git status --porcelain dockers/docker-sonic-mgmt/files)
+        if [ -z "$GIT_STATUS" ]; then
+          echo "Skipped to send the pull request, no version change in docker-sonic-mgmt versions"
+          exit 0
+        fi
+        if [ ! -d "$HOME" ]; then
+          sudo mkdir -p $HOME
+          sudo chown -R $(id -un):$(id -gn) $HOME
+        fi
+        SOURCE_BRANCH=$(Build.SourceBranch)
+        REPO_NAME=$(Build.Repository.Name)
+        [ -z "$GIT_REPO" ] && GIT_REPO=${REPO_NAME#*/}
+        BRANCH_NAME=repd/docker-sonic-mgmt-versions/${SOURCE_BRANCH#refs/heads/}
+
+        gh auth setup-git
+        git config user.name "Sonic Build Admin"
+        git config user.email "sonicbld@microsoft.com"
+        git add dockers/docker-sonic-mgmt/files
+        git commit -s -m "[docker-sonic-mgmt] Upgrade docker-sonic-mgmt package versions"
+        git checkout -b $BRANCH_NAME
+        git push origin HEAD:refs/heads/$BRANCH_NAME -f
+
+        TITLE="[${SOURCE_BRANCH#refs/heads/}] Upgrade docker-sonic-mgmt package versions"
+        PR_URL=$(gh pr list -R $REPO_NAME -H $BRANCH_NAME -B ${SOURCE_BRANCH#refs/heads/} --state open --json url --jq '.[].url' | head -1)
+        if [ -n "$PR_URL" ]; then
+          echo "Skipped to send the pull request, an open pull request was updated: $PR_URL"
+          exit 0
+        fi
+
+        RET=0
+        if ! gh pr create -t "$TITLE" -b "$TITLE" -B $(Build.SourceBranch) -R $(Build.Repository.Name) > pr.log 2>&1; then
+          if ! grep -q "already exists" pr.log; then
+            RET=1
+          fi
+        fi
+        cat pr.log
+        exit $RET
+      displayName: 'Send Pull Request'


### PR DESCRIPTION
#### Why I did it

Backport #28834 to `202511` so `docker-sonic-mgmt` can reproduce the Debian Bookworm build environment with stored package versions and Debian snapshot timestamps.

This change freezes only the Debian build dependencies. Ubuntu Noble packages installed in the final image continue to use the live Ubuntu repositories.

##### Work item tracking
- Microsoft ADO **(number only)**: 39277119

#### How I did it

Cherry-picked the merged change from #28834 and resolved `.azure-pipelines/docker-sonic-mgmt.yml` conflicts against `202511`:

- Keep the pipeline schedule, PR filter, and `sonic-mgmt` resource on `202511`.
- Preserve the branch's existing non-SBOM build behavior.
- Add the `use_frozen_versions` parameter, Debian snapshot timestamps, stored-version restore flow, and version-control build options.
- Add the `UpdateVersions` stage that updates `dockers/docker-sonic-mgmt/files/`.
- Publish with the branch-derived Docker tag, which resolves to `docker-sonic-mgmt:202511`.

The backport is a single signed-off commit.

#### How to verify it

1. Run the pipeline with `use_frozen_versions: false` and confirm the normal build succeeds and the version-update flow creates or updates a version-file PR.
2. Run it again with `use_frozen_versions: true` after the generated version files are available.
3. Confirm the frozen build restores `dockers/docker-sonic-mgmt/files/` into `files/build/versions/`.
4. Confirm `target/versions/default/versions-mirror` contains the Debian and Debian security snapshot timestamps.

#### Which release branch to backport (provide reason below if selected)

This PR is the backport of #28834 to `202511`.

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39277119
Failure type: other

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: The normal version-update flow and frozen-version build passed while validating #28834.
- 202511: The `docker-sonic-mgmt` build and test pipeline passed while validating #28834.

#### Description for the changelog

Add frozen versions support for docker-sonic-mgmt Debian build dependencies on 202511.

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)
