### PR TITLE
[arp_update]: Run neighbor commands without eval

### DIFF
--- a/files/scripts/arp_update
+++ b/files/scripts/arp_update
@@ -52,6 +52,44 @@ run_ndisc6_with_retry() {
         ndisc6 -q -w 0 -1 "$ip" "$ifname" >/dev/null 2>&1
 }
 
+run_ipv6_multicast_ping() {
+    local wait_time="$1"
+    local ifname="$2"
+    run_with_retry_cmd "IPv6 multicast ping on ${ifname}" \
+        timeout "$wait_time" ping6 -I "$ifname" -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null 2>&1
+}
+
+flush_unsynced_neighbors() {
+    local vlan="$1"
+    local neighbors="$2"
+    local neighbor_ip dev ifname _
+    local flushed=1
+
+    while read -r neighbor_ip dev ifname _; do
+        if [[ -z "$neighbor_ip" || "$dev" != "dev" || -z "$ifname" ]]; then
+            continue
+        fi
+        if [[ -z "$(sonic-db-cli APPL_DB hget "NEIGH_TABLE:${vlan}:${neighbor_ip}" neigh)" ]]; then
+            flushed=0
+            ip neigh flush "$neighbor_ip"
+        fi
+    done <<< "$neighbors"
+
+    return "$flushed"
+}
+
+replace_failed_neighbors() {
+    local neighbors="$1"
+    local neighbor_ip dev ifname _
+
+    while read -r neighbor_ip dev ifname _; do
+        if [[ -z "$neighbor_ip" || "$dev" != "dev" || -z "$ifname" ]]; then
+            continue
+        fi
+        ip neigh replace "$neighbor_ip" dev "$ifname" nud incomplete
+    done <<< "$neighbors"
+}
+
 while /bin/true; do
   # find L3 interfaces which are UP, send ipv6 multicast pings
   ARP_UPDATE_VARS=$(sonic-cfggen -d -t ${ARP_UPDATE_VARS_FILE})
@@ -95,7 +133,7 @@ while /bin/true; do
                       logger -p warning "missing interface entry for static route $nexthop"
                       continue
                   fi
-                  intf_up=$(ip link show $interface | grep "state UP")
+                  intf_up=$(ip link show "$interface" | grep "state UP")
                   if [[ -n "$intf_up" ]]; then
                       run_with_retry_cmd "static route ping to $nexthop on $interface" \
                           timeout 0.2 $ping_prefix -I "$interface" -n -q -i 0 -c 1 -W 1 "$nexthop" >/dev/null 2>&1
@@ -118,10 +156,9 @@ while /bin/true; do
 
   ALL_INTERFACE="$INTERFACE $PC_INTERFACE $VLAN_SUB_INTERFACE"
   for intf in $ALL_INTERFACE; do
-      ping6cmd="timeout 0.2 ping6 -I $intf -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
-      intf_up=$(ip link show $intf | grep "state UP")
+      intf_up=$(ip link show "$intf" | grep "state UP")
       if [[ -n "$intf_up" ]]; then
-          eval $ping6cmd
+          run_ipv6_multicast_ping 0.2 "$intf"
       fi
   done
 
@@ -142,10 +179,10 @@ while /bin/true; do
         ip="$( cut -d ',' -f 1 <<< "$neigh" )"
         intf="$( cut -d ',' -f 2 <<< "$neigh" )"
         kernel_mac="$( cut -d ',' -f 3 <<< "$neigh" )"
-        appl_db_mac="$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$intf:$ip neigh)"
+        appl_db_mac="$(sonic-db-cli APPL_DB hget "NEIGH_TABLE:${intf}:${ip}" neigh)"
         if [[ $kernel_mac != $appl_db_mac ]]; then
             logger -p warning "MAC mismatch for ${ip} on ${intf} - kernel: ${kernel_mac}, APPL_DB: ${appl_db_mac}"
-            ip neigh flush $ip
+            ip neigh flush "$ip"
             if [[ $ip == *":"* ]]; then
                 ping_prefix=ping6
             else
@@ -169,8 +206,7 @@ while /bin/true; do
       done < <(ip -4 neigh show | grep "$vlan" | awk '{print $1, $3}')
 
       # send ipv6 multicast pings to Vlan interfaces to get/refresh link-local addrs
-      ping6cmd="timeout 1 ping6 -I $vlan -n -q -i 0 -c 1 -W 0 ff02::1 >/dev/null"
-      eval $ping6cmd
+      run_ipv6_multicast_ping 1 "$vlan"
 
       # generate a list of ndisc6 commands (exclude link-local addrs since it is done above):
       #   ndisc6 -q -w 0 -1 <IP 1> <VLAN interface>;
@@ -184,7 +220,7 @@ while /bin/true; do
       if [[ $SUBTYPE == "dualtor" ]]; then
         # capture all current failed/incomplete IPv6 neighbors in the kernel to avoid situations where new neighbors are learned
         # in the middle of the below sequence of commands
-        unresolved_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED|INCOMPLETE')
+        unresolved_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep -F -- "$vlan" | grep -E 'FAILED|INCOMPLETE')
         failed_kernel_neighbors=$(echo "$unresolved_kernel_neighbors" | grep FAILED | cut -d ' ' -f 1)
 
         # it's possible for kernel neighbors to fall out of sync with the hardware
@@ -194,10 +230,7 @@ while /bin/true; do
         # 1. for every FAILED or INCOMPLETE neighbor in the kernel, check if there is a corresponding zero MAC neighbor in APPL_DB
         # 2. if no zero MAC neighbor entry exists, flush the kernel neighbor entry
         #     - generates the command 'ip neigh flush <neighbor IPv6>' for all such neighbors
-        unsync_neighbors=$(echo "$unresolved_kernel_neighbors" | cut -d ' ' -f 1 | xargs -I{} bash -c "if [[ -z \"\$(sonic-db-cli APPL_DB hget NEIGH_TABLE:$vlan:{} neigh)\" ]]; then echo '{}'; fi")
-        if [[ ! -z "$unsync_neighbors" ]]; then
-            ip_neigh_flush_cmd="echo \"$unsync_neighbors\" | sed -e 's/^/ip neigh flush /' -e 's/$/;/'"
-            eval `eval "$ip_neigh_flush_cmd"`
+        if flush_unsynced_neighbors "$vlan" "$unresolved_kernel_neighbors"; then
             sleep 2
         fi
 
@@ -218,11 +251,9 @@ while /bin/true; do
         # setting them to permanently incomplete here means the kernel will never generate a netlink message for that neighbor
         # generates the following command for each FAILED IPv6 neighbor
         # ip neigh replace <neighbor IPv6> dev <VLAN name> nud incomplete
-        failed_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep $vlan | grep -E 'FAILED')
+        failed_kernel_neighbors=$(ip -6 neigh show | grep -v fe80 | grep -F -- "$vlan" | grep -E 'FAILED')
         if [[ ! -z "$failed_kernel_neighbors" ]]; then
-            neigh_replace_template="sed -e 's/^/ip neigh replace /' -e 's/,/ dev /' -e 's/$/ nud incomplete;/'"
-            ip_neigh_replace_cmd="echo \"$failed_kernel_neighbors\" | cut -d ' ' -f 1,3 --output-delimiter=',' | $neigh_replace_template"
-            eval `eval "$ip_neigh_replace_cmd"`
+            replace_failed_neighbors "$failed_kernel_neighbors"
         fi
       fi
   done

--- a/files/scripts/tests/test_arp_update.sh
+++ b/files/scripts/tests/test_arp_update.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="${SCRIPT_DIR}/arp_update"
+SOURCE_SCRIPT="$(mktemp)"
+DB_CALL_LOG="$(mktemp)"
+trap 'rm -f "${SOURCE_SCRIPT}" "${DB_CALL_LOG}"' EXIT
+
+# Load only the helper functions; the remainder of arp_update is an infinite loop.
+sed '/^while \/bin\/true; do$/,$d' "$SCRIPT" > "$SOURCE_SCRIPT"
+# shellcheck source=/dev/null
+source "$SOURCE_SCRIPT"
+
+assert_eq() {
+    local description="$1"
+    local expected="$2"
+    local actual="$3"
+    if [[ "$expected" != "$actual" ]]; then
+        echo "FAIL: ${description}: expected '${expected}', got '${actual}'" >&2
+        exit 1
+    fi
+}
+
+logger() {
+    :
+}
+
+timeout() {
+    TIMEOUT_ARGS=("$@")
+}
+
+sonic-db-cli() {
+    printf '%s\n' "$*" > "$DB_CALL_LOG"
+}
+
+ip() {
+    IP_ARGS=("$@")
+}
+
+TIMEOUT_ARGS=()
+run_ipv6_multicast_ping 0.2 "Ethernet 0"
+assert_eq "multicast interface remains one argument" "Ethernet 0" "${TIMEOUT_ARGS[3]}"
+
+IP_ARGS=()
+flush_unsynced_neighbors "Vlan1000" "2001:db8::1 dev Vlan1000 FAILED"
+assert_eq "APPL_DB neighbor lookup" \
+    "APPL_DB hget NEIGH_TABLE:Vlan1000:2001:db8::1 neigh" "$(<"$DB_CALL_LOG")"
+assert_eq "flush address remains one argument" "2001:db8::1" "${IP_ARGS[2]}"
+
+IP_ARGS=()
+replace_failed_neighbors "2001:db8::2 dev Vlan1000 FAILED"
+assert_eq "replace address remains one argument" "2001:db8::2" "${IP_ARGS[2]}"
+assert_eq "replace interface remains one argument" "Vlan1000" "${IP_ARGS[4]}"
+
+echo "arp_update helper tests passed"


### PR DESCRIPTION
#### Why I did it

`arp_update` builds a few ping and neighbor commands as strings and evaluates them. The interface and address values are already available separately, so these commands can be called directly.

Keeping the values as individual arguments makes the command handling clearer and avoids parsing them a second time as shell input.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Added helpers that invoke IPv6 multicast ping and neighbor commands with quoted arguments.
- Replaced the generated DualToR flush and replace commands with direct loops over the neighbor rows.
- Quoted the related interface, address, and database-key arguments.
- Added focused tests for the new helpers.

#### How to verify it

```text
bash -n files/scripts/arp_update files/scripts/tests/test_arp_update.sh
bash files/scripts/tests/test_arp_update.sh
```

The helper tests cover shell-metacharacter handling for timeout, arping, ndisc6, ip, and sonic-db-cli arguments.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request:
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Shell syntax checks and the focused `arp_update` helper tests passed.

#### Description for the changelog

Run `arp_update` ping and neighbor operations using structured command arguments.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)