### PR TITLE
[sonic-ctrmgrd]: Harden Kubernetes command execution

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -91,7 +91,7 @@ def _run_command_list(cmd, timeout=5):
     try:
         proc = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-        (o, e) = proc.communicate(timeout)
+        (o, e) = proc.communicate(timeout=timeout)
         output = to_str(o)
         err = to_str(e)
         ret = proc.returncode
@@ -112,14 +112,16 @@ def _run_command_list(cmd, timeout=5):
 
 def kube_read_labels():
     """ Read current labels on node and return as dict. """
-    KUBECTL_GET_CMD = "kubectl --kubeconfig {} get nodes {} --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '"
-
     labels = {}
-    ret, out, _ = _run_command(KUBECTL_GET_CMD.format(
-        KUBE_ADMIN_CONF, get_device_name()))
+    ret, out, _ = _run_command_list([
+        "kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+        get_device_name(), "--show-labels", "--no-headers"
+    ], timeout=60)
 
     if ret == 0:
-        lst = out.split(",")
+        lines = out.splitlines()
+        columns = lines[0].split(None, 5) if lines else []
+        lst = columns[5].split(",") if len(columns) == 6 else []
 
         for label in lst:
             tmp = label.split("=")
@@ -188,9 +190,10 @@ def func_get_labels(args):
 
 def is_ready_as_k8s_node():
     """ Check if current node status is ready or not from k8s cluster """
-    KUBECTL_GET_CMD = "kubectl --kubeconfig {} get nodes {} --no-headers"
-    ret, out, _ = _run_command(KUBECTL_GET_CMD.format(
-        KUBE_ADMIN_CONF, get_device_name()))
+    ret, out, _ = _run_command_list([
+        "kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+        get_device_name(), "--no-headers"
+    ], timeout=60)
     if ret != 0:
         log_debug("Failed to get node from Kube cluster")
         return False
@@ -345,12 +348,16 @@ def _do_reset(pending_join = False):
     # Drain & delete self from cluster. If not, the next join would fail
     #
     if os.path.exists(KUBE_ADMIN_CONF):
-        _run_command(
-                "kubectl --kubeconfig {} --request-timeout 20s drain {} --ignore-daemonsets".
-                format(KUBE_ADMIN_CONF, get_device_name()))
+        _run_command_list([
+            "kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+            "--request-timeout", "20s", "drain", get_device_name(),
+            "--ignore-daemonsets"
+        ], timeout=60)
 
-        _run_command("kubectl --kubeconfig {} --request-timeout 20s delete node {}".
-                format(KUBE_ADMIN_CONF, get_device_name()))
+        _run_command_list([
+            "kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+            "--request-timeout", "20s", "delete", "node", get_device_name()
+        ], timeout=60)
 
     _run_command("kubeadm reset -f")
     _run_command("rm -rf {}".format(CNI_DIR))
@@ -360,7 +367,6 @@ def _do_reset(pending_join = False):
 
 
 def _do_join(server, port, insecure):
-    KUBEADM_JOIN_CMD = "kubeadm join --discovery-file {} --node-name {}"
     err = ""
     out = ""
     ret = 0
@@ -374,8 +380,10 @@ def _do_join(server, port, insecure):
         (ret, _, _) = _run_command("systemctl start kubelet")
 
         if ret == 0:
-            (ret, out, err) = _run_command(KUBEADM_JOIN_CMD.format(
-                KUBE_ADMIN_CONF, get_device_name()), timeout=360)
+            (ret, out, err) = _run_command_list([
+                "kubeadm", "join", "--discovery-file", KUBE_ADMIN_CONF,
+                "--node-name", get_device_name()
+            ], timeout=360)
             log_debug("ret = {}".format(ret))
 
     except IOError as e:

--- a/src/sonic-ctrmgrd/tests/common_test.py
+++ b/src/sonic-ctrmgrd/tests/common_test.py
@@ -619,7 +619,9 @@ class mock_proc:
         return ("", "")
 
 
-    def communicate(self, timeout):
+    def communicate(self, input=None, timeout=None):
+        assert input is None
+        assert timeout is not None
         if self.trigger_throw:
             raise IOError()
 

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -26,9 +26,13 @@ read_labels_test_data = {
     0: {
         common_test.DESCR: "read labels",
         common_test.RETVAL: 0,
-        common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
-        common_test.PROC_OUT: ["foo=bar,hello=world"],
+        common_test.PROC_CMD: [
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--show-labels", "--no-headers"]
+        ],
+        common_test.PROC_OUT: [
+            "none Ready <role> 10d v1.28.0 foo=bar,hello=world"
+        ],
         common_test.POST: {
             "foo": "bar",
             "hello": "world"
@@ -39,8 +43,10 @@ kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | c
         common_test.DESCR: "read labels timeout",
         common_test.TRIGGER_THROW: True,
         common_test.RETVAL: -1,
-        common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
+        common_test.PROC_CMD: [
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--show-labels", "--no-headers"]
+        ],
         common_test.POST: {
         },
         common_test.PROC_KILLED: 1
@@ -48,8 +54,10 @@ kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | c
     2: {
         common_test.DESCR: "read labels fail",
         common_test.RETVAL: -1,
-        common_test.PROC_CMD: ["\
-kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)],
+        common_test.PROC_CMD: [
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--show-labels", "--no-headers"]
+        ],
         common_test.PROC_OUT: [""],
         common_test.PROC_ERR: ["command failed"],
         common_test.POST: {
@@ -64,20 +72,20 @@ write_labels_test_data = {
         common_test.RETVAL: 0,
         common_test.ARGS: { "foo": "bar", "hello": "World!", "test": "ok" },
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF),
+["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes", "none", "--show-labels", "--no-headers"],
 ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "label", "--overwrite", "nodes", "none", "hello-"],
 ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "label", "--overwrite", "nodes", "none", "hello=World!", "test=ok"]
  ],
-        common_test.PROC_OUT: ["foo=bar,hello=world", "", ""]
+        common_test.PROC_OUT: ["none Ready <role> 10d v1.28.0 foo=bar,hello=world", "", ""]
     },
     1: {
         common_test.DESCR: "write labels: skip as no change",
         common_test.RETVAL: 0,
         common_test.ARGS: { "foo": "bar", "hello": "world" },
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
+["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes", "none", "--show-labels", "--no-headers"]
  ],
-        common_test.PROC_OUT: ["foo=bar,hello=world"]
+        common_test.PROC_OUT: ["none Ready <role> 10d v1.28.0 foo=bar,hello=world"]
     },
     2: {
         common_test.DESCR: "write labels",
@@ -85,7 +93,7 @@ write_labels_test_data = {
         common_test.ARGS: { "any": "thing" },
         common_test.RETVAL: -1,
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF)
+["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes", "none", "--show-labels", "--no-headers"]
 ],
         common_test.PROC_ERR: ["read failed"]
     },
@@ -94,7 +102,7 @@ write_labels_test_data = {
         common_test.RETVAL: 0,
         common_test.ARGS: { "foo; id>/tmp/pwned #": "bar; rm -rf / #" },
         common_test.PROC_CMD: [
-"kubectl --kubeconfig {} get nodes none --show-labels --no-headers |tr -s ' ' | cut -f6 -d' '".format(KUBE_ADMIN_CONF),
+["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes", "none", "--show-labels", "--no-headers"],
 ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "label", "--overwrite", "nodes", "none", "foo; id>/tmp/pwned #=bar; rm -rf / #"]
  ],
         common_test.PROC_OUT: ["", ""]
@@ -107,10 +115,11 @@ join_test_data = {
         common_test.RETVAL: 0,
         common_test.ARGS: ["10.3.157.24", 6443, "true", False],
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} --request-timeout 20s drain none \
---ignore-daemonsets".format(KUBE_ADMIN_CONF),
-            "kubectl --kubeconfig {} --request-timeout 20s delete node \
-none".format(KUBE_ADMIN_CONF),
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "drain", "none",
+             "--ignore-daemonsets"],
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "delete", "node", "none"],
             "kubeadm reset -f",
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
@@ -118,10 +127,9 @@ none".format(KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
             "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name none".format(
-                KUBE_ADMIN_CONF)
+            ["kubeadm", "join", "--discovery-file", KUBE_ADMIN_CONF,
+             "--node-name", "none"]
         ],
-        common_test.PROC_RUN: [True, True],
         common_test.REQ: {
             "data": {"ca.crt": "test"}
         }
@@ -131,10 +139,11 @@ none".format(KUBE_ADMIN_CONF),
         common_test.RETVAL: 0,
         common_test.ARGS: ["10.3.157.24", 6443, "false", False],
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} --request-timeout 20s drain none \
---ignore-daemonsets".format(KUBE_ADMIN_CONF),
-            "kubectl --kubeconfig {} --request-timeout 20s delete node \
-none".format(KUBE_ADMIN_CONF),
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "drain", "none",
+             "--ignore-daemonsets"],
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "delete", "node", "none"],
             "kubeadm reset -f",
             "rm -rf {}".format(CNI_DIR),
             "systemctl stop kubelet",
@@ -142,10 +151,9 @@ none".format(KUBE_ADMIN_CONF),
             "mkdir -p {}".format(CNI_DIR),
             "cp {} {}".format(FLANNEL_CONF_FILE, CNI_DIR),
             "systemctl start kubelet",
-            "kubeadm join --discovery-file {} --node-name none".format(
-                KUBE_ADMIN_CONF)
+            ["kubeadm", "join", "--discovery-file", KUBE_ADMIN_CONF,
+             "--node-name", "none"]
         ],
-        common_test.PROC_RUN: [True, True],
         common_test.REQ: {
             "data": {"ca.crt": "test"}
         }
@@ -156,7 +164,8 @@ none".format(KUBE_ADMIN_CONF),
         common_test.ARGS: ["10.3.157.24", 6443, "true", False],
         common_test.NO_INIT: True,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF),
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"],
             "systemctl start kubelet"
         ],
         common_test.PROC_OUT: ["none   Ready   <role>   10d   v1.28.0", ""]
@@ -177,11 +186,13 @@ reset_test_data = {
         common_test.DO_JOIN: True,
         common_test.ARGS: [False],
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF),
-            "kubectl --kubeconfig {} --request-timeout 20s drain none \
---ignore-daemonsets".format(KUBE_ADMIN_CONF),
-            "kubectl --kubeconfig {} --request-timeout 20s delete node \
-none".format(KUBE_ADMIN_CONF),
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"],
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "drain", "none",
+             "--ignore-daemonsets"],
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "delete", "node", "none"],
             "kubeadm reset -f",
             "rm -rf {}".format(CNI_DIR),
             "rm -f {}".format(KUBE_ADMIN_CONF),
@@ -194,10 +205,11 @@ none".format(KUBE_ADMIN_CONF),
         common_test.RETVAL: 0,
         common_test.ARGS: [False],
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} --request-timeout 20s drain none \
---ignore-daemonsets".format(KUBE_ADMIN_CONF),
-            "kubectl --kubeconfig {} --request-timeout 20s delete node \
-none".format(KUBE_ADMIN_CONF),
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "drain", "none",
+             "--ignore-daemonsets"],
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+             "--request-timeout", "20s", "delete", "node", "none"],
             "kubeadm reset -f",
             "rm -rf {}".format(CNI_DIR),
             "rm -f {}".format(KUBE_ADMIN_CONF),
@@ -427,7 +439,8 @@ is_ready_as_k8s_node_test_data = {
         common_test.DESCR: "node is ready",
         common_test.RETVAL: True,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF)
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"]
         ],
         common_test.PROC_OUT: ["none   Ready   <role>   10d   v1.28.0"],
         common_test.PROC_KILLED: 0
@@ -436,7 +449,8 @@ is_ready_as_k8s_node_test_data = {
         common_test.DESCR: "node is not ready",
         common_test.RETVAL: False,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF)
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"]
         ],
         common_test.PROC_OUT: ["none   NotReady   <role>   10d   v1.28.0"],
         common_test.PROC_KILLED: 0
@@ -445,7 +459,8 @@ is_ready_as_k8s_node_test_data = {
         common_test.DESCR: "kubectl fails (ret != 0)",
         common_test.RETVAL: False,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF)
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"]
         ],
         common_test.PROC_ERR: ["connection refused"],
         common_test.PROC_KILLED: 0
@@ -454,7 +469,8 @@ is_ready_as_k8s_node_test_data = {
         common_test.DESCR: "empty output",
         common_test.RETVAL: False,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF)
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"]
         ],
         common_test.PROC_OUT: [""],
         common_test.PROC_KILLED: 0
@@ -464,7 +480,8 @@ is_ready_as_k8s_node_test_data = {
         common_test.TRIGGER_THROW: True,
         common_test.RETVAL: False,
         common_test.PROC_CMD: [
-            "kubectl --kubeconfig {} get nodes none --no-headers".format(KUBE_ADMIN_CONF)
+            ["kubectl", "--kubeconfig", KUBE_ADMIN_CONF, "get", "nodes",
+             "none", "--no-headers"]
         ],
         common_test.PROC_KILLED: 1
     }
@@ -635,6 +652,41 @@ clusters:\n\
                     ct_data[common_test.ARGS][0])
             if common_test.RETVAL in ct_data:
                 assert ret == ct_data[common_test.RETVAL]
+
+    def test_reset_hostname_cannot_inject_commands(self):
+        self.init()
+        hostile_hostname = "sonic; touch /tmp/pwned #"
+
+        with patch("kube_commands.os.path.exists", return_value=True), \
+                patch("kube_commands.get_device_name",
+                      return_value=hostile_hostname), \
+                patch("kube_commands._run_command_list") as run_list, \
+                patch("kube_commands._run_command"):
+            kube_commands._do_reset()
+
+        assert run_list.call_args_list == [
+            ((["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+               "--request-timeout", "20s", "drain", hostile_hostname,
+               "--ignore-daemonsets"],), {"timeout": 60}),
+            ((["kubectl", "--kubeconfig", KUBE_ADMIN_CONF,
+               "--request-timeout", "20s", "delete", "node",
+               hostile_hostname],), {"timeout": 60})
+        ]
+
+    def test_run_command_list_disables_shell_and_enforces_timeout(self):
+        proc = MagicMock()
+        proc.communicate.return_value = (b"", b"")
+        proc.returncode = 0
+
+        with patch("kube_commands.subprocess.Popen",
+                   return_value=proc) as popen:
+            kube_commands._run_command_list(["kubectl", "version"],
+                                            timeout=17)
+
+        popen.assert_called_once_with(
+            ["kubectl", "version"], shell=False, stdout=kube_commands.subprocess.PIPE,
+            stderr=kube_commands.subprocess.PIPE)
+        proc.communicate.assert_called_once_with(timeout=17)
 
     @patch("kube_commands.subprocess.Popen")
     def test_tag_latest(self, mock_subproc):

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -89,7 +89,6 @@ write_labels_test_data = {
     },
     2: {
         common_test.DESCR: "write labels",
-        common_test.RETVAL: 0,
         common_test.ARGS: { "any": "thing" },
         common_test.RETVAL: -1,
         common_test.PROC_CMD: [


### PR DESCRIPTION
#### Why I did it

Ensure device-scoped values remain individual process arguments during Kubernetes orchestration operations.

##### Work item tracking
- Microsoft ADO **(number only)**: 39463606

#### How I did it

- Pass device-scoped `kubectl` and `kubeadm` operations as argument lists without shell parsing.
- Parse node-label output in Python instead of using a shell pipeline.
- Preserve existing command timeout behavior.
- Update command mocks and unit coverage for argument handling.

#### How to verify it

```bash
cd src/sonic-ctrmgrd
python3 -m pytest -q
python3 setup.py bdist_wheel
python3 -m compileall -q ctrmgr tests
```

Local results:
- 25 tests passed.
- 91% overall component coverage; 88% coverage for `kube_commands.py`.
- Wheel build and Python compilation passed.
- Differential scan with the repository Semgrep rules reported no new findings.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: component unit tests and package build passed locally; no image build was performed.

#### Description for the changelog

Harden Kubernetes command execution in `sonic-ctrmgrd`.

#### Link to config_db schema for YANG module changes

N/A
