### PR TITLE
[alpinevs] Add alpinevs-lite to the azure build

### DIFF
--- a/.azure-pipelines/azure-pipelines-build.yml
+++ b/.azure-pipelines/azure-pipelines-build.yml
@@ -176,6 +176,7 @@ jobs:
             make $BUILD_OPTIONS target/sonic-vpp.img.gz
           elif [ $(GROUP_NAME) == alpinevs ]; then
             make $BUILD_OPTIONS target/sonic-alpinevs.img.gz
+            make $BUILD_OPTIONS target/docker-sonic-alpinevs.gz
           else
             if [ $(dbg_image) == yes ]; then
               make  $BUILD_OPTIONS INSTALL_DEBUG_TOOLS=y target/sonic-$(GROUP_NAME).bin


### PR DESCRIPTION
#### Why I did it

To create nightly builds for alpinevs-lite along with alpine

#### How I did it

Added alpinevs-lite to the azure-pipelines-build file

#### How to verify it

Downloaded the images of sonic-alpine and docker-sonic-alpinevs from the artifacts and brought them up

docker-sonic-alpinevs :

```
root@docker-alpine-dut:/home/admin# show ver

SONiC Software Version: SONiC.
SONiC OS Version: 13
Distribution: Debian N/A
Kernel: 6.18.14-1rodete4-amd64
Build commit: aec4ae6
Build date: Wed Sep  2 17:44:30 UTC 2026
Built by: azureuser@ac5b3498c000001

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 12:06:59 up 0 min,  load average: 3.59, 2.85, 2.64
Date: Thu 03 Sep 2026 12:06:59

Docker images:

root@docker-alpine-dut:/home/admin# 
```

sonic-alpine 

```
root@sonic:/home/admin# show ver

SONiC Software Version: SONiC.master-29307.1209832-92dfdf918
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: 92dfdf918
Build date: Wed Sep  2 17:22:08 UTC 2026
Built by: azureuser@ac5b3498c000001

Platform: x86_64-kvm_x86_64-r0
HwSKU: alpine_vs
ASIC: alpinevs
ASIC Count: 1
Serial Number: N/A
Model Number: N/A
Hardware Revision: N/A
Uptime: 12:16:14 up 4 min,  1 user,  load average: 1.17, 0.78, 0.34
Date: Thu 03 Sep 2026 12:16:14

Docker images:
REPOSITORY                    TAG                              IMAGE ID       SIZE
docker-snmp                   latest                           71490355c1d3   331MB
docker-snmp                   master-29307.1209832-92dfdf918   71490355c1d3   331MB
docker-fpm-frr                latest                           c492b1965723   409MB
docker-fpm-frr                master-29307.1209832-92dfdf918   c492b1965723   409MB
<snip>
```

#### Description for the changelog

Added alpinevs-lite to the azure-pipeline-builds file
