### PR TITLE
Add regex to validate NETWORK_TIME is numerical

### DIFF
--- a/files/image_config/systemd/set-epoch.sh
+++ b/files/image_config/systemd/set-epoch.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 NETWORK_TIME=$({ chronyc -n -c tracking | cut -d, -f 4 | cut -d. -f 1; } || echo 0)
-if [[ ${NETWORK_TIME} -gt 0 ]]; then
+if [[ $NETWORK_TIME =~ ^[0-9]+$ ]] && [[ ${NETWORK_TIME} -gt 0 ]]; then
 	touch -t $(date -d @${NETWORK_TIME} +%Y%m%d%H%M.%S) -m /host/clock-epoch
 else
 	touch -m /host/clock-epoch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
chronyc can return non-numeric text when it cannot query the daemon. If that text's prefix is a number, Bash interprets the entire value arithmetically during the -gt comparison, causing an unbound-variable error under set -u.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Validate NETWORK_TIME is numeric-only with regular expression before comparing or using it.

#### How to verify it
Configure set-epoch.timer to run shortly after boot, reboot the switch, and confirm
set-epoch.service succeeds without an unbound-variable error and updates /host/clock-epoch.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Validate chronyc output numerical before using it as an epoch timestamp

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
