### PR TITLE
sonic-yang-models: add optional listen_addresses to SSH_SERVER|POLICIES

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/ssh-server.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/ssh-server.json
@@ -60,5 +60,32 @@
     "SSH_SERVER_INVALID_MACS": {
         "desc": "Configure invalid macs value in SSH_SERVER.",
         "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV4": {
+        "desc": "Configure a single IPv4 listen address in SSH_SERVER."
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV6": {
+        "desc": "Configure a single IPv6 listen address in SSH_SERVER."
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV4_IPV6": {
+        "desc": "Configure combined IPv4 and IPv6 listen addresses in SSH_SERVER."
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_MULTIPLE": {
+        "desc": "Configure multiple listen addresses in SSH_SERVER."
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_ABSENT": {
+        "desc": "Configure SSH_SERVER without listen_addresses."
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_MALFORMED_IPV4": {
+        "desc": "Configure malformed IPv4 listen address in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_MALFORMED_IPV6": {
+        "desc": "Configure malformed IPv6 listen address in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_WITH_PORT": {
+        "desc": "Configure listen address with a port in SSH_SERVER.",
+        "eStrKey": "InvalidValue"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/ssh-server.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/ssh-server.json
@@ -162,5 +162,77 @@
                 }
             }
         }
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV4": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "10.0.0.1" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV6": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "fe80::1" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_IPV4_IPV6": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "10.0.0.1", "fe80::1" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_MULTIPLE": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "10.0.0.1", "10.0.0.2", "fe80::1", "fe80::2" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_LISTEN_ADDRESSES_ABSENT": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "ports": "22"
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_MALFORMED_IPV4": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "10.0.0.999" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_MALFORMED_IPV6": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "fe80::zzzz" ]
+                }
+            }
+        }
+    },
+    "SSH_SERVER_INVALID_LISTEN_ADDRESSES_WITH_PORT": {
+        "sonic-ssh-server:sonic-ssh-server": {
+            "sonic-ssh-server:SSH_SERVER": {
+                "POLICIES":{
+                    "listen_addresses": [ "10.0.0.1:22" ]
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
@@ -5,6 +5,10 @@ module sonic-ssh-server {
     namespace "http://github.com/sonic-net/sonic-ssh-server";
     prefix sshg;
 
+    import ietf-inet-types {
+        prefix inet;
+    }
+
     description "SSH server daemon configuration YANG module for SONiC OS.";
 
     revision 2022-08-29 {
@@ -15,6 +19,11 @@ module sonic-ssh-server {
     revision 2023-06-07 {
         description
             "Introduce inactivity timeout and max syslogins options";
+    }
+
+    revision 2026-08-31 {
+        description
+            "Introduce listen_addresses option";
     }
 
     container sonic-ssh-server {
@@ -128,6 +137,11 @@ module sonic-ssh-server {
                         enum "umac-64-etm@openssh.com";
                         enum "umac-128-etm@openssh.com";
                     }
+                }
+                leaf-list listen_addresses {
+                    description
+                        "IPv4 and IPv6 addresses on which the SSH daemon accepts connections.";
+                    type inet:ip-address;
                 }
             }/*container policies */
         } /* container SSH_SERVER  */

--- a/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
+++ b/src/sonic-yang-models/yang-models/sonic-ssh-server.yang
@@ -11,19 +11,19 @@ module sonic-ssh-server {
 
     description "SSH server daemon configuration YANG module for SONiC OS.";
 
-    revision 2022-08-29 {
+    revision 2026-08-31 {
         description
-            "First Revision";
+            "Introduce listen_addresses option";
     }
-    
+
     revision 2023-06-07 {
         description
             "Introduce inactivity timeout and max syslogins options";
     }
 
-    revision 2026-08-31 {
+    revision 2022-08-29 {
         description
-            "Introduce listen_addresses option";
+            "First Revision";
     }
 
     container sonic-ssh-server {


### PR DESCRIPTION
## Why I did it
Implements Feature 29390131: configurable OpenSSH `ListenAddress` support. This PR adds the YANG model support for an optional `listen_addresses` field under `SSH_SERVER|POLICIES`, allowing operators to explicitly restrict the SSH daemon to a specific set of assigned IPv4/IPv6 addresses.

## Work item tracking
ADO 29390131

## How I did it
`src/sonic-yang-models/yang-models/sonic-ssh-server.yang`:
- Imported `ietf-inet-types` (prefix `inet`).
- Added revision `2026-08-31`.
- Added optional `leaf-list listen_addresses` (type `inet:ip-address`) — no default, no `min-elements`, so the field remains fully optional and devices without a management address (e.g. M0/MX) are unaffected. `inet:ip-address` rejects malformed addresses and address+port values.

Schema tests added covering: single IPv4, single IPv6, combined IPv4+IPv6, multiple addresses, config without `listen_addresses`, malformed IPv4, malformed IPv6, and address+port (all pass/fail as expected).

Note: only YANG-level syntax validation is added here. Runtime validation (whether a configured address is currently assigned to the DUT) is implemented in `hostcfgd` — see the linked sonic-host-services PR.

## How to verify it
Run the YANG model tests under `src/sonic-yang-models/tests/yang_model_tests/` for `ssh-server`.

Also validated with a full VS image build (`make target/sonic-vs.img.gz`) and an end-to-end test on a live KVM `vms-kvm-t0` testbed running this build.

Related PRs:
- sonic-net/sonic-host-services#431 (runtime implementation)
- sonic-net/sonic-mgmt#27679 (integration test)