### PR TITLE
[sonic-py-common] Cache HwSKU to avoid repeated CONFIG_DB reads

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -64,6 +64,7 @@ DPU_NAME_PREFIX = "dpu"
 # Cacheable Objects
 sonic_ver_info = {}
 hw_info_dict = {}
+hwsku_info = None
 
 def get_localhost_info(field, config_db=None):
     try:
@@ -158,8 +159,23 @@ def get_hwsku():
     Returns:
         A string containing the device's hardware SKU identifier
     """
+    global hwsku_info
 
-    return get_localhost_info('hwsku')
+    # Cache the first valid answer so callers stop opening a CONFIG_DB connection on
+    # every call. A falsy result means the lookup failed, so it is deliberately not
+    # cached and the next call retries.
+    #
+    # Changing the HwSKU needs a config reload, which restarts everything under
+    # sonic.target, so containerized callers always see the new value. Host daemons
+    # outside that target (system-health, for one) are not restarted and keep the
+    # cached value until they are.
+    #
+    # The slot is unsynchronized on purpose: racing threads may both perform the
+    # read, but they store the same value, so the interleaving does not matter.
+    if not hwsku_info:
+        hwsku_info = get_localhost_info('hwsku')
+
+    return hwsku_info
 
 
 def get_platform_and_hwsku():

--- a/src/sonic-py-common/tests/device_info_test.py
+++ b/src/sonic-py-common/tests/device_info_test.py
@@ -189,6 +189,38 @@ class TestDeviceInfo(object):
         assert device_info.is_packet_chassis() == False
         assert device_info.is_chassis() == False
 
+    @mock.patch("sonic_py_common.device_info.get_localhost_info")
+    def test_get_hwsku_is_cached(self, mock_localhost_info):
+        """A valid HwSKU is read from CONFIG_DB once and reused afterwards."""
+        device_info.hwsku_info = None
+        try:
+            mock_localhost_info.return_value = "Mellanox-SN2700"
+            for _ in range(5):
+                assert device_info.get_hwsku() == "Mellanox-SN2700"
+            mock_localhost_info.assert_called_once_with("hwsku")
+        finally:
+            device_info.hwsku_info = None
+
+    @mock.patch("sonic_py_common.device_info.get_localhost_info")
+    def test_get_hwsku_does_not_cache_failure(self, mock_localhost_info):
+        """A failed lookup must be retried, not cached, so a transient CONFIG_DB
+           error does not pin an empty HwSKU for the lifetime of the process."""
+        device_info.hwsku_info = None
+        try:
+            mock_localhost_info.return_value = None
+            assert device_info.get_hwsku() is None
+            assert device_info.get_hwsku() is None
+            assert mock_localhost_info.call_count == 2
+
+            mock_localhost_info.return_value = "Mellanox-SN2700"
+            assert device_info.get_hwsku() == "Mellanox-SN2700"
+            assert mock_localhost_info.call_count == 3
+            # Now that a valid value is known, no further reads happen.
+            assert device_info.get_hwsku() == "Mellanox-SN2700"
+            assert mock_localhost_info.call_count == 3
+        finally:
+            device_info.hwsku_info = None
+
     @mock.patch("sonic_py_common.device_info.ConfigDBConnector", autospec=True)
     @mock.patch("sonic_py_common.device_info.get_sonic_version_info")
     @mock.patch("sonic_py_common.device_info.get_machine_info")


### PR DESCRIPTION
#### Why I did it

`get_hwsku()` calls `get_localhost_info('hwsku')`, which builds a new `ConfigDBConnector` and opens a connection every time. Nothing caches it, so hot paths pay a CONFIG_DB round trip per call. On an SN6600_LD platform `Chassis.get_sfp()` reaches it through `is_module_host_management_mode()` and opened one connection per call, hundreds of times during pmon startup. Callers span `device_info` itself, the mlnx, pensando and celestica platform APIs, and `ctrmgrd`.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

Cache the value in a module-level slot beside the existing `sonic_ver_info` and `hw_info_dict` caches. The guard is `if not hwsku_info`, not `is None`, on purpose: a falsy result means the lookup failed, so it is never cached and the next call retries. A transient CONFIG_DB error must not pin an empty HwSKU for the life of the process.

Two caveats are stated in the comment rather than glossed over. Changing the HwSKU needs a config reload, which restarts everything under `sonic.target`, so containerized callers always see the new value; host daemons outside that target keep the cached value until they restart. The slot is also unsynchronized on purpose, since racing threads store the same value.

#### How to verify it

Two new unit tests cover both branches: a valid value is read once and reused, and a failed lookup is retried until it succeeds.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202605

#### Tested branch (Please provide the tested image version)

Unit tests, plus an A/B on an SN6600_LD switch running `202605`: instrumenting every DB connector construction, 30 `get_sfp()` calls built 60 connectors before the change and 0 after.

#### Description for the changelog

[sonic-py-common] Cache the HwSKU after the first successful CONFIG_DB read.

#### Link to config_db schema for YANG module changes

N/A
