### PR TITLE
[build-hooks] Retry transient git clone failures

### DIFF
--- a/src/sonic-build-hooks/hooks/git
+++ b/src/sonic-build-hooks/hooks/git
@@ -43,15 +43,38 @@ get_clone_path(){
     [ -z $clone_PATH ] && clone_PATH=`echo $URL | sed 's/\/$//' | awk -F/ '{print$NF}' | awk -F. '{print$1}'`
 }
 
+run_git(){
+    local attempt=1
+    local result
+
+    while true; do
+        $REAL_COMMAND "$@"
+        result=$?
+
+        if [[ $result == 0 || $MODE_CLONE != 1 || $attempt -ge $GET_RETRY_COUNT ]];then
+            return $result
+        fi
+
+        log_err "git clone failed (attempt $attempt/$GET_RETRY_COUNT), retrying"
+        sleep $((attempt * 2))
+        attempt=$((attempt + 1))
+    done
+}
+
 main(){
     parse_config "$@"
 
     # execute git.
-    $REAL_COMMAND "$@"
+    run_git "$@"
     result=$?
 
     # if sub command is not "clone", exit
     if [[ $MODE_CLONE != 1 ]];then
+        exit $result
+    fi
+
+    # A failed clone has no repository to version or record.
+    if [[ $result != 0 ]];then
         exit $result
     fi
 


### PR DESCRIPTION
#### Why I did it

GitHub-backed source clones currently run once through the SONiC `git` hook. A transient network error or upstream rate limit therefore fails the build immediately, even though web downloads already use bounded retries.

##### Work item tracking
- Microsoft ADO **(number only)**: 39378630

#### How I did it

- Retry only `git clone` commands up to the existing build-hook retry limit.
- Use bounded incremental backoff between attempts.
- Preserve single-attempt behavior and exit codes for all other git commands.
- Stop before version bookkeeping when every clone attempt fails.

#### How to verify it

Run the hook with a normal non-clone command and with a clone target that fails transiently. Confirm non-clone commands execute once, clone commands execute up to five times, successful retries continue into version handling, and final failures preserve the git exit code.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): 39378630
Failure type: build reliability

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: Shell syntax passed. Failure injection confirmed five clone attempts, preserved exit status 128, no leftover clone directory, and unchanged single-attempt behavior for non-clone commands.

#### Description for the changelog

Retry transient git clone failures in the SONiC build hook.

#### Link to config_db schema for YANG module changes

N/A. No YANG or config_db schema changes.

#### A picture of a cute animal (not mandatory but encouraged)