### PR TITLE
[Mellanox] Disable autoneg by default on Mellanox-SN6600_LD-P128C2 hwsku

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/hwsku.json
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/hwsku.json
@@ -1,199 +1,264 @@
 {
     "interfaces": {
         "Ethernet0": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet8": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet16": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet24": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet32": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet40": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet48": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet56": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet64": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet72": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet80": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet88": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet96": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet104": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet112": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet120": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet128": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet136": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet144": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet152": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet160": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet168": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet176": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet184": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet192": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet200": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet208": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet216": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet224": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet232": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet240": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet248": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet256": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet264": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet272": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet280": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet288": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet296": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet304": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet312": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet320": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet328": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet336": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet344": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet352": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet360": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet368": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet376": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet384": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet392": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet400": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet408": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet416": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet424": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet432": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet440": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet448": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet456": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet464": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet472": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet480": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet488": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet496": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet504": {
-            "default_brkout_mode": "2x800G[400G]"
+            "default_brkout_mode": "2x800G[400G]",
+            "autoneg": "off"
         },
         "Ethernet512": {
-            "default_brkout_mode": "2x100G"
+            "default_brkout_mode": "2x100G",
+            "autoneg": "off"
         }
     }
 }


### PR DESCRIPTION
#### Why I did it
Explicitly set the default auto-negotiation mode to off for all interfaces on the Mellanox-SN6600_LD-P128C2.

#### Work item
N/A

#### How I did it
Added `"autoneg": "off"` to every interface entry in `device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/hwsku.json`.

#### How to verify it
Load the Mellanox-SN6600_LD-P128C2 hwsku and confirm each interface comes up with auto-negotiation disabled by default.

#### Which release branch to backport
202605

#### Tested branch
202605

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

master_RC: master_RC.345-8fd124fc8c_Internal - https://nbuprod.blsm.nvidia.com/nbu-sws-sonic/job/sonic_ci/5107 

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Set default auto-negotiation to off for all interfaces on the Mellanox-SN6600_LD-P128C2 SKU.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)