### PR TITLE
[Build] Fix SKIP_BUILD_HOOK case mismatch in python wheel install rule

### DIFF
--- a/slave.mk
+++ b/slave.mk
@@ -1224,7 +1224,7 @@ $(SONIC_INSTALL_WHEELS) : $(PYTHON_WHEELS_PATH)/%-install : .platform $$(addsuff
 	# Use flock for serialized pip install - eliminates busy-wait polling from the
 	# previous mkdir lock. Waiters block in the kernel until the lock is released.
 ifneq ($(CROSS_BUILD_ENVIRON),y)
-	flock $(PYTHON_WHEELS_PATH)/pip_lock.lk sudo -E SKIP_BUILD_HOOK=Y pip$($*_PYTHON_VERSION) install $(PYTHON_WHEELS_PATH)/$* $(LOG)
+	flock $(PYTHON_WHEELS_PATH)/pip_lock.lk sudo -E SKIP_BUILD_HOOK=y pip$($*_PYTHON_VERSION) install $(PYTHON_WHEELS_PATH)/$* $(LOG)
 else
 	# Link python script and data expected location to the cross python virtual env installation locations
 	flock $(PYTHON_WHEELS_PATH)/pip_lock.lk bash -c '\


### PR DESCRIPTION
#### Why I did it
`slave.mk` passes `SKIP_BUILD_HOOK=Y` (uppercase) when installing built Python
wheels into the slave container, but the build hook checks for lowercase `y`
(`buildinfo_base.sh`, `run_pip_command`: `[[ "$SKIP_BUILD_HOOK" == y || ... ]]`).
Bash `[[ == ]]` is case-sensitive, so the skip flag never takes effect: every
wheel install is silently routed through the version-control path, which appends
a `-c <versions-file>` constraint to pip.

When the version recorded in the versions file drifts from the package actually
installed in the container (e.g. after the slave image is rebuilt), pip is forced
to upgrade a dependency owned by `apt` (no pip RECORD file) and the install fails
with `uninstall-no-record-file`, blocking the whole build.

Introduced by #12005 (2022-12). All other call sites use lowercase
(e.g. `scripts/build_debian_base_system.sh`), so the uppercase `Y` looks like a typo.

Fixes #29355 

#### How I did it
One-line change in the `SONIC_INSTALL_WHEELS` install rule: `SKIP_BUILD_HOOK=Y`
→ `SKIP_BUILD_HOOK=y`, matching the case expected by the hook scripts
(`buildinfo_base.sh`, `hooks/curl`, `hooks/wget`).

#### How to verify it
Inside the slave container:

    # before the fix (uppercase Y): forced upgrade
    SKIP_BUILD_HOOK=Y /usr/local/sbin/pip3 install --dry-run 'pyroute2>=0.7.7'
    -> Would install pyroute2-0.9.6

    # after the fix (lowercase y): correctly satisfied
    SKIP_BUILD_HOOK=y /usr/local/sbin/pip3 install --dry-run 'pyroute2>=0.7.7'
    -> Requirement already satisfied: pyroute2>=0.7.7 (0.7.7)

End-to-end: `make target/sonic-vs.img.gz` completes; the
`sonic_utilities-*.whl-install` step reports `Requirement already satisfied`
instead of failing with `uninstall-no-record-file`.

#### Which release branch to backport (provide reason below if selected)
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):

Failure type:

#### Tested branch
- [x] master

#### Test result
Verified in a sonic-slave-trixie container: with `SKIP_BUILD_HOOK=y` the hook
passes through to the real pip and `pyroute2>=0.7.7` is correctly reported as
already satisfied; full build of the affected wheel install target succeeds.

#### Description for the changelog
Fixed a case mismatch (`SKIP_BUILD_HOOK=Y` vs `== y`) that caused python wheel
installs in the build slave to be unexpectedly constrained by the version-control
hook, failing with `uninstall-no-record-file` when recorded versions drifted from
the installed ones.

#### Link to config_db schema for YANG module changes
N/A

#### A picture of a cute animal (not mandatory but encouraged)
Signed-off-by:  phil@supranett.com
