### PR TITLE
Add tuning file to Quicksilver platforms

### DIFF
--- a/device/arista/x86_64-arista_7060x6_64de/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64de/media_settings.json
@@ -1,134 +1,6 @@
 {
     "PORT_MEDIA_SETTINGS": {
         "1": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0x00000000",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x0000000c",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000004",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffda",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffda"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000060",
-                        "lane6": "0x00000068",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff0",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff0",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff0",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff0"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -441,134 +313,6 @@
             }
         },
         "2": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0x00000000",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x0000000c",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000004",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffda",
-                        "lane6": "0xffffffd6",
-                        "lane7": "0xffffffda"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000060",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff0",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff0",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff0",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff0",
-                        "lane7": "0xfffffff0"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -881,134 +625,6 @@
             }
         },
         "3": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff8",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0x00000000",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x0000000c",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000004",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffda",
-                        "lane6": "0xffffffd6",
-                        "lane7": "0xffffffde"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000054",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000060",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff0",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff0",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff0",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff0",
-                        "lane7": "0xfffffff0"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -1321,134 +937,6 @@
             }
         },
         "4": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff8",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0x00000000",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x0000000c",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffda",
-                        "lane6": "0xffffffde",
-                        "lane7": "0xffffffde"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000054",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000066",
-                        "lane6": "0x00000066",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff0",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff0",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff0",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff0"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -1761,134 +1249,6 @@
             }
         },
         "5": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x0000005d",
-                        "lane1": "0x0000005d",
-                        "lane2": "0x0000005d",
-                        "lane3": "0x0000005d",
-                        "lane4": "0x0000005d",
-                        "lane5": "0x0000005d",
-                        "lane6": "0x0000005d",
-                        "lane7": "0x0000005d"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -2201,134 +1561,6 @@
             }
         },
         "6": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x0000005d",
-                        "lane1": "0x0000005d",
-                        "lane2": "0x0000005d",
-                        "lane3": "0x0000005d",
-                        "lane4": "0x0000005d",
-                        "lane5": "0x0000005d",
-                        "lane6": "0x0000005d",
-                        "lane7": "0x0000005d"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -2355,10 +1587,10 @@
                     "lane1": "0xffffffe8",
                     "lane2": "0xffffffe4",
                     "lane3": "0xffffffe8",
-                    "lane4": "0xffffffe4",
+                    "lane4": "0xffffffe8",
                     "lane5": "0xffffffe8",
                     "lane6": "0xffffffe4",
-                    "lane7": "0xffffffe8"
+                    "lane7": "0xffffffe4"
                 },
                 "main": {
                     "lane0": "0x78",
@@ -2375,10 +1607,10 @@
                     "lane1": "0xffffffec",
                     "lane2": "0xfffffff0",
                     "lane3": "0xffffffec",
-                    "lane4": "0xfffffff0",
+                    "lane4": "0xffffffec",
                     "lane5": "0xffffffec",
                     "lane6": "0xfffffff0",
-                    "lane7": "0xffffffec"
+                    "lane7": "0xfffffff0"
                 },
                 "post2": {
                     "lane0": "0x0",
@@ -2413,44 +1645,44 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffa",
+                    "lane0": "0xfffffffb",
                     "lane1": "0xfffffffa",
                     "lane2": "0xfffffffa",
-                    "lane3": "0xfffffffb",
+                    "lane3": "0xfffffffa",
                     "lane4": "0xfffffffb",
                     "lane5": "0xfffffffb",
-                    "lane6": "0xfffffffa",
-                    "lane7": "0xfffffffb"
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffa"
                 },
                 "main": {
-                    "lane0": "0x9f",
+                    "lane0": "0xa2",
                     "lane1": "0x9f",
                     "lane2": "0x9f",
-                    "lane3": "0xa2",
+                    "lane3": "0x9f",
                     "lane4": "0xa2",
                     "lane5": "0xa2",
-                    "lane6": "0x9f",
-                    "lane7": "0xa2"
+                    "lane6": "0xa2",
+                    "lane7": "0x9f"
                 },
                 "post1": {
-                    "lane0": "0xffffffff",
+                    "lane0": "0x0",
                     "lane1": "0xffffffff",
                     "lane2": "0xffffffff",
-                    "lane3": "0x0",
+                    "lane3": "0xffffffff",
                     "lane4": "0x0",
                     "lane5": "0x0",
-                    "lane6": "0xffffffff",
-                    "lane7": "0x0"
+                    "lane6": "0x0",
+                    "lane7": "0xffffffff"
                 },
                 "post2": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xffffffff",
                     "lane1": "0xfffffffe",
                     "lane2": "0xfffffffe",
-                    "lane3": "0xffffffff",
+                    "lane3": "0xfffffffe",
                     "lane4": "0xffffffff",
                     "lane5": "0xffffffff",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
+                    "lane6": "0xffffffff",
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -2475,14 +1707,14 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xfffffffa",
                     "lane1": "0xfffffffe",
                     "lane2": "0xfffffffe",
-                    "lane3": "0xfffffffa",
+                    "lane3": "0xfffffffe",
                     "lane4": "0xfffffffa",
                     "lane5": "0xfffffffa",
-                    "lane6": "0xfffffffe",
-                    "lane7": "0xfffffffa"
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffe"
                 },
                 "main": {
                     "lane0": "0x66",
@@ -2495,14 +1727,14 @@
                     "lane7": "0x66"
                 },
                 "post1": {
-                    "lane0": "0xffffffe9",
+                    "lane0": "0xffffffed",
                     "lane1": "0xffffffe9",
                     "lane2": "0xffffffe9",
-                    "lane3": "0xffffffed",
+                    "lane3": "0xffffffe9",
                     "lane4": "0xffffffed",
                     "lane5": "0xffffffed",
-                    "lane6": "0xffffffe9",
-                    "lane7": "0xffffffed"
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffe9"
                 },
                 "post2": {
                     "lane0": "0x0",
@@ -2641,134 +1873,6 @@
             }
         },
         "7": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffd",
-                        "lane1": "0xfffffffd",
-                        "lane2": "0xfffffffd",
-                        "lane3": "0xfffffffd",
-                        "lane4": "0xfffffffd",
-                        "lane5": "0xfffffffd",
-                        "lane6": "0xfffffffd",
-                        "lane7": "0xfffffffd"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x0000005a",
-                        "lane1": "0x0000005a",
-                        "lane2": "0x0000005a",
-                        "lane3": "0x0000005a",
-                        "lane4": "0x0000005a",
-                        "lane5": "0x0000005a",
-                        "lane6": "0x0000005a",
-                        "lane7": "0x0000005a"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -2796,8 +1900,8 @@
                     "lane2": "0xffffffe4",
                     "lane3": "0xffffffe8",
                     "lane4": "0xffffffe4",
-                    "lane5": "0xffffffe8",
-                    "lane6": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe8",
                     "lane7": "0xffffffe8"
                 },
                 "main": {
@@ -2816,8 +1920,8 @@
                     "lane2": "0xfffffff0",
                     "lane3": "0xffffffec",
                     "lane4": "0xfffffff0",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xffffffec",
                     "lane7": "0xffffffec"
                 },
                 "post2": {
@@ -3081,134 +2185,6 @@
             }
         },
         "8": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffd",
-                        "lane1": "0xfffffffd",
-                        "lane2": "0xfffffffd",
-                        "lane3": "0xfffffffd",
-                        "lane4": "0xfffffffd",
-                        "lane5": "0xfffffffd",
-                        "lane6": "0xfffffffd",
-                        "lane7": "0xfffffffd"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x0000005a",
-                        "lane1": "0x0000005a",
-                        "lane2": "0x0000005a",
-                        "lane3": "0x0000005a",
-                        "lane4": "0x0000005a",
-                        "lane5": "0x0000005a",
-                        "lane6": "0x0000005a",
-                        "lane7": "0x0000005a"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -3521,134 +2497,6 @@
             }
         },
         "9": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000068",
-                        "lane1": "0x00000068",
-                        "lane2": "0x00000068",
-                        "lane3": "0x00000068",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000068",
-                        "lane6": "0x00000068",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffe0",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffdc",
-                        "lane4": "0xffffffd6",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffdc"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000060",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x00000068",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff0",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -3961,134 +2809,6 @@
             }
         },
         "10": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000068",
-                        "lane1": "0x00000068",
-                        "lane2": "0x00000068",
-                        "lane3": "0x00000068",
-                        "lane4": "0x00000068",
-                        "lane5": "0x00000068",
-                        "lane6": "0x00000068",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffe0",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffdc",
-                        "lane4": "0xffffffd6",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffdc"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x00000060",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x00000068",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff0",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -4401,134 +3121,6 @@
             }
         },
         "11": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x0000005c",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x0000005c",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x0000005c"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffdc",
-                        "lane4": "0xffffffd6",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffd6",
-                        "lane7": "0xffffffdc"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000060",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x00000068",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff0",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -4563,9 +3155,9 @@
                 "main": {
                     "lane0": "0x78",
                     "lane1": "0x78",
-                    "lane2": "0x80",
+                    "lane2": "0x78",
                     "lane3": "0x78",
-                    "lane4": "0x78",
+                    "lane4": "0x80",
                     "lane5": "0x78",
                     "lane6": "0x78",
                     "lane7": "0x78"
@@ -4573,9 +3165,9 @@
                 "post1": {
                     "lane0": "0xfffffff0",
                     "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff8",
+                    "lane2": "0xfffffff0",
                     "lane3": "0xfffffff0",
-                    "lane4": "0xfffffff0",
+                    "lane4": "0xfffffff8",
                     "lane5": "0xfffffff0",
                     "lane6": "0xfffffff0",
                     "lane7": "0xfffffff0"
@@ -4841,134 +3433,6 @@
             }
         },
         "12": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x0000005c",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x0000005c",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x0000005c"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffdc",
-                        "lane4": "0xffffffd6",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffdc",
-                        "lane7": "0xffffffdc"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000060",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x00000068",
-                        "lane6": "0x00000068",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff0",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -5045,50 +3509,50 @@
                 "pre2": {
                     "lane0": "0x0",
                     "lane1": "0x0",
-                    "lane2": "0x0",
+                    "lane2": "0x1",
                     "lane3": "0x0",
                     "lane4": "0x0",
-                    "lane5": "0x1",
+                    "lane5": "0x0",
                     "lane6": "0x0",
                     "lane7": "0x1"
                 },
                 "pre1": {
                     "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffb",
+                    "lane2": "0xfffffff3",
                     "lane3": "0xfffffffb",
                     "lane4": "0xfffffffb",
-                    "lane5": "0xfffffff3",
+                    "lane5": "0xfffffffb",
                     "lane6": "0xfffffffb",
                     "lane7": "0xfffffff3"
                 },
                 "main": {
                     "lane0": "0x9d",
                     "lane1": "0x9d",
-                    "lane2": "0x9d",
+                    "lane2": "0x98",
                     "lane3": "0x9d",
                     "lane4": "0x9d",
-                    "lane5": "0x98",
+                    "lane5": "0x9d",
                     "lane6": "0x9d",
                     "lane7": "0x98"
                 },
                 "post1": {
                     "lane0": "0xfffffffd",
                     "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
+                    "lane2": "0x0",
                     "lane3": "0xfffffffd",
                     "lane4": "0xfffffffd",
-                    "lane5": "0x0",
+                    "lane5": "0xfffffffd",
                     "lane6": "0xfffffffd",
                     "lane7": "0x0"
                 },
                 "post2": {
                     "lane0": "0xfffffffd",
                     "lane1": "0xfffffffd",
-                    "lane2": "0xfffffffd",
+                    "lane2": "0xfffffffe",
                     "lane3": "0xfffffffd",
                     "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
+                    "lane5": "0xfffffffd",
                     "lane6": "0xfffffffd",
                     "lane7": "0xfffffffe"
                 }
@@ -5117,30 +3581,30 @@
                 "pre1": {
                     "lane0": "0xfffffff9",
                     "lane1": "0xfffffff9",
-                    "lane2": "0xfffffff9",
+                    "lane2": "0xfffffffc",
                     "lane3": "0xfffffff9",
                     "lane4": "0xfffffff9",
-                    "lane5": "0xfffffffc",
+                    "lane5": "0xfffffff9",
                     "lane6": "0xfffffff9",
                     "lane7": "0xfffffffc"
                 },
                 "main": {
                     "lane0": "0x52",
                     "lane1": "0x52",
-                    "lane2": "0x52",
+                    "lane2": "0x67",
                     "lane3": "0x52",
                     "lane4": "0x52",
-                    "lane5": "0x67",
+                    "lane5": "0x52",
                     "lane6": "0x52",
                     "lane7": "0x67"
                 },
                 "post1": {
                     "lane0": "0xfffffff8",
                     "lane1": "0xfffffff8",
-                    "lane2": "0xfffffff8",
+                    "lane2": "0xffffffec",
                     "lane3": "0xfffffff8",
                     "lane4": "0xfffffff8",
-                    "lane5": "0xffffffec",
+                    "lane5": "0xfffffff8",
                     "lane6": "0xfffffff8",
                     "lane7": "0xffffffec"
                 },
@@ -5281,134 +3745,6 @@
             }
         },
         "13": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005e",
-                        "lane1": "0x0000005e",
-                        "lane2": "0x0000005e",
-                        "lane3": "0x0000005e",
-                        "lane4": "0x0000005e",
-                        "lane5": "0x0000005e",
-                        "lane6": "0x0000005e",
-                        "lane7": "0x0000005e"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffff8"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x0000000c",
-                        "lane7": "0x0000000c"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe2",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffde",
-                        "lane4": "0xffffffe2",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000054",
-                        "lane1": "0x00000060",
-                        "lane2": "0x00000054",
-                        "lane3": "0x00000058",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000058",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000054"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -5721,134 +4057,6 @@
             }
         },
         "14": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005e",
-                        "lane1": "0x0000005e",
-                        "lane2": "0x0000005e",
-                        "lane3": "0x0000005e",
-                        "lane4": "0x0000005e",
-                        "lane5": "0x0000005e",
-                        "lane6": "0x0000005e",
-                        "lane7": "0x0000005e"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffff8"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x0000000c",
-                        "lane7": "0x0000000c"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe2",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffde",
-                        "lane4": "0xffffffe2",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000054",
-                        "lane1": "0x00000060",
-                        "lane2": "0x00000054",
-                        "lane3": "0x00000058",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000058",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000054"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -5933,24 +4141,24 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffd",
+                    "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
                     "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffb",
                     "lane5": "0xfffffffb",
                     "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffb"
+                    "lane7": "0xfffffffd"
                 },
                 "main": {
-                    "lane0": "0xa3",
+                    "lane0": "0xa2",
                     "lane1": "0xa2",
                     "lane2": "0xa3",
-                    "lane3": "0xa2",
-                    "lane4": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa2",
                     "lane5": "0xa2",
                     "lane6": "0xa3",
-                    "lane7": "0xa2"
+                    "lane7": "0xa3"
                 },
                 "post1": {
                     "lane0": "0x0",
@@ -5963,14 +4171,14 @@
                     "lane7": "0x0"
                 },
                 "post2": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xffffffff",
                     "lane1": "0xffffffff",
                     "lane2": "0xfffffffe",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xffffffff",
                     "lane5": "0xffffffff",
                     "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -6161,134 +4369,6 @@
             }
         },
         "15": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffff8"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x0000000c",
-                        "lane7": "0x0000000c"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe2",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffde",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe2",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe2"
-                    },
-                    "main": {
-                        "lane0": "0x00000054",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000050",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x00000054",
-                        "lane5": "0x00000054",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -6364,52 +4444,52 @@
                 },
                 "pre2": {
                     "lane0": "0x0",
-                    "lane1": "0x1",
-                    "lane2": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
                     "lane3": "0x1",
                     "lane4": "0x0",
-                    "lane5": "0x1",
-                    "lane6": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
                     "lane7": "0x1"
                 },
                 "pre1": {
                     "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff3",
-                    "lane2": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffff3",
                     "lane3": "0xfffffff3",
                     "lane4": "0xfffffffb",
-                    "lane5": "0xfffffff3",
-                    "lane6": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffff3",
                     "lane7": "0xfffffff3"
                 },
                 "main": {
                     "lane0": "0x9d",
-                    "lane1": "0x98",
-                    "lane2": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x98",
                     "lane3": "0x98",
                     "lane4": "0x9d",
-                    "lane5": "0x98",
-                    "lane6": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x98",
                     "lane7": "0x98"
                 },
                 "post1": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "post2": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffe",
                     "lane3": "0xfffffffe",
                     "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffe",
                     "lane7": "0xfffffffe"
                 }
             },
@@ -6436,32 +4516,32 @@
                 },
                 "pre1": {
                     "lane0": "0xfffffff9",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffffc",
                     "lane3": "0xfffffffc",
                     "lane4": "0xfffffff9",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "main": {
                     "lane0": "0x52",
-                    "lane1": "0x67",
-                    "lane2": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x67",
                     "lane3": "0x67",
                     "lane4": "0x52",
-                    "lane5": "0x67",
-                    "lane6": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x67",
                     "lane7": "0x67"
                 },
                 "post1": {
                     "lane0": "0xfffffff8",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xffffffec",
                     "lane3": "0xffffffec",
                     "lane4": "0xfffffff8",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xffffffec",
                     "lane7": "0xffffffec"
                 },
                 "post2": {
@@ -6601,134 +4681,6 @@
             }
         },
         "16": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffff8"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x0000000c"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe2",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffe2",
-                        "lane3": "0xffffffde",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe2",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe2"
-                    },
-                    "main": {
-                        "lane0": "0x00000054",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000050",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x00000054",
-                        "lane5": "0x00000054",
-                        "lane6": "0x00000058",
-                        "lane7": "0x00000058"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffff8",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -7041,134 +4993,6 @@
             }
         },
         "17": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x0000005c",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x0000005c",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x0000005c"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff9",
-                        "lane1": "0xfffffff9",
-                        "lane2": "0xfffffff9",
-                        "lane3": "0xfffffff9",
-                        "lane4": "0xfffffff9",
-                        "lane5": "0xfffffff9",
-                        "lane6": "0xfffffff9",
-                        "lane7": "0xfffffff9"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -7481,134 +5305,6 @@
             }
         },
         "18": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x0000005c",
-                        "lane2": "0x0000005c",
-                        "lane3": "0x0000005c",
-                        "lane4": "0x0000005c",
-                        "lane5": "0x0000005c",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x0000005c"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff9",
-                        "lane1": "0xfffffff9",
-                        "lane2": "0xfffffff9",
-                        "lane3": "0xfffffff9",
-                        "lane4": "0xfffffff9",
-                        "lane5": "0xfffffff9",
-                        "lane6": "0xfffffff9",
-                        "lane7": "0xfffffff9"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -7631,11 +5327,11 @@
                     "lane7": "0x6"
                 },
                 "pre1": {
-                    "lane0": "0xffffffe4",
+                    "lane0": "0xffffffe0",
                     "lane1": "0xffffffe4",
                     "lane2": "0xffffffe0",
                     "lane3": "0xffffffe4",
-                    "lane4": "0xffffffe0",
+                    "lane4": "0xffffffe4",
                     "lane5": "0xffffffe4",
                     "lane6": "0xffffffe0",
                     "lane7": "0xffffffe0"
@@ -7651,11 +5347,11 @@
                     "lane7": "0x80"
                 },
                 "post1": {
-                    "lane0": "0xfffffff8",
+                    "lane0": "0xfffffffc",
                     "lane1": "0xfffffff8",
                     "lane2": "0xfffffffc",
                     "lane3": "0xfffffff8",
-                    "lane4": "0xfffffffc",
+                    "lane4": "0xfffffff8",
                     "lane5": "0xfffffff8",
                     "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
@@ -7693,24 +5389,24 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffd",
+                    "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
                     "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffb",
                     "lane5": "0xfffffffb",
                     "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffb"
+                    "lane7": "0xfffffffd"
                 },
                 "main": {
-                    "lane0": "0xa3",
+                    "lane0": "0xa2",
                     "lane1": "0xa2",
                     "lane2": "0xa3",
-                    "lane3": "0xa2",
-                    "lane4": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa2",
                     "lane5": "0xa2",
                     "lane6": "0xa3",
-                    "lane7": "0xa2"
+                    "lane7": "0xa3"
                 },
                 "post1": {
                     "lane0": "0x0",
@@ -7723,14 +5419,14 @@
                     "lane7": "0x0"
                 },
                 "post2": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xffffffff",
                     "lane1": "0xffffffff",
                     "lane2": "0xfffffffe",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xffffffff",
                     "lane5": "0xffffffff",
                     "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -7921,134 +5617,6 @@
             }
         },
         "19": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000060",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000060",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000060",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -8072,11 +5640,11 @@
                 },
                 "pre1": {
                     "lane0": "0xffffffe0",
-                    "lane1": "0xffffffe0",
+                    "lane1": "0xffffffe4",
                     "lane2": "0xffffffe0",
                     "lane3": "0xffffffe4",
                     "lane4": "0xffffffe0",
-                    "lane5": "0xffffffe4",
+                    "lane5": "0xffffffe0",
                     "lane6": "0xffffffe4",
                     "lane7": "0xffffffe4"
                 },
@@ -8092,11 +5660,11 @@
                 },
                 "post1": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffc",
+                    "lane1": "0xfffffff8",
                     "lane2": "0xfffffffc",
                     "lane3": "0xfffffff8",
                     "lane4": "0xfffffffc",
-                    "lane5": "0xfffffff8",
+                    "lane5": "0xfffffffc",
                     "lane6": "0xfffffff8",
                     "lane7": "0xfffffff8"
                 },
@@ -8124,52 +5692,52 @@
                 },
                 "pre2": {
                     "lane0": "0x0",
-                    "lane1": "0x1",
-                    "lane2": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
                     "lane3": "0x1",
                     "lane4": "0x0",
-                    "lane5": "0x1",
-                    "lane6": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
                     "lane7": "0x1"
                 },
                 "pre1": {
                     "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff3",
-                    "lane2": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffff3",
                     "lane3": "0xfffffff3",
                     "lane4": "0xfffffffb",
-                    "lane5": "0xfffffff3",
-                    "lane6": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffff3",
                     "lane7": "0xfffffff3"
                 },
                 "main": {
                     "lane0": "0x9d",
-                    "lane1": "0x98",
-                    "lane2": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x98",
                     "lane3": "0x98",
                     "lane4": "0x9d",
-                    "lane5": "0x98",
-                    "lane6": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x98",
                     "lane7": "0x98"
                 },
                 "post1": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "post2": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffe",
                     "lane3": "0xfffffffe",
                     "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffe",
                     "lane7": "0xfffffffe"
                 }
             },
@@ -8196,32 +5764,32 @@
                 },
                 "pre1": {
                     "lane0": "0xfffffff9",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffffc",
                     "lane3": "0xfffffffc",
                     "lane4": "0xfffffff9",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "main": {
                     "lane0": "0x52",
-                    "lane1": "0x67",
-                    "lane2": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x67",
                     "lane3": "0x67",
                     "lane4": "0x52",
-                    "lane5": "0x67",
-                    "lane6": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x67",
                     "lane7": "0x67"
                 },
                 "post1": {
                     "lane0": "0xfffffff8",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xffffffec",
                     "lane3": "0xffffffec",
                     "lane4": "0xfffffff8",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xffffffec",
                     "lane7": "0xffffffec"
                 },
                 "post2": {
@@ -8361,134 +5929,6 @@
             }
         },
         "20": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000060",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000060",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000060",
-                        "lane6": "0x00000060",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -8801,134 +6241,6 @@
             }
         },
         "21": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe0",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000054",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -9241,134 +6553,6 @@
             }
         },
         "22": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe0",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000054",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -9681,134 +6865,6 @@
             }
         },
         "23": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -10121,134 +7177,6 @@
             }
         },
         "24": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -10561,161 +7489,33 @@
             }
         },
         "25": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffeb",
-                        "lane1": "0xffffffeb",
-                        "lane2": "0xffffffeb",
-                        "lane3": "0xffffffeb",
-                        "lane4": "0xffffffeb",
-                        "lane5": "0xffffffeb",
-                        "lane6": "0xffffffeb",
-                        "lane7": "0xffffffeb"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
-                    "lane0": "0xfffffffc",
-                    "lane1": "0x0",
+                    "lane0": "0x0",
+                    "lane1": "0xfffffffc",
                     "lane2": "0xfffffffc",
-                    "lane3": "0x0",
-                    "lane4": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0x0",
                     "lane5": "0x0",
                     "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "pre2": {
-                    "lane0": "0xa",
-                    "lane1": "0x6",
+                    "lane0": "0x6",
+                    "lane1": "0xa",
                     "lane2": "0xa",
-                    "lane3": "0x6",
-                    "lane4": "0xa",
+                    "lane3": "0xa",
+                    "lane4": "0x6",
                     "lane5": "0x6",
                     "lane6": "0xa",
                     "lane7": "0xa"
                 },
                 "pre1": {
-                    "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe0",
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe8",
                     "lane2": "0xffffffe8",
-                    "lane3": "0xffffffe0",
-                    "lane4": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe0",
                     "lane5": "0xffffffe0",
                     "lane6": "0xffffffe8",
                     "lane7": "0xffffffe8"
@@ -11001,134 +7801,6 @@
             }
         },
         "26": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffeb",
-                        "lane1": "0xffffffeb",
-                        "lane2": "0xffffffeb",
-                        "lane3": "0xffffffeb",
-                        "lane4": "0xffffffeb",
-                        "lane5": "0xffffffeb",
-                        "lane6": "0xffffffeb",
-                        "lane7": "0xffffffeb"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -11441,134 +8113,6 @@
             }
         },
         "27": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x00000052",
-                        "lane1": "0x00000052",
-                        "lane2": "0x00000052",
-                        "lane3": "0x00000052",
-                        "lane4": "0x00000052",
-                        "lane5": "0x00000052",
-                        "lane6": "0x00000052",
-                        "lane7": "0x00000052"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -11881,134 +8425,6 @@
             }
         },
         "28": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x00000052",
-                        "lane1": "0x00000052",
-                        "lane2": "0x00000052",
-                        "lane3": "0x00000052",
-                        "lane4": "0x00000052",
-                        "lane5": "0x00000052",
-                        "lane6": "0x00000052",
-                        "lane7": "0x00000052"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -12321,161 +8737,33 @@
             }
         },
         "29": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x00000004",
-                        "lane2": "0x00000004",
-                        "lane3": "0x00000004",
-                        "lane4": "0x00000004",
-                        "lane5": "0x00000004",
-                        "lane6": "0x00000004",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffed",
-                        "lane1": "0xffffffed",
-                        "lane2": "0xffffffed",
-                        "lane3": "0xffffffed",
-                        "lane4": "0xffffffed",
-                        "lane5": "0xffffffed",
-                        "lane6": "0xffffffed",
-                        "lane7": "0xffffffed"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffb",
-                        "lane1": "0xfffffffb",
-                        "lane2": "0xfffffffb",
-                        "lane3": "0xfffffffb",
-                        "lane4": "0xfffffffb",
-                        "lane5": "0xfffffffb",
-                        "lane6": "0xfffffffb",
-                        "lane7": "0xfffffffb"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000004",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0x0",
+                    "lane1": "0xfffffffc",
                     "lane2": "0xfffffffc",
                     "lane3": "0xfffffffc",
-                    "lane4": "0xfffffffc",
+                    "lane4": "0x0",
                     "lane5": "0xfffffffc",
                     "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "pre2": {
                     "lane0": "0xa",
-                    "lane1": "0x6",
+                    "lane1": "0xa",
                     "lane2": "0xa",
                     "lane3": "0xa",
-                    "lane4": "0xa",
+                    "lane4": "0x6",
                     "lane5": "0xa",
                     "lane6": "0xa",
                     "lane7": "0xa"
                 },
                 "pre1": {
                     "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe0",
+                    "lane1": "0xffffffe8",
                     "lane2": "0xffffffe8",
                     "lane3": "0xffffffe8",
-                    "lane4": "0xffffffe8",
+                    "lane4": "0xffffffe0",
                     "lane5": "0xffffffe8",
                     "lane6": "0xffffffe8",
                     "lane7": "0xffffffe8"
@@ -12761,134 +9049,6 @@
             }
         },
         "30": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000004",
-                        "lane1": "0x00000004",
-                        "lane2": "0x00000004",
-                        "lane3": "0x00000004",
-                        "lane4": "0x00000004",
-                        "lane5": "0x00000004",
-                        "lane6": "0x00000004",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffed",
-                        "lane1": "0xffffffed",
-                        "lane2": "0xffffffed",
-                        "lane3": "0xffffffed",
-                        "lane4": "0xffffffed",
-                        "lane5": "0xffffffed",
-                        "lane6": "0xffffffed",
-                        "lane7": "0xffffffed"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffb",
-                        "lane1": "0xfffffffb",
-                        "lane2": "0xfffffffb",
-                        "lane3": "0xfffffffb",
-                        "lane4": "0xfffffffb",
-                        "lane5": "0xfffffffb",
-                        "lane6": "0xfffffffb",
-                        "lane7": "0xfffffffb"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -13201,134 +9361,6 @@
             }
         },
         "31": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -13641,163 +9673,35 @@
             }
         },
         "32": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe8",
-                        "lane1": "0xffffffe8",
-                        "lane2": "0xffffffe8",
-                        "lane3": "0xffffffe8",
-                        "lane4": "0xffffffe8",
-                        "lane5": "0xffffffe8",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe8"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffc",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "pre2": {
                     "lane0": "0xa",
-                    "lane1": "0x6",
-                    "lane2": "0xa",
+                    "lane1": "0xa",
+                    "lane2": "0x6",
                     "lane3": "0x6",
                     "lane4": "0xa",
-                    "lane5": "0x6",
-                    "lane6": "0xa",
+                    "lane5": "0xa",
+                    "lane6": "0x6",
                     "lane7": "0x6"
                 },
                 "pre1": {
                     "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe0",
-                    "lane2": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe0",
                     "lane3": "0xffffffe0",
                     "lane4": "0xffffffe8",
-                    "lane5": "0xffffffe0",
-                    "lane6": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe0",
                     "lane7": "0xffffffe0"
                 },
                 "main": {
@@ -14081,134 +9985,6 @@
             }
         },
         "33": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffee",
-                        "lane1": "0xffffffee",
-                        "lane2": "0xffffffee",
-                        "lane3": "0xffffffee",
-                        "lane4": "0xffffffee",
-                        "lane5": "0xffffffee",
-                        "lane6": "0xffffffee",
-                        "lane7": "0xffffffee"
-                    },
-                    "main": {
-                        "lane0": "0x00000059",
-                        "lane1": "0x00000059",
-                        "lane2": "0x00000059",
-                        "lane3": "0x00000059",
-                        "lane4": "0x00000059",
-                        "lane5": "0x00000059",
-                        "lane6": "0x00000059",
-                        "lane7": "0x00000059"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0xfffffffc",
@@ -14521,134 +10297,6 @@
             }
         },
         "34": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffee",
-                        "lane1": "0xffffffee",
-                        "lane2": "0xffffffee",
-                        "lane3": "0xffffffee",
-                        "lane4": "0xffffffee",
-                        "lane5": "0xffffffee",
-                        "lane6": "0xffffffee",
-                        "lane7": "0xffffffee"
-                    },
-                    "main": {
-                        "lane0": "0x00000059",
-                        "lane1": "0x00000059",
-                        "lane2": "0x00000059",
-                        "lane3": "0x00000059",
-                        "lane4": "0x00000059",
-                        "lane5": "0x00000059",
-                        "lane6": "0x00000059",
-                        "lane7": "0x00000059"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -14961,134 +10609,6 @@
             }
         },
         "35": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff9",
-                        "lane1": "0xfffffff9",
-                        "lane2": "0xfffffff9",
-                        "lane3": "0xfffffff9",
-                        "lane4": "0xfffffff9",
-                        "lane5": "0xfffffff9",
-                        "lane6": "0xfffffff9",
-                        "lane7": "0xfffffff9"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -15401,163 +10921,35 @@
             }
         },
         "36": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000056",
-                        "lane1": "0x00000056",
-                        "lane2": "0x00000056",
-                        "lane3": "0x00000056",
-                        "lane4": "0x00000056",
-                        "lane5": "0x00000056",
-                        "lane6": "0x00000056",
-                        "lane7": "0x00000056"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff9",
-                        "lane1": "0xfffffff9",
-                        "lane2": "0xfffffff9",
-                        "lane3": "0xfffffff9",
-                        "lane4": "0xfffffff9",
-                        "lane5": "0xfffffff9",
-                        "lane6": "0xfffffff9",
-                        "lane7": "0xfffffff9"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x0000004e",
-                        "lane1": "0x0000004e",
-                        "lane2": "0x0000004e",
-                        "lane3": "0x0000004e",
-                        "lane4": "0x0000004e",
-                        "lane5": "0x0000004e",
-                        "lane6": "0x0000004e",
-                        "lane7": "0x0000004e"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffc",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "pre2": {
                     "lane0": "0xa",
-                    "lane1": "0x6",
-                    "lane2": "0xa",
+                    "lane1": "0xa",
+                    "lane2": "0x6",
                     "lane3": "0x6",
                     "lane4": "0xa",
-                    "lane5": "0x6",
-                    "lane6": "0xa",
+                    "lane5": "0xa",
+                    "lane6": "0x6",
                     "lane7": "0x6"
                 },
                 "pre1": {
                     "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe0",
-                    "lane2": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe0",
                     "lane3": "0xffffffe0",
                     "lane4": "0xffffffe8",
-                    "lane5": "0xffffffe0",
-                    "lane6": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe0",
                     "lane7": "0xffffffe0"
                 },
                 "main": {
@@ -15841,134 +11233,6 @@
             }
         },
         "37": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -16281,134 +11545,6 @@
             }
         },
         "38": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -16721,134 +11857,6 @@
             }
         },
         "39": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -17161,134 +12169,6 @@
             }
         },
         "40": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000005",
-                        "lane1": "0x00000005",
-                        "lane2": "0x00000005",
-                        "lane3": "0x00000005",
-                        "lane4": "0x00000005",
-                        "lane5": "0x00000005",
-                        "lane6": "0x00000005",
-                        "lane7": "0x00000005"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffea",
-                        "lane1": "0xffffffea",
-                        "lane2": "0xffffffea",
-                        "lane3": "0xffffffea",
-                        "lane4": "0xffffffea",
-                        "lane5": "0xffffffea",
-                        "lane6": "0xffffffea",
-                        "lane7": "0xffffffea"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff7",
-                        "lane1": "0xfffffff7",
-                        "lane2": "0xfffffff7",
-                        "lane3": "0xfffffff7",
-                        "lane4": "0xfffffff7",
-                        "lane5": "0xfffffff7",
-                        "lane6": "0xfffffff7",
-                        "lane7": "0xfffffff7"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -17601,134 +12481,6 @@
             }
         },
         "41": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe2",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x0000005c",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -18041,134 +12793,6 @@
             }
         },
         "42": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -18481,134 +13105,6 @@
             }
         },
         "43": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -18921,134 +13417,6 @@
             }
         },
         "44": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe6",
-                        "lane1": "0xffffffe6",
-                        "lane2": "0xffffffe6",
-                        "lane3": "0xffffffe6",
-                        "lane4": "0xffffffe6",
-                        "lane5": "0xffffffe6",
-                        "lane6": "0xffffffe6",
-                        "lane7": "0xffffffe6"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff6",
-                        "lane1": "0xfffffff6",
-                        "lane2": "0xfffffff6",
-                        "lane3": "0xfffffff6",
-                        "lane4": "0xfffffff6",
-                        "lane5": "0xfffffff6",
-                        "lane6": "0xfffffff6",
-                        "lane7": "0xfffffff6"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -19361,134 +13729,6 @@
             }
         },
         "45": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000063",
-                        "lane1": "0x00000063",
-                        "lane2": "0x00000063",
-                        "lane3": "0x00000063",
-                        "lane4": "0x00000063",
-                        "lane5": "0x00000063",
-                        "lane6": "0x00000063",
-                        "lane7": "0x00000063"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -19801,134 +14041,6 @@
             }
         },
         "46": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000063",
-                        "lane1": "0x00000063",
-                        "lane2": "0x00000063",
-                        "lane3": "0x00000063",
-                        "lane4": "0x00000063",
-                        "lane5": "0x00000063",
-                        "lane6": "0x00000063",
-                        "lane7": "0x00000063"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -20013,24 +14125,24 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffd",
+                    "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
                     "lane2": "0xfffffffd",
                     "lane3": "0xfffffffd",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffd",
                     "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffb"
+                    "lane7": "0xfffffffd"
                 },
                 "main": {
-                    "lane0": "0xa3",
+                    "lane0": "0xa2",
                     "lane1": "0xa2",
                     "lane2": "0xa3",
                     "lane3": "0xa3",
-                    "lane4": "0xa3",
-                    "lane5": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa3",
                     "lane6": "0xa3",
-                    "lane7": "0xa2"
+                    "lane7": "0xa3"
                 },
                 "post1": {
                     "lane0": "0x0",
@@ -20043,14 +14155,14 @@
                     "lane7": "0x0"
                 },
                 "post2": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xffffffff",
                     "lane1": "0xffffffff",
                     "lane2": "0xfffffffe",
                     "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffe",
-                    "lane5": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xfffffffe",
                     "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -20078,9 +14190,9 @@
                     "lane0": "0xfffffffa",
                     "lane1": "0xfffffffa",
                     "lane2": "0xfffffffa",
-                    "lane3": "0x0",
+                    "lane3": "0xfffffffa",
                     "lane4": "0xfffffffa",
-                    "lane5": "0xfffffffa",
+                    "lane5": "0x0",
                     "lane6": "0xfffffffa",
                     "lane7": "0xfffffffa"
                 },
@@ -20088,9 +14200,9 @@
                     "lane0": "0x66",
                     "lane1": "0x66",
                     "lane2": "0x66",
-                    "lane3": "0x47",
+                    "lane3": "0x66",
                     "lane4": "0x66",
-                    "lane5": "0x66",
+                    "lane5": "0x47",
                     "lane6": "0x66",
                     "lane7": "0x66"
                 },
@@ -20098,9 +14210,9 @@
                     "lane0": "0xffffffed",
                     "lane1": "0xffffffed",
                     "lane2": "0xffffffed",
-                    "lane3": "0xfffffffd",
+                    "lane3": "0xffffffed",
                     "lane4": "0xffffffed",
-                    "lane5": "0xffffffed",
+                    "lane5": "0xfffffffd",
                     "lane6": "0xffffffed",
                     "lane7": "0xffffffed"
                 },
@@ -20241,134 +14353,6 @@
             }
         },
         "47": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000063",
-                        "lane1": "0x00000063",
-                        "lane2": "0x00000063",
-                        "lane3": "0x00000063",
-                        "lane4": "0x00000063",
-                        "lane5": "0x00000063",
-                        "lane6": "0x00000063",
-                        "lane7": "0x00000063"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -20681,134 +14665,6 @@
             }
         },
         "48": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000063",
-                        "lane1": "0x00000063",
-                        "lane2": "0x00000063",
-                        "lane3": "0x00000063",
-                        "lane4": "0x00000063",
-                        "lane5": "0x00000063",
-                        "lane6": "0x00000063",
-                        "lane7": "0x00000063"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff5",
-                        "lane1": "0xfffffff5",
-                        "lane2": "0xfffffff5",
-                        "lane3": "0xfffffff5",
-                        "lane4": "0xfffffff5",
-                        "lane5": "0xfffffff5",
-                        "lane6": "0xfffffff5",
-                        "lane7": "0xfffffff5"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe8",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -21121,134 +14977,6 @@
             }
         },
         "49": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -21271,14 +14999,14 @@
                     "lane7": "0x6"
                 },
                 "pre1": {
-                    "lane0": "0xffffffe0",
-                    "lane1": "0xffffffe0",
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
                     "lane2": "0xffffffe0",
                     "lane3": "0xffffffe4",
                     "lane4": "0xffffffe0",
                     "lane5": "0xffffffe4",
-                    "lane6": "0xffffffe4",
-                    "lane7": "0xffffffe4"
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
                 },
                 "main": {
                     "lane0": "0x80",
@@ -21291,14 +15019,14 @@
                     "lane7": "0x80"
                 },
                 "post1": {
-                    "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffc",
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
                     "lane2": "0xfffffffc",
                     "lane3": "0xfffffff8",
                     "lane4": "0xfffffffc",
                     "lane5": "0xfffffff8",
-                    "lane6": "0xfffffff8",
-                    "lane7": "0xfffffff8"
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
                 },
                 "post2": {
                     "lane0": "0x0",
@@ -21561,134 +15289,6 @@
             }
         },
         "50": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -21773,24 +15373,24 @@
                     "lane7": "0x0"
                 },
                 "pre1": {
-                    "lane0": "0xfffffffd",
+                    "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
                     "lane2": "0xfffffffd",
-                    "lane3": "0xfffffffb",
-                    "lane4": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffb",
                     "lane5": "0xfffffffb",
                     "lane6": "0xfffffffd",
-                    "lane7": "0xfffffffb"
+                    "lane7": "0xfffffffd"
                 },
                 "main": {
-                    "lane0": "0xa3",
+                    "lane0": "0xa2",
                     "lane1": "0xa2",
                     "lane2": "0xa3",
-                    "lane3": "0xa2",
-                    "lane4": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa2",
                     "lane5": "0xa2",
                     "lane6": "0xa3",
-                    "lane7": "0xa2"
+                    "lane7": "0xa3"
                 },
                 "post1": {
                     "lane0": "0x0",
@@ -21803,14 +15403,14 @@
                     "lane7": "0x0"
                 },
                 "post2": {
-                    "lane0": "0xfffffffe",
+                    "lane0": "0xffffffff",
                     "lane1": "0xffffffff",
                     "lane2": "0xfffffffe",
-                    "lane3": "0xffffffff",
-                    "lane4": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xffffffff",
                     "lane5": "0xffffffff",
                     "lane6": "0xfffffffe",
-                    "lane7": "0xffffffff"
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -22001,134 +15601,6 @@
             }
         },
         "51": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -22204,52 +15676,52 @@
                 },
                 "pre2": {
                     "lane0": "0x0",
-                    "lane1": "0x1",
-                    "lane2": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
                     "lane3": "0x1",
                     "lane4": "0x0",
-                    "lane5": "0x1",
-                    "lane6": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
                     "lane7": "0x1"
                 },
                 "pre1": {
                     "lane0": "0xfffffffb",
-                    "lane1": "0xfffffff3",
-                    "lane2": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffff3",
                     "lane3": "0xfffffff3",
                     "lane4": "0xfffffffb",
-                    "lane5": "0xfffffff3",
-                    "lane6": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffff3",
                     "lane7": "0xfffffff3"
                 },
                 "main": {
                     "lane0": "0x9d",
-                    "lane1": "0x98",
-                    "lane2": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x98",
                     "lane3": "0x98",
                     "lane4": "0x9d",
-                    "lane5": "0x98",
-                    "lane6": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x98",
                     "lane7": "0x98"
                 },
                 "post1": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "post2": {
                     "lane0": "0xfffffffd",
-                    "lane1": "0xfffffffe",
-                    "lane2": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffe",
                     "lane3": "0xfffffffe",
                     "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffe",
                     "lane7": "0xfffffffe"
                 }
             },
@@ -22276,32 +15748,32 @@
                 },
                 "pre1": {
                     "lane0": "0xfffffff9",
-                    "lane1": "0xfffffffc",
-                    "lane2": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffffc",
                     "lane3": "0xfffffffc",
                     "lane4": "0xfffffff9",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "main": {
                     "lane0": "0x52",
-                    "lane1": "0x67",
-                    "lane2": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x67",
                     "lane3": "0x67",
                     "lane4": "0x52",
-                    "lane5": "0x67",
-                    "lane6": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x67",
                     "lane7": "0x67"
                 },
                 "post1": {
                     "lane0": "0xfffffff8",
-                    "lane1": "0xffffffec",
-                    "lane2": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xffffffec",
                     "lane3": "0xffffffec",
                     "lane4": "0xfffffff8",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xffffffec",
                     "lane7": "0xffffffec"
                 },
                 "post2": {
@@ -22441,134 +15913,6 @@
             }
         },
         "52": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000050",
-                        "lane1": "0x00000050",
-                        "lane2": "0x00000050",
-                        "lane3": "0x00000050",
-                        "lane4": "0x00000050",
-                        "lane5": "0x00000050",
-                        "lane6": "0x00000050",
-                        "lane7": "0x00000050"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -22591,13 +15935,13 @@
                     "lane7": "0x6"
                 },
                 "pre1": {
-                    "lane0": "0xffffffe4",
+                    "lane0": "0xffffffe0",
                     "lane1": "0xffffffe4",
                     "lane2": "0xffffffe4",
                     "lane3": "0xffffffe4",
-                    "lane4": "0xffffffe0",
-                    "lane5": "0xffffffe4",
-                    "lane6": "0xffffffe0",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe4",
                     "lane7": "0xffffffe4"
                 },
                 "main": {
@@ -22611,13 +15955,13 @@
                     "lane7": "0x80"
                 },
                 "post1": {
-                    "lane0": "0xfffffff8",
+                    "lane0": "0xfffffffc",
                     "lane1": "0xfffffff8",
                     "lane2": "0xfffffff8",
                     "lane3": "0xfffffff8",
-                    "lane4": "0xfffffffc",
-                    "lane5": "0xfffffff8",
-                    "lane6": "0xfffffffc",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff8",
                     "lane7": "0xfffffff8"
                 },
                 "post2": {
@@ -22881,134 +16225,6 @@
             }
         },
         "53": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -23321,134 +16537,6 @@
             }
         },
         "54": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -23535,22 +16623,22 @@
                 "pre1": {
                     "lane0": "0xfffffffb",
                     "lane1": "0xfffffffb",
-                    "lane2": "0xfffffffd",
+                    "lane2": "0xfffffffb",
                     "lane3": "0xfffffffb",
                     "lane4": "0xfffffffb",
                     "lane5": "0xfffffffb",
                     "lane6": "0xfffffffb",
-                    "lane7": "0xfffffffb"
+                    "lane7": "0xfffffffd"
                 },
                 "main": {
                     "lane0": "0xa2",
                     "lane1": "0xa2",
-                    "lane2": "0xa3",
+                    "lane2": "0xa2",
                     "lane3": "0xa2",
                     "lane4": "0xa2",
                     "lane5": "0xa2",
                     "lane6": "0xa2",
-                    "lane7": "0xa2"
+                    "lane7": "0xa3"
                 },
                 "post1": {
                     "lane0": "0x0",
@@ -23565,12 +16653,12 @@
                 "post2": {
                     "lane0": "0xffffffff",
                     "lane1": "0xffffffff",
-                    "lane2": "0xfffffffe",
+                    "lane2": "0xffffffff",
                     "lane3": "0xffffffff",
                     "lane4": "0xffffffff",
                     "lane5": "0xffffffff",
                     "lane6": "0xffffffff",
-                    "lane7": "0xffffffff"
+                    "lane7": "0xfffffffe"
                 }
             },
             "OPTICAL25": {
@@ -23761,134 +16849,6 @@
             }
         },
         "55": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -23922,22 +16882,22 @@
                 },
                 "main": {
                     "lane0": "0x80",
-                    "lane1": "0x78",
-                    "lane2": "0x80",
-                    "lane3": "0x78",
+                    "lane1": "0x80",
+                    "lane2": "0x78",
+                    "lane3": "0x80",
                     "lane4": "0x80",
                     "lane5": "0x80",
-                    "lane6": "0x80",
+                    "lane6": "0x78",
                     "lane7": "0x80"
                 },
                 "post1": {
                     "lane0": "0xfffffff8",
-                    "lane1": "0xfffffff0",
-                    "lane2": "0xfffffff8",
-                    "lane3": "0xfffffff0",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff8",
                     "lane4": "0xfffffff8",
                     "lane5": "0xfffffff8",
-                    "lane6": "0xfffffff8",
+                    "lane6": "0xfffffff0",
                     "lane7": "0xfffffff8"
                 },
                 "post2": {
@@ -23964,52 +16924,52 @@
                 },
                 "pre2": {
                     "lane0": "0x1",
-                    "lane1": "0x1",
+                    "lane1": "0x0",
                     "lane2": "0x1",
                     "lane3": "0x1",
-                    "lane4": "0x0",
-                    "lane5": "0x1",
-                    "lane6": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
                     "lane7": "0x1"
                 },
                 "pre1": {
                     "lane0": "0xfffffff3",
-                    "lane1": "0xfffffff3",
+                    "lane1": "0xfffffffb",
                     "lane2": "0xfffffff3",
                     "lane3": "0xfffffff3",
-                    "lane4": "0xfffffffb",
-                    "lane5": "0xfffffff3",
-                    "lane6": "0xfffffffb",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffff3",
                     "lane7": "0xfffffff3"
                 },
                 "main": {
                     "lane0": "0x98",
-                    "lane1": "0x98",
+                    "lane1": "0x9d",
                     "lane2": "0x98",
                     "lane3": "0x98",
-                    "lane4": "0x9d",
-                    "lane5": "0x98",
-                    "lane6": "0x9d",
+                    "lane4": "0x98",
+                    "lane5": "0x9d",
+                    "lane6": "0x98",
                     "lane7": "0x98"
                 },
                 "post1": {
                     "lane0": "0x0",
-                    "lane1": "0x0",
+                    "lane1": "0xfffffffd",
                     "lane2": "0x0",
                     "lane3": "0x0",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffd",
+                    "lane4": "0x0",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "post2": {
                     "lane0": "0xfffffffe",
-                    "lane1": "0xfffffffe",
+                    "lane1": "0xfffffffd",
                     "lane2": "0xfffffffe",
                     "lane3": "0xfffffffe",
-                    "lane4": "0xfffffffd",
-                    "lane5": "0xfffffffe",
-                    "lane6": "0xfffffffd",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffe",
                     "lane7": "0xfffffffe"
                 }
             },
@@ -24036,32 +16996,32 @@
                 },
                 "pre1": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffc",
+                    "lane1": "0xfffffff9",
                     "lane2": "0xfffffffc",
                     "lane3": "0xfffffffc",
-                    "lane4": "0xfffffff9",
-                    "lane5": "0xfffffffc",
-                    "lane6": "0xfffffff9",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffffc",
                     "lane7": "0xfffffffc"
                 },
                 "main": {
                     "lane0": "0x67",
-                    "lane1": "0x67",
+                    "lane1": "0x52",
                     "lane2": "0x67",
                     "lane3": "0x67",
-                    "lane4": "0x52",
-                    "lane5": "0x67",
-                    "lane6": "0x52",
+                    "lane4": "0x67",
+                    "lane5": "0x52",
+                    "lane6": "0x67",
                     "lane7": "0x67"
                 },
                 "post1": {
                     "lane0": "0xffffffec",
-                    "lane1": "0xffffffec",
+                    "lane1": "0xfffffff8",
                     "lane2": "0xffffffec",
                     "lane3": "0xffffffec",
-                    "lane4": "0xfffffff8",
-                    "lane5": "0xffffffec",
-                    "lane6": "0xfffffff8",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xffffffec",
                     "lane7": "0xffffffec"
                 },
                 "post2": {
@@ -24201,134 +17161,6 @@
             }
         },
         "56": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe4",
-                        "lane1": "0xffffffe4",
-                        "lane2": "0xffffffe4",
-                        "lane3": "0xffffffe4",
-                        "lane4": "0xffffffe4",
-                        "lane5": "0xffffffe4",
-                        "lane6": "0xffffffe4",
-                        "lane7": "0xffffffe4"
-                    },
-                    "main": {
-                        "lane0": "0x00000064",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000064",
-                        "lane3": "0x00000064",
-                        "lane4": "0x00000064",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000064"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffffa",
-                        "lane1": "0xfffffffa",
-                        "lane2": "0xfffffffa",
-                        "lane3": "0xfffffffa",
-                        "lane4": "0xfffffffa",
-                        "lane5": "0xfffffffa",
-                        "lane6": "0xfffffffa",
-                        "lane7": "0xfffffffa"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff2",
-                        "lane1": "0xfffffff2",
-                        "lane2": "0xfffffff2",
-                        "lane3": "0xfffffff2",
-                        "lane4": "0xfffffff2",
-                        "lane5": "0xfffffff2",
-                        "lane6": "0xfffffff2",
-                        "lane7": "0xfffffff2"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0xfffffffc"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x00000008",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000008"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffec",
-                        "lane1": "0xffffffec",
-                        "lane2": "0xffffffec",
-                        "lane3": "0xffffffec",
-                        "lane4": "0xffffffec",
-                        "lane5": "0xffffffec",
-                        "lane6": "0xffffffec",
-                        "lane7": "0xffffffec"
-                    },
-                    "main": {
-                        "lane0": "0x00000055",
-                        "lane1": "0x00000055",
-                        "lane2": "0x00000055",
-                        "lane3": "0x00000055",
-                        "lane4": "0x00000055",
-                        "lane5": "0x00000055",
-                        "lane6": "0x00000055",
-                        "lane7": "0x00000055"
-                    },
-                    "post1": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -24641,134 +17473,6 @@
             }
         },
         "57": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffd6",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffd6",
-                        "lane6": "0xffffffd2",
-                        "lane7": "0xffffffd2"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000064",
-                        "lane4": "0x0000006c",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -25081,134 +17785,6 @@
             }
         },
         "58": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffd6",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffd6",
-                        "lane6": "0xffffffd2",
-                        "lane7": "0xffffffd2"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000064",
-                        "lane4": "0x0000006c",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -25521,134 +18097,6 @@
             }
         },
         "59": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffd6",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffd6",
-                        "lane6": "0xffffffd2",
-                        "lane7": "0xffffffd2"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000064",
-                        "lane4": "0x0000006c",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -25961,134 +18409,6 @@
             }
         },
         "60": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xfffffffe",
-                        "lane1": "0xfffffffe",
-                        "lane2": "0xfffffffe",
-                        "lane3": "0xfffffffe",
-                        "lane4": "0xfffffffe",
-                        "lane5": "0xfffffffe",
-                        "lane6": "0xfffffffe",
-                        "lane7": "0xfffffffe"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe5",
-                        "lane1": "0xffffffe5",
-                        "lane2": "0xffffffe5",
-                        "lane3": "0xffffffe5",
-                        "lane4": "0xffffffe5",
-                        "lane5": "0xffffffe5",
-                        "lane6": "0xffffffe5",
-                        "lane7": "0xffffffe5"
-                    },
-                    "main": {
-                        "lane0": "0x0000005f",
-                        "lane1": "0x0000005f",
-                        "lane2": "0x0000005f",
-                        "lane3": "0x0000005f",
-                        "lane4": "0x0000005f",
-                        "lane5": "0x0000005f",
-                        "lane6": "0x0000005f",
-                        "lane7": "0x0000005f"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0xfffffffc",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000008",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x0000000c",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffda",
-                        "lane1": "0xffffffda",
-                        "lane2": "0xffffffd6",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffde",
-                        "lane5": "0xffffffd6",
-                        "lane6": "0xffffffd2",
-                        "lane7": "0xffffffd2"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000064",
-                        "lane2": "0x00000060",
-                        "lane3": "0x00000064",
-                        "lane4": "0x0000006c",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000068"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff8",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff8"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -26401,134 +18721,6 @@
             }
         },
         "61": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000061",
-                        "lane1": "0x00000061",
-                        "lane2": "0x00000061",
-                        "lane3": "0x00000061",
-                        "lane4": "0x00000061",
-                        "lane5": "0x00000061",
-                        "lane6": "0x00000061",
-                        "lane7": "0x00000061"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0x00000000",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000004",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd2",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffd2",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffd2",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffd6"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000054",
-                        "lane6": "0x00000068",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff0",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -26552,23 +18744,23 @@
                 },
                 "pre1": {
                     "lane0": "0xffffffe8",
-                    "lane1": "0xffffffe8",
+                    "lane1": "0xffffffe4",
                     "lane2": "0xffffffe8",
                     "lane3": "0xffffffe8",
                     "lane4": "0xffffffe8",
                     "lane5": "0xffffffe4",
                     "lane6": "0xffffffe8",
-                    "lane7": "0xffffffe4"
+                    "lane7": "0xffffffe8"
                 },
                 "main": {
                     "lane0": "0x78",
-                    "lane1": "0x78",
+                    "lane1": "0x74",
                     "lane2": "0x78",
                     "lane3": "0x78",
                     "lane4": "0x78",
                     "lane5": "0x74",
                     "lane6": "0x78",
-                    "lane7": "0x74"
+                    "lane7": "0x78"
                 },
                 "post1": {
                     "lane0": "0xffffffec",
@@ -26841,134 +19033,6 @@
             }
         },
         "62": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000006",
-                        "lane1": "0x00000006",
-                        "lane2": "0x00000006",
-                        "lane3": "0x00000006",
-                        "lane4": "0x00000006",
-                        "lane5": "0x00000006",
-                        "lane6": "0x00000006",
-                        "lane7": "0x00000006"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe7",
-                        "lane1": "0xffffffe7",
-                        "lane2": "0xffffffe7",
-                        "lane3": "0xffffffe7",
-                        "lane4": "0xffffffe7",
-                        "lane5": "0xffffffe7",
-                        "lane6": "0xffffffe7",
-                        "lane7": "0xffffffe7"
-                    },
-                    "main": {
-                        "lane0": "0x00000061",
-                        "lane1": "0x00000061",
-                        "lane2": "0x00000061",
-                        "lane3": "0x00000061",
-                        "lane4": "0x00000061",
-                        "lane5": "0x00000061",
-                        "lane6": "0x00000061",
-                        "lane7": "0x00000061"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff1",
-                        "lane1": "0xfffffff1",
-                        "lane2": "0xfffffff1",
-                        "lane3": "0xfffffff1",
-                        "lane4": "0xfffffff1",
-                        "lane5": "0xfffffff1",
-                        "lane6": "0xfffffff1",
-                        "lane7": "0xfffffff1"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff4",
-                        "lane1": "0xfffffff4",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0x00000000",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd2",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffd2",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffd2",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffd6"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000054",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff4",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -27281,134 +19345,6 @@
             }
         },
         "63": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x00000062",
-                        "lane1": "0x00000062",
-                        "lane2": "0x00000062",
-                        "lane3": "0x00000062",
-                        "lane4": "0x00000062",
-                        "lane5": "0x00000062",
-                        "lane6": "0x00000062",
-                        "lane7": "0x00000062"
-                    },
-                    "post1": {
-                        "lane0": "0",
-                        "lane1": "0",
-                        "lane2": "0",
-                        "lane3": "0",
-                        "lane4": "0",
-                        "lane5": "0",
-                        "lane6": "0",
-                        "lane7": "0"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0x00000000",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffff8",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x0000000c",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd2",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffd2",
-                        "lane3": "0xffffffda",
-                        "lane4": "0xffffffd2",
-                        "lane5": "0xffffffde",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffd6"
-                    },
-                    "main": {
-                        "lane0": "0x0000005c",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000054",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000054",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff8",
-                        "lane5": "0xfffffff0",
-                        "lane6": "0xfffffff0",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -27432,22 +19368,22 @@
                 },
                 "pre1": {
                     "lane0": "0xffffffe4",
-                    "lane1": "0xffffffe4",
+                    "lane1": "0xffffffe8",
                     "lane2": "0xffffffe4",
                     "lane3": "0xffffffe4",
                     "lane4": "0xffffffe4",
                     "lane5": "0xffffffe4",
-                    "lane6": "0xffffffe8",
+                    "lane6": "0xffffffe4",
                     "lane7": "0xffffffe4"
                 },
                 "main": {
                     "lane0": "0x74",
-                    "lane1": "0x74",
+                    "lane1": "0x78",
                     "lane2": "0x74",
                     "lane3": "0x74",
                     "lane4": "0x74",
                     "lane5": "0x74",
-                    "lane6": "0x78",
+                    "lane6": "0x74",
                     "lane7": "0x74"
                 },
                 "post1": {
@@ -27484,52 +19420,52 @@
                 },
                 "pre2": {
                     "lane0": "0x1",
-                    "lane1": "0x0",
-                    "lane2": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0x1",
-                    "lane5": "0x0",
-                    "lane6": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "pre1": {
                     "lane0": "0xfffffff3",
-                    "lane1": "0xfffffff7",
-                    "lane2": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff7",
                     "lane3": "0xfffffff7",
                     "lane4": "0xfffffff3",
-                    "lane5": "0xfffffff7",
-                    "lane6": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff7",
                     "lane7": "0xfffffff7"
                 },
                 "main": {
                     "lane0": "0x98",
-                    "lane1": "0x9e",
-                    "lane2": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x9e",
                     "lane3": "0x9e",
                     "lane4": "0x98",
-                    "lane5": "0x9e",
-                    "lane6": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x9e",
                     "lane7": "0x9e"
                 },
                 "post1": {
                     "lane0": "0x0",
-                    "lane1": "0xffffffff",
-                    "lane2": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0xffffffff",
                     "lane3": "0xffffffff",
                     "lane4": "0x0",
-                    "lane5": "0xffffffff",
-                    "lane6": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0xffffffff",
                     "lane7": "0xffffffff"
                 },
                 "post2": {
                     "lane0": "0xfffffffe",
-                    "lane1": "0x0",
-                    "lane2": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0xfffffffe",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 }
             },
@@ -27556,32 +19492,32 @@
                 },
                 "pre1": {
                     "lane0": "0xfffffffc",
-                    "lane1": "0xfffffffa",
-                    "lane2": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffa",
                     "lane3": "0xfffffffa",
                     "lane4": "0xfffffffc",
-                    "lane5": "0xfffffffa",
-                    "lane6": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffa",
                     "lane7": "0xfffffffa"
                 },
                 "main": {
                     "lane0": "0x67",
-                    "lane1": "0x63",
-                    "lane2": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x63",
                     "lane3": "0x63",
                     "lane4": "0x67",
-                    "lane5": "0x63",
-                    "lane6": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x63",
                     "lane7": "0x63"
                 },
                 "post1": {
                     "lane0": "0xffffffec",
-                    "lane1": "0xffffffea",
-                    "lane2": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffea",
                     "lane3": "0xffffffea",
                     "lane4": "0xffffffec",
-                    "lane5": "0xffffffea",
-                    "lane6": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffea",
                     "lane7": "0xffffffea"
                 },
                 "post2": {
@@ -27721,134 +19657,6 @@
             }
         },
         "64": {
-            "EOPTOLINK-(EO138HGPCT\\d{2}SL1|EO138HGPCT\\d{2}CSL1|EOLO138HG5HSDLC)": {
-                "speed:100GAUI-1-S|400GAUI-4-S|800G.*": {
-                    "pre3": {
-                        "lane0": "0xffffffff",
-                        "lane1": "0xffffffff",
-                        "lane2": "0xffffffff",
-                        "lane3": "0xffffffff",
-                        "lane4": "0xffffffff",
-                        "lane5": "0xffffffff",
-                        "lane6": "0xffffffff",
-                        "lane7": "0xffffffff"
-                    },
-                    "pre2": {
-                        "lane0": "0x00000007",
-                        "lane1": "0x00000007",
-                        "lane2": "0x00000007",
-                        "lane3": "0x00000007",
-                        "lane4": "0x00000007",
-                        "lane5": "0x00000007",
-                        "lane6": "0x00000007",
-                        "lane7": "0x00000007"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffe3",
-                        "lane1": "0xffffffe3",
-                        "lane2": "0xffffffe3",
-                        "lane3": "0xffffffe3",
-                        "lane4": "0xffffffe3",
-                        "lane5": "0xffffffe3",
-                        "lane6": "0xffffffe3",
-                        "lane7": "0xffffffe3"
-                    },
-                    "main": {
-                        "lane0": "0x00000062",
-                        "lane1": "0x00000062",
-                        "lane2": "0x00000062",
-                        "lane3": "0x00000062",
-                        "lane4": "0x00000062",
-                        "lane5": "0x00000062",
-                        "lane6": "0x00000062",
-                        "lane7": "0x00000062"
-                    },
-                    "post1": {
-                        "lane0": "0",
-                        "lane1": "0",
-                        "lane2": "0",
-                        "lane3": "0",
-                        "lane4": "0",
-                        "lane5": "0",
-                        "lane6": "0",
-                        "lane7": "0"
-                    },
-                    "post2": {
-                        "lane0": "0xfffffff3",
-                        "lane1": "0xfffffff3",
-                        "lane2": "0xfffffff3",
-                        "lane3": "0xfffffff3",
-                        "lane4": "0xfffffff3",
-                        "lane5": "0xfffffff3",
-                        "lane6": "0xfffffff3",
-                        "lane7": "0xfffffff3"
-                    }
-                }
-            },
-            "PINEWAVE-(L-OS8CNS\\d{3}-NMT|L-OSG8CNS\\d{3}-NMT|L-OH8CNH-NME)": {
-                "speed:100GAUI-1-L C2M (Annex 120G)|400GAUI-4-L C2M (Annex 120G)|LEI-400G-PAM4-4|LEI-800G-PAM4-8|LEI-200G-PAM4-2|LEI-100G-PAM4-1": {
-                    "pre3": {
-                        "lane0": "0xfffffffc",
-                        "lane1": "0x00000000",
-                        "lane2": "0xfffffffc",
-                        "lane3": "0xfffffffc",
-                        "lane4": "0xfffffffc",
-                        "lane5": "0xfffffffc",
-                        "lane6": "0xfffffffc",
-                        "lane7": "0x00000000"
-                    },
-                    "pre2": {
-                        "lane0": "0x0000000c",
-                        "lane1": "0x00000008",
-                        "lane2": "0x0000000c",
-                        "lane3": "0x00000008",
-                        "lane4": "0x00000008",
-                        "lane5": "0x00000008",
-                        "lane6": "0x00000008",
-                        "lane7": "0x00000004"
-                    },
-                    "pre1": {
-                        "lane0": "0xffffffd6",
-                        "lane1": "0xffffffde",
-                        "lane2": "0xffffffda",
-                        "lane3": "0xffffffe2",
-                        "lane4": "0xffffffe2",
-                        "lane5": "0xffffffda",
-                        "lane6": "0xffffffda",
-                        "lane7": "0xffffffd6"
-                    },
-                    "main": {
-                        "lane0": "0x00000060",
-                        "lane1": "0x00000058",
-                        "lane2": "0x00000058",
-                        "lane3": "0x00000060",
-                        "lane4": "0x00000060",
-                        "lane5": "0x00000064",
-                        "lane6": "0x00000064",
-                        "lane7": "0x00000060"
-                    },
-                    "post1": {
-                        "lane0": "0xfffffff8",
-                        "lane1": "0xfffffff0",
-                        "lane2": "0xfffffff4",
-                        "lane3": "0xfffffff4",
-                        "lane4": "0xfffffff4",
-                        "lane5": "0xfffffff4",
-                        "lane6": "0xfffffff8",
-                        "lane7": "0xfffffff4"
-                    },
-                    "post2": {
-                        "lane0": "0x00000000",
-                        "lane1": "0x00000000",
-                        "lane2": "0x00000000",
-                        "lane3": "0x00000000",
-                        "lane4": "0x00000000",
-                        "lane5": "0x00000000",
-                        "lane6": "0x00000000",
-                        "lane7": "0x00000000"
-                    }
-                }
-            },
             "OPTICAL100": {
                 "pre3": {
                     "lane0": "0x0",
@@ -27876,8 +19684,8 @@
                     "lane2": "0xffffffe4",
                     "lane3": "0xffffffe4",
                     "lane4": "0xffffffe4",
-                    "lane5": "0xffffffe4",
-                    "lane6": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe4",
                     "lane7": "0xffffffe4"
                 },
                 "main": {
@@ -27886,8 +19694,8 @@
                     "lane2": "0x74",
                     "lane3": "0x74",
                     "lane4": "0x74",
-                    "lane5": "0x74",
-                    "lane6": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x74",
                     "lane7": "0x74"
                 },
                 "post1": {
@@ -27928,8 +19736,8 @@
                     "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 },
                 "pre1": {
@@ -27938,8 +19746,8 @@
                     "lane2": "0xfffffff7",
                     "lane3": "0xfffffff7",
                     "lane4": "0xfffffff7",
-                    "lane5": "0xfffffff7",
-                    "lane6": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff7",
                     "lane7": "0xfffffff7"
                 },
                 "main": {
@@ -27948,8 +19756,8 @@
                     "lane2": "0x9e",
                     "lane3": "0x9e",
                     "lane4": "0x9e",
-                    "lane5": "0x9e",
-                    "lane6": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x9e",
                     "lane7": "0x9e"
                 },
                 "post1": {
@@ -27958,8 +19766,8 @@
                     "lane2": "0xffffffff",
                     "lane3": "0xffffffff",
                     "lane4": "0xffffffff",
-                    "lane5": "0xffffffff",
-                    "lane6": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0xffffffff",
                     "lane7": "0xffffffff"
                 },
                 "post2": {
@@ -27968,8 +19776,8 @@
                     "lane2": "0x0",
                     "lane3": "0x0",
                     "lane4": "0x0",
-                    "lane5": "0x0",
-                    "lane6": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0x0",
                     "lane7": "0x0"
                 }
             },
@@ -28000,8 +19808,8 @@
                     "lane2": "0xfffffffa",
                     "lane3": "0xfffffffa",
                     "lane4": "0xfffffffa",
-                    "lane5": "0xfffffffa",
-                    "lane6": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffa",
                     "lane7": "0xfffffffa"
                 },
                 "main": {
@@ -28010,8 +19818,8 @@
                     "lane2": "0x63",
                     "lane3": "0x63",
                     "lane4": "0x63",
-                    "lane5": "0x63",
-                    "lane6": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x63",
                     "lane7": "0x63"
                 },
                 "post1": {
@@ -28020,8 +19828,8 @@
                     "lane2": "0xffffffea",
                     "lane3": "0xffffffea",
                     "lane4": "0xffffffea",
-                    "lane5": "0xffffffea",
-                    "lane6": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffea",
                     "lane7": "0xffffffea"
                 },
                 "post2": {
@@ -28161,23 +19969,6 @@
             }
         },
         "65": {
-            "OPTICAL10": {
-                "pre1": {
-                    "lane0": "0x0"
-                },
-                "main": {
-                    "lane0": "0x1f"
-                },
-                "post1": {
-                    "lane0": "0xb"
-                },
-                "post2": {
-                    "lane0": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0"
-                }
-            },
             "COPPER10": {
                 "pre1": {
                     "lane0": "0x2"
@@ -28187,6 +19978,23 @@
                 },
                 "post1": {
                     "lane0": "0xc"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
+                }
+            },
+            "OPTICAL10": {
+                "pre1": {
+                    "lane0": "0x0"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xb"
                 },
                 "post2": {
                     "lane0": "0x0"
@@ -28197,23 +20005,6 @@
             }
         },
         "66": {
-            "OPTICAL10": {
-                "pre1": {
-                    "lane0": "0x0"
-                },
-                "main": {
-                    "lane0": "0x1f"
-                },
-                "post1": {
-                    "lane0": "0xb"
-                },
-                "post2": {
-                    "lane0": "0x0"
-                },
-                "post3": {
-                    "lane0": "0x0"
-                }
-            },
             "COPPER10": {
                 "pre1": {
                     "lane0": "0x2"
@@ -28223,6 +20014,23 @@
                 },
                 "post1": {
                     "lane0": "0xc"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
+                }
+            },
+            "OPTICAL10": {
+                "pre1": {
+                    "lane0": "0x0"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xb"
                 },
                 "post2": {
                     "lane0": "0x0"

--- a/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
+++ b/device/arista/x86_64-arista_7060x6_64pe_b/media_settings.json
@@ -223,6 +223,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x9f",
+                    "lane1": "0x9f",
+                    "lane2": "0x9f",
+                    "lane3": "0x9f",
+                    "lane4": "0x9f",
+                    "lane5": "0x9f",
+                    "lane6": "0x9f",
+                    "lane7": "0x9f"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe9",
+                    "lane4": "0xffffffe9",
+                    "lane5": "0xffffffe9",
+                    "lane6": "0xffffffe9",
+                    "lane7": "0xffffffe9"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -457,6 +817,366 @@
                         "lane6": "0x0",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x74",
+                    "lane1": "0x74",
+                    "lane2": "0x74",
+                    "lane3": "0x74",
+                    "lane4": "0x74",
+                    "lane5": "0x74",
+                    "lane6": "0x74",
+                    "lane7": "0x74"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x9f",
+                    "lane1": "0x9f",
+                    "lane2": "0x9f",
+                    "lane3": "0x9f",
+                    "lane4": "0x9f",
+                    "lane5": "0x9f",
+                    "lane6": "0x9f",
+                    "lane7": "0x9f"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe9",
+                    "lane4": "0xffffffe9",
+                    "lane5": "0xffffffe9",
+                    "lane6": "0xffffffe9",
+                    "lane7": "0xffffffe9"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -695,6 +1415,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x74",
+                    "lane1": "0x74",
+                    "lane2": "0x74",
+                    "lane3": "0x74",
+                    "lane4": "0x74",
+                    "lane5": "0x74",
+                    "lane6": "0x74",
+                    "lane7": "0x74"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff7",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff7",
+                    "lane3": "0xfffffff7",
+                    "lane4": "0xfffffff7",
+                    "lane5": "0xfffffff7",
+                    "lane6": "0xfffffff7",
+                    "lane7": "0xfffffff7"
+                },
+                "main": {
+                    "lane0": "0x9e",
+                    "lane1": "0x9e",
+                    "lane2": "0x9e",
+                    "lane3": "0x9e",
+                    "lane4": "0x9e",
+                    "lane5": "0x9e",
+                    "lane6": "0x9e",
+                    "lane7": "0x9e"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x63",
+                    "lane1": "0x63",
+                    "lane2": "0x63",
+                    "lane3": "0x63",
+                    "lane4": "0x63",
+                    "lane5": "0x63",
+                    "lane6": "0x63",
+                    "lane7": "0x63"
+                },
+                "post1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffea",
+                    "lane3": "0xffffffea",
+                    "lane4": "0xffffffea",
+                    "lane5": "0xffffffea",
+                    "lane6": "0xffffffea",
+                    "lane7": "0xffffffea"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -929,6 +2009,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -1167,6 +2607,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -1401,6 +3201,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9f",
+                    "lane1": "0x9f",
+                    "lane2": "0x9f",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0x9f",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0xffffffff",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffe9",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -1639,6 +3799,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -1873,6 +4393,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -2111,6 +4991,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -2345,6 +5585,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -2583,6 +6183,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x80",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -2817,6 +6777,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x98",
+                    "lane6": "0x9d",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x67",
+                    "lane6": "0x52",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -3055,6 +7375,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -3289,6 +7969,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa2",
+                    "lane4": "0xa3",
+                    "lane5": "0xa2",
+                    "lane6": "0xa3",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -3527,6 +8567,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x98",
+                    "lane2": "0x9d",
+                    "lane3": "0x98",
+                    "lane4": "0x9d",
+                    "lane5": "0x98",
+                    "lane6": "0x9d",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x67",
+                    "lane2": "0x52",
+                    "lane3": "0x67",
+                    "lane4": "0x52",
+                    "lane5": "0x67",
+                    "lane6": "0x52",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -3761,6 +9161,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -3999,6 +9759,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -4233,6 +10353,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa2",
+                    "lane4": "0xa3",
+                    "lane5": "0xa2",
+                    "lane6": "0xa3",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -4471,6 +10951,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x98",
+                    "lane2": "0x9d",
+                    "lane3": "0x98",
+                    "lane4": "0x9d",
+                    "lane5": "0x98",
+                    "lane6": "0x9d",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x67",
+                    "lane2": "0x52",
+                    "lane3": "0x67",
+                    "lane4": "0x52",
+                    "lane5": "0x67",
+                    "lane6": "0x52",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -4705,6 +11545,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -4943,6 +12143,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -5177,6 +12737,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x66",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -5415,6 +13335,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -5649,6 +13929,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -5887,6 +14527,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "pre2": {
+                    "lane0": "0xa",
+                    "lane1": "0x6",
+                    "lane2": "0xa",
+                    "lane3": "0x6",
+                    "lane4": "0xa",
+                    "lane5": "0x6",
+                    "lane6": "0xa",
+                    "lane7": "0xa"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -6121,6 +15121,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -6359,6 +15719,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -6593,6 +16313,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -6831,6 +16911,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "pre2": {
+                    "lane0": "0xa",
+                    "lane1": "0x6",
+                    "lane2": "0xa",
+                    "lane3": "0xa",
+                    "lane4": "0xa",
+                    "lane5": "0xa",
+                    "lane6": "0xa",
+                    "lane7": "0xa"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -7065,6 +17505,366 @@
                         "lane6": "0x0",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -7303,6 +18103,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -7537,6 +18697,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0xa",
+                    "lane1": "0x6",
+                    "lane2": "0xa",
+                    "lane3": "0x6",
+                    "lane4": "0xa",
+                    "lane5": "0x6",
+                    "lane6": "0xa",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -7775,6 +19295,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "pre2": {
+                    "lane0": "0xa",
+                    "lane1": "0xa",
+                    "lane2": "0xa",
+                    "lane3": "0xa",
+                    "lane4": "0xa",
+                    "lane5": "0xa",
+                    "lane6": "0xa",
+                    "lane7": "0xa"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -8009,6 +19889,366 @@
                         "lane6": "0x0",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -8247,6 +20487,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -8481,6 +21081,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0xa",
+                    "lane1": "0x6",
+                    "lane2": "0xa",
+                    "lane3": "0x6",
+                    "lane4": "0xa",
+                    "lane5": "0x6",
+                    "lane6": "0xa",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -8719,6 +21679,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -8953,6 +22273,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -9191,6 +22871,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -9425,6 +23465,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -9663,6 +24063,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -9897,6 +24657,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa3",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa3",
+                    "lane6": "0xa3",
+                    "lane7": "0xa3"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "main": {
+                    "lane0": "0x47",
+                    "lane1": "0x47",
+                    "lane2": "0x47",
+                    "lane3": "0x47",
+                    "lane4": "0x47",
+                    "lane5": "0x47",
+                    "lane6": "0x47",
+                    "lane7": "0x47"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -10135,6 +25255,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -10369,6 +25849,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -10607,6 +26447,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -10841,6 +27041,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa3",
+                    "lane4": "0xa3",
+                    "lane5": "0xa2",
+                    "lane6": "0xa3",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x47",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -11079,6 +27639,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -11313,6 +28233,366 @@
                         "lane6": "0x0",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe0",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe0",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe0"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -11551,6 +28831,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe0",
+                    "lane1": "0xffffffe0",
+                    "lane2": "0xffffffe0",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -11785,6 +29425,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa3",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa2",
+                    "lane4": "0xa3",
+                    "lane5": "0xa2",
+                    "lane6": "0xa3",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -12023,6 +30023,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x98",
+                    "lane2": "0x9d",
+                    "lane3": "0x98",
+                    "lane4": "0x9d",
+                    "lane5": "0x98",
+                    "lane6": "0x9d",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x67",
+                    "lane2": "0x52",
+                    "lane3": "0x67",
+                    "lane4": "0x52",
+                    "lane5": "0x67",
+                    "lane6": "0x52",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -12257,6 +30617,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe0",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe0",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0x9d",
+                    "lane1": "0x9d",
+                    "lane2": "0x9d",
+                    "lane3": "0x9d",
+                    "lane4": "0x9d",
+                    "lane5": "0x9d",
+                    "lane6": "0x9d",
+                    "lane7": "0x9d"
+                },
+                "post1": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "post2": {
+                    "lane0": "0xfffffffd",
+                    "lane1": "0xfffffffd",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffd",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffd",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffd"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff9",
+                    "lane1": "0xfffffff9",
+                    "lane2": "0xfffffff9",
+                    "lane3": "0xfffffff9",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffff9",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffff9"
+                },
+                "main": {
+                    "lane0": "0x52",
+                    "lane1": "0x52",
+                    "lane2": "0x52",
+                    "lane3": "0x52",
+                    "lane4": "0x52",
+                    "lane5": "0x52",
+                    "lane6": "0x52",
+                    "lane7": "0x52"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -12495,6 +31215,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -12729,6 +31809,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x78",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffd",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa3",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -12967,6 +32407,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x78",
+                    "lane2": "0x80",
+                    "lane3": "0x78",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x9d",
+                    "lane5": "0x98",
+                    "lane6": "0x9d",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffd",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffd",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffff9",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffff9",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x52",
+                    "lane5": "0x67",
+                    "lane6": "0x52",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -13201,6 +33001,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x80",
+                    "lane1": "0x80",
+                    "lane2": "0x80",
+                    "lane3": "0x80",
+                    "lane4": "0x80",
+                    "lane5": "0x80",
+                    "lane6": "0x80",
+                    "lane7": "0x80"
+                },
+                "post1": {
+                    "lane0": "0xfffffff8",
+                    "lane1": "0xfffffff8",
+                    "lane2": "0xfffffff8",
+                    "lane3": "0xfffffff8",
+                    "lane4": "0xfffffff8",
+                    "lane5": "0xfffffff8",
+                    "lane6": "0xfffffff8",
+                    "lane7": "0xfffffff8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -13439,6 +33599,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -13673,6 +34193,366 @@
                         "lane6": "0x1",
                         "lane7": "0x1"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffb",
+                    "lane1": "0xfffffffb",
+                    "lane2": "0xfffffffb",
+                    "lane3": "0xfffffffb",
+                    "lane4": "0xfffffffb",
+                    "lane5": "0xfffffffb",
+                    "lane6": "0xfffffffb",
+                    "lane7": "0xfffffffb"
+                },
+                "main": {
+                    "lane0": "0xa2",
+                    "lane1": "0xa2",
+                    "lane2": "0xa2",
+                    "lane3": "0xa2",
+                    "lane4": "0xa2",
+                    "lane5": "0xa2",
+                    "lane6": "0xa2",
+                    "lane7": "0xa2"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffed",
+                    "lane1": "0xffffffed",
+                    "lane2": "0xffffffed",
+                    "lane3": "0xffffffed",
+                    "lane4": "0xffffffed",
+                    "lane5": "0xffffffed",
+                    "lane6": "0xffffffed",
+                    "lane7": "0xffffffed"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
                 }
             },
             "Default": {
@@ -13911,6 +34791,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -14145,6 +35385,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe4",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xfffffff0",
+                    "lane1": "0xfffffff0",
+                    "lane2": "0xfffffff0",
+                    "lane3": "0xfffffff0",
+                    "lane4": "0xfffffff0",
+                    "lane5": "0xfffffff0",
+                    "lane6": "0xfffffff0",
+                    "lane7": "0xfffffff0"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x1",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x1"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff3",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff3",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff3",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff3"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x98",
+                    "lane2": "0x98",
+                    "lane3": "0x98",
+                    "lane4": "0x98",
+                    "lane5": "0x98",
+                    "lane6": "0x98",
+                    "lane7": "0x98"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffc",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffc",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffc",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffc"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x67",
+                    "lane2": "0x67",
+                    "lane3": "0x67",
+                    "lane4": "0x67",
+                    "lane5": "0x67",
+                    "lane6": "0x67",
+                    "lane7": "0x67"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -14383,6 +35983,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x74",
+                    "lane6": "0x78",
+                    "lane7": "0x74"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x9f",
+                    "lane1": "0x9f",
+                    "lane2": "0x9f",
+                    "lane3": "0x9f",
+                    "lane4": "0x9f",
+                    "lane5": "0x9f",
+                    "lane6": "0x9f",
+                    "lane7": "0x9f"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe9",
+                    "lane4": "0xffffffe9",
+                    "lane5": "0xffffffe9",
+                    "lane6": "0xffffffe9",
+                    "lane7": "0xffffffe9"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x1",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x1",
@@ -14617,6 +36577,366 @@
                         "lane6": "0x1",
                         "lane7": "0x0"
                     }
+                }
+            },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x9f",
+                    "lane1": "0x9f",
+                    "lane2": "0x9f",
+                    "lane3": "0x9f",
+                    "lane4": "0x9f",
+                    "lane5": "0x9f",
+                    "lane6": "0x9f",
+                    "lane7": "0x9f"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0xffffffff",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0xfffffffe",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0xfffffffe",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0xfffffffe",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0xfffffffe"
+                },
+                "main": {
+                    "lane0": "0x66",
+                    "lane1": "0x66",
+                    "lane2": "0x66",
+                    "lane3": "0x66",
+                    "lane4": "0x66",
+                    "lane5": "0x66",
+                    "lane6": "0x66",
+                    "lane7": "0x66"
+                },
+                "post1": {
+                    "lane0": "0xffffffe9",
+                    "lane1": "0xffffffe9",
+                    "lane2": "0xffffffe9",
+                    "lane3": "0xffffffe9",
+                    "lane4": "0xffffffe9",
+                    "lane5": "0xffffffe9",
+                    "lane6": "0xffffffe9",
+                    "lane7": "0xffffffe9"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
                 }
             },
             "Default": {
@@ -14855,6 +37175,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x74",
+                    "lane1": "0x74",
+                    "lane2": "0x74",
+                    "lane3": "0x74",
+                    "lane4": "0x74",
+                    "lane5": "0x74",
+                    "lane6": "0x78",
+                    "lane7": "0x74"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x1",
+                    "lane1": "0x0",
+                    "lane2": "0x1",
+                    "lane3": "0x0",
+                    "lane4": "0x1",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff3",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff3",
+                    "lane3": "0xfffffff7",
+                    "lane4": "0xfffffff3",
+                    "lane5": "0xfffffff7",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff7"
+                },
+                "main": {
+                    "lane0": "0x98",
+                    "lane1": "0x9e",
+                    "lane2": "0x98",
+                    "lane3": "0x9e",
+                    "lane4": "0x98",
+                    "lane5": "0x9e",
+                    "lane6": "0x98",
+                    "lane7": "0x9e"
+                },
+                "post1": {
+                    "lane0": "0x0",
+                    "lane1": "0xffffffff",
+                    "lane2": "0x0",
+                    "lane3": "0xffffffff",
+                    "lane4": "0x0",
+                    "lane5": "0xffffffff",
+                    "lane6": "0x0",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0xfffffffe",
+                    "lane1": "0x0",
+                    "lane2": "0xfffffffe",
+                    "lane3": "0x0",
+                    "lane4": "0xfffffffe",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffc",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffc",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffc",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x67",
+                    "lane1": "0x63",
+                    "lane2": "0x67",
+                    "lane3": "0x63",
+                    "lane4": "0x67",
+                    "lane5": "0x63",
+                    "lane6": "0x67",
+                    "lane7": "0x63"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffea",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffea",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffea"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -15091,6 +37771,366 @@
                     }
                 }
             },
+            "OPTICAL100": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x6",
+                    "lane1": "0x6",
+                    "lane2": "0x6",
+                    "lane3": "0x6",
+                    "lane4": "0x6",
+                    "lane5": "0x6",
+                    "lane6": "0x6",
+                    "lane7": "0x6"
+                },
+                "pre1": {
+                    "lane0": "0xffffffe4",
+                    "lane1": "0xffffffe4",
+                    "lane2": "0xffffffe4",
+                    "lane3": "0xffffffe4",
+                    "lane4": "0xffffffe4",
+                    "lane5": "0xffffffe4",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe4"
+                },
+                "main": {
+                    "lane0": "0x74",
+                    "lane1": "0x74",
+                    "lane2": "0x74",
+                    "lane3": "0x74",
+                    "lane4": "0x74",
+                    "lane5": "0x74",
+                    "lane6": "0x78",
+                    "lane7": "0x74"
+                },
+                "post1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x1",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff7",
+                    "lane1": "0xfffffff7",
+                    "lane2": "0xfffffff7",
+                    "lane3": "0xfffffff7",
+                    "lane4": "0xfffffff7",
+                    "lane5": "0xfffffff7",
+                    "lane6": "0xfffffff3",
+                    "lane7": "0xfffffff7"
+                },
+                "main": {
+                    "lane0": "0x9e",
+                    "lane1": "0x9e",
+                    "lane2": "0x9e",
+                    "lane3": "0x9e",
+                    "lane4": "0x9e",
+                    "lane5": "0x9e",
+                    "lane6": "0x98",
+                    "lane7": "0x9e"
+                },
+                "post1": {
+                    "lane0": "0xffffffff",
+                    "lane1": "0xffffffff",
+                    "lane2": "0xffffffff",
+                    "lane3": "0xffffffff",
+                    "lane4": "0xffffffff",
+                    "lane5": "0xffffffff",
+                    "lane6": "0x0",
+                    "lane7": "0xffffffff"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0xfffffffe",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "OPTICAL25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffc",
+                    "lane7": "0xfffffffa"
+                },
+                "main": {
+                    "lane0": "0x63",
+                    "lane1": "0x63",
+                    "lane2": "0x63",
+                    "lane3": "0x63",
+                    "lane4": "0x63",
+                    "lane5": "0x63",
+                    "lane6": "0x67",
+                    "lane7": "0x63"
+                },
+                "post1": {
+                    "lane0": "0xffffffea",
+                    "lane1": "0xffffffea",
+                    "lane2": "0xffffffea",
+                    "lane3": "0xffffffea",
+                    "lane4": "0xffffffea",
+                    "lane5": "0xffffffea",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffea"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER50": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x4",
+                    "lane1": "0x4",
+                    "lane2": "0x4",
+                    "lane3": "0x4",
+                    "lane4": "0x4",
+                    "lane5": "0x4",
+                    "lane6": "0x4",
+                    "lane7": "0x4"
+                },
+                "pre1": {
+                    "lane0": "0xffffffec",
+                    "lane1": "0xffffffec",
+                    "lane2": "0xffffffec",
+                    "lane3": "0xffffffec",
+                    "lane4": "0xffffffec",
+                    "lane5": "0xffffffec",
+                    "lane6": "0xffffffec",
+                    "lane7": "0xffffffec"
+                },
+                "main": {
+                    "lane0": "0x78",
+                    "lane1": "0x78",
+                    "lane2": "0x78",
+                    "lane3": "0x78",
+                    "lane4": "0x78",
+                    "lane5": "0x78",
+                    "lane6": "0x78",
+                    "lane7": "0x78"
+                },
+                "post1": {
+                    "lane0": "0xffffffe8",
+                    "lane1": "0xffffffe8",
+                    "lane2": "0xffffffe8",
+                    "lane3": "0xffffffe8",
+                    "lane4": "0xffffffe8",
+                    "lane5": "0xffffffe8",
+                    "lane6": "0xffffffe8",
+                    "lane7": "0xffffffe8"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
+            "COPPER25": {
+                "pre3": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "pre1": {
+                    "lane0": "0xfffffff2",
+                    "lane1": "0xfffffff2",
+                    "lane2": "0xfffffff2",
+                    "lane3": "0xfffffff2",
+                    "lane4": "0xfffffff2",
+                    "lane5": "0xfffffff2",
+                    "lane6": "0xfffffff2",
+                    "lane7": "0xfffffff2"
+                },
+                "main": {
+                    "lane0": "0x6b",
+                    "lane1": "0x6b",
+                    "lane2": "0x6b",
+                    "lane3": "0x6b",
+                    "lane4": "0x6b",
+                    "lane5": "0x6b",
+                    "lane6": "0x6b",
+                    "lane7": "0x6b"
+                },
+                "post1": {
+                    "lane0": "0xfffffffa",
+                    "lane1": "0xfffffffa",
+                    "lane2": "0xfffffffa",
+                    "lane3": "0xfffffffa",
+                    "lane4": "0xfffffffa",
+                    "lane5": "0xfffffffa",
+                    "lane6": "0xfffffffa",
+                    "lane7": "0xfffffffa"
+                },
+                "post2": {
+                    "lane0": "0x0",
+                    "lane1": "0x0",
+                    "lane2": "0x0",
+                    "lane3": "0x0",
+                    "lane4": "0x0",
+                    "lane5": "0x0",
+                    "lane6": "0x0",
+                    "lane7": "0x0"
+                },
+                "rxpolarity": {
+                    "lane0": "0x0",
+                    "lane1": "0x1",
+                    "lane2": "0x0",
+                    "lane3": "0x1",
+                    "lane4": "0x0",
+                    "lane5": "0x1",
+                    "lane6": "0x0",
+                    "lane7": "0x1"
+                }
+            },
             "Default": {
                 "rxpolarity": {
                     "lane0": "0x0",
@@ -15101,6 +38141,78 @@
                     "lane5": "0x1",
                     "lane6": "0x0",
                     "lane7": "0x1"
+                }
+            }
+        },
+        "65": {
+            "OPTICAL10": {
+                "pre1": {
+                    "lane0": "0x0"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xb"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
+                }
+            },
+            "COPPER10": {
+                "pre1": {
+                    "lane0": "0x2"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xc"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
+                }
+            }
+        },
+        "66": {
+            "OPTICAL10": {
+                "pre1": {
+                    "lane0": "0x0"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xb"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
+                }
+            },
+            "COPPER10": {
+                "pre1": {
+                    "lane0": "0x2"
+                },
+                "main": {
+                    "lane0": "0x1f"
+                },
+                "post1": {
+                    "lane0": "0xc"
+                },
+                "post2": {
+                    "lane0": "0x0"
+                },
+                "post3": {
+                    "lane0": "0x0"
                 }
             }
         }


### PR DESCRIPTION
Why I did it
Manual backport of PR#22956


(cherry picked from commit 5785463b5ad1890a6023e47a45e96ae1cc7865cf)

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
New tuning files are needed in the 202605 branch.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->
202605: 2026-08-30 16:15:43 UTC - 2c2da2bc-eda6-4ecd-b0c3-0e50073e5376
#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
