### PR TITLE
snmp: prevent newline injection in generated config

### DIFF
--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -47,7 +47,7 @@ view   systemonly  included   .1.3.6.1.2.1.25.1
 
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
-{% set safe_community = community | replace('\n', '') | replace('\r', '') %}
+{% set safe_community = community | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RO' %}
 rocommunity {{ safe_community }}
 rocommunity6 {{ safe_community }}
@@ -57,7 +57,7 @@ rocommunity6 {{ safe_community }}
 
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
-{% set safe_community = community | replace('\n', '') | replace('\r', '') %}
+{% set safe_community = community | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RW' %}
 rwcommunity {{ safe_community }}
 rwcommunity6 {{ safe_community }}
@@ -67,12 +67,12 @@ rwcommunity6 {{ safe_community }}
 
 {% if SNMP_USER is defined %}
 {% for user in SNMP_USER %}
-{% set safe_user = user | replace('\n', '') | replace('\r', '') %}
-{% set safe_user_type = SNMP_USER[user]['SNMP_USER_TYPE'] | replace('\n', '') | replace('\r', '') %}
-{% set safe_auth_type = SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] | replace('\n', '') | replace('\r', '') %}
-{% set safe_auth_password = SNMP_USER[user]['SNMP_USER_AUTH_PASSWORD'] | replace('\n', '') | replace('\r', '') %}
-{% set safe_encryption_type = SNMP_USER[user]['SNMP_USER_ENCRYPTION_TYPE'] | replace('\n', '') | replace('\r', '') %}
-{% set safe_encryption_password = SNMP_USER[user]['SNMP_USER_ENCRYPTION_PASSWORD'] | replace('\n', '') | replace('\r', '') %}
+{% set safe_user = user | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
+{% set safe_user_type = SNMP_USER[user]['SNMP_USER_TYPE'] | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
+{% set safe_auth_type = SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
+{% set safe_auth_password = SNMP_USER[user]['SNMP_USER_AUTH_PASSWORD'] | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
+{% set safe_encryption_type = SNMP_USER[user]['SNMP_USER_ENCRYPTION_TYPE'] | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
+{% set safe_encryption_password = SNMP_USER[user]['SNMP_USER_ENCRYPTION_PASSWORD'] | replace(' ', '') | replace('\t', '') | replace('\v', '') | replace('\f', '') | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_USER[user]['SNMP_USER_PERMISSION'] == 'RO' %}
 rouser {{ safe_user }} {{ safe_user_type }}
 CreateUser {{ safe_user }} {{ safe_auth_type }} {{ safe_auth_password }} {{ safe_encryption_type }} {{ safe_encryption_password }}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -47,18 +47,20 @@ view   systemonly  included   .1.3.6.1.2.1.25.1
 
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
+{% set safe_community = community | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RO' %}
-rocommunity {{ community }}
-rocommunity6 {{ community }}
+rocommunity {{ safe_community }}
+rocommunity6 {{ safe_community }}
 {% endif %}
 {% endfor %}
 {% endif %}
 
 {% if SNMP_COMMUNITY is defined %}
 {% for community in SNMP_COMMUNITY %}
+{% set safe_community = community | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_COMMUNITY[community]['TYPE'] == 'RW' %}
-rwcommunity {{ community }}
-rwcommunity6 {{ community }}
+rwcommunity {{ safe_community }}
+rwcommunity6 {{ safe_community }}
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/dockers/docker-snmp/snmpd.conf.j2
+++ b/dockers/docker-snmp/snmpd.conf.j2
@@ -65,12 +65,18 @@ rwcommunity6 {{ community }}
 
 {% if SNMP_USER is defined %}
 {% for user in SNMP_USER %}
+{% set safe_user = user | replace('\n', '') | replace('\r', '') %}
+{% set safe_user_type = SNMP_USER[user]['SNMP_USER_TYPE'] | replace('\n', '') | replace('\r', '') %}
+{% set safe_auth_type = SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] | replace('\n', '') | replace('\r', '') %}
+{% set safe_auth_password = SNMP_USER[user]['SNMP_USER_AUTH_PASSWORD'] | replace('\n', '') | replace('\r', '') %}
+{% set safe_encryption_type = SNMP_USER[user]['SNMP_USER_ENCRYPTION_TYPE'] | replace('\n', '') | replace('\r', '') %}
+{% set safe_encryption_password = SNMP_USER[user]['SNMP_USER_ENCRYPTION_PASSWORD'] | replace('\n', '') | replace('\r', '') %}
 {% if SNMP_USER[user]['SNMP_USER_PERMISSION'] == 'RO' %}
-rouser {{ user }} {{ SNMP_USER[user]['SNMP_USER_TYPE'] }}
-CreateUser {{ user }} {{ SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] }} {{ SNMP_USER[user]['SNMP_USER_AUTH_PASSWORD'] }} {{ SNMP_USER[user]['SNMP_USER_ENCRYPTION_TYPE'] }} {{ SNMP_USER[user]['SNMP_USER_ENCRYPTION_PASSWORD'] }}
+rouser {{ safe_user }} {{ safe_user_type }}
+CreateUser {{ safe_user }} {{ safe_auth_type }} {{ safe_auth_password }} {{ safe_encryption_type }} {{ safe_encryption_password }}
 {% elif SNMP_USER[user]['SNMP_USER_PERMISSION'] == 'RW' %}
-rwuser {{ user }} {{ SNMP_USER[user]['SNMP_USER_TYPE'] }}
-CreateUser {{ user }} {{ SNMP_USER[user]['SNMP_USER_AUTH_TYPE'] }} {{ SNMP_USER[user]['SNMP_USER_AUTH_PASSWORD'] }} {{ SNMP_USER[user]['SNMP_USER_ENCRYPTION_TYPE'] }} {{ SNMP_USER[user]['SNMP_USER_ENCRYPTION_PASSWORD'] }}
+rwuser {{ safe_user }} {{ safe_user_type }}
+CreateUser {{ safe_user }} {{ safe_auth_type }} {{ safe_auth_password }} {{ safe_encryption_type }} {{ safe_encryption_password }}
 {% endif %}
 {% endfor %}
 {% else %}

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -342,6 +342,49 @@ class TestJ2Files(TestCase):
         argument = ['-a', json.dumps({'SNMP_USER': users}), '-t', snmpd_conf_template]
         return self.run_script(argument)
 
+    def render_snmpd_community_conf(self, communities):
+        snmpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-snmp', 'snmpd.conf.j2')
+        argument = ['-a', json.dumps({'SNMP_COMMUNITY': communities}), '-t', snmpd_conf_template]
+        return self.run_script(argument)
+
+    def test_snmpd_community_rendering(self):
+        communities = {
+            'readcommunity': {'TYPE': 'RO'},
+            'writecommunity': {'TYPE': 'RW'}
+        }
+
+        output = self.render_snmpd_community_conf(communities)
+
+        self.assertIn('rocommunity readcommunity\n', output)
+        self.assertIn('rocommunity6 readcommunity\n', output)
+        self.assertIn('rwcommunity writecommunity\n', output)
+        self.assertIn('rwcommunity6 writecommunity\n', output)
+
+    def test_snmpd_community_newline_injection(self):
+        line_endings = ('\n', '\r', '\r\n')
+        communities = {}
+        expected_values = []
+
+        for community_type in ('RO', 'RW'):
+            for ending_index, line_ending in enumerate(line_endings):
+                marker = '{}_{}'.format(community_type, ending_index)
+                injected_directive = 'rwcommunity\tevil_{}'.format(marker)
+                safe_community = 'safe_{}{}'.format(marker, injected_directive)
+                community = 'safe_{}{}{}'.format(marker, line_ending, injected_directive)
+                communities[community] = {'TYPE': community_type}
+                expected_values.append((community_type, safe_community, injected_directive))
+
+        output = self.render_snmpd_community_conf(communities)
+
+        self.assertNotIn('\r', output)
+        for community_type, safe_community, injected_directive in expected_values:
+            directive = 'rocommunity' if community_type == 'RO' else 'rwcommunity'
+            self.assertIn('{} {}\n'.format(directive, safe_community), output)
+            self.assertFalse(any(
+                line.strip() == injected_directive
+                for line in output.splitlines()
+            ))
+
     def test_snmpd_user_rendering(self):
         users = {
             'readuser': {

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -337,6 +337,76 @@ class TestJ2Files(TestCase):
         output = self.run_script(argument)
 
         self.assertIn('configure system hostname DUT_ASW-01.example\n', output)
+    def render_snmpd_conf(self, users):
+        snmpd_conf_template = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-snmp', 'snmpd.conf.j2')
+        argument = ['-a', json.dumps({'SNMP_USER': users}), '-t', snmpd_conf_template]
+        return self.run_script(argument)
+
+    def test_snmpd_user_rendering(self):
+        users = {
+            'readuser': {
+                'SNMP_USER_TYPE': 'Priv',
+                'SNMP_USER_PERMISSION': 'RO',
+                'SNMP_USER_AUTH_TYPE': 'SHA',
+                'SNMP_USER_AUTH_PASSWORD': 'auth_pass',
+                'SNMP_USER_ENCRYPTION_TYPE': 'AES',
+                'SNMP_USER_ENCRYPTION_PASSWORD': 'encry_pass'
+            },
+            'writeuser': {
+                'SNMP_USER_TYPE': 'Priv',
+                'SNMP_USER_PERMISSION': 'RW',
+                'SNMP_USER_AUTH_TYPE': 'SHA',
+                'SNMP_USER_AUTH_PASSWORD': 'auth_pass',
+                'SNMP_USER_ENCRYPTION_TYPE': 'AES',
+                'SNMP_USER_ENCRYPTION_PASSWORD': 'encry_pass'
+            }
+        }
+
+        output = self.render_snmpd_conf(users)
+
+        self.assertIn('rouser readuser Priv\n', output)
+        self.assertIn('CreateUser readuser SHA auth_pass AES encry_pass\n', output)
+        self.assertIn('rwuser writeuser Priv\n', output)
+        self.assertIn('CreateUser writeuser SHA auth_pass AES encry_pass\n', output)
+
+    def test_snmpd_user_newline_injection(self):
+        rendered_fields = (
+            'name',
+            'SNMP_USER_TYPE',
+            'SNMP_USER_AUTH_TYPE',
+            'SNMP_USER_AUTH_PASSWORD',
+            'SNMP_USER_ENCRYPTION_TYPE',
+            'SNMP_USER_ENCRYPTION_PASSWORD'
+        )
+        line_endings = ('\n', '\r', '\r\n')
+        users = {}
+        expected_values = []
+
+        for permission in ('RO', 'RW'):
+            for field_index, field in enumerate(rendered_fields):
+                for ending_index, line_ending in enumerate(line_endings):
+                    marker = '{}_{}_{}'.format(permission, field_index, ending_index)
+                    injected_directive = 'rocommunity\t{}'.format(marker)
+                    values = {
+                        'name': 'user{}'.format(marker),
+                        'SNMP_USER_TYPE': 'Priv',
+                        'SNMP_USER_PERMISSION': permission,
+                        'SNMP_USER_AUTH_TYPE': 'SHA',
+                        'SNMP_USER_AUTH_PASSWORD': 'auth_pass',
+                        'SNMP_USER_ENCRYPTION_TYPE': 'AES',
+                        'SNMP_USER_ENCRYPTION_PASSWORD': 'encry_pass'
+                    }
+                    values[field] += line_ending + injected_directive
+                    user = values.pop('name')
+                    users[user] = values
+                    expected_values.append((line_ending, injected_directive))
+
+        output = self.render_snmpd_conf(users)
+
+        self.assertNotIn('\r', output)
+        for line_ending, injected_directive in expected_values:
+            self.assertNotIn(line_ending + injected_directive, output)
+            self.assertIn(injected_directive, output)
 
     def test_ipinip(self):
         ipinip_file = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ipinip.json.j2')

--- a/src/sonic-config-engine/tests/test_j2files.py
+++ b/src/sonic-config-engine/tests/test_j2files.py
@@ -360,28 +360,34 @@ class TestJ2Files(TestCase):
         self.assertIn('rwcommunity writecommunity\n', output)
         self.assertIn('rwcommunity6 writecommunity\n', output)
 
-    def test_snmpd_community_newline_injection(self):
-        line_endings = ('\n', '\r', '\r\n')
+    def test_snmpd_community_configuration_injection(self):
+        whitespace_separators = (' ', '\t', '\v', '\f', '\n', '\r', '\r\n')
         communities = {}
         expected_values = []
 
         for community_type in ('RO', 'RW'):
-            for ending_index, line_ending in enumerate(line_endings):
-                marker = '{}_{}'.format(community_type, ending_index)
-                injected_directive = 'rwcommunity\tevil_{}'.format(marker)
-                safe_community = 'safe_{}{}'.format(marker, injected_directive)
-                community = 'safe_{}{}{}'.format(marker, line_ending, injected_directive)
+            for separator_index, separator in enumerate(whitespace_separators):
+                marker = '{}_{}'.format(community_type, separator_index)
+                injected_tokens = 'rwcommunity evil_{}'.format(marker)
+                unsafe_community = 'safe_{}{}{}'.format(marker, separator, injected_tokens)
+                safe_community = 'safe_{}{}'.format(marker, injected_tokens.replace(' ', ''))
+                community = unsafe_community
                 communities[community] = {'TYPE': community_type}
-                expected_values.append((community_type, safe_community, injected_directive))
+                expected_values.append((community_type, unsafe_community, safe_community, injected_tokens))
 
         output = self.render_snmpd_community_conf(communities)
 
         self.assertNotIn('\r', output)
-        for community_type, safe_community, injected_directive in expected_values:
+        self.assertNotIn('\t', output)
+        self.assertNotIn('\v', output)
+        self.assertNotIn('\f', output)
+        for community_type, unsafe_community, safe_community, injected_tokens in expected_values:
             directive = 'rocommunity' if community_type == 'RO' else 'rwcommunity'
+            self.assertNotIn(unsafe_community, output)
             self.assertIn('{} {}\n'.format(directive, safe_community), output)
+            self.assertIn('{}6 {}\n'.format(directive, safe_community), output)
             self.assertFalse(any(
-                line.strip() == injected_directive
+                line.strip() == injected_tokens
                 for line in output.splitlines()
             ))
 
@@ -412,7 +418,7 @@ class TestJ2Files(TestCase):
         self.assertIn('rwuser writeuser Priv\n', output)
         self.assertIn('CreateUser writeuser SHA auth_pass AES encry_pass\n', output)
 
-    def test_snmpd_user_newline_injection(self):
+    def test_snmpd_user_configuration_injection(self):
         rendered_fields = (
             'name',
             'SNMP_USER_TYPE',
@@ -421,15 +427,15 @@ class TestJ2Files(TestCase):
             'SNMP_USER_ENCRYPTION_TYPE',
             'SNMP_USER_ENCRYPTION_PASSWORD'
         )
-        line_endings = ('\n', '\r', '\r\n')
+        whitespace_separators = (' ', '\t', '\v', '\f', '\n', '\r', '\r\n')
         users = {}
         expected_values = []
 
         for permission in ('RO', 'RW'):
             for field_index, field in enumerate(rendered_fields):
-                for ending_index, line_ending in enumerate(line_endings):
-                    marker = '{}_{}_{}'.format(permission, field_index, ending_index)
-                    injected_directive = 'rocommunity\t{}'.format(marker)
+                for separator_index, separator in enumerate(whitespace_separators):
+                    marker = '{}_{}_{}'.format(permission, field_index, separator_index)
+                    injected_tokens = 'rocommunity {}'.format(marker)
                     values = {
                         'name': 'user{}'.format(marker),
                         'SNMP_USER_TYPE': 'Priv',
@@ -439,17 +445,26 @@ class TestJ2Files(TestCase):
                         'SNMP_USER_ENCRYPTION_TYPE': 'AES',
                         'SNMP_USER_ENCRYPTION_PASSWORD': 'encry_pass'
                     }
-                    values[field] += line_ending + injected_directive
+                    unsafe_value = values[field] + separator + injected_tokens
+                    safe_value = values[field] + injected_tokens.replace(' ', '')
+                    values[field] = unsafe_value
                     user = values.pop('name')
                     users[user] = values
-                    expected_values.append((line_ending, injected_directive))
+                    expected_values.append((unsafe_value, safe_value, injected_tokens))
 
         output = self.render_snmpd_conf(users)
 
         self.assertNotIn('\r', output)
-        for line_ending, injected_directive in expected_values:
-            self.assertNotIn(line_ending + injected_directive, output)
-            self.assertIn(injected_directive, output)
+        self.assertNotIn('\t', output)
+        self.assertNotIn('\v', output)
+        self.assertNotIn('\f', output)
+        for unsafe_value, safe_value, injected_tokens in expected_values:
+            self.assertNotIn(unsafe_value, output)
+            self.assertIn(safe_value, output)
+            self.assertFalse(any(
+                line.strip() == injected_tokens
+                for line in output.splitlines()
+            ))
 
     def test_ipinip(self):
         ipinip_file = os.path.join(self.test_dir, '..', '..', '..', 'dockers', 'docker-orchagent', 'ipinip.json.j2')

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -41,6 +41,10 @@
         "desc": "Load SNMP community string containing CRLF.",
         "eStr": "Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
     },
+    "SNMP_COMMUNITY_TAB_NEG_TEST": {
+        "desc": "Load SNMP community string containing tab.",
+        "eStr": "Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+    },
     "SNMP_RO_USER_NAME_TEST": {
         "desc": "Load valid RO SNMP user"
     },
@@ -69,6 +73,10 @@
     },
     "SNMP_USER_NAME_CRLF_NEG_TEST": {
         "desc": "Load SNMP user name containing CRLF",
+        "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
+    },
+    "SNMP_USER_NAME_TAB_NEG_TEST": {
+        "desc": "Load SNMP user name containing tab",
         "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
     },
     "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
@@ -124,6 +132,10 @@
         "desc": "Load SNMP authentication password containing CRLF",
         "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
+    "SNMP_USER_AUTH_PASSWORD_TAB_NEG_TEST": {
+        "desc": "Load SNMP authentication password containing tab",
+        "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
     "SNMP_USER_PRIV_TEST": {
         "desc": "Load SNMP user with user type Priv with AES encryption type"
     },
@@ -156,6 +168,10 @@
     },
     "SNMP_USER_ENCRYPTION_PASSWORD_CRLF_NEG_TEST": {
         "desc": "Load SNMP encryption password containing CRLF",
+        "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_TAB_NEG_TEST": {
+        "desc": "Load SNMP encryption password containing tab",
         "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
     "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -29,6 +29,18 @@
         "desc": "Load SNMP community string with un supported type.",
         "eStrKey": "InvalidValue"
     },
+    "SNMP_COMMUNITY_LF_NEG_TEST": {
+        "desc": "Load SNMP community string containing LF.",
+        "eStr": "Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+    },
+    "SNMP_COMMUNITY_CR_NEG_TEST": {
+        "desc": "Load SNMP community string containing CR.",
+        "eStr": "Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+    },
+    "SNMP_COMMUNITY_CRLF_NEG_TEST": {
+        "desc": "Load SNMP community string containing CRLF.",
+        "eStr": "Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\" and \"\\\")"
+    },
     "SNMP_RO_USER_NAME_TEST": {
         "desc": "Load valid RO SNMP user"
     },

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/snmp.json
@@ -47,6 +47,18 @@
         "desc": "Load SNMP user with invalid value",
         "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
     },
+    "SNMP_USER_NAME_LF_NEG_TEST": {
+        "desc": "Load SNMP user name containing LF",
+        "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
+    },
+    "SNMP_USER_NAME_CR_NEG_TEST": {
+        "desc": "Load SNMP user name containing CR",
+        "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
+    },
+    "SNMP_USER_NAME_CRLF_NEG_TEST": {
+        "desc": "Load SNMP user name containing CRLF",
+        "eStr": "Invalid snmp user string (Valid chars are ASCII printable except SPACE, single quote,\"@\", \",\", \"\\\" and \":\")"
+    },
     "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
         "desc": "Load SNMP user with no user type",
         "eStrKey": "Must"
@@ -88,6 +100,18 @@
         "desc": "Load SNMP user with user type AuthNoPriv with invalid auth password",
         "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
+    "SNMP_USER_AUTH_PASSWORD_LF_NEG_TEST": {
+        "desc": "Load SNMP authentication password containing LF",
+        "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_AUTH_PASSWORD_CR_NEG_TEST": {
+        "desc": "Load SNMP authentication password containing CR",
+        "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_AUTH_PASSWORD_CRLF_NEG_TEST": {
+        "desc": "Load SNMP authentication password containing CRLF",
+        "eStr": "Invalid snmp user authentication password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
     "SNMP_USER_PRIV_TEST": {
         "desc": "Load SNMP user with user type Priv with AES encryption type"
     },
@@ -108,6 +132,18 @@
     },
     "SNMP_USER_PRIV_INVALID_ENCRYPT_PASS_NEG_TEST": {
         "desc": "Load SNMP user with user type Priv with invalid encryption password",
+        "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_LF_NEG_TEST": {
+        "desc": "Load SNMP encryption password containing LF",
+        "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_CR_NEG_TEST": {
+        "desc": "Load SNMP encryption password containing CR",
+        "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_CRLF_NEG_TEST": {
+        "desc": "Load SNMP encryption password containing CRLF",
         "eStr": "Invalid snmp user encryption password (Valid chars are ASCII printable except \":\" and\"@\")"
     },
     "SNMP_USER_PRIV_SHORT_ENCRYPT_PASS_NEG_TEST": {
@@ -153,4 +189,3 @@
         "eStr": ["ip"]
     }
 }
-

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -175,6 +175,57 @@
             }
          }
     },
+    "SNMP_USER_NAME_LF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser\nrocommunity\tevil",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_CR_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser\rrocommunity\tevil",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_CRLF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser\r\nrocommunity\tevil",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
     "SNMP_USER_NO_USER_TYPE_NEG_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {
@@ -376,6 +427,57 @@
             }
          }
     },
+    "SNMP_USER_AUTH_PASSWORD_LF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "authpass\nrocommunity\tevil",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_PASSWORD_CR_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "authpass\rrocommunity\tevil",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_AUTH_PASSWORD_CRLF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "authpass\r\nrocommunity\tevil",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
     "SNMP_USER_PRIV_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {
@@ -473,6 +575,57 @@
                        "SNMP_USER_AUTH_TYPE": "SHA",
                        "SNMP_USER_ENCRYPTION_TYPE": "AES",
                        "SNMP_USER_ENCRYPTION_PASSWORD": "encry@pass"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_LF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encrypass\nrocommunity\tevil"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_CR_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encrypass\rrocommunity\tevil"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_CRLF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encrypass\r\nrocommunity\tevil"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -125,6 +125,18 @@
             }
         }
     },
+    "SNMP_COMMUNITY_TAB_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_COMMUNITY": {
+                "SNMP_COMMUNITY_LIST": [
+                    {
+                        "name": "safe\tevil",
+                        "TYPE": "RO"
+                    }
+                ]
+            }
+        }
+    },
     "SNMP_RO_USER_NAME_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {
@@ -251,6 +263,23 @@
                 "SNMP_USER_LIST": [
                     {
                        "name": "testuser\r\nrocommunity\tevil",
+                       "SNMP_USER_TYPE": "noAuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RO",
+                       "SNMP_USER_AUTH_TYPE": "",
+                       "SNMP_USER_AUTH_PASSWORD": "",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_NAME_TAB_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser\tevil",
                        "SNMP_USER_TYPE": "noAuthNoPriv",
                        "SNMP_USER_PERMISSION": "RO",
                        "SNMP_USER_AUTH_TYPE": "",
@@ -514,6 +543,23 @@
             }
          }
     },
+    "SNMP_USER_AUTH_PASSWORD_TAB_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "AuthNoPriv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "authpass\tevil",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": ""
+                    }
+                ]
+            }
+         }
+    },
     "SNMP_USER_PRIV_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {
@@ -662,6 +708,23 @@
                        "SNMP_USER_AUTH_TYPE": "SHA",
                        "SNMP_USER_ENCRYPTION_TYPE": "AES",
                        "SNMP_USER_ENCRYPTION_PASSWORD": "encrypass\r\nrocommunity\tevil"
+                    }
+                ]
+            }
+         }
+    },
+    "SNMP_USER_ENCRYPTION_PASSWORD_TAB_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_USER": {
+                "SNMP_USER_LIST": [
+                    {
+                       "name": "testuser",
+                       "SNMP_USER_TYPE": "Priv",
+                       "SNMP_USER_PERMISSION": "RW",
+                       "SNMP_USER_AUTH_PASSWORD": "auth_pass",
+                       "SNMP_USER_AUTH_TYPE": "SHA",
+                       "SNMP_USER_ENCRYPTION_TYPE": "AES",
+                       "SNMP_USER_ENCRYPTION_PASSWORD": "encrypass\tevil"
                     }
                 ]
             }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/snmp.json
@@ -89,6 +89,42 @@
             }
         }
     },
+    "SNMP_COMMUNITY_LF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_COMMUNITY": {
+                "SNMP_COMMUNITY_LIST": [
+                    {
+                        "name": "safe\nrwcommunity\tevil",
+                        "TYPE": "RO"
+                    }
+                ]
+            }
+        }
+    },
+    "SNMP_COMMUNITY_CR_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_COMMUNITY": {
+                "SNMP_COMMUNITY_LIST": [
+                    {
+                        "name": "safe\rrwcommunity\tevil",
+                        "TYPE": "RO"
+                    }
+                ]
+            }
+        }
+    },
+    "SNMP_COMMUNITY_CRLF_NEG_TEST": {
+        "sonic-snmp:sonic-snmp": {
+            "sonic-snmp:SNMP_COMMUNITY": {
+                "SNMP_COMMUNITY_LIST": [
+                    {
+                        "name": "safe\r\nrwcommunity\tevil",
+                        "TYPE": "RO"
+                    }
+                ]
+            }
+        }
+    },
     "SNMP_RO_USER_NAME_TEST": {
         "sonic-snmp:sonic-snmp": {
             "sonic-snmp:SNMP_USER": {

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -59,7 +59,7 @@ module sonic-snmp {
         leaf name {
           type string {
               length "4..32";
-              pattern '[^ @,\\' +"']*" {
+              pattern '[^ @,\n\r\\' +"']*" {
                   error-message 'Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,"@", "," and "\")';
               }
           }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -87,7 +87,7 @@ module sonic-snmp {
         leaf name {
           type string {
               length "4..32";
-              pattern '[^ :@,\\' +"']*" {
+              pattern '[^ :@,\n\r\\' +"']*" {
                   error-message 'Invalid snmp user string (Valid chars are ASCII printable except \
                                  SPACE, single quote,"@", ",", "\" and ":")';
               }
@@ -127,7 +127,7 @@ module sonic-snmp {
         leaf SNMP_USER_AUTH_PASSWORD {
           type string {
               length "0..64";
-              pattern '[^ @:]*' {
+              pattern '[^ @:\n\r]*' {
                   error-message 'Invalid snmp user authentication password (Valid chars are ASCII
                                  printable except ":" and"@")';
               }
@@ -151,7 +151,7 @@ module sonic-snmp {
           mandatory true;
           type string {
               length "0..64";
-              pattern '[^ @:]*' {
+              pattern '[^ @:\n\r]*' {
                   error-message 'Invalid snmp user encryption password (Valid chars are ASCII \
                                  printable except ":" and"@")';
               }

--- a/src/sonic-yang-models/yang-models/sonic-snmp.yang
+++ b/src/sonic-yang-models/yang-models/sonic-snmp.yang
@@ -59,7 +59,7 @@ module sonic-snmp {
         leaf name {
           type string {
               length "4..32";
-              pattern '[^ @,\n\r\\' +"']*" {
+              pattern '[^ @,\t\n\r\\' +"']*" {
                   error-message 'Invalid snmp community string (Valid chars are ASCII printable except SPACE, single quote,"@", "," and "\")';
               }
           }
@@ -87,7 +87,7 @@ module sonic-snmp {
         leaf name {
           type string {
               length "4..32";
-              pattern '[^ :@,\n\r\\' +"']*" {
+              pattern '[^ :@,\t\n\r\\' +"']*" {
                   error-message 'Invalid snmp user string (Valid chars are ASCII printable except \
                                  SPACE, single quote,"@", ",", "\" and ":")';
               }
@@ -127,7 +127,7 @@ module sonic-snmp {
         leaf SNMP_USER_AUTH_PASSWORD {
           type string {
               length "0..64";
-              pattern '[^ @:\n\r]*' {
+              pattern '[^ @:\t\n\r]*' {
                   error-message 'Invalid snmp user authentication password (Valid chars are ASCII
                                  printable except ":" and"@")';
               }
@@ -151,7 +151,7 @@ module sonic-snmp {
           mandatory true;
           type string {
               length "0..64";
-              pattern '[^ @:\n\r]*' {
+              pattern '[^ @:\t\n\r]*' {
                   error-message 'Invalid snmp user encryption password (Valid chars are ASCII \
                                  printable except ":" and"@")';
               }


### PR DESCRIPTION
#### Why I did it

`SNMP_USER` values and `SNMP_COMMUNITY` keys were rendered directly into whitespace-delimited `snmpd.conf` directives. Values containing LF, CR, CRLF, spaces, tabs, vertical tabs, or form feeds could create additional directives or alter directive arguments when ConfigDB/YANG validation was bypassed through a direct Redis write.

##### Work item tracking
- Microsoft ADO **(number only)**: 39463594

#### How I did it

- Added leaf-specific YANG patterns rejecting carriage returns, line feeds, and tabs in SNMP user names, authentication passwords, encryption passwords, and community names.
- Kept the validation changes local to the affected leaves; no shared typedef was broadened or changed.
- Removed Net-SNMP whitespace separators (space, tab, vertical tab, form feed, CR, and LF) from every rendered `SNMP_USER` value at the `snmpd.conf.j2` sink.
- Applied the same sink protection to community keys used by `rocommunity`, `rocommunity6`, `rwcommunity`, and `rwcommunity6`.
- Protected both RO and RW paths and retained valid clean rendering behavior.
- Added YANG negative cases for LF, CR, CRLF, and tabs in all affected free-form fields.
- Added real `sonic-cfggen` coverage for same-line argument injection and newline configuration injection.

#### How to verify it

```bash
make target/python-wheels/trixie/sonic_yang_models-1.0-py3-none-any.whl

cd src/sonic-config-engine
python3 -m pytest -q tests/test_j2files.py \
  -k "snmpd_community or snmpd_user"
python3 -m pytest -q tests/test_j2files.py
```

Latest results after addressing review comments:
- Complete YANG model package suite: `930 passed`
- Focused SNMP rendering suite: `4 passed, 56 deselected`
- Complete configuration rendering suite: `60 passed`
- SNMP user rendering covers six fields, seven whitespace separators, and RO/RW: 84 malicious combinations.
- Community rendering covers seven whitespace separators, RO/RW, and IPv4/IPv6 directives: 14 malicious combinations.
- No malicious value produced a standalone directive or retained whitespace-delimited injected arguments.
- Independent review of the final diff found no significant issues.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master (`805f84fda`): YANG `930 passed`; focused SNMP rendering `4 passed, 56 deselected`; complete rendering `60 passed`

#### Description for the changelog

Prevent Net-SNMP configuration and argument injection through whitespace characters in SNMP user and community configuration values.

#### Link to config_db schema for YANG module changes

https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#snmp

#### A picture of a cute animal (not mandatory but encouraged)