### PR TITLE
[P4RT] Route pinned GitHub downloads through wget hook

### DIFF
--- a/src/sonic-p4rt/Makefile
+++ b/src/sonic-p4rt/Makefile
@@ -5,6 +5,16 @@ SHELL = /bin/bash
 BAZEL_TARGET_PATH = p4rt_app
 BAZEL_BUILD_TARGETS = //p4rt_app:p4rt_deb //p4rt_app:p4rt_dbg_deb
 
+# Bazel's downloader bypasses the SONiC wget hook. Prefetch the archives that
+# failed in the Official build, then let Bazel consume them from a distdir.
+BAZEL_DISTDIR = $(CURDIR)/bazel-distdir
+GRPC_ARCHIVE = v1.63.0.zip
+GRPC_ARCHIVE_URL = https://github.com/grpc/grpc/archive/$(GRPC_ARCHIVE)
+GRPC_ARCHIVE_SHA256 = daa1b06a19b5f7e4603e1f8980eeab43cf69b6e89bee3b2547f275fa5af7f480
+GOOGLEAPIS_ARCHIVE = f405c718d60484124808adb7fb5963974d654bb4.zip
+GOOGLEAPIS_ARCHIVE_URL = https://github.com/googleapis/googleapis/archive/$(GOOGLEAPIS_ARCHIVE)
+GOOGLEAPIS_ARCHIVE_SHA256 = 406b64643eede84ce3e0821a1d01f66eaf6254e79cb9c4f53be9054551935e79
+
 # Enable debug symbols for remote debugging (generate a .dwp).
 BAZEL_BUILD_OPTS += --copt=-gsplit-dwarf
 
@@ -30,6 +40,7 @@ BAZEL_BUILD_OPTS += -c opt
 #
 BAZEL_CACHE ?= /bazel
 BAZEL_OPTS += $(shell test -d $(BAZEL_CACHE) && echo --output_user_root=$(BAZEL_CACHE)/cache)
+BAZEL_BUILD_OPTS += --distdir=$(BAZEL_DISTDIR)
 
 MAIN_TARGET = $(SONIC_P4RT)
 DERIVED_TARGETS = $(SONIC_P4RT_DBG)
@@ -38,8 +49,21 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	function cleanup {
 		# Note: make seems to hang if Bazel is still running
 		cd $(CURDIR)/sonic-pins && bazel $(BAZEL_OPTS) shutdown
+		rm -rf $(BAZEL_DISTDIR)
 	}
 	trap cleanup EXIT
+
+	grep -Fq 'url = "$(GRPC_ARCHIVE_URL)"' sonic-pins/pins_infra_deps.bzl
+	grep -Fq 'sha256 = "$(GRPC_ARCHIVE_SHA256)"' sonic-pins/pins_infra_deps.bzl
+	grep -Fq 'url = "$(GOOGLEAPIS_ARCHIVE_URL)"' sonic-pins/pins_infra_deps.bzl
+	grep -Fq 'sha256 = "$(GOOGLEAPIS_ARCHIVE_SHA256)"' sonic-pins/pins_infra_deps.bzl
+
+	rm -rf $(BAZEL_DISTDIR)
+	mkdir -p $(BAZEL_DISTDIR)
+	wget --no-verbose --tries=3 -O $(BAZEL_DISTDIR)/$(GRPC_ARCHIVE) $(GRPC_ARCHIVE_URL)
+	echo "$(GRPC_ARCHIVE_SHA256)  $(BAZEL_DISTDIR)/$(GRPC_ARCHIVE)" | sha256sum -c -
+	wget --no-verbose --tries=3 -O $(BAZEL_DISTDIR)/$(GOOGLEAPIS_ARCHIVE) $(GOOGLEAPIS_ARCHIVE_URL)
+	echo "$(GOOGLEAPIS_ARCHIVE_SHA256)  $(BAZEL_DISTDIR)/$(GOOGLEAPIS_ARCHIVE)" | sha256sum -c -
 
 	# TODO: Remove this Makefile workaround
 	# once Bazel natively supports generating cfg_schema.h.


### PR DESCRIPTION
#### Why I did it

Bazel downloads P4RT external repositories directly and bypasses the SONiC `wget` hook. This prevents the web version-control flow from recording and mirroring the pinned archives, leaving builds exposed to upstream rate limiting.

##### Work item tracking
- Microsoft ADO **(number only)**: 39378630

#### How I did it

- Prefetch the pinned gRPC and googleapis archives through the SONiC `wget` hook.
- Verify their URLs and SHA256 values still match `sonic-pins`.
- Pass the local archives to Bazel through `--distdir`.
- Remove the temporary distdir when the build exits.

#### How to verify it

Build the P4RT package with a clean Bazel repository cache:

```bash
make configure PLATFORM=vs
make target/debs/bookworm/sonic-p4rt_0.0.1_amd64.deb
```

Confirm the gRPC and googleapis archives are fetched by the SONiC `wget` hook and Bazel consumes them from the configured distdir.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39378630
Failure type: build failure

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: The P4RT packages built successfully with the pinned archives supplied through the Bazel distdir.

#### Description for the changelog

Route P4RT pinned GitHub archives through SONiC web version control.

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)
