### PR TITLE
Don't have monit try to restart chrony on its own

### DIFF
--- a/files/image_config/monit/conf.d/sonic-host
+++ b/files/image_config/monit/conf.d/sonic-host
@@ -22,8 +22,6 @@ check process rsyslog with pidfile /var/run/rsyslogd.pid
     if totalmem > 800 MB for 10 times within 20 cycles then restart
 
 check process chrony with pidfile /var/run/chrony/chronyd.pid
-    start program = "/bin/systemctl start chrony.service"
-    stop program = "/bin/systemctl stop chrony.service"
 
 # route_check.py Verify routes between APPL-DB & ASIC-DB are in sync.
 # For any discrepancy, details are logged and a non-zero code is returned


### PR DESCRIPTION


Fixes: #28943

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This prevents a potential for multiple restarts of chrony to happen on its own, as well as monit bringing up all of SONiC by starting chrony (due to the defined service dependencies).

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Remove commands for monit to start chrony on its own.

#### How to verify it

Stopped chrony and `sonic.target`, waited a while, and verified that SONiC containers did not start up, and verified that `sudo monit status` showed that chrony was not running.

```
Process 'chrony'
  status                       Does not exist
  monitoring status            Monitored
  monitoring mode              active
  on reboot                    start
  data collected               Tue, 01 Sep 2026 23:28:46
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
