### PR TITLE
Reload kdump-tools config after platform string substitution

### DIFF
--- a/files/image_config/platform/rc.local
+++ b/files/image_config/platform/rc.local
@@ -456,7 +456,15 @@ if [ -f $FIRST_BOOT_FILE ]; then
     mkdir -p /var/platform
 
     # Kdump tools configuration
-    [ -f /etc/default/kdump-tools ] && sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
+    if [ -f /etc/default/kdump-tools ]; then
+        sed -i -e "s/__PLATFORM__/$platform/g" /etc/default/kdump-tools
+
+        # The crash kernel was loaded earlier in boot, before the substitution
+        # above, so it still carries sonic_platform=__PLATFORM__. Reload it so
+        # a panic on this first boot can find the platform reboot hook.
+        # condreload is a no-op when no crash kernel is loaded.
+        kdump-config condreload || true
+    fi
 
     # On Switch-BMC systems, create the persistent BMC event log directory and
     # file on /host (eMMC-backed) so that leak, power and host-state events


### PR DESCRIPTION
#### Why I did it

On the first boot, `kdump-tools.service` loads the crash kernel early in boot
(`Before=basic.target`), but `rc.local` substitutes the `__PLATFORM__`
placeholder in `/etc/default/kdump-tools` only later in boot and does not
reload kdump. So the crash kernel stays loaded with
`sonic_platform=__PLATFORM__` unsubstituted.

If a kernel panic occurs on that first boot, the crash kernel's
`/usr/local/bin/reboot` wrapper resolves `PLATFORM=__PLATFORM__`, the
`-x /usr/share/sonic/device/__PLATFORM__/platform_reboot` check fails, and it
falls back to `/sbin/reboot` + `echo b > /proc/sysrq-trigger`, so the
platform-specific reboot hook / `platform_reboot` never runs.


kdump-tools config is loaded before rc.local is run. `Before=basic.target` in kdump-tools.service and `After=basic.target` in rc.local.service

```
admin@sonic:~$ systemctl show kdump-tools.service -p Before -p After -p DefaultDependencies
Before=basic.target
After=system.slice local-fs.target networking.service systemd-journald.socket
DefaultDependencies=no

admin@sonic:~$ systemctl show rc-local.service -p After
After=sysinit.target basic.target network.target system.slice systemd-journald.socket
```


```
admin@sonic:~$   dpkg -l kdump-tools
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-==========================================================
ii  kdump-tools    1:1.10.7     amd64        scripts and tools for automating kdump (Linux crash dumps)


admin@sonic:~$ show ver|head

SONiC Software Version: SONiC.master-29343.1211149-c9f495a2c
SONiC OS Version: 13
Distribution: Debian 13.6
Kernel: 6.12.41+deb13-sonic-amd64
Build commit: c9f495a2c
Build date: Fri Sep  4 05:29:44 UTC 2026
Built by: azureuser@6ccd305cc000001
```


Resolves #29344

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

In `rc.local`, run `kdump-config condreload` right after the platform string
substitution, so the crash kernel is reloaded with the correct
`sonic_platform=` value. `condreload` is a no-op when no crash kernel is
loaded.

#### How to verify it

On a fresh image install, trigger a panic with `echo c > /proc/sysrq-trigger`.

Before the fix, the on-disk config is already substituted by `rc.local`:

```
admin@sonic:~$ grep sonic_platform /etc/default/kdump-tools
KDUMP_CMDLINE_APPEND="${KDUMP_CMDLINE_APPEND} panic=10 debug loglevel=4 ... sonic_platform=x86_64-<vendor>_<platform>"
```

but the loaded crash kernel still carries the unsubstituted placeholder (`__PLATFORM__` verbatim):

```
admin@sonic:~$ sudo kdump-config show
...
kexec command:
  /sbin/kexec -p -c --command-line="BOOT_IMAGE=/image-<version>/boot/vmlinuz-6.12.41+deb13-sonic-amd64 root=LABEL=SONiC-OS rw ... sonic_platform=__PLATFORM__" --initrd=/var/lib/kdump/initrd.img /var/lib/kdump/vmlinuz
```

On a panic in this state, the console shows `sysrq: Resetting` and the
platform reboot hook does not run.

After reloading the kdump config (what this PR does automatically right after
substitution):

```
admin@sonic:~$ sudo kdump-config show
...
kexec command:
  /sbin/kexec -p -c --command-line="BOOT_IMAGE=/image-<version>/boot/vmlinuz-6.12.41+deb13-sonic-amd64 root=LABEL=SONiC-OS rw ... sonic_platform=x86_64-<vendor>_<platform>" --initrd=/var/lib/kdump/initrd.img /var/lib/kdump/vmlinuz
```

and a first-boot kernel panic now finds and executes `platform_reboot`
instead of falling back to the sysrq reset.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- 202511: 202511-based image on a platform with a `platform_reboot` hook —
  verified the kexec command line carries the substituted `sonic_platform=`
  value after first boot, and a first-boot kernel panic now executes
  `platform_reboot` instead of falling back to the sysrq reset.

#### Description for the changelog

Reload the kdump crash kernel after the platform string is substituted so a
kernel panic on the first boot after install runs the platform-specific
reboot hook.
