### PR TITLE
healthd: Pass service names to systemctl without shell parsing

### DIFF
--- a/src/system-health/health_checker/sysmonitor.py
+++ b/src/system-health/health_checker/sysmonitor.py
@@ -314,7 +314,13 @@ class Sysmonitor(ThreadTaskBase):
 
     #Gets the service properties
     def run_systemctl_show(self, service):
-        command = ('systemctl show {} --property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult,ConditionTimestampMonotonic'.format(service))
+        command = [
+            'systemctl',
+            'show',
+            '--property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult,ConditionTimestampMonotonic',
+            '--',
+            service
+        ]
         output = utils.run_command(command)
         srv_properties = output.split('\n')
         prop_dict = {}

--- a/src/system-health/health_checker/utils.py
+++ b/src/system-health/health_checker/utils.py
@@ -17,14 +17,15 @@ logger = SysLogger(
 
 def run_command(command, timeout=None):
     """
-    Utility function to run an shell command and return the output.
-    :param command: Shell command string.
-    :return: Output of the shell command.
+    Utility function to run a command and return the output.
+    :param command: Argument list or shell command string.
+    :return: Output of the command.
     """
     try:
+        use_shell = isinstance(command, str)
         process = subprocess.Popen(
             command,
-            shell=True,
+            shell=use_shell,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,

--- a/src/system-health/tests/test_system_health.py
+++ b/src/system-health/tests/test_system_health.py
@@ -11,6 +11,7 @@
 """
 import copy
 import os
+import subprocess
 import sys
 import docker
 import importlib.util
@@ -1095,6 +1096,42 @@ def test_utils():
 
     output = utils.run_command('ls')
     assert output
+
+
+@patch('subprocess.Popen')
+def test_utils_argv_without_shell(mock_popen):
+    command = ['systemctl', 'show', '--', 'sample.service']
+    process = MagicMock()
+    process.communicate.return_value = ('output', '')
+    mock_popen.return_value = process
+
+    assert utils.run_command(command) == 'output'
+    mock_popen.assert_called_once_with(
+        command,
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        start_new_session=True
+    )
+
+
+@patch('health_checker.utils.run_command')
+def test_run_systemctl_show_uses_argv(mock_run_command):
+    mock_run_command.return_value = 'Id=sample.service\nActiveState=active\n'
+    sysmon = Sysmonitor()
+
+    assert sysmon.run_systemctl_show('sample.service') == {
+        'Id': 'sample.service',
+        'ActiveState': 'active'
+    }
+    mock_run_command.assert_called_once_with([
+        'systemctl',
+        'show',
+        '--property=Id,LoadState,UnitFileState,Type,ActiveState,SubState,Result,ConditionResult,ConditionTimestampMonotonic',
+        '--',
+        'sample.service'
+    ])
 
 
 @patch('health_checker.utils.logger.log_warning')


### PR DESCRIPTION
#### Why I did it

`Sysmonitor.run_systemctl_show()` builds a command using a service name from the `FEATURE` table. The command was passed through a shell even though the service name only needs to be a single argument to `systemctl`.

Passing it as an argument prevents the shell from interpreting the service name and avoids having to maintain a separate list of allowed systemd unit-name characters.

##### Work item tracking

- Microsoft ADO **(number only)**: N/A

#### How I did it

Changed the `systemctl show` call to use an argument list, with `--` before the service name to end option parsing.

Updated the shared command helper to run argument lists without a shell. Existing callers that pass command strings continue to use the current shell-based behavior.

Added tests for the non-shell execution path and the exact `systemctl show` arguments.

#### How to verify it

From `src/system-health`:

```text
python3 -m pytest tests/test_system_health.py -q
```

The tests cover argv execution, option termination, and preserving service names containing shell metacharacters as one argument.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request: N/A  
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: system-health unit tests — 57 passed.

#### Description for the changelog

Run healthd service-status queries without shell parsing.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)

N/A