### PR TITLE
[redfish] Deliver bridged-container syslog to the host over docker0

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -1,4 +1,5 @@
 #!/bin/bash
+{%- set bridged_containers = ["dhcp_server", "redfish"] %}
 
 # single instance containers are still supported (even though it might not look like it)
 # if no instance number is passed to this script, $DEV will simply be unset, resulting in docker
@@ -60,8 +61,11 @@ get_pmon_device_cgroup_rules() {
 }
 {%- endif %}
 
-{%- if docker_container_name == "dhcp_server" %}
-DHCP_SERVER_SYSLOG_CHECK=(iptables -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment dhcp_server_syslog -j ACCEPT)
+{%- if docker_container_name in bridged_containers %}
+{#- redfish.service runs as the sonicadmin user, so its rule check needs sudo. #}
+{%- set ipt = "sudo iptables" if docker_container_name == "redfish" else "iptables" %}
+BRIDGE_SYSLOG_CHECK=({{ ipt }} -C INPUT -i docker0 -p tcp -m tcp --dport 2514 -m comment --comment {{ docker_container_name }}_syslog -j ACCEPT)
+BRIDGE_SYSLOG_WAIT_SECS=10
 {%- endif %}
 
 function updateSyslogConf()
@@ -154,18 +158,18 @@ function preStartAction()
         echo "Cannot fetch system eeprom information. Setting chassis serial number to N/A."
         $SONIC_DB_CLI STATE_DB HSET 'DEVICE_METADATA|localhost' chassis_serial_number "N/A"
     fi
-{%- elif docker_container_name == "dhcp_server" %}
-    # Wait for caclmgrd to allow dhcp_server syslog before startup.
-    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "enabled" ]; then
+{%- elif docker_container_name in bridged_containers %}
+    # Wait for caclmgrd to allow {{ docker_container_name }} syslog before startup.
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|{{ docker_container_name }}' state 2>/dev/null)" = "enabled" ]; then
         local attempt status
-        for attempt in {0..10}; do
-            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+        for (( attempt=0; attempt<=BRIDGE_SYSLOG_WAIT_SECS; attempt++ )); do
+            "${BRIDGE_SYSLOG_CHECK[@]}" 2>/dev/null
             status=$?
 
             if [ "$status" -eq 0 ]; then
                 break
-            elif [ "$attempt" -eq 10 ]; then
-                echo "Warning: dhcp_server syslog rule not present after 10 seconds (iptables status $status)."
+            elif [ "$attempt" -eq "$BRIDGE_SYSLOG_WAIT_SECS" ]; then
+                echo "Warning: {{ docker_container_name }} syslog rule not present after ${BRIDGE_SYSLOG_WAIT_SECS} seconds (iptables status $status)."
             else
                 sleep 1
             fi
@@ -483,7 +487,7 @@ start() {
     fi
 
     # Default rsyslog target IP for single ASIC platform
-{%- if docker_container_name == "dhcp_server" %}
+{%- if docker_container_name in bridged_containers %}
     SYSLOG_TARGET_IP=$(docker network inspect bridge --format={{ "'{{(index .IPAM.Config 0).Gateway}}'" }})
 {%- else %}
     SYSLOG_TARGET_IP=127.0.0.1
@@ -963,18 +967,18 @@ stop() {
         /usr/local/bin/container stop $DOCKERNAME
     {%- endif %}
     fi
-{%- if docker_container_name == "dhcp_server" %}
+{%- if docker_container_name in bridged_containers %}
     # Wait for caclmgrd to remove the rule after feature disable.
-    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|dhcp_server' state 2>/dev/null)" = "disabled" ]; then
+    if [ "$($SONIC_DB_CLI CONFIG_DB HGET 'FEATURE|{{ docker_container_name }}' state 2>/dev/null)" = "disabled" ]; then
         local attempt status
-        for attempt in {0..10}; do
-            "${DHCP_SERVER_SYSLOG_CHECK[@]}" 2>/dev/null
+        for (( attempt=0; attempt<=BRIDGE_SYSLOG_WAIT_SECS; attempt++ )); do
+            "${BRIDGE_SYSLOG_CHECK[@]}" 2>/dev/null
             status=$?
 
             if [ "$status" -eq 1 ]; then
                 break
-            elif [ "$attempt" -eq 10 ]; then
-                echo "Warning: dhcp_server syslog rule not absent after 10 seconds (iptables status $status)."
+            elif [ "$attempt" -eq "$BRIDGE_SYSLOG_WAIT_SECS" ]; then
+                echo "Warning: {{ docker_container_name }} syslog rule still present after ${BRIDGE_SYSLOG_WAIT_SECS} seconds (iptables status $status)."
             else
                 sleep 1
             fi

--- a/files/image_config/rsyslog/rsyslog-config.sh
+++ b/files/image_config/rsyslog/rsyslog-config.sh
@@ -18,10 +18,13 @@ else
     udp_server_ip=$(ip -j -4 addr list lo scope host | jq -r -M '.[0].addr_info[0].local')
 fi
 
-contain_dhcp_server=$(sonic-db-cli CONFIG_DB keys "FEATURE|dhcp_server")
-if [ $contain_dhcp_server ]; then
-    docker0_ip=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
-fi
+bridged_syslog_features="dhcp_server redfish"
+for feature in $bridged_syslog_features; do
+    if [ -n "$(sonic-db-cli CONFIG_DB keys "FEATURE|$feature")" ]; then
+        docker0_ip=$(ip -o -4 addr list docker0 | awk '{print $4}' | cut -d/ -f1)
+        break
+    fi
+done
 
 hostname=$(hostname)
 


### PR DESCRIPTION
#### Why I did it

`redfish` runs bridge-networked, as `docker_image_ctl.j2` already notes at the port-mapping block, so its `127.0.0.1` is not the host's and its rsyslog cannot reach the host over loopback. Logs emitted inside the container never reach the host `/var/log/syslog`, including a process going FATAL at startup, which is exactly when they are most needed.

Three pieces are missing for `redfish`, all of which `dhcp_server` already has:

1. **Container target.** RELP is sent to `SYSLOG_TARGET_IP=127.0.0.1`, which loops back inside the container. Only `dhcp_server` is pointed at the docker0 gateway.
2. **Host listener not configured.** `docker0_ip` is keyed on the `dhcp_server` FEATURE entry, which aspeed images do not have, so no docker0 input is generated for the host rsyslog.
3. **Firewall.** With a control-plane ACL configured, the syslog arrives on `docker0` rather than `lo`, matches no ACCEPT, and is swept into `caclmgrd`'s catch-all DROP. That side is handled by sonic-net/sonic-host-services#429.

This extends #28580, which added the `dhcp_server` start and stop waits on the caclmgrd-owned rule.

#### How I did it

**`files/build_templates/docker_image_ctl.j2`**

* A `bridged_containers` list names the bridge-networked containers once, and the rule check, both waits, and the syslog target render from single parametrized blocks, so the `dhcp_server` and `redfish` copies cannot drift.
* `SYSLOG_TARGET_IP` points at the docker0 gateway for `redfish`, as it already does for `dhcp_server`.
* The rule check runs under `sudo` for `redfish`, since `redfish.service` runs as `sonicadmin`.
* `BRIDGE_SYSLOG_WAIT_SECS` replaces the hardcoded 10 second bound.
* The `stop()` warning read "rule not absent" and now reads "rule still present".

**`files/image_config/rsyslog/rsyslog-config.sh`**

* `docker0_ip` is populated when any bridged feature entry exists, so the host rsyslog binds its RELP listener on the docker0 gateway. The `redfish` entry is only appended on aspeed images, so other platforms are unaffected.
* The presence test was an unquoted command substitution; it is now a quoted `-n` test.

Both waits warn and continue rather than fail, as in #28580.

#### How to verify it

On an aspeed platform with `redfish` enabled:

1. The container is aimed at the docker0 gateway:
```
docker exec redfish env | grep SYSLOG_TARGET_IP
docker exec redfish grep -E 'omrelp|port=' /etc/rsyslog.conf
```

2. The host is listening on both loopback and the docker0 gateway, with no manual intervention:
```
ss -tlnp | grep 2514
```

3. The caclmgrd-owned exception is present:
```
sudo iptables -S INPUT | grep redfish_syslog
```

4. End to end, forcing a new RELP connection so that an existing conntrack `ESTABLISHED` entry cannot mask the result:
```
docker exec redfish supervisorctl restart rsyslogd
docker exec redfish logger -t probe HELLO
sudo grep probe /var/log/syslog
```

5. Runtime enable, starting from `redfish` disabled and without rebooting:
```
sudo config feature state redfish enabled
docker exec redfish logger -t probe RUNTIME
sudo grep RUNTIME /var/log/syslog
```

`dhcp_server` behaviour is unchanged: the rendered script for that container is equivalent to what #28580 produced, with the container name and the wait bound now supplied by the shared blocks.

#### Which release branch to port

- [x] master

#### Description for the changelog

[redfish] Deliver bridged-container syslog to the host over the docker0 gateway, and render the bridged-container syslog handling in docker_image_ctl from a single list so dhcp_server and redfish cannot drift.

#### Link to config_db schema for YANG module changes

N/A, no schema change.
