### PR TITLE
[Mellanox] Increase queue 3 DWRR weight to 26 for SN6600_LD SPC6 SKUs

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/qos.json.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/qos.json.j2
@@ -116,7 +116,7 @@
         },
         "scheduler_q3_downlink": {
             "type": "DWRR",
-            "weight": "22"
+            "weight": "26"
         },
         "scheduler_q4_downlink": {
             "type": "DWRR",
@@ -144,7 +144,7 @@
         },
         "scheduler_q3_uplink": {
             "type": "DWRR",
-            "weight": "22"
+            "weight": "26"
         },
         "scheduler_q4_uplink": {
             "type": "DWRR",


### PR DESCRIPTION
#### Why I did it
On SPC6 trimming scenarios, the queue 4 DWRR weight was previously increased to 48 to resolve packets being dropped without trimming. That change resolved the drops, but introduced a side effect: the retransmission queue queue 3 started congesting.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
Increased the queue 3 DWRR weight from 22 to 26 for both `downlink` and `uplink` schedulers in the shared SPC6 QoS template.

#### How to verify it
```bash
$ redis-cli -n 4 hget "SCHEDULER|scheduler_q3_downlink" weight
"26"
$ redis-cli -n 4 hget "SCHEDULER|scheduler_q3_uplink" weight
"26"
```

Test the SRv6 leaf trimming case and confirm queue 3 occupancy.
Before (queue 3=22): queue 3 occAvg ~105200 (congested)
After  (queue 3=26): queue 3 occAvg ~12 (empty), queue 4 no drop

#### Which release branch to backport (provide reason below if selected)

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

#### Tested branch
- [x] master

#### Test result
Performance trimming test on switch: queue 3 occAvg dropped from ~105200 to ~12 with no queue 4 drops.

#### Description for the changelog
Increase queue 3 DWRR weight from 22 to 26 for SPC6 SKUs to fix queue 3 congestion in trimming scenarios.

#### Link to config_db schema for YANG module changes
No YANG model changes (DWRR scheduler weight value change only).

#### A picture of a cute animal (not mandatory but encouraged)
