### PR TITLE
[docker_image_ctl] Fall back to default_sku when the HWSKU is missing

### DIFF
--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -545,6 +545,12 @@ start() {
     if [ "$DEV" ]; then
         MOUNTPATH="$MOUNTPATH/$DEV"
     fi
+    # docker -v silently creates a missing source path as an empty directory
+    if [ ! -d "$MOUNTPATH" ]; then
+        echo "Error: HWSKU $HWSKU is not present in this image, $MOUNTPATH not found"
+        echo "Error: set DEVICE_METADATA.localhost.hwsku to an HWSKU available under /usr/share/sonic/device/$PLATFORM"
+        exit 1
+    fi
         HWSKU_MOUNT_MODE="ro"
         {%- if docker_container_name == "swss" %}
         if [ -f "$MOUNTPATH/hwsku-init" ]; then

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -547,9 +547,25 @@ start() {
     fi
     # docker -v silently creates a missing source path as an empty directory
     if [ ! -d "$MOUNTPATH" ]; then
-        echo "Error: HWSKU $HWSKU is not present in this image, $MOUNTPATH not found"
-        echo "Error: set DEVICE_METADATA.localhost.hwsku to an HWSKU available under /usr/share/sonic/device/$PLATFORM"
-        exit 1
+        DEFAULT_SKU_FILE="/usr/share/sonic/device/$PLATFORM/default_sku"
+        DEFAULT_HWSKU=""
+        if [ -f "$DEFAULT_SKU_FILE" ]; then
+            DEFAULT_HWSKU=`awk 'NR==1{print $1}' $DEFAULT_SKU_FILE`
+        fi
+        DEFAULT_MOUNTPATH="/usr/share/sonic/device/$PLATFORM/$DEFAULT_HWSKU"
+        if [ "$DEV" ]; then
+            DEFAULT_MOUNTPATH="$DEFAULT_MOUNTPATH/$DEV"
+        fi
+        if [ -n "$DEFAULT_HWSKU" ] && [ -d "$DEFAULT_MOUNTPATH" ]; then
+            echo "Warning: HWSKU $HWSKU is not present in this image, $MOUNTPATH not found"
+            echo "Warning: falling back to the platform default HWSKU $DEFAULT_HWSKU"
+            HWSKU="$DEFAULT_HWSKU"
+            MOUNTPATH="$DEFAULT_MOUNTPATH"
+        else
+            echo "Error: HWSKU $HWSKU is not present in this image, $MOUNTPATH not found"
+            echo "Error: set DEVICE_METADATA.localhost.hwsku to an HWSKU available under /usr/share/sonic/device/$PLATFORM"
+            exit 1
+        fi
     fi
         HWSKU_MOUNT_MODE="ro"
         {%- if docker_container_name == "swss" %}


### PR DESCRIPTION
#### Why I did it

Fixes #29277.

`start()` in `docker_image_ctl.j2` derives `MOUNTPATH` from `DEVICE_METADATA.localhost.hwsku` and hands it straight to `docker create`:

```
-v /usr/share/sonic/device/$PLATFORM/$HWSKU/$DEV:/usr/share/sonic/hwsku:$HWSKU_MOUNT_MODE
```

Docker creates a missing bind-mount source as an empty directory, so when the configured HWSKU is not shipped in the running image the container is created anyway, with an empty `/usr/share/sonic/hwsku`, and nothing reports the mismatch. The first symptom appears much later and much further from the cause:

```
syncd ERR loadProfileMap: failed to open profile map file: /usr/share/sonic/hwsku/sai.profile: No such file or directory
```

This is reachable through a normal upgrade, as the issue describes: `sonic-installer` checks platform compatibility but not HWSKU, and `config-setup` restores the previous `config_db.json` on first boot, so an HWSKU renamed or dropped between images survives migration and selects a directory that no longer exists.

This PR keeps the box up through that upgrade rather than blocking it. The first revision refused to start the container; per review feedback that is no better an outcome than the empty mount, since the data plane is down either way, so it now resolves a valid HWSKU instead.

It still does not do the install-time half the issue asks for — rejecting an incompatible HWSKU before the image is accepted lives in `sonic_installer/main.py`, and mapping an old HWSKU to a replacement would be db_migrator; both are sonic-utilities, so neither can land in this repo. I have asked on the issue whether the intended compatibility contract (are HWSKU directory names required to stay stable across in-service upgrades?) needs settling before a companion change is written there.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

When `MOUNTPATH` is absent, resolve the platform default from `/usr/share/sonic/device/$PLATFORM/default_sku` (first whitespace-separated field is the HWSKU name) and mount that instead, warning twice with both the missing HWSKU and the one being substituted. Both `HWSKU` and `MOUNTPATH` are reassigned, so the `docker create -v` flag, the `DOCKERMOUNT` comparison that decides whether an existing container is recreated, and `HWSKU_FOLDER` in the swss block all follow.

276 of the platform directories in tree ship `default_sku`; the ones without it are shared or common directories rather than real platforms.

The hard error is kept only for the case where there is nothing valid to substitute — the platform ships no `default_sku`, or the HWSKU it names is also absent. Without that branch docker would go back to fabricating an empty directory.

`DEVICE_METADATA.localhost.hwsku` in CONFIG_DB is deliberately left alone, so the mount and the configured name disagree after a fallback. Rewriting it from a container start script would mean persistent state changes racing across every container that starts, and reconciling migrated configuration belongs to db_migrator. Raised on the PR to confirm that split is what maintainers want.

The check sits inside `start()`, so `stop` and `kill` are unaffected and a broken box can still be torn down. `database` does not get it: it sets `HWSKU` and `MOUNTPATH` empty and does not mount the directory at all.

#### How to verify it

No image build and no hardware, so I did not reproduce the `sai.profile` failure itself. What I ran was the template and the script it generates.

Rendered the template for each container variant and syntax-checked the output:

```
database   bash -n:OK    fallback:0
syncd      bash -n:OK    fallback:1
pmon       bash -n:OK    fallback:1
gbsyncd    bash -n:OK    fallback:1
bgp        bash -n:OK    fallback:1
swss       bash -n:OK    fallback:1
```

Then ran the rendered swss script under bubblewrap against fake `/usr/share/sonic/device` trees, with `sonic-cfggen`, `docker` and `sonic-db-cli` stubbed so the `docker create` argv could be read back.

Configured HWSKU missing from the image, before this change — note the `-v` for a path that does not exist:

```
Creating new swss container with HWSKU Example-HwSku-A
docker create ... -v /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Example-HwSku-A/:/usr/share/sonic/hwsku:ro ...
```

Same input, after:

```
Warning: HWSKU Example-HwSku-A is not present in this image, /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Example-HwSku-A not found
Warning: falling back to the platform default HWSKU Force10-S6000
Creating new swss container with HWSKU Force10-S6000
docker create ... -v /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/:/usr/share/sonic/hwsku:ro ...
```

Multi-ASIC, 4-ASIC platform with `DEV=0`, `default_sku` of `msft_four_asic_vs` — the per-ASIC subdirectory is resolved:

```
Warning: HWSKU Example-HwSku-A is not present in this image, /usr/share/sonic/device/x86_64-kvm_x86_64_4_asic-r0/Example-HwSku-A/0 not found
Warning: falling back to the platform default HWSKU msft_four_asic_vs
docker create ... -v /usr/share/sonic/device/x86_64-kvm_x86_64_4_asic-r0/msft_four_asic_vs/0:/usr/share/sonic/hwsku:ro ...
```

HWSKU present in the image — passes through untouched, `docker create` line unchanged:

```
Creating new swss container with HWSKU Force10-S6000
docker create ... -v /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Force10-S6000/:/usr/share/sonic/hwsku:ro ...
```

Both no-fallback-available cases still stop, rather than letting docker fabricate the directory — platform ships no `default_sku`, and `default_sku` naming a directory that is also absent:

```
Error: HWSKU Example-HwSku-A is not present in this image, /usr/share/sonic/device/x86_64-kvm_x86_64-r0/Example-HwSku-A not found
Error: set DEVICE_METADATA.localhost.hwsku to an HWSKU available under /usr/share/sonic/device/x86_64-kvm_x86_64-r0
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: day-one issue

Not requesting a backport. This is a diagnosability change, not a fix for a regression.

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [x] N/A

Template and generated-script level only, not on a built image.

#### Test result

No image build. Render and script-level verification only, output above.

#### Description for the changelog

Fall back to the platform default_sku when the configured HWSKU is not present in the image, instead of letting docker bind-mount an empty directory over /usr/share/sonic/hwsku.

#### Link to config_db schema for YANG module changes

No YANG change.

