### PR TITLE
[mellanox] Add datetime seconds to the sai_failure_dump archive name

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx/platform_syncd_dump.sh
+++ b/platform/mellanox/docker-syncd-mlnx/platform_syncd_dump.sh
@@ -23,7 +23,7 @@
 
 # Source the platform specific dump file
 
-sai_dump_name="sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%p")"
+sai_dump_name="sai_sdk_dump_$(date +"%m_%d_%Y_%I_%M_%S_%p")"
 sai_dump_path="${DUMPDIR}/$sai_dump_name"
 mkdir -p $sai_dump_path
 sai_dump_file="${sai_dump_path}/$sai_dump_name"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Mellanox `sai_failure_dump` name precision is only to the minute, meaning that if two dumps occur in the same minute there is a collision and gzip will refuse to archive the file. I have seen this on multiple devices such as the 4600C and the 4280 which leaves leftover uncompressed .tar files, leading to /var/log partition filling up.

##### Work item tracking
- Microsoft ADO **(number only)**: 
- https://github.com/sonic-net/sonic-buildimage/issues/29305

#### How I did it
Added seconds to the timestamp used by `platform_syncd_dump.sh` for example:
Before: `sai_sdk_dump_09_02_2026_06_15_AM`
After: `sai_sdk_dump_09_02_2026_06_15_39_AM`

#### How to verify it
Invoke the SAI failure dump script twice within the same minute:

```
sudo docker exec -w / syncd /usr/bin/sai_failure_dump.sh   
sudo docker exec -w / syncd /usr/bin/sai_failure_dump.sh
```

Verify that each invocation creates a uniquely named `.tar.gz` archive and does not leave a new uncompressed `.tar` file:

```
sudo ls -lh /var/log/sai_failure_dump/
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result
- **202605:** Manually validated on a live Mellanox SN4280 DUT using the updated script. Invoked the production SAI failure dump entry point:
```
sudo docker exec -w / syncd /usr/bin/sai_failure_dump.sh
```
Confirmed that seconds were included consistently in the generated directory, archive contents, and SDK dump filenames:
```
 sai_sdk_dump_09_02_2026_06_15_39_AM
```
SDK generation and tar creation completed using the second-qualified path.

Tested image version: SONiC.202605

#### Description for the changelog
Added datetime seconds to the sai_failure_dump archive name.