### PR TITLE
[mgmt-framework] Restore CONFIG_DB-driven REST client_auth default

### DIFF
--- a/dockers/docker-sonic-mgmt-framework/rest-server.sh
+++ b/dockers/docker-sonic-mgmt-framework/rest-server.sh
@@ -17,17 +17,12 @@ REST_SERVER=$(echo $MGMT_VARS | jq -r '.rest_server')
 
 if [ -n "$REST_SERVER" ]; then
     SERVER_PORT=$(echo $REST_SERVER | jq -r '.port // empty')
-    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth // "user"')
+    CLIENT_AUTH=$(echo $REST_SERVER | jq -r '.client_auth // empty')
     LOG_LEVEL=$(echo $REST_SERVER | jq -r '.log_level // empty')
 
     SERVER_CRT=$(echo $REST_SERVER | jq -r '.server_crt // empty')
     SERVER_KEY=$(echo $REST_SERVER | jq -r '.server_key // empty')
     CA_CRT=$(echo $REST_SERVER | jq -r '.ca_crt // empty')
-fi
-
-# Default to user authentication when not explicitly configured
-if [ -z "$CLIENT_AUTH" ]; then
-    CLIENT_AUTH="user"
 fi
 
 if [[ -z $SERVER_CRT ]] && [[ -z $SERVER_KEY ]] && [[ -z $CA_CRT ]]; then


### PR DESCRIPTION
#### Why I did it

Fixes #29262.

afacdc772 (#26656) made `rest-server.sh` fall back to `-client_auth user` whenever `REST_SERVER|default|client_auth` is absent from CONFIG_DB, which is the state on a fresh image. That switches on HTTP basic auth for every RESTCONF request.

The on-box klish CLI is a client of that same REST server, and it has no credentials to send. `ApiClient.request()` in `CLI/actioner/cli_client.py` (sonic-mgmt-framework) issues requests to `https://localhost` with only a `User-Agent` header, so every write returns 401 and `format_error_message()` renders the `access-denied` tag as `%Error: not authorized`. Reads still work because they go to Redis instead of REST, so the breakage looks partial, but config from `sonic-cli` is entirely non-functional.

There is no credential path for the CLI to satisfy today. `rest_server` only implements basic auth against sshd in `PAMAuthenAndAuthor()`, there is no client-certificate or loopback exemption when `client_auth=user`, and the `sonic-cli` wrapper passes only `CLI_USER` into the container, never a secret. The server default and the bundled client cannot both be correct until the CLI gains a way to authenticate, and that change lives in sonic-mgmt-framework.

So this restores the operator-controlled default. Secure-by-default is the right goal, but it needs to land together with a CLI credential mechanism rather than ahead of one, otherwise on-box configuration is dead in the interval. I have asked on the issue which way the maintainers want to take it.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Reverted the two hunks of afacdc772 in `dockers/docker-sonic-mgmt-framework/rest-server.sh`. `CLIENT_AUTH` goes back to `// empty`, and the unconditional `CLIENT_AUTH="user"` fallback is dropped, so `-client_auth` is passed to `rest_server` only when an operator configures it. The resulting file is byte-identical to the pre-26656 version (blob `63ccbf5df`).

Explicit `none`, `user` and `cert` settings are unaffected — only the implicit default changes back.

#### How to verify it

I do not have a switch running the mgmt-framework container, so I did not reproduce the 401 end to end. What I did run is the startup script itself under bubblewrap with `sonic-cfggen`, `rest_server` and `generate_cert` stubbed, checking the argv the script builds for `rest_server`.

Before, on a fresh image with no `REST_SERVER` table:

```
REST_SERVER_ARGS = -ui /rest_ui -logtostderr -client_auth user -cert /tmp/cert.pem -key /tmp/key.pem
```

After, same input:

```
REST_SERVER_ARGS = -ui /rest_ui -logtostderr -cert /tmp/cert.pem -key /tmp/key.pem
```

`rest_server`'s own flag default is `none`, and `main()` only sets `rtrConfig.AuthEnable` when `clientAuth == "user"`, so with the flag absent the router comes up with authentication off and the klish writes go through again.

The configured cases still behave as before:

```
client_auth=none  -> -client_auth none
client_auth=user  -> -client_auth user
client_auth=cert  -> -client_auth cert -cacert /etc/ssl/ca.pem
REST_SERVER|default present but no client_auth -> no -client_auth flag
```

`bash -n dockers/docker-sonic-mgmt-framework/rest-server.sh` is clean. I have not built an image or run the mgmt-framework container.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: regression

Not requesting a backport myself — afacdc772 is recent and I have not checked which release branches picked it up. If it went anywhere, this should follow it there.

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

Leaving master unticked because I only exercised the script in isolation, not on a built image.

#### Test result

No image build. Script-level verification only, output above.

#### Description for the changelog

Restore the CONFIG_DB-driven default for the management REST server's client_auth, fixing 401 errors on sonic-cli writes.

#### Link to config_db schema for YANG module changes

No YANG change. `REST_SERVER` is defined in sonic-mgmt-common.
