### PR TITLE
[202511][Broadcom][SAI] Upgrade Broadcom XGS SAI 14.3.0.0.0.0.31.0 -> 14.3.0.0.0.0.35.0

### DIFF
--- a/platform/broadcom/sai-xgs.mk
+++ b/platform/broadcom/sai-xgs.mk
@@ -1,5 +1,5 @@
 # Broadcom XGS SAI definitions
-LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.31.0
+LIBSAIBCM_XGS_VERSION = 14.3.0.0.0.0.35.0
 LIBSAIBCM_XGS_BRANCH_NAME = SAI_14.3.0_GA
 
 LIBSAIBCM_XGS_URL_PREFIX = "https://packages.trafficmanager.net/public/sai/sai-broadcom/$(LIBSAIBCM_XGS_BRANCH_NAME)/$(LIBSAIBCM_XGS_VERSION)/xgs"


### PR DESCRIPTION
#### Why I did it
Bump the Broadcom XGS SAI on the `202511` branch from `14.3.0.0.0.0.31.0` to `14.3.0.0.0.0.35.0`. Changes since `.31.0`:

- `14.3.0.0.0.0.32.0`: Add `sai_query_attribute_capability` support for `SAI_PORT_ATTR_INGRESS_MIRROR_SESSION` and `SAI_PORT_ATTR_EGRESS_MIRROR_SESSION` (SONIC-117724).
- `14.3.0.0.0.0.33.0`: Improve SAI 14.3 router-interface create/remove/set performance through the corresponding SDK update.
- `14.3.0.0.0.0.34.0`: Honor custom PFC class profiles on Tomahawk 6 when `Sai_pfc_dlr_init_capability=2` (SONIC-124044).
- `14.3.0.0.0.0.35.0`: Include Broadcom field-alert fix SDK-448354 for KNET transmission suspension. The CMICr packet-I/O configuration now reserves 2 TX and 12 RX DMA channels.

##### Work item tracking
- Microsoft ADO **(number only)**: 39487567

#### How I did it
Bump `LIBSAIBCM_XGS_VERSION` from `14.3.0.0.0.0.31.0` to `14.3.0.0.0.0.35.0` in `platform/broadcom/sai-xgs.mk`. The corresponding `libsaibcm` and `libsaibcm-dev` `.35.0` XGS packages are published. The package-level symbol-completeness comparison against `.31.0` reports no new hard-undefined Broadcom-internal symbols.

#### How to verify it
- Build the `202511` Broadcom image from this draft PR and confirm it contains SAI `14.3.0.0.0.0.35.0`.
- Run baseline-versus-candidate A/B smoke on a Broadcom 7260 t0 testbed.
- If A/B is equivalent and clean, run the regular 12-script SAI qualification on Broadcom 7260 t0 and t1.
- Priyansh will perform the TH5-specific validation for the original ARP/KNET symptom separately.

#### Which release branch to backport (provide reason below if selected)
N/A - this PR targets `202511` directly; master is on SAI 15.2.

#### Tested branch (Please provide the tested image version)
- [x] `202511` - qualification pending on the draft PR CI artifact.

#### Description for the changelog
Upgrade Broadcom XGS SAI on `202511` to `14.3.0.0.0.0.35.0`, including SDK-448354 for KNET transmission suspension.

#### Link to config_db schema for YANG module changes
N/A - this PR does not change YANG modules or `config_db` schema.

#### A picture of a cute animal (not mandatory but encouraged)
N/A.

Signed-off-by: Aaron Bernardino <aaronber@microsoft.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
