### PR TITLE
[bgpcfgd]: Stabilize unnumbered neighbor configuration

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/general/instance.conf.j2
@@ -1,6 +1,9 @@
 !
 ! template: bgpd/templates/general/instance.conf.j2
 !
+{% if is_interface_neighbor | default(neighbor_addr | is_interface) %}
+  neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
+{% endif %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
 {# set the bgp neighbor timers if they have not default values #}
@@ -15,7 +18,6 @@
 {% endif %}
 !
 {% if is_interface_neighbor | default(neighbor_addr | is_interface) %}
-  neighbor {{ neighbor_addr }} interface peer-group PEER_UNNUMBERED
 {% if bgp_session.get('address_family', 'both') in ['both', 'v4'] %}
   address-family ipv4
 {%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/internal/instance.conf.j2
@@ -1,13 +1,15 @@
 !
 ! template: bgpd/templates/internal/instance.conf.j2
 !
+{% if is_interface_neighbor | default(neighbor_addr | is_interface) %}
+  neighbor {{ neighbor_addr }} interface peer-group INTERNAL_PEER_UNNUMBERED
+{% endif %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
   neighbor {{ neighbor_addr }} timers 3 10
   neighbor {{ neighbor_addr }} timers connect 10
 !
 {% if is_interface_neighbor | default(neighbor_addr | is_interface) %}
-  neighbor {{ neighbor_addr }} interface peer-group INTERNAL_PEER_UNNUMBERED
 {% if bgp_session.get('address_family', 'both') in ['both', 'v4'] %}
   address-family ipv4
 {%   if 'rrclient' in bgp_session and bgp_session['rrclient'] | int != 0 %}

--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -5,8 +5,8 @@
   bgp bestpath peer-type multipath-relax
 !
 {% if is_interface_neighbor | default(neighbor_addr | is_interface) %}
-  neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} interface peer-group VOQ_CHASSIS_PEER_UNNUMBERED
+  neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
 {% if bgp_session.get('address_family', 'both') in ['both', 'v4'] %}
   address-family ipv4
     neighbor {{ neighbor_addr }} activate

--- a/src/sonic-bgpcfgd/bgpcfgd/main.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/main.py
@@ -87,6 +87,7 @@ def do_work():
         BGPDataBaseMgr(common_objs, "CONFIG_DB", swsscommon.CFG_DEVICE_METADATA_TABLE_NAME),
         BGPDataBaseMgr(common_objs, "CONFIG_DB", swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME),
         BGPDataBaseMgr(common_objs, "CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME),
+        BGPDataBaseMgr(common_objs, "CONFIG_DB", "PORTCHANNEL"),
         # Interface managers
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_INTF_TABLE_NAME),
         InterfaceMgr(common_objs, "CONFIG_DB", swsscommon.CFG_LOOPBACK_INTERFACE_TABLE_NAME),

--- a/src/sonic-bgpcfgd/bgpcfgd/manager.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/manager.py
@@ -39,6 +39,7 @@ class Manager(object):
         :param data: associated data of the event. Empty for 'DEL' operation.
         """
         if op == swsscommon.SET_COMMAND:
+            self._remove_pending_set(key)
             if (not self.wait_for_all_deps) or self.directory.available_deps(self.deps):  # all required dependencies are set in the Directory?
                 res = self.set_handler(key, data)
                 if not res:  # set handler returned False, which means it is not ready to process is. Save it for later.
@@ -48,9 +49,15 @@ class Manager(object):
                 log_debug("Not all dependencies are met for the Manager: %s" % self.__class__)
                 self.set_queue.append((key, data))
         elif op == swsscommon.DEL_COMMAND:
+            self._remove_pending_set(key)
             self.del_handler(key)
         else:
             log_err("Invalid operation '%s' for key '%s'" % (op, key))
+
+    def _remove_pending_set(self, key):
+        """Remove a superseded full-row SET before handling the key's latest event."""
+        self.set_queue = [(queued_key, queued_data) for queued_key, queued_data in self.set_queue
+                          if queued_key != key]
 
     def on_deps_change(self):
         """ This method is being executed on every dependency change """

--- a/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
+++ b/src/sonic-bgpcfgd/bgpcfgd/managers_bgp.py
@@ -12,9 +12,13 @@ from .utils import run_command
 from .managers_device_global import DeviceGlobalCfgMgr
 
 
-def is_interface_neighbor(neighbor, ports=None, interfaces=None):
-    """Return True if neighbor key is an interface name, not an IP address."""
-    return TemplateFabric.is_interface(neighbor, ports, interfaces)
+def is_interface_neighbor(neighbor, ports=None, interfaces=None, portchannels=None):
+    """Return True for a configured interface, or a known name form without DB data."""
+    if ports is not None or interfaces is not None or portchannels is not None:
+        if neighbor in (ports or {}) or neighbor in (portchannels or {}):
+            return True
+        return any(neighbor == key.split('|', 1)[0] for key in (interfaces or {}))
+    return TemplateFabric.is_interface(neighbor)
 
 
 class BGPPeerGroupMgr(object):
@@ -179,6 +183,13 @@ class BGPPeerMgrBase(Manager):
             table_name,
         )
 
+        if self.supports_unnumbered:
+            # PORTCHANNEL is optional: subscribe for retries without making it a startup dependency.
+            self.directory.subscribe(
+                [("CONFIG_DB", "PORTCHANNEL", "")],
+                self.on_deps_change
+            )
+
         self.peers = self.load_peers()
         self.peer_group_mgr = BGPPeerGroupMgr(self.common_objs, base_template)
         return
@@ -220,12 +231,13 @@ class BGPPeerMgrBase(Manager):
 
         if self.supports_unnumbered:
             ports = self.directory.get_slot("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME)
+            portchannels = self.directory.get_slot("CONFIG_DB", "PORTCHANNEL")
             interfaces = self.directory.get_slot("LOCAL", "interfaces")
-            interface_neighbor = is_interface_neighbor(nbr, ports, interfaces)
+            interface_neighbor = is_interface_neighbor(nbr, ports, interfaces, portchannels)
             if (not interface_neighbor
                     and not TemplateFabric.is_ipv4(nbr)
                     and not TemplateFabric.is_ipv6(nbr)):
-                log_err("Peer '%s' is neither a valid IP address nor present in the PORT or interface tables" % nbr)
+                log_debug("Peer '%s' is not yet present in the PORT, PORTCHANNEL, or interface tables" % nbr)
                 return False
         else:
             interface_neighbor = is_interface_neighbor(nbr)

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered.conf
@@ -1,11 +1,11 @@
 !
 ! template: bgpd/templates/general/instance.conf.j2
 !
+  neighbor PortChannel101 interface peer-group PEER_UNNUMBERED
   neighbor PortChannel101 remote-as 65200
   neighbor PortChannel101 description spine1
   neighbor PortChannel101 timers connect 10
 !
-  neighbor PortChannel101 interface peer-group PEER_UNNUMBERED
   address-family ipv4
     neighbor PortChannel101 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v4.conf
@@ -1,11 +1,11 @@
 !
 ! template: bgpd/templates/general/instance.conf.j2
 !
+  neighbor Ethernet4 interface peer-group PEER_UNNUMBERED
   neighbor Ethernet4 remote-as 65200
   neighbor Ethernet4 description spine3
   neighbor Ethernet4 timers connect 10
 !
-  neighbor Ethernet4 interface peer-group PEER_UNNUMBERED
   address-family ipv4
     neighbor Ethernet4 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/general/instance.conf/result_unnumbered_v6.conf
@@ -1,11 +1,11 @@
 !
 ! template: bgpd/templates/general/instance.conf.j2
 !
+  neighbor Ethernet0 interface peer-group PEER_UNNUMBERED
   neighbor Ethernet0 remote-as 65200
   neighbor Ethernet0 description spine2
   neighbor Ethernet0 timers connect 10
 !
-  neighbor Ethernet0 interface peer-group PEER_UNNUMBERED
   address-family ipv6
     neighbor Ethernet0 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered.conf
@@ -1,12 +1,12 @@
 !
 ! template: bgpd/templates/internal/instance.conf.j2
 !
+  neighbor PortChannel101 interface peer-group INTERNAL_PEER_UNNUMBERED
   neighbor PortChannel101 remote-as 65100
   neighbor PortChannel101 description peer_switch
   neighbor PortChannel101 timers 3 10
   neighbor PortChannel101 timers connect 10
 !
-  neighbor PortChannel101 interface peer-group INTERNAL_PEER_UNNUMBERED
   address-family ipv4
     neighbor PortChannel101 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered_backplane.conf
+++ b/src/sonic-bgpcfgd/tests/data/internal/instance.conf/result_unnumbered_backplane.conf
@@ -1,12 +1,12 @@
 !
 ! template: bgpd/templates/internal/instance.conf.j2
 !
+  neighbor Ethernet-BP0 interface peer-group INTERNAL_PEER_UNNUMBERED
   neighbor Ethernet-BP0 remote-as 65100
   neighbor Ethernet-BP0 description peer_asic
   neighbor Ethernet-BP0 timers 3 10
   neighbor Ethernet-BP0 timers connect 10
 !
-  neighbor Ethernet-BP0 interface peer-group INTERNAL_PEER_UNNUMBERED
   address-family ipv4
     neighbor Ethernet-BP0 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_unnumbered.conf
@@ -4,8 +4,8 @@
   bgp bestpath as-path multipath-relax
   bgp bestpath peer-type multipath-relax
 !
-  neighbor Ethernet0 remote-as 65100
   neighbor Ethernet0 interface peer-group VOQ_CHASSIS_PEER_UNNUMBERED
+  neighbor Ethernet0 remote-as 65100
   address-family ipv4
     neighbor Ethernet0 activate
   exit-address-family

--- a/src/sonic-bgpcfgd/tests/test_bgp.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import os
 from bgpcfgd.directory import Directory
 from bgpcfgd.template import TemplateFabric
+from bgpcfgd import manager as manager_mod
 from . import swsscommon_test
 from .util import load_constants, render_constants
 from swsscommon import swsscommon
@@ -70,6 +71,75 @@ def constructor(constants_path, bgp_router_id="", peer_type="general", with_lo0_
         m.directory.put("CONFIG_DB", swsscommon.CFG_DEVICE_NEIGHBOR_METADATA_TABLE_NAME, "TOR", {})
 
     return m
+
+
+def satisfy_non_port_dependencies(manager):
+    """Populate the manager's metadata, loopback, global, and LOCAL dependencies."""
+    values = {
+        "localhost/type": "LeafRouter",
+        "localhost/deployment_id": "0",
+        "Loopback0": {},
+        "Loopback4096": {},
+        "tsa_enabled": "false",
+        "idf_isolation_state": "unisolated",
+    }
+    for db_name, table_name, path in manager.deps:
+        if table_name == swsscommon.CFG_PORT_TABLE_NAME or manager.directory.path_exist(db_name, table_name, path):
+            continue
+        if path:
+            path_parts = path.split("/")
+            root = path_parts.pop(0)
+            root_value = dict(manager.directory.get_slot(db_name, table_name).get(root, {}))
+            destination = root_value
+            for part in path_parts[:-1]:
+                destination = destination.setdefault(part, {})
+            if path_parts:
+                destination[path_parts[-1]] = values.get(path, {})
+            else:
+                root_value = values.get(path, {})
+            manager.directory.put(db_name, table_name, root, root_value)
+        else:
+            manager.directory.put(db_name, table_name, "__ready__", {})
+
+
+def deferred_test_manager():
+    """Build a minimal manager for verifying the shared pending-event contract."""
+    common_objs = {
+        'directory': Directory(),
+        'cfg_mgr': MagicMock(),
+        'constants': {},
+    }
+    manager = manager_mod.Manager(
+        common_objs, [], "CONFIG_DB", "TEST", wait_for_all_deps=False
+    )
+    del_handler = MagicMock()
+    manager.set_handler = MagicMock(return_value=False)
+    manager.del_handler = del_handler
+    return manager, del_handler
+
+
+def test_manager_latest_pending_set_replaces_same_key_only():
+    manager, _ = deferred_test_manager()
+    manager.handler("peer-a", manager_mod.swsscommon.SET_COMMAND, {'asn': '65100'})
+    manager.handler("peer-b", manager_mod.swsscommon.SET_COMMAND, {'asn': '65200'})
+    manager.handler("peer-a", manager_mod.swsscommon.SET_COMMAND, {'asn': '65300'})
+
+    assert manager.set_queue == [
+        ("peer-b", {'asn': '65200'}),
+        ("peer-a", {'asn': '65300'}),
+    ]
+
+
+def test_manager_delete_cancels_only_matching_pending_set():
+    manager, del_handler = deferred_test_manager()
+    manager.handler("peer-a", manager_mod.swsscommon.SET_COMMAND, {'asn': '65100'})
+    manager.handler("peer-b", manager_mod.swsscommon.SET_COMMAND, {'asn': '65200'})
+
+    manager.handler("peer-a", manager_mod.swsscommon.DEL_COMMAND, {})
+
+    assert manager.set_queue == [("peer-b", {'asn': '65200'})]
+    del_handler.assert_called_once_with("peer-a")
+
 
 @patch('bgpcfgd.managers_bgp.log_info')
 def test_update_peer_up(mocked_log_info):
@@ -260,32 +330,171 @@ def test_add_unnumbered_peer_in_vrf():
 
 def test_unnumbered_peer_manager_depends_on_port_table():
     for constant in load_constant_files():
+        peers = load_constants(constant)['constants']['bgp']['peers']
         port_dependency = ("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, "")
-        assert port_dependency in constructor(constant).deps
-        assert port_dependency not in constructor(constant, peer_type="dynamic").deps
+        portchannel_dependency = ("CONFIG_DB", "PORTCHANNEL", "")
+        for peer_type in ("general", "internal", "voq_chassis"):
+            dependencies = constructor(constant, peer_type=peer_type).deps
+            assert port_dependency in dependencies
+            assert portchannel_dependency not in dependencies
+        for peer_type in ("dynamic", "monitors", "sentinels"):
+            if peer_type in peers:
+                dependencies = constructor(constant, peer_type=peer_type).deps
+                assert port_dependency not in dependencies
+                assert portchannel_dependency not in dependencies
 
 
 def test_add_unnumbered_peer_from_port_table():
     for constant in load_constant_files():
+        for neighbor in ("Ethernet-Future0", "Ethernet-BP0", "Ethernet-Rec0", "Ethernet-IB0"):
+            m = constructor(constant)
+            m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, neighbor, {})
+            res = m.set_handler(neighbor, {'asn': '65200', 'name': 'TOR'})
+            assert res, "Expect True return value"
+            assert any(
+                'neighbor %s interface peer-group PEER_UNNUMBERED' % neighbor in call.args[0]
+                for call in m.cfg_mgr.push.call_args_list
+            )
+
+
+def test_add_unnumbered_peer_from_interface_table():
+    for constant in load_constant_files():
+        for neighbor in ("PortChannel101", "Vlan1000", "Eth24.15"):
+            m = constructor(constant)
+            m.directory.put("LOCAL", "interfaces", neighbor, {})
+            res = m.set_handler(neighbor, {'asn': '65200', 'name': 'TOR'})
+            assert res, "Expect True return value"
+            assert any(
+                'neighbor %s interface peer-group PEER_UNNUMBERED' % neighbor in call.args[0]
+                for call in m.cfg_mgr.push.call_args_list
+            )
+
+
+def test_late_portchannel_neighbor_converges():
+    for constant in load_constant_files():
+        for peer_type, peer_group in (
+            ("general", "PEER_UNNUMBERED"),
+            ("internal", "INTERNAL_PEER_UNNUMBERED"),
+            ("voq_chassis", "VOQ_CHASSIS_PEER_UNNUMBERED"),
+        ):
+            m = constructor(
+                constant,
+                peer_type=peer_type,
+                with_lo4096_ipv4=(peer_type == "internal")
+            )
+            satisfy_non_port_dependencies(m)
+            m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, "Ethernet0", {})
+
+            m.handler(
+                "PortChannel101",
+                manager_mod.swsscommon.SET_COMMAND,
+                {'asn': '65200', 'name': 'TOR'}
+            )
+            assert len(m.set_queue) == 1
+
+            m.directory.put("CONFIG_DB", "PORTCHANNEL", "PortChannel101", {})
+
+            assert m.set_queue == []
+            assert any(
+                'neighbor PortChannel101 interface peer-group %s' % peer_group in call.args[0]
+                for call in m.cfg_mgr.push.call_args_list
+            )
+
+
+def test_latest_pending_set_replaces_earlier_data():
+    for constant in load_constant_files():
         m = constructor(constant)
+        satisfy_non_port_dependencies(m)
+
+        m.handler(
+            "Ethernet-Future0",
+            manager_mod.swsscommon.SET_COMMAND,
+            {'asn': '65200', 'name': 'TOR'}
+        )
+        m.handler(
+            "Ethernet-Future0",
+            manager_mod.swsscommon.SET_COMMAND,
+            {'asn': '65300', 'name': 'TOR'}
+        )
+
+        assert m.set_queue == [
+            ("Ethernet-Future0", {'asn': '65300', 'name': 'TOR'})
+        ]
+
         m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, "Ethernet-Future0", {})
+
+        assert m.set_queue == []
+        assert any(
+            'neighbor Ethernet-Future0 remote-as 65300' in call.args[0]
+            for call in m.cfg_mgr.push.call_args_list
+        )
+        assert not any(
+            'neighbor Ethernet-Future0 remote-as 65200' in call.args[0]
+            for call in m.cfg_mgr.push.call_args_list
+        )
+
+
+@patch('bgpcfgd.managers_bgp.log_debug')
+def test_defer_non_ip_neighbor_missing_from_interface_tables(mocked_log_debug):
+    for constant in load_constant_files():
+        m = constructor(constant)
         res = m.set_handler("Ethernet-Future0", {'asn': '65200', 'name': 'TOR'})
-        assert res, "Expect True return value"
+        assert not res, "Expect False return value"
+        mocked_log_debug.assert_called_with(
+            "Peer 'Ethernet-Future0' is not yet present in the PORT, PORTCHANNEL, or interface tables"
+        )
+
+
+@patch('bgpcfgd.managers_bgp.log_err')
+@patch('bgpcfgd.managers_bgp.log_warn')
+def test_late_port_neighbor_converges_without_errors(mocked_log_warn, mocked_log_err):
+    for constant in load_constant_files():
+        m = constructor(constant)
+        satisfy_non_port_dependencies(m)
+
+        m.handler(
+            "Ethernet-Future0",
+            manager_mod.swsscommon.SET_COMMAND,
+            {'asn': '65200', 'name': 'TOR'}
+        )
+        assert len(m.set_queue) == 1
+
+        for port in ("Ethernet0", "Ethernet4", "Ethernet8"):
+            m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, port, {})
+
+        assert len(m.set_queue) == 1
+        m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, "Ethernet-Future0", {})
+
+        assert m.set_queue == []
+        mocked_log_err.assert_not_called()
+        mocked_log_warn.assert_not_called()
         assert any(
             'neighbor Ethernet-Future0 interface peer-group PEER_UNNUMBERED' in call.args[0]
             for call in m.cfg_mgr.push.call_args_list
         )
 
 
-@patch('bgpcfgd.managers_bgp.log_err')
-def test_reject_unknown_non_ip_neighbor(mocked_log_err):
+def test_delete_removes_pending_peer():
     for constant in load_constant_files():
-        m = constructor(constant)
-        res = m.set_handler("Ethernet-Future0", {'asn': '65200', 'name': 'TOR'})
-        assert not res, "Expect False return value"
-        mocked_log_err.assert_called_with(
-            "Peer 'Ethernet-Future0' is neither a valid IP address nor present in the PORT or interface tables"
-        )
+        for key in ("Ethernet-Future0", "Vrf-10|Ethernet-Future0"):
+            m = constructor(constant)
+            satisfy_non_port_dependencies(m)
+
+            m.handler(
+                key,
+                manager_mod.swsscommon.SET_COMMAND,
+                {'asn': '65200', 'name': 'TOR'}
+            )
+            assert len(m.set_queue) == 1
+
+            m.handler(key, manager_mod.swsscommon.DEL_COMMAND, {})
+            assert m.set_queue == []
+
+            m.directory.put("CONFIG_DB", swsscommon.CFG_PORT_TABLE_NAME, "Ethernet-Future0", {})
+            assert not any(
+                'neighbor Ethernet-Future0 interface peer-group' in call.args[0]
+                for call in m.cfg_mgr.push.call_args_list
+            )
 
 
 @patch('bgpcfgd.managers_bgp.log_info')

--- a/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
@@ -64,6 +64,16 @@ def test_is_interface_neighbor_uses_interface_table():
     assert is_interface_neighbor('FutureInterface0', {}, interfaces) is True
     assert is_interface_neighbor('FutureInterface0', {}, {}) is False
 
+def test_is_interface_neighbor_uses_portchannel_table():
+    portchannels = {'PortChannel101': {}}
+    assert is_interface_neighbor('PortChannel101', {}, {}, portchannels) is True
+    assert is_interface_neighbor('PortChannel101', {}, {}, {}) is False
+
+
+def test_is_interface_neighbor_normalizes_interface_table_keys():
+    interfaces = {'PortChannel101|10.0.0.1/31': {}}
+    assert is_interface_neighbor('PortChannel101', {}, interfaces) is True
+
 def test_is_interface_neighbor_vlan_high():
     assert is_interface_neighbor('Vlan1000') is True
 

--- a/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
+++ b/src/sonic-bgpcfgd/tests/test_bgp_unnumbered.py
@@ -209,9 +209,48 @@ def test_internal_and_voq_unnumbered_peer_groups_are_distinct():
 
 
 def test_unnumbered_remote_as():
-    """Interface neighbor renders remote-as correctly."""
+    """Interface neighbor is created before remote-as is configured."""
     result = render_general_instance('PortChannel101', {'asn': '65200', 'name': 'spine1'})
-    assert 'neighbor PortChannel101 remote-as 65200' in result
+    interface = 'neighbor PortChannel101 interface peer-group PEER_UNNUMBERED'
+    remote_as = 'neighbor PortChannel101 remote-as 65200'
+    assert interface in result
+    assert remote_as in result
+    assert result.index(interface) < result.index(remote_as)
+
+
+def test_internal_unnumbered_remote_as_order():
+    """Internal interface neighbor is created before remote-as is configured."""
+    tf = TemplateFabric(TEMPLATE_PATH)
+    template = tf.from_file('bgpd/templates/internal/instance.conf.j2')
+    result = template.render(
+        CONFIG_DB__DEVICE_METADATA={'localhost': {'switch_type': 'switch'}},
+        neighbor_addr='PortChannel101',
+        bgp_session={'asn': '65100', 'name': 'peer_switch'},
+        bgp_asn='65100',
+    )
+    interface = 'neighbor PortChannel101 interface peer-group INTERNAL_PEER_UNNUMBERED'
+    remote_as = 'neighbor PortChannel101 remote-as 65100'
+    assert interface in result
+    assert remote_as in result
+    assert result.index(interface) < result.index(remote_as)
+
+
+def test_voq_unnumbered_remote_as_order():
+    """VoQ interface neighbor is created before remote-as is configured."""
+    tf = TemplateFabric(TEMPLATE_PATH)
+    template = tf.from_file('bgpd/templates/voq_chassis/instance.conf.j2')
+    result = template.render(
+        CONFIG_DB__DEVICE_METADATA={'localhost': {'type': 'SpineRouter', 'bgp_asn': '65100'}},
+        neighbor_addr='Ethernet0',
+        bgp_session={'asn': '65100', 'name': 'lc_peer'},
+        bgp_asn='65100',
+        constants={'bgp': {'maximum_paths': {'enabled': True, 'ipv4': 64, 'ipv6': 64}}},
+    )
+    interface = 'neighbor Ethernet0 interface peer-group VOQ_CHASSIS_PEER_UNNUMBERED'
+    remote_as = 'neighbor Ethernet0 remote-as 65100'
+    assert interface in result
+    assert remote_as in result
+    assert result.index(interface) < result.index(remote_as)
 
 
 def test_unnumbered_shutdown():


### PR DESCRIPTION
#### Why I did it

Addresses failing mgmt tests tracked in #26960.

`bgpcfgd` renders interface neighbor attributes before the command creating the interface neighbor. FRR rejects those attributes with `Create the peer-group or interface first`. This prevents BGP session establishment.

`bgpcfgd` can also reject PortChannel neighbors before rendering them because it does not populate the PortChannel inventory used to identify interface peers. Interface and neighbor updates arrive independently, so deferred neighbor events must retain only the latest configuration intent and retry after the interface appears.

#### How I did it

* Create general, internal, and VoQ interface neighbors before configuring their attributes
* Populate optional PortChannel state and retry deferred interface peers without blocking ordinary neighbors
* Replace stale queued SET data, cancel pending SET on DEL, and cover startup ordering with regression tests

#### How to verify it

1. Run `python3 -m pytest -q tests/test_bgp_unnumbered.py tests/test_bgp.py tests/test_templates.py` in `src/sonic-bgpcfgd`
2. Build a VS image and run the Ethernet and PortChannel `test_bgp_link_local` variants through CONFIG_DB
3. Verify dual-stack BGP establishes, exchanges IPv4 and IPv6 routes, and uses a link-local next hop

#### Description for the changelog

Stabilize BGP unnumbered neighbor creation and deferred interface processing.