### PR TITLE
[frr] Fix NEXT-CSID length for combined IS-IS uA SIDs

### DIFF
--- a/src/sonic-frr/patch/0118-isisd-Fix-NEXT-CSID-length-for-combined-uA-SIDs.patch
+++ b/src/sonic-frr/patch/0118-isisd-Fix-NEXT-CSID-length-for-combined-uA-SIDs.patch
@@ -1,0 +1,35 @@
+From b134d3053be6dee874f6d444b325a91ad677ece8 Mon Sep 17 00:00:00 2001
+From: Grigory Solovyev <gs1571@gmail.com>
+Date: Sat, 29 Aug 2026 00:01:30 +0300
+Subject: [PATCH] isisd: Fix NEXT-CSID length for combined uA SIDs
+
+RFC 9800 defines the compressed SID length, LNFL, as the sum of
+the Locator-Node and Function lengths.
+
+IS-IS installs a combined uA SID using a B:G:L prefix, but passes
+only the Locator-Node length to the NEXT-CSID flavor. Include the
+Function length so the kernel shifts the complete G:L CSID.
+
+For an F3216 locator this changes nflen from 16 to 32 while keeping
+the existing route, behavior, nexthop, and interface.
+
+Related: #18823
+Signed-off-by: Grigory Solovyev <gs1571@gmail.com>
+---
+ isisd/isis_zebra.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/isisd/isis_zebra.c b/isisd/isis_zebra.c
+index 9389d6665a74..c08ff6e2c94b 100644
+--- a/isisd/isis_zebra.c
++++ b/isisd/isis_zebra.c
+@@ -1081,7 +1081,8 @@ void isis_zebra_srv6_adj_sid_install(struct srv6_adjacency *sra)
+ 		SET_SRV6_FLV_OP(ctx.flv.flv_ops,
+ 				ZEBRA_SEG6_LOCAL_FLV_OP_NEXT_CSID);
+ 		ctx.flv.lcblock_len = sra->locator->block_bits_length;
+-		ctx.flv.lcnode_func_len = sra->locator->node_bits_length;
++		ctx.flv.lcnode_func_len = sra->locator->node_bits_length +
++					  sra->locator->function_bits_length;
+ 		break;
+ 	case SRV6_ENDPOINT_BEHAVIOR_RESERVED:
+ 	case SRV6_ENDPOINT_BEHAVIOR_END:

--- a/src/sonic-frr/patch/0119-tests-Verify-NEXT-CSID-length-for-IS-IS-uA-SIDs.patch
+++ b/src/sonic-frr/patch/0119-tests-Verify-NEXT-CSID-length-for-IS-IS-uA-SIDs.patch
@@ -1,0 +1,65 @@
+From 7e5e953cebeeb84deb6c9dbacc6c7efdf47cf8b3 Mon Sep 17 00:00:00 2001
+From: Grigory Solovyev <gs1571@gmail.com>
+Date: Sun, 30 Aug 2026 09:21:52 +0300
+Subject: [PATCH] tests: Verify NEXT-CSID length for IS-IS uA SIDs
+
+Check detailed iproute2 output for the dynamic IS-IS uA SID.
+
+Run the check before exercising the existing forwarding path.
+
+Verify F3216 NEXT-CSID uses lblen 32 and nflen 32.
+
+Signed-off-by: Grigory Solovyev <gs1571@gmail.com>
+---
+ .../isis_srv6_topo1/test_isis_srv6_topo1.py   | 38 +++++++++++++++++++
+ 1 file changed, 38 insertions(+)
+
+diff --git a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+index d651849efa25..16b2cb9f2430 100644
+--- a/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
++++ b/tests/topotests/isis_srv6_topo1/test_isis_srv6_topo1.py
+@@ -1126,6 +1126,44 @@ def test_ping_step9():
+     check_ping("rt1", "fc00:0:9::1", True, 10, 1)
+ 
+ 
++def iproute2_can_show_seg6local_flavors(router):
++    """Check whether iproute2 can display SEG6_LOCAL_FLAVORS attributes."""
++    version = router.run("ip -Version").strip()
++    help_output = router.run("ip -6 route help 2>&1")
++
++    return (
++        "flavors FLAVORS" in help_output and "next-csid" in help_output,
++        version,
++    )
++
++
++def test_srv6_ua_sid_kernel_attributes():
++    """Verify the NEXT-CSID flavor of the dynamic uA SID."""
++    logger.info("Test: Verify NEXT-CSID flavor of the dynamic uA SID")
++    tgen = get_topogen()
++
++    # Required linux kernel version for this case to run.
++    result = required_linux_kernel_version("6.17")
++    if result is not True:
++        pytest.skip("Kernel requirements are not met, kernel version should be >=6.17")
++
++    # Skip if previous fatal error condition is raised
++    if tgen.routers_have_failure():
++        pytest.skip(tgen.errors)
++
++    rt2 = tgen.gears["rt2"]
++    supported, version = iproute2_can_show_seg6local_flavors(rt2)
++    logger.info("Installed iproute2: %s", version)
++    if not supported:
++        pytest.skip(
++            "Installed iproute2 cannot display SEG6_LOCAL_FLAVORS "
++            f"attributes: {version}"
++        )
++
++    output = rt2.run("ip -6 -d route show exact fc00:0:2:4::/64")
++    assert "flavors next-csid lblen 32 nflen 32" in output, output
++
++
+ # Memory leak test template
+ def test_memory_leak():
+     "Run the memory leak test and report results."

--- a/src/sonic-frr/patch/series
+++ b/src/sonic-frr/patch/series
@@ -86,3 +86,5 @@
 0115-zebra-Update-promiscuity-flag-silently-without-route.patch
 0116-zebra-keep-route_node-lock-in-NB-RIB-route-lookup_next.patch
 0117-zebra-Allow-quick-flaps-of-interfaces-to-be-handled.patch
+0118-isisd-Fix-NEXT-CSID-length-for-combined-uA-SIDs.patch
+0119-tests-Verify-NEXT-CSID-length-for-IS-IS-uA-SIDs.patch


### PR DESCRIPTION
#### Why I did it

FRR 10.5.4 programs the NEXT-CSID node-function length of combined IS-IS uA SIDs using only the locator node length. The kernel must consume both the node and function fields. For F3216, the required `nflen` is 32 rather than 16.

##### Work item tracking

Upstream fix: https://github.com/FRRouting/frr/pull/23204

FRR 10.5 backport: https://github.com/FRRouting/frr/pull/23232

SONiC backport tracking issue: TBD.

#### How I did it

Add the production fix and its regression test from FRR `stable/10.5` to the SONiC FRR patch series:

- `b134d3053be6dee874f6d444b325a91ad677ece8`
- `7e5e953cebeeb84deb6c9dbacc6c7efdf47cf8b3`

The production change sets `lcnode_func_len` to the sum of the locator node and function lengths. The regression test checks the kernel route's NEXT-CSID attributes and skips that inspection when the installed iproute2 cannot display flavors.

The FRR version, submodule revision, route prefix length, and separate SID structure fields exported through the SONiC FPM module remain unchanged. This change does not add local-only uA SID allocation.

#### How to verify it

Build the FRR package and `target/docker-fpm-frr.gz` against `master` and `202605`. Record the source revisions, image identifiers, and artifact checksums, and verify that the image contains the intended FRR package and SONiC FPM module.

Load each image and run an isolated smoke container with networking disabled, a read-only root filesystem, writable tmpfs mounts, and the capabilities required by FRR. Check the installed package version, resolve `isisd` shared libraries, locate `dplane_fpm_sonic.so`, and start and terminate `isisd` with an empty configuration. This checks packaging and daemon startup, not the full SONiC container entrypoint.

On Linux 6.17 or newer with iproute2 capable of displaying NEXT-CSID flavors, run the following focused topotests from `tests/topotests` with the built FRR package installed:

```bash
pytest -v \
  isis_srv6_topo1/test_isis_srv6_topo1.py::test_isis_adjacencies_step1 \
  isis_srv6_topo1/test_isis_srv6_topo1.py::test_srv6_ua_sid_kernel_attributes
```

The first test waits for IS-IS adjacencies. The second checks `flavors next-csid lblen 32 nflen 32` on the combined uA route. A skipped kernel-attribute check does not validate the fix. These checks do not establish ASIC programming or packet forwarding.

#### Which release branch to backport

- [x] 202605

Reason: this branch also uses FRR 10.5.4 and requires the same correction for combined IS-IS uA SIDs.

Tracking issue/work item for backport/cherry-pick request: pending.

Failure type: incorrect NEXT-CSID node-function length for combined IS-IS uA SIDs.

#### Tested branch

- [x] master
- [x] 202605

#### Test result

- `master`, source `f2871e49b738b46fe12cf255aaf8dcd3fa22b13c` plus this patch set: FRR package and `docker-fpm-frr.gz` built successfully; two focused tests passed without failures or skips; archive integrity and image smoke checks passed.
- `202605`, source `e67e59c3ecab41bccfef08fa005c013fbbd884c1` plus this patch set: the same package, image, focused test, archive integrity, and smoke checks passed.

Tested image versions:

- `master`: `frr-ua-lnfl.0-dirty-20260904.102849`, image ID `sha256:f73916098cd06b195508ed313537204ced5cc7860856ef391b83b73301bc622d`.
- `202605`: `frr-ua-lnfl-202605.0-dirty-20260904.124139`, image ID `sha256:e75c09929e50bf74cc8896c041d7acff83f023fcb620d9e05c0a739c47f9a9ff`.

Both images contain `frr 10.5.4-sonic-0` and `dplane_fpm_sonic.so`; `isisd` starts successfully. Images were built before committing the patch set, hence `dirty` in the version strings. Packet forwarding and ASIC programming were not tested.

#### Description for the changelog

Fix the NEXT-CSID node-function length of combined IS-IS uA SIDs in FRR.

#### Link to config_db schema for YANG module changes

Not applicable; no YANG schema changes.
