### PR TITLE
Micas/fix bug get_position_in_parent for micas

### DIFF
--- a/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/fan.py
@@ -149,7 +149,7 @@ class Fan(FanBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.fan_index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/fan_drawer.py
@@ -109,7 +109,7 @@ class FanDrawer(FanDrawerBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.fantray_index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/psu.py
@@ -117,7 +117,7 @@ class Psu(PsuBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-micas/common/sonic_platform/thermal.py
@@ -108,7 +108,7 @@ class Thermal(ThermalBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/fan.py
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/fan.py
@@ -142,7 +142,7 @@ class Fan(FanBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.fan_index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/fan_drawer.py
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/fan_drawer.py
@@ -109,7 +109,7 @@ class FanDrawer(FanDrawerBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.fantray_index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/psu.py
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/psu.py
@@ -223,7 +223,7 @@ class Psu(PsuBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.index
 
     def is_replaceable(self):
         """

--- a/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/thermal.py
+++ b/platform/broadcom/sonic-platform-modules-micas/m2-w6940-128qc/sonic_platform/thermal.py
@@ -139,7 +139,7 @@ class Thermal(ThermalBase):
         Returns:
             integer: The 1-based relative physical position in parent device or -1 if cannot determine the position
         """
-        return -1
+        return self.index + 1
 
     def is_replaceable(self):
         """


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
fix bug get_position_in_parent for micas
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
add get_position_in_parent for micas
#### How to verify it
redis-cli -n 6 KEYS 'PHYSICAL_ENTITY_INFO*'

redis-cli -n 6 HGETALL 'PHYSICAL_ENTITY_INFO|PSU2_FAN1'

snmpwalk -v2c -c public localhost \

  .1.3.6.1.2.1.47.1.1.1.1.6


<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
<img width="733" height="520" alt="image" src="https://github.com/user-attachments/assets/0cc15276-e10c-4f5e-bf34-93304ee20ed9" />
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
