### PR TITLE
[syncd] Align syncd syslog timestamps with host timezone

### DIFF
--- a/files/image_config/config-setup/config-setup
+++ b/files/image_config/config-setup/config-setup
@@ -204,6 +204,30 @@ check_system_warm_boot()
     fi
 }
 
+# Apply system timezone from DEVICE_METADATA|localhost.timezone in CONFIG_DB
+apply_timezone_from_config_db()
+{
+    local timezone=""
+
+    timezone=$(sonic-db-cli CONFIG_DB HGET "DEVICE_METADATA|localhost" "timezone" 2>/dev/null)
+
+    if [ -z "${timezone}" ] && [ -r "${CONFIG_DB_JSON}" ]; then
+        timezone=$(sonic-cfggen -j "${CONFIG_DB_JSON}" -v "DEVICE_METADATA['localhost']['timezone']" 2>/dev/null)
+    fi
+
+    if [ -z "${timezone}" ]; then
+        return 0
+    fi
+
+    if timedatectl set-timezone "${timezone}" 2>/dev/null; then
+        echo "Configured system timezone from config DB: ${timezone}"
+    else
+        echo "Failed to configure timezone '${timezone}' from config DB"
+    fi
+
+    return 0
+}
+
 # Check if Zero Touch Provisioning is available and is administratively enabled
 ztp_is_enabled()
 {
@@ -524,6 +548,7 @@ fi
 # Process switch bootup event
 if [ "$CMD" = "boot" ]; then
     boot_config
+    apply_timezone_from_config_db
 fi
 
 # Process factory default configuration creation request

--- a/platform/template/docker-syncd-base.mk
+++ b/platform/template/docker-syncd-base.mk
@@ -36,6 +36,7 @@ $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 
 SONIC_BUSTER_DOCKERS += $(DOCKER_SYNCD_BASE)
 SONIC_BUSTER_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)

--- a/platform/template/docker-syncd-trixie.mk
+++ b/platform/template/docker-syncd-trixie.mk
@@ -24,8 +24,8 @@ $(DOCKER_SYNCD_BASE)_CONTAINER_NAME = syncd
 $(DOCKER_SYNCD_BASE)_RUN_OPT += --cap-add=SYS_RAWIO --cap-add=SYS_ADMIN --cap-add=NET_ADMIN -t --security-opt apparmor=unconfined --security-opt="systempaths=unconfined"
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/machine.conf:/etc/machine.conf
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /etc/localtime:/etc/localtime:ro
 
 SONIC_TRIXIE_DOCKERS += $(DOCKER_SYNCD_BASE)
 SONIC_TRIXIE_DBG_DOCKERS += $(DOCKER_SYNCD_BASE_DBG)
-
 


### PR DESCRIPTION
#### Why I did it
`syncd` timestamps could drift from host/`swss`/`pmon` on non-UTC systems, causing inconsistent syslog timing after host-side rsyslog switched to source timestamps.

##### Work item tracking
 - Microsoft ADO **(number only)**: 27774

#### How I did it
- Mount host timezone file into `syncd` container:
  - `platform/template/docker-syncd-base.mk`
  - `platform/template/docker-syncd-trixie.mk`
  - add: `-v /etc/localtime:/etc/localtime:ro`
- Apply configured timezone during boot in `config-setup`:
  - `files/image_config/config-setup/config-setup`
  - read `DEVICE_METADATA|localhost.timezone` (from `CONFIG_DB`, fallback to `config_db.json`)
  - run `timedatectl set-timezone` during `config-setup boot`

#### How to verify it
1. Set non-UTC timezone in CONFIG_DB (example Israel timezone):
   - `sonic-db-cli CONFIG_DB HSET "DEVICE_METADATA|localhost" timezone "Asia/Jerusalem"`
2. Reboot switch.
3. Verify host timezone:
   - `date`
   - `readlink -f /etc/localtime`
4. Verify container timezone alignment:
   - `docker exec swss date`
   - `docker exec syncd date`
5. Verify syslog timestamps are aligned for `syncd` and `swss` logs in `/var/log/syslog`.

#### Which release branch to backport (provide reason below if selected)

#### Tested branch
- [x] master

#### Test result
Verified post-reboot alignment with Israel timezone (`Asia/Jerusalem`) for `HOST/SWSS/SYNCD` and syslog timestamp consistency.
