### PR TITLE
[Mellanox] fwutil: clear stale ONIE pending updates before staging

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -348,9 +348,77 @@ class ONIEUpdater(object):
 
         return firmware_info
 
+    def __get_pending_updates(self):
+        cmd = self.ONIE_FW_UPDATE_CMD_SHOW_PENDING
+
+        try:
+            output = subprocess.check_output(cmd,
+                                             stderr=subprocess.STDOUT,
+                                             universal_newlines=True).rstrip('\n')
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError("Failed to get pending firmware updates: {}".format(str(e)))
+
+        if self.ONIE_NO_PENDING_UPDATES_ATTR in output:
+            return []
+
+        names = []
+        for line in output.splitlines():
+            # Data rows are "<name> | ... | <date>"; skip the "**"/footer lines
+            # (no '|'), the '===+===' separators, and the "Name" header.
+            if '|' not in line:
+                continue
+            name = line.split('|', 1)[0].strip()
+            if not name or name == 'Name':
+                continue
+            names.append(name)
+
+        return names
+
+    def __clear_pending_updates(self):
+        # ONIE runs every file in pending/ as an installer on the next update-mode
+        # boot, so a stale entry (e.g. a BIOS .cab sidecar) hangs the switch. Use
+        # 'remove' not 'purge': it clears pending but keeps the results history/backup.
+        # Any failure here (listing or removing) is raised so update_firmware aborts
+        # before staging/reboot: rebooting with a stale entry still in pending is
+        # exactly the hang this guards against.
+        pending = self.__get_pending_updates()
+
+        if not pending:
+            return
+
+        logger.log_notice(
+            "Found stale firmware update(s) in the ONIE pending directory: {}. "
+            "ONIE runs every pending file as an installer on the next update-mode "
+            "reboot, so these would break the update and can leave the switch stuck "
+            "in ONIE; removing them before staging the new image (firmware update "
+            "history and rollback backup are preserved).".format(", ".join(pending)),
+            also_print_to_console=True)
+
+        removed = []
+        failed = []
+        for name in pending:
+            self.ONIE_FW_UPDATE_CMD_REMOVE[2] = name
+            try:
+                subprocess.check_call(self.ONIE_FW_UPDATE_CMD_REMOVE, universal_newlines=True)
+                removed.append(name)
+            except subprocess.CalledProcessError as e:
+                failed.append(name)
+                logger.log_warning("Failed to clear pending firmware update '{}': {}".format(name, str(e)))
+
+        if removed:
+            logger.log_notice("Removed stale pending firmware update(s): {}".format(", ".join(removed)),
+                              also_print_to_console=True)
+
+        if failed:
+            raise RuntimeError("Failed to clear stale pending firmware update(s): {}".format(", ".join(failed)))
+
     def update_firmware(self, image_path, allow_reboot=True):
 
         try:
+            # Standalone (allow_reboot=True) update must start from a clean pending dir.
+            # The batched path (allow_reboot=False) accumulates staged updates, so skip it.
+            if allow_reboot:
+                self.__clear_pending_updates()
             self.__stage_update(image_path)
             self.__trigger_update(allow_reboot)
         except:

--- a/platform/mellanox/mlnx-platform-api/tests/test_component.py
+++ b/platform/mellanox/mlnx-platform-api/tests/test_component.py
@@ -545,7 +545,9 @@ class TestComponent:
         o._ONIEUpdater__trigger_update = mock.MagicMock()
         o._ONIEUpdater__is_update_staged = mock.MagicMock()
         o._ONIEUpdater__unstage_update = mock.MagicMock()
+        o._ONIEUpdater__clear_pending_updates = mock.MagicMock()
         o.update_firmware('')
+        o._ONIEUpdater__clear_pending_updates.assert_called_once()
         o._ONIEUpdater__stage_update.assert_called_once()
         o._ONIEUpdater__trigger_update.assert_called_once()
         o._ONIEUpdater__is_update_staged.assert_not_called()
@@ -559,6 +561,60 @@ class TestComponent:
         with pytest.raises(RuntimeError):
             o.update_firmware('')
             o._ONIEUpdater__unstage_update.assert_called_once()
+
+    def test_onie_updater_update_firmware_clear_pending_aborts(self):
+        # A failure clearing stale pending updates must abort before staging,
+        # so a poisoned pending dir cannot trigger the ONIE update-mode hang.
+        o = ONIEUpdater()
+        o._ONIEUpdater__clear_pending_updates = mock.MagicMock(side_effect=RuntimeError(''))
+        o._ONIEUpdater__stage_update = mock.MagicMock()
+        o._ONIEUpdater__trigger_update = mock.MagicMock()
+        o._ONIEUpdater__is_update_staged = mock.MagicMock(return_value=False)
+        o._ONIEUpdater__unstage_update = mock.MagicMock()
+        with pytest.raises(RuntimeError):
+            o.update_firmware('')
+        o._ONIEUpdater__stage_update.assert_not_called()
+        o._ONIEUpdater__trigger_update.assert_not_called()
+        o._ONIEUpdater__unstage_update.assert_not_called()
+
+        # Batched path (allow_reboot=False) must NOT clear pending.
+        o._ONIEUpdater__clear_pending_updates = mock.MagicMock()
+        o._ONIEUpdater__stage_update = mock.MagicMock()
+        o._ONIEUpdater__trigger_update = mock.MagicMock()
+        o.update_firmware('', allow_reboot=False)
+        o._ONIEUpdater__clear_pending_updates.assert_not_called()
+        o._ONIEUpdater__stage_update.assert_called_once()
+
+    @mock.patch('sonic_platform.component.subprocess.check_call')
+    @mock.patch('sonic_platform.component.subprocess.check_output')
+    def test_onie_updater_clear_pending_updates(self, mock_check_output, mock_check_call):
+        o = ONIEUpdater()
+        header = ("** Pending firmware update information:\n"
+                  "Name               | Version / Type | Attempts |Size (Bytes)  | Date\n"
+                  "===================+================+==========+==============+====\n")
+        # Empty pending -> nothing removed.
+        mock_check_output.return_value = \
+            "** Pending firmware update information:\nNo pending firmware updates present."
+        o._ONIEUpdater__clear_pending_updates()
+        mock_check_call.assert_not_called()
+
+        # Two stale entries (incl. a non-firmware sidecar) -> both removed.
+        mock_check_output.return_value = header + \
+            "0ACTV.metainfo.xml | unknown     | 0 | 11       | d\n" + \
+            "0ACTV.rom          | bios_update | 0 | 16777216 | d\n"
+        o._ONIEUpdater__clear_pending_updates()
+        assert mock_check_call.call_count == 2
+
+        # A removal failure must abort (raise), not silently proceed.
+        mock_check_call.side_effect = subprocess.CalledProcessError(1, None)
+        with pytest.raises(RuntimeError):
+            o._ONIEUpdater__clear_pending_updates()
+
+        # A listing failure must abort (raise) too.
+        mock_check_call.side_effect = None
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, None)
+        with pytest.raises(RuntimeError):
+            o._ONIEUpdater__clear_pending_updates()
 
     @mock.patch('sonic_platform.component.os.path.lexists')
     @mock.patch('sonic_platform.component.os.path.exists', mock.MagicMock(return_value=False))


### PR DESCRIPTION
#### Why I did it
`fwutil install ... ONIE fw <img>` performed after a prior BIOS update leaves the switch stuck in **ONIE Update Mode** for ~50 min if there is pending file, until a PDU power-cycle.

**Root cause:** An ONIE update reboots into ONIE update mode, where ONIE runs **every** file in `onie/update/pending/` as an installer. A prior BIOS `.rom` flash leaves stale sidecar files in that directory — `0ACTV.metainfo.xml`,`*.rom.sha512`,`bios_restore.cab`, a bare `0ACTV.rom` — which ONIE does not recognize. ONIE tries to "install" one (e.g. the `.metainfo.xml`), fails with *"Invalid ONIE update image format"*, and falls into an endless net-install discovery loop.

Confirmed on hardware that these sidecars are **not** staged by SONiC: `onie-fwpkg add` rejects a `.metainfo.xml` ("Input file is not an ONIE firmware update image"). They are ONIE's own BIOS-flash byproducts dropped straight into `pending/`; SONiC then triggers an ONIE update over the already-poisoned pending directory.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it
On the standalone path (`allow_reboot=True`), before staging, enumerate `onie-fwpkg show-pending` and `onie-fwpkg remove` each entry, so ONIE sees only the image we stage. `remove` is used instead of `purge` because it clears pending while **preserving** the results history and the BIOS rollback backup. The batched path (`allow_reboot=False`) is untouched. A NOTICE is logged (and printed) listing the stale entries and why they are removed.

- Only affects the standalone ONIE-updater path in `ONIEUpdater.update_firmware`.
- Batched staging (`auto_update_firmware` / `allow_reboot=False`) unchanged.
- History and rollback backup preserved (no `purge`).

#### How to verify it
**1. the bug repro without the fix of this PR**
step 1: manually installed file in /pending dir to reproduce
```
$ sudo mkdir -p /mnt/x && sudo mount LABEL=ONIE-BOOT /mnt/x
$ printf '<metainfo/>' | sudo tee /mnt/x/onie/update/pending/0ACTV.metainfo.xml >/dev/null
$ printf 'deadbeef' | sudo tee /mnt/x/onie/update/pending/0ACTV.rom.sha512 >/dev/null
$ sudo umount /mnt/x
$ sudo /usr/bin/mlnx-onie-fw-update.sh show-pending
** Pending firmware update information:
Name               | Version / Type | Attempts |Size (Bytes)  | Date
===================+================+==========+==============+====================
0ACTV.metainfo.xml | unknown       |        0 |           11 | 2026-08-29 00:12:14
0ACTV.rom.sha512   | unknown        |       0 |            8 | 2026-08-29 00:12:18
===================+================+==========+==============+====================
```
step 2: triggered ONIE downgrade from 17 to 15, then confirmed onie install hang on 0ACTV.metainfo.xml.
```
ONIE:/ # ONIE: Success: Firmware update URL: /mnt/onie-boot/onie/update/pending/00-onie-5.3.0015
ONIE: Success: Firmware update version: 2024.08-5.3.0015-9600-dev
ONIE: Executing installer: /mnt/onie-boot/onie/update/pending/0ACTV.metainfo.xml
Failure: ONIE Update: Invalid ONIE update image format.
```
step 3:  manually purged all pending files and continued reboot, confirm ONIE downgrade succeed after system reboot on switch

**2.the bug did not repro with the fix installed via py wheel on switch**
step 1 same as above.

step 2: then, triggered ONIE downgrade from 17 to 16, this time do nothing till the system came  back

step 3: confirm downgrade succeed and syslog confirmed pending removal
```
$ sudo fwutil show status | grep ONIE
SN4280               ONIE         2024.08-5.3.0015-9600-dev  ONIE - Open Network Install Environment
$ sudo grep mlnx-platform-api /var/log/syslog | grep -iE "stale|Removed"
$ show logging "stale"
2026 Aug 29 00:41:07.768159 NOTICE mlnx-platform-api: Found stale firmware update(s) in the ONIE pending directory: 0ACTV.metainfo.xml, 0ACTV.rom.sha512. ONIE runs every pending file as an installer on the next update-mode reboot, so these would break the update and can leave the switch stuck in ONIE; removing them before staging the new image (firmware update history and rollback backup are preserved).
2026 Aug 29 00:41:07.885379 NOTICE mlnx-platform-api: Removed stale pending firmware update(s): 0ACTV.metainfo.xml, 0ACTV.rom.sha512
```

#### Which release branch to backport (provide reason below if selected)
- [ ] 201811
- [ ] 201911
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [X] 202605
- [X] master

#### Tested branch (Please provide the tested image version)
- [X] 202605
- [X] master

#### Description for the changelog
[fwutil][ONIE install] clear stale ONIE pending updates before staging

#### A picture of a cute animal (not mandatory but encouraged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware update handling by removing stale pending ONIE updates before standalone reboots.
  * Firmware updates now stop safely if pending-update cleanup or status checks fail.
  * Batched updates continue without cleanup when rebooting is disabled.

* **Tests**
  * Added coverage for pending updates, cleanup failures, status-check failures, and batched update behavior.