### PR TITLE
[Nexthop] Fix NH-4010 thermal_policy.json dangling thermal object types

### DIFF
--- a/device/nexthop/x86_64-nexthop_4010-r0/thermal_policy.json
+++ b/device/nexthop/x86_64-nexthop_4010-r0/thermal_policy.json
@@ -2,7 +2,7 @@
     "interval": 5,
     "info_types": [
         {
-            "type": "fan_info"
+            "type": "fan_drawer_info"
         },
         {
             "type": "thermal_info"
@@ -13,16 +13,66 @@
     ],
     "policies": [
         {
-            "name": "Two or fewer fans present",
+            "name": "One fan drawer present",
             "conditions": [
                 {
-                    "type": "fan.two.or.fewer.present"
+                    "type": "fandrawer.one.present"
                 }
             ],
             "actions": [
                 {
+                    "type": "fan.set_max_speed",
+                    "max_speed": 100
+                },
+                {
                     "type": "fan.set_speed",
-                    "speed": "100"
+                    "speed": 100
+                }
+            ]
+        },
+        {
+            "name": "Two fan drawers present",
+            "conditions": [
+                {
+                    "type": "fandrawer.two.present"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.set_max_speed",
+                    "max_speed": 95
+                },
+                {
+                    "type": "fan.set_speed",
+                    "speed": 95
+                }
+            ]
+        },
+        {
+            "name": "Three fan drawers present",
+            "conditions": [
+                {
+                    "type": "fandrawer.three.present"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.set_max_speed",
+                    "max_speed": 80
+                }
+            ]
+        },
+        {
+            "name": "Four fan drawers present",
+            "conditions": [
+                {
+                    "type": "fandrawer.four.present"
+                }
+            ],
+            "actions": [
+                {
+                    "type": "fan.set_max_speed",
+                    "max_speed": 75
                 }
             ]
         },
@@ -37,8 +87,7 @@
                 {
                     "type": "thermal.control_algo",
                     "fan_limits": {
-                        "min": 30,
-                        "max": 70
+                        "min": 30
                     },
                     "pid_domains": {
                         "asic": {


### PR DESCRIPTION
#### Why I did it
The NH-5010 platform support change (#24169) reworked thermal_conditions.py / thermal_infos.py (fan_info -> fan_drawer_info, fan.two.or.fewer.present -> fandrawer.<n>.present) but did not update the NH-4010 policy JSON, which x86_64-nexthop_4010-r1 and x86_64-nexthop_4020-r0 also use via symlink. thermalctld's thermal manager init throws "ThermalJsonObject type fan.two.or.fewer.present not found" on every pmon start on those platforms, leaving thermal policy inactive.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Update thermal_policy for nexthop_4010 platform

#### How to verify it
1. Check syslog does not show thermalctld error:
`2026 Sep  2 16:44:12.622205 gold207 ERR pmon#thermalctld[154]: Caught exception while initializing thermal manager - Exception('ThermalJsonObject type fan.two.or.fewer.present not found')`
2. Fan speed on initial boot should be ~30% based on thermal policy. If thermal policy is not taking effect, will be set to 50% instead.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
1. Nexthop master image without fix (baseline) (build-id 169431)
```
$ sudo grep "initializing thermal manager" /var/log/syslog | tail -3
2026 Sep  2 16:44:12.622205 gold207 ERR pmon#thermalctld[154]: Caught exception while initializing thermal manager - Exception('ThermalJsonObject type fan.two.or.fewer.present not found')
$ show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      50%      exhaust     Present        OK  20260902 16:45:17
Fantray1  green  Fantray1_2      50%      exhaust     Present        OK  20260902 16:45:17
Fantray2  green  Fantray2_1      50%      exhaust     Present        OK  20260902 16:45:17
Fantray2  green  Fantray2_2      50%      exhaust     Present        OK  20260902 16:45:17
Fantray3  green  Fantray3_1      50%      exhaust     Present        OK  20260902 16:45:17
Fantray3  green  Fantray3_2      50%      exhaust     Present        OK  20260902 16:45:17
Fantray4  green  Fantray4_1      50%      exhaust     Present        OK  20260902 16:45:17
Fantray4  green  Fantray4_2      50%      exhaust     Present        OK  20260902 16:45:17
     N/A    N/A   PSU1_FAN1      47%      exhaust     Present        OK  20260902 16:45:17
     N/A    N/A   PSU2_FAN1      44%      exhaust     Present        OK  20260902 16:45:17
```
2. Nexthop fix image based on master (build-id 170520)
```
$ sudo grep -cE "initializing thermal manager|ThermalJsonObject" /var/log/syslog
0
$ show platform fan
  Drawer    LED         FAN    Speed    Direction    Presence    Status          Timestamp
--------  -----  ----------  -------  -----------  ----------  --------  -----------------
Fantray1  green  Fantray1_1      30%      exhaust     Present        OK  20260902 16:58:26
Fantray1  green  Fantray1_2      30%      exhaust     Present        OK  20260902 16:58:26
Fantray2  green  Fantray2_1      30%      exhaust     Present        OK  20260902 16:58:26
Fantray2  green  Fantray2_2      30%      exhaust     Present        OK  20260902 16:58:26
Fantray3  green  Fantray3_1      30%      exhaust     Present        OK  20260902 16:58:26
Fantray3  green  Fantray3_2      30%      exhaust     Present        OK  20260902 16:58:26
Fantray4  green  Fantray4_1      30%      exhaust     Present        OK  20260902 16:58:26
Fantray4  green  Fantray4_2      30%      exhaust     Present        OK  20260902 16:58:26
     N/A    N/A   PSU1_FAN1      35%      exhaust     Present        OK  20260902 16:58:26
     N/A    N/A   PSU2_FAN1      41%      exhaust     Present        OK  20260902 16:58:26
```
3. Nexthop fix image based on 202605 (build-id 172662)
```
$ sudo grep -cE "initializing thermal manager|ThermalJsonObject" /var/log/syslog
0
$ show platform fan   (all 8 fantray fans)
Fantray1  green  Fantray1_1      30%      exhaust     Present        OK  20260902 17:52:56
<...> (Fantray1-4, all at 30%)
```
#### Description for the changelog
[Nexthop] Fix NH-4010 thermal_policy.json dangling thermal object types

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
