### PR TITLE
[frrcfgd] Fix BGP peer-group re-add and neighbors processed before their group

### DIFF
--- a/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
+++ b/src/sonic-frr-mgmt-framework/frrcfgd/frrcfgd.py
@@ -2473,14 +2473,15 @@ class BGPConfigDaemon:
             dval.op = CachedDataWithOp.OP_DELETE
         return True
 
-    def __cleanup_nbr_cache(self, vrf, nbr):
-        nbr_key = ExtConfigDBConnector.get_table_key('BGP_NEIGHBOR',
+    def __cleanup_nbr_cache(self, vrf, nbr, is_peer_grp = False):
+        table = 'BGP_PEER_GROUP' if is_peer_grp else 'BGP_NEIGHBOR'
+        nbr_key = ExtConfigDBConnector.get_table_key(table,
                                             self.config_db.serialize_key((vrf, nbr)))
         self.table_data_cache.pop(nbr_key, None)
-        for af in ['ipv4', 'ipv6']:
-            nbr_af_key = ExtConfigDBConnector.get_table_key('BGP_NEIGHBOR_AF',
-                                                self.config_db.serialize_key((vrf, nbr, af + '_unicast')))
-            self.table_data_cache.pop(nbr_af_key, None)
+        af_key_prefix = ExtConfigDBConnector.get_table_key(table + '_AF',
+                                            self.config_db.serialize_key((vrf, nbr))) + '|'
+        for af_key in [key for key in self.table_data_cache if key.startswith(af_key_prefix)]:
+            del(self.table_data_cache[af_key])
 
     def __delete_vrf_neighbor(self, vrf, peer, data, is_peer_grp):
         if is_peer_grp:
@@ -2493,7 +2494,7 @@ class BGPConfigDaemon:
                         peer_grp.ref_nbrs.remove(peer)
             if not self.__peer_is_ip(peer) and vrf in self.bgp_intf_nbr and peer in self.bgp_intf_nbr[vrf]:
                 self.bgp_intf_nbr[vrf].remove(peer)
-        self.__cleanup_nbr_cache(vrf, peer)
+        self.__cleanup_nbr_cache(vrf, peer, is_peer_grp)
         for dkey, dval in data.items():
             # bypass cache update because cache entry was removed
             dval.status = CachedDataWithOp.STAT_SUCC
@@ -2552,9 +2553,9 @@ class BGPConfigDaemon:
     @staticmethod
     def __nbr_impl_action(data, peer, is_pg):
         if is_pg:
-            chk_attrs = ['asn']
+            chk_attrs = ['asn', 'peer_type']
         elif BGPConfigDaemon.__peer_is_ip(peer):
-            chk_attrs = ['asn', 'peer_group_name']
+            chk_attrs = ['asn', 'peer_type', 'peer_group_name']
         else:
             chk_attrs = ['peer_group_name']
         for attr in chk_attrs:
@@ -2851,6 +2852,9 @@ class BGPConfigDaemon:
                             self.__apply_dep_vrf_table(vrf, 'BGP_GLOBALS_LISTEN_PREFIX', match = match_pg)
                             match_nbr = lambda data: data.get('peer_group_name', None) == key
                             self.__apply_dep_vrf_table(vrf, 'BGP_NEIGHBOR', match = match_nbr)
+                            for af in ['ipv4_unicast', 'ipv6_unicast', 'l2vpn_evpn']:
+                                syslog.syslog(syslog.LOG_DEBUG, 'apply attributes to FRR for vrf %s peer_group %s af %s' % (vrf, key, af))
+                                self.__apply_dep_vrf_table(vrf, 'BGP_PEER_GROUP_AF', key, af)
                         else:
                             for af in ['ipv4_unicast', 'ipv6_unicast']:
                                 syslog.syslog(syslog.LOG_DEBUG, 'apply attributes to FRR for vrf %s neighbor %s af %s' % (vrf, key, af))

--- a/src/sonic-frr-mgmt-framework/tests/test_config.py
+++ b/src/sonic-frr-mgmt-framework/tests/test_config.py
@@ -2,6 +2,8 @@ import copy
 import re
 from unittest.mock import MagicMock, NonCallableMagicMock, patch
 
+import pytest
+
 swsscommon_module_mock = MagicMock(ConfigDBConnector = NonCallableMagicMock)
 # because can’t use dotted names directly in a call, have to create a dictionary and unpack it using **:
 mockmapping = {'swsscommon.swsscommon': swsscommon_module_mock}
@@ -307,3 +309,124 @@ def test_bgp_neighbor_description_injection(run_cmd):
         if any('description' in arg for arg in cmd):
             assert any(injection_payload in arg for arg in cmd), \
                 "injection payload not found as literal arg: {}".format(cmd)
+
+
+# Regression tests for BGP peer-group handling in `config load` event order
+
+class PeerGroupHarness:
+    """BGPConfigDaemon wired to a dict-backed CONFIG_DB and to a fake bgpd.
+
+    get_table(), get_entry() and serialize_key() stand in for the CONFIG_DB reads
+    frrcfgd does when it re-applies dependent rows. run_command() stands in for
+    g_run_command(): it records every vtysh command and, like bgpd's "% Configure
+    the peer-group first", rejects any command that refers to peer-group PG while
+    PG does not exist. The tests use no other peer-group name."""
+
+    def __init__(self, run_cmd):
+        from frrcfgd.frrcfgd import BGPConfigDaemon
+
+        self.rows = {}  # CONFIG_DB content: {table: {key: data}}
+        self.sent = []  # last '-c' argument of every vtysh call
+        self.failed = []  # the rejected ones among them
+        self.peer_group_exists = False
+
+        self.daemon = BGPConfigDaemon()
+        self.daemon.config_db.serialize_key = self.serialize_key
+        self.daemon.config_db.get_table = self.get_table
+        self.daemon.config_db.get_entry = self.get_entry
+        self.handlers = dict(self.daemon.table_handler_list)
+        run_cmd.side_effect = self.run_command
+
+        self.load([('BGP_GLOBALS', 'default', {'local_asn': '100'})])  # neighbor commands need this
+
+    @staticmethod
+    def serialize_key(key):
+        if isinstance(key, tuple):
+            key = '|'.join(key)
+        return key
+
+    def get_table(self, table):
+        return {
+            tuple(key.split('|')): copy.deepcopy(data)
+            for key, data in self.rows.get(table, {}).items()
+        }
+
+    def get_entry(self, table, key):
+        # a missing row is None, like ExtConfigDBConnector.raw_to_typed()
+        return copy.deepcopy(self.rows.get(table, {}).get(self.serialize_key(key)))
+
+    def run_command(self, _table, command, *_args):
+        success = True
+        match cmd := command[-1]:
+            case 'neighbor PG peer-group':
+                self.peer_group_exists = True
+            case 'no neighbor PG':
+                self.peer_group_exists = False
+            case _ if 'PG' in cmd.split():
+                success = self.peer_group_exists
+
+        self.sent.append(cmd)
+        if not success:
+            self.failed.append(cmd)
+        return success
+
+    def load(self, rows):
+        """Like `config load`: write all rows first, then deliver the events in
+        table/key order. A row with data None is a delete."""
+        for table, key, data in rows:
+            if data is None:
+                self.rows.get(table, {}).pop(key, None)
+            else:
+                self.rows.setdefault(table, {})[key] = data
+        for table, key, data in sorted(rows, key=lambda row: row[:2]):
+            data = copy.deepcopy(data)
+            self.handlers[table](table, key, data)
+
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_peer_group_delete_and_readd(run_cmd):
+    """Regression test: deleting a peer-group must evict its BGP_PEER_GROUP and
+    BGP_PEER_GROUP_AF rows from the cache, so that re-adding the same rows sends
+    `remote-as` and the address-family config to bgpd again."""
+
+    peer_group_rows = [
+        ('BGP_PEER_GROUP', 'default|PG', {'peer_type': 'external'}),
+        ('BGP_PEER_GROUP_AF', 'default|PG|ipv4_unicast', {'admin_status': 'true'}),
+        ('BGP_PEER_GROUP_AF', 'default|PG|ipv6_unicast', {'admin_status': 'true'}),
+    ]
+
+    harness = PeerGroupHarness(run_cmd)
+    harness.load(peer_group_rows)
+    assert 'neighbor PG remote-as external' in harness.sent
+    assert harness.sent.count('neighbor PG activate') == 2
+
+    # the AF rows leave the cache together with the group, so their delete events
+    # send no `no neighbor PG activate` to a group that is already gone
+    harness.sent.clear()
+    harness.load([(table, key, None) for table, key, _ in peer_group_rows])
+    assert harness.sent == ['no neighbor PG']
+
+    harness.sent.clear()
+    harness.load(peer_group_rows)
+    assert 'neighbor PG remote-as external' in harness.sent
+    assert harness.sent.count('neighbor PG activate') == 2
+    assert harness.failed == []
+
+@pytest.mark.parametrize('peer', ['Ethernet0', '10.0.0.1'])
+@patch.dict('sys.modules', **mockmapping)
+@patch('frrcfgd.frrcfgd.g_run_command')
+def test_bgp_neighbor_before_peer_group(run_cmd, peer):
+    """Regression test: a neighbor processed before its peer-group exists is rejected
+    by bgpd and must be re-applied when the BGP_PEER_GROUP row arrives, also for a
+    peer-group defined by `peer_type` instead of `asn`."""
+
+    harness = PeerGroupHarness(run_cmd)
+    bind_cmd = f'neighbor {peer} peer-group PG'
+    harness.load([('BGP_NEIGHBOR', 'default|' + peer, {'peer_group_name': 'PG'})])
+    assert harness.failed == [bind_cmd]
+
+    harness.sent.clear()
+    harness.failed.clear()
+    harness.load([('BGP_PEER_GROUP', 'default|PG', {'peer_type': 'external'})])
+    assert bind_cmd in harness.sent
+    assert harness.failed == []


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`config load` delivers CONFIG_DB events to frrcfgd sorted by table and key: `BGP_NEIGHBOR` before `BGP_PEER_GROUP`, and `BGP_PEER_GROUP_AF` deletes after the `BGP_PEER_GROUP` delete. Two bugs leave a peer-group based config (e.g. BGP unnumbered with `peer_type: external`) incomplete:

1. **A deleted peer-group stays cached.** `__cleanup_nbr_cache()` did not delete `BGP_PEER_GROUP_AF` keys, only `BGP_NEIGHBOR*`. The later `BGP_PEER_GROUP_AF` deletes fail against the removed group and stay cached too. Re-adding the same group is diffed as unchanged, so `remote-as` and the address-family config are never sent again until frrcfgd restarts.
2. **Neighbors processed before their peer-group are not retried.** bgpd rejects `neighbor <intf> peer-group <PG>` while the group does not exist. Once it appears, `__nbr_impl_action()` re-applies the dependent neighbors only for `asn`, not for `peer_type`, so they stay unbound.

Symptom: after `config load` switches from plain IP neighbors to BGP unnumbered, `show running-config bgpd` lacks the `neighbor <intf> interface peer-group <PG>` lines and, if the group had been deleted earlier in frrcfgd's lifetime, also `neighbor <PG> remote-as external` and the address-family block. `config reload` of the same config_db.json yields the full config.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- `__cleanup_nbr_cache()` also evicts the `BGP_PEER_GROUP` row and all its `BGP_PEER_GROUP_AF` rows when called for a peer-group.
- `__nbr_impl_action()` treats `peer_type` like `asn`: a `peer_type` group re-applies the neighbors and listen prefixes that reference it, and removing `peer_type` takes the same delete path as removing `asn`.
- A peer-group that becomes ready re-applies its own `BGP_PEER_GROUP_AF` rows, as neighbors already do for `BGP_NEIGHBOR_AF`.

Re-applied commands are idempotent.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

Regression tests in `src/sonic-frr-mgmt-framework/tests/test_config.py`, both failing on the unfixed code:

- `test_bgp_peer_group_delete_and_readd`: delete a `peer_type` group and its AF rows, re-add them; `remote-as` and `activate` are sent again and nothing fails.
- `test_bgp_neighbor_before_peer_group`: a neighbor (interface and IP) processed before its group is bound once the group row arrives.

On a switch or sonic-vs, without `config reload`: `config load -y` a BGP unnumbered config (`peer_type` peer-group, its AF rows, interface neighbors with `peer_group_name`), then a config that nulls those rows and adds plain IP neighbors, then the first config again. Before the fix, `show running-config bgpd` then lacks `remote-as`, the address-family block and the interface bindings that `config reload` produces.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: 72be036d5..08d4f16c7 - https://gist.github.com/leenr/6e607ebddb8ace753f02ef7e488d9f5d

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

[frrcfgd] Re-apply BGP peer-group config after delete/re-add and bind neighbors processed before their peer-group

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
<img width="1397" height="958" alt="image" src="https://github.com/user-attachments/assets/e47cf59d-0902-4b9b-accd-da5635b2bc7d" />