### PR TITLE
lldp: prevent hostname newline injection in generated config

### DIFF
--- a/dockers/docker-lldp/lldpd.conf.j2
+++ b/dockers/docker-lldp/lldpd.conf.j2
@@ -26,7 +26,7 @@ configure system ip management pattern {{ mgmt_if.ipv4 }}
 configure system ip management pattern {{ mgmt_if.ipv6 }}
 {% endif %}
 {% endif %}
-configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] }}
+configure system hostname {{ DEVICE_METADATA['localhost']['hostname'] | replace('\n', '') | replace('\r', '') }}
 {# Use ifname globally to avoid MAC-as-Port-ID; lldpmgrd sets alias per port later. #}
 configure lldp portidsubtype ifname
 {# pause lldpd operations until all interfaces are well configured, resume command will run in lldpmgrd #}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -273,6 +273,71 @@ class TestJ2Files(TestCase):
         self.run_script(argument, output_file=self.output_file)
         self.assertTrue(utils.cmp(expected_mgmt_ipv4_with_ports, self.output_file))
 
+    def test_lldp_hostname_injection_stripped(self):
+        lldpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-lldp',
+                                           'lldpd.conf.j2')
+        config_db_json = os.path.join(self.test_dir, 'data', 'lldp', 'mgmt_iface_ipv4.json')
+        payloads = (
+            ('LF', 'switch-t0\nconfigure system description injected'),
+            ('CR', 'switch-t0\rconfigure system description injected'),
+            ('CRLF', 'switch-t0\r\nconfigure system description injected'),
+        )
+
+        for separator, payload in payloads:
+            additional_data = json.dumps({
+                'DEVICE_METADATA': {
+                    'localhost': {
+                        'hostname': payload,
+                    },
+                },
+            })
+            argument = ['-j', config_db_json, '-t', lldpd_conf_template, '-a', additional_data]
+            output = self.run_script(argument)
+
+            hostname_lines = [
+                line for line in output.splitlines()
+                if line.startswith('configure system hostname ')
+            ]
+            self.assertEqual(
+                len(hostname_lines),
+                1,
+                '{} payload created multiple hostname lines'.format(separator)
+            )
+            self.assertEqual(
+                hostname_lines[0],
+                'configure system hostname switch-t0configure system description injected',
+                '{} payload was not collapsed onto the hostname line'.format(separator)
+            )
+            self.assertNotIn(
+                '\r',
+                output,
+                '{} payload left a carriage return in the rendered output'.format(separator)
+            )
+            self.assertFalse(
+                any(
+                    line.strip().startswith('configure system description injected')
+                    for line in output.splitlines()
+                ),
+                '{} payload created a standalone injected command'.format(separator)
+            )
+
+    def test_lldp_hostname_clean(self):
+        lldpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-lldp',
+                                           'lldpd.conf.j2')
+        config_db_json = os.path.join(self.test_dir, 'data', 'lldp', 'mgmt_iface_ipv4.json')
+        additional_data = json.dumps({
+            'DEVICE_METADATA': {
+                'localhost': {
+                    'hostname': 'DUT_ASW-01.example',
+                },
+            },
+        })
+
+        argument = ['-j', config_db_json, '-t', lldpd_conf_template, '-a', additional_data]
+        output = self.run_script(argument)
+
+        self.assertIn('configure system hostname DUT_ASW-01.example\n', output)
+
     def test_ipinip(self):
         ipinip_file = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ipinip.json.j2')
         argument = ['-m', self.t0_minigraph, '-p', self.t0_port_config, '-t', ipinip_file]

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -303,5 +303,20 @@
             "key": "sonic-device_metadata:dpu_auto_recovery",
             "value": "disable"
         }
+    },
+    "DEVICE_METADATA_VALID_HOSTNAME_FORMAT": {
+        "desc": "Verifying hostname accepts existing SONiC hostname characters."
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_LF": {
+        "desc": "Verifying hostname rejects a line feed.",
+        "eStrKey": "Pattern"
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_CR": {
+        "desc": "Verifying hostname rejects a carriage return.",
+        "eStrKey": "Pattern"
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_CRLF": {
+        "desc": "Verifying hostname rejects a carriage return and line feed.",
+        "eStrKey": "Pattern"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -910,5 +910,41 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_HOSTNAME_FORMAT": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "DUT_ASW-01.example"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_LF": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "sonic\nconfigure system description injected"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_CR": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "sonic\rconfigure system description injected"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_HOSTNAME_CRLF": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "hostname": "sonic\r\nconfigure system description injected"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -92,7 +92,9 @@ module sonic-device_metadata {
                 }
 
                 leaf hostname {
-                    type stypes:hostname;
+                    type stypes:hostname {
+                        pattern '[^\n\r]+';
+                    }
                     description "System hostname for the device.";
                 }
 


### PR DESCRIPTION
#### Why I did it

`DEVICE_METADATA.localhost.hostname` was rendered directly into `lldpd.conf`. A hostname containing LF or CRLF could create a second LLDP configuration command when ConfigDB validation was bypassed.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Added a leaf-specific YANG pattern that rejects carriage returns and line feeds only for `DEVICE_METADATA.localhost.hostname`.
- Kept the shared `stypes:hostname` typedef unchanged so other hostname consumers are unaffected.
- Stripped CR/LF at the `lldpd.conf.j2` rendering sink, providing defense in depth for direct ConfigDB writes.
- Added YANG validation cases for valid, LF, CR, and CRLF values.
- Added LLDP rendering tests for malicious and clean hostname values.

#### How to verify it

```bash
make -j1 target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl

cd src/sonic-yang-models
python3 -m pytest tests/yang_model_tests/test_yang_model.py

cd src/sonic-config-engine
python3 -m pytest -q tests/test_j2files.py \
  -k "test_lldp or test_lldp_hostname_injection_stripped or test_lldp_hostname_clean"
```

Final rebased branch results:
- Complete YANG model suite: `1 passed`
- Focused LLDP rendering suite: `3 passed, 55 deselected`
- Clean hostname remains unchanged.
- LF, CR, and CRLF are removed from rendered hostname input.
- No injected standalone LLDP command is produced.

Independent AI reviews were also run against the old and new code:
- Security review confirmed the vulnerable LF/CRLF data flow and found no remaining exploitable issue in the fixed LLDP path.
- Code review found no significant correctness or regression issues.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master (`21ae7a72b`): YANG `1 passed`; LLDP rendering `3 passed, 55 deselected`

#### Description for the changelog

Prevent LLDP configuration injection through newline characters in the device hostname.

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#device_metadata

#### A picture of a cute animal (not mandatory but encouraged)