### PR TITLE
Treat DHCP-provided SNMP community values as data

### DIFF
--- a/files/dhcp/snmpcommunity
+++ b/files/dhcp/snmpcommunity
@@ -1,14 +1,63 @@
+sonic_is_valid_snmp_community()
+(
+    snmp_value=$1
+    LC_ALL=C
+    export LC_ALL
+
+    [ "${#snmp_value}" -ge 4 ] && [ "${#snmp_value}" -le 32 ] || return 1
+
+    # Keep this aligned with the SNMP_COMMUNITY key restrictions in
+    # sonic-snmp.yang: visible ASCII except space, single quote, @, comma,
+    # and backslash.
+    case "$snmp_value" in
+        *[![:graph:]]*|*"'"*|*@*|*,*|*\\*) return 1 ;;
+    esac
+)
+
+sonic_write_snmp_community()
+(
+    snmp_value=$1
+    snmp_config=$2
+    snmp_tmp=$(mktemp "${snmp_config}.XXXXXX") || return 1
+    trap 'rm -f "$snmp_tmp"' 0 1 2 15
+
+    snmp_updated=false
+    if [ -f "$snmp_config" ]; then
+        while IFS= read -r snmp_line || [ -n "$snmp_line" ]; do
+            case "$snmp_line" in
+                snmp_rocommunity:*)
+                    printf "snmp_rocommunity: '%s'\n" "$snmp_value"
+                    snmp_updated=true
+                    ;;
+                *)
+                    printf '%s\n' "$snmp_line"
+                    ;;
+            esac
+        done < "$snmp_config" > "$snmp_tmp" || return 1
+
+        if [ "$snmp_updated" = false ]; then
+            printf "snmp_rocommunity: '%s'\n" "$snmp_value" >> "$snmp_tmp" || return 1
+        fi
+
+        chown --reference="$snmp_config" "$snmp_tmp" || return 1
+        chmod --reference="$snmp_config" "$snmp_tmp" || return 1
+    else
+        printf "snmp_rocommunity: '%s'\n" "$snmp_value" > "$snmp_tmp" || return 1
+        chmod 0644 "$snmp_tmp" || return 1
+    fi
+
+    mv -f -- "$snmp_tmp" "$snmp_config"
+)
+
 case $reason in
     BOUND|RENEW|REBIND|REBOOT)
         if [ -n "${new_snmp_community}" ]; then
-            if [ -f /etc/sonic/snmp.yml ]; then
-                if grep -q "^snmp_rocommunity:" /etc/sonic/snmp.yml; then
-                    sed -i "s/^snmp_rocommunity:.*/snmp_rocommunity: $new_snmp_community/g" /etc/sonic/snmp.yml
-                else
-                    echo "snmp_rocommunity: $new_snmp_community" >> /etc/sonic/snmp.yml
+            if sonic_is_valid_snmp_community "$new_snmp_community"; then
+                if ! sonic_write_snmp_community "$new_snmp_community" /etc/sonic/snmp.yml; then
+                    logger -t snmpcommunity "failed to update /etc/sonic/snmp.yml"
                 fi
             else
-                echo "snmp_rocommunity: $new_snmp_community" > /etc/sonic/snmp.yml
+                logger -t snmpcommunity "rejecting invalid DHCP-supplied SNMP community"
             fi
         fi
         ;;

--- a/files/dhcp/tests/test_snmpcommunity.sh
+++ b/files/dhcp/tests/test_snmpcommunity.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+reason=TEST
+export reason
+. "$SCRIPT_DIR/../snmpcommunity"
+
+assert_valid()
+{
+    sonic_is_valid_snmp_community "$1" || {
+        printf 'expected valid community: %s\n' "$1" >&2
+        exit 1
+    }
+}
+
+assert_invalid()
+{
+    if sonic_is_valid_snmp_community "$1"; then
+        printf 'expected invalid community: %s\n' "$1" >&2
+        exit 1
+    fi
+}
+
+assert_valid 'public'
+assert_valid 'site-1_ro'
+assert_valid 'safe;id>/tmp/example'
+assert_valid 'hash#colon:value'
+assert_valid '01234567890123456789012345678901'
+
+assert_invalid 'abc'
+assert_invalid '012345678901234567890123456789012'
+assert_invalid 'has space'
+assert_invalid "has'quote"
+assert_invalid 'has@sign'
+assert_invalid 'has,comma'
+assert_invalid 'has\backslash'
+assert_invalid "line
+break"
+
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' 0 1 2 15
+
+config=$test_dir/snmp.yml
+printf '%s\n' \
+    'snmp_location: lab' \
+    'snmp_rocommunity: old-value' \
+    'other_setting: true' > "$config"
+chmod 0640 "$config"
+
+sonic_write_snmp_community 'safe;id>/tmp/example' "$config"
+[ "$(stat -c '%a' "$config")" = 640 ]
+expected=$test_dir/expected.yml
+printf '%s\n' \
+    'snmp_location: lab' \
+    "snmp_rocommunity: 'safe;id>/tmp/example'" \
+    'other_setting: true' > "$expected"
+cmp "$expected" "$config"
+
+printf '%s\n' 'snmp_location: lab' > "$config"
+sonic_write_snmp_community 'hash#colon:value' "$config"
+printf '%s\n' \
+    'snmp_location: lab' \
+    "snmp_rocommunity: 'hash#colon:value'" > "$expected"
+cmp "$expected" "$config"
+
+rm -f "$config"
+sonic_write_snmp_community 'site-1_ro' "$config"
+printf '%s\n' "snmp_rocommunity: 'site-1_ro'" > "$expected"
+cmp "$expected" "$config"


### PR DESCRIPTION
#### Why I did it

The dhclient exit hook currently inserts DHCP option 224 directly into a `sed` program. Since the option comes from the DHCP response, characters in the value can change what `sed` does instead of remaining part of the SNMP community string.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Validate the supplied value using the same length and character restrictions as the `SNMP_COMMUNITY` YANG key.
- Write the community as a quoted YAML value using `printf`, without placing it in a shell or `sed` program.
- Replace `snmp.yml` through a temporary file and preserve the existing file ownership and permissions.
- Add regression coverage for valid punctuation, malformed values, replacement, append, and new-file cases.

#### How to verify it

```text
dash -n files/dhcp/snmpcommunity
dash -n files/dhcp/tests/test_snmpcommunity.sh
files/dhcp/tests/test_snmpcommunity.sh
shellcheck -x -s dash -e SC1091,SC2154 \
    files/dhcp/snmpcommunity \
    files/dhcp/tests/test_snmpcommunity.sh
```

The tests cover accepted and rejected values, existing-file ownership, unchanged content after invalid input, and preserving the original file when replacement fails.

#### Which release branch to backport (provide reason below if selected)

No backport requested.

#### Tested branch

- [x] master

#### Test result

The focused shell regression test passed on `master`. It verifies that shell and `sed` metacharacters remain data while malformed community values are rejected.

#### Description for the changelog

Safely handle DHCP-provided SNMP community values when updating `snmp.yml`.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)