### PR TITLE
[build] Fix stale host-base-image version pins missing "-security" upgrades

### DIFF
--- a/scripts/collect_host_image_version_files.sh
+++ b/scripts/collect_host_image_version_files.sh
@@ -44,15 +44,17 @@ sudo LANG=C chroot $FILESYSTEM_ROOT post_run_cleanup ${IMAGENAME}
 BASEIMAGE_VERSIONS_FILE=$TARGET/versions/host-base-image/versions-deb-${DISTRO}-${ARCH}
 if [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," != *,all,* ]] && [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," != *,deb,* ]] && [ -f "$BASEIMAGE_VERSIONS_FILE" ]; then
     TMP_INSTALLED_VERSIONS=$(mktemp)
-    sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "dpkg-query -W -f '\${Package}==\${Version}\n'" > $TMP_INSTALLED_VERSIONS
-    # Walk the original base-image file in its own order, substituting in the
-    # freshly-installed version only when the package is still present; keep
-    # the original line as-is for anything not found (e.g. renamed/removed
-    # during the upgrade), so the package set/order is never dropped.
-    awk -F'==' '
-        NR==FNR { installed[$1]=$0; next }
-        { print ($1 in installed) ? installed[$1] : $0 }
-    ' $TMP_INSTALLED_VERSIONS "$BASEIMAGE_VERSIONS_FILE" > "${BASEIMAGE_VERSIONS_FILE}.new"
-    mv "${BASEIMAGE_VERSIONS_FILE}.new" "$BASEIMAGE_VERSIONS_FILE"
+    trap 'rm -f "$TMP_INSTALLED_VERSIONS"' EXIT
+    if ! sudo LANG=C chroot "$FILESYSTEM_ROOT" /bin/bash -c "dpkg-query -W -f '\${Package}==\${Version}\n'" > "$TMP_INSTALLED_VERSIONS"; then
+         echo "Failed to capture installed host-base-image package versions" >&2
+         exit 1
+     fi
+     awk -F'==' '
+         FILENAME == ARGV[1] { installed[$1]=$0; next }
+         { print ($1 in installed) ? installed[$1] : $0 }
+     ' "$TMP_INSTALLED_VERSIONS" "$BASEIMAGE_VERSIONS_FILE" > "${BASEIMAGE_VERSIONS_FILE}.new" && \
+         mv "${BASEIMAGE_VERSIONS_FILE}.new" "$BASEIMAGE_VERSIONS_FILE" || \
+         rm -f "${BASEIMAGE_VERSIONS_FILE}.new"
     rm -f $TMP_INSTALLED_VERSIONS
+    trap - EXIT
 fi

--- a/scripts/collect_host_image_version_files.sh
+++ b/scripts/collect_host_image_version_files.sh
@@ -24,3 +24,35 @@ cp -r $FILESYSTEM_ROOT/usr/local/share/buildinfo/pre-versions $VERSIONS_PATH/
 cp -r $FILESYSTEM_ROOT/usr/local/share/buildinfo/post-versions $VERSIONS_PATH/
 
 sudo LANG=C chroot $FILESYSTEM_ROOT post_run_cleanup ${IMAGENAME}
+
+# Re-capture host-base-image package versions from the finished rootfs.
+# host-base-image was originally captured right after the initial debootstrap,
+# which only pulls from the plain Debian archive (no "-security" suite). By
+# now the rootfs has been apt-upgraded against the full mirrors (including
+# "-security"). Refresh the tracked version file to match what's actually
+# installed, unless deb versions are pinned for a reproducible build
+# (SONIC_VERSION_CONTROL_COMPONENTS includes "deb"/"all"), where the file is
+# authoritative input and must stay untouched.
+#
+# host-base-image only tracks the minbase package set, not the full
+# host-image package set that ends up installed in this same rootfs, so we
+# must not blindly dump the whole "dpkg-query -W" output here -- that would
+# pollute host-base-image with host-image-only packages. Instead, only
+# refresh the versions of packages that were already present in the
+# base-image's own version file (written earlier in this build by
+# build_debian_base_system.sh), keeping its package set unchanged.
+BASEIMAGE_VERSIONS_FILE=$TARGET/versions/host-base-image/versions-deb-${DISTRO}-${ARCH}
+if [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," != *,all,* ]] && [[ ",$SONIC_VERSION_CONTROL_COMPONENTS," != *,deb,* ]] && [ -f "$BASEIMAGE_VERSIONS_FILE" ]; then
+    TMP_INSTALLED_VERSIONS=$(mktemp)
+    sudo LANG=C chroot $FILESYSTEM_ROOT /bin/bash -c "dpkg-query -W -f '\${Package}==\${Version}\n'" > $TMP_INSTALLED_VERSIONS
+    # Walk the original base-image file in its own order, substituting in the
+    # freshly-installed version only when the package is still present; keep
+    # the original line as-is for anything not found (e.g. renamed/removed
+    # during the upgrade), so the package set/order is never dropped.
+    awk -F'==' '
+        NR==FNR { installed[$1]=$0; next }
+        { print ($1 in installed) ? installed[$1] : $0 }
+    ' $TMP_INSTALLED_VERSIONS "$BASEIMAGE_VERSIONS_FILE" > "${BASEIMAGE_VERSIONS_FILE}.new"
+    mv "${BASEIMAGE_VERSIONS_FILE}.new" "$BASEIMAGE_VERSIONS_FILE"
+    rm -f $TMP_INSTALLED_VERSIONS
+fi


### PR DESCRIPTION
#### Why I did it
`files/build/versions-public/host-base-image/versions-deb-*` is captured right after the initial `debootstrap` in `scripts/build_debian_base_system.sh`, which only resolves packages from the plain Debian archive/snapshot (no `-security` suite). Later in `build_debian.sh`, the rootfs's `sources.list` is switched to the full mirrors (including `-security`) and `apt-get upgrade` is run — so the *installed* packages can be newer than what's recorded in `host-base-image`.

This caused `host-base-image` version pins (e.g. util-linux/bsdutils/libmount1/etc.) to silently drift stale relative to `host-image`, which does capture the post-upgrade state. Example: #29406 had to manually bump `util-linux` in `host-base-image` from `2.41-5` to `2.41.5-0+deb13u1`, even though `host-image`'s version file already reflected that patched version from the automated "Upgrade SONiC package versions" pipeline.
##### Work item tracking
- Microsoft ADO **(number only)**: 39606502

#### How I did it
Re-capture `host-base-image`'s package versions in `scripts/collect_host_image_version_files.sh`, which already runs once at
the end of `build_debian.sh` after the rootfs has been fully upgraded and all packages installed.

`host-base-image` only tracks the minbase package set, not the full host-image package set installed in this same rootfs, so we can't blindly dump the whole `dpkg-query -W` output — that would pollute `host-base-image` with host-image-only packages. Instead, the refresh is filtered to only the package names already present in `host-base-image`'s own version file (written earlier in the same build by `build_debian_base_system.sh`), so its package set stays unchanged while stale versions get updated.

The re-capture is skipped when `SONIC_VERSION_CONTROL_COMPONENTS` includes `deb` or `all` (i.e. Debian package versions are pinned for a reproducible build), since in that mode the version file is authoritative input and must not be overwritten by build output.
#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
