### PR TITLE
[CodeQL] Use pytest temporary paths in Nexthop EEPROM tests

### DIFF
--- a/platform/broadcom/sonic-platform-modules-nexthop/test/integration/nexthop/test_eeprom_utils_integration.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/integration/nexthop/test_eeprom_utils_integration.py
@@ -15,9 +15,7 @@ Usage:
     python -m pytest test/integration/nexthop/test_eeprom_utils.py -v
 """
 
-import os
 import pytest
-import tempfile
 
 # Import shared test helpers
 from fixtures.test_helpers_eeprom import EepromTestMixin
@@ -33,12 +31,10 @@ def eeprom_utils_module():
 class TestEepromUtilsIntegration(EepromTestMixin):
     """Integration test class for EEPROM utilities with full SONiC environment."""
 
-    def test_program_and_decode(self, eeprom_utils_module, capsys):
+    def test_program_and_decode(self, eeprom_utils_module, capsys, tmp_path):
         """Test programming and decoding EEPROM data with full SONiC environment."""
         # Given
-        root = tempfile.mktemp()
-        os.makedirs(root)
-        eeprom_path = os.path.join(root, "eeprom")
+        eeprom_path = str(tmp_path / "eeprom")
         self.create_fake_eeprom(eeprom_path)
 
         # When
@@ -52,16 +48,14 @@ class TestEepromUtilsIntegration(EepromTestMixin):
         out, _ = capsys.readouterr()
         assert expected in out
 
-    def test_decode_known_buggy_custom_serial_number(self, eeprom_utils_module, capsys):
+    def test_decode_known_buggy_custom_serial_number(self, eeprom_utils_module, capsys, tmp_path):
         """
         Under full SONiC environment,
         Test decoding and reprogramming EEPROM data when "Custom Serial Number"
         TLV has a known bug, where byte 2 of the TLV contains a garbage value.
         """
         # Given
-        root = tempfile.mktemp()
-        os.makedirs(root)
-        eeprom_path = os.path.join(root, "eeprom")
+        eeprom_path = str(tmp_path / "eeprom")
         self.create_fake_eeprom(eeprom_path)
 
         # When
@@ -136,7 +130,7 @@ CRC-32                    0xFE   4 0x8F92A23C
         out, _ = capsys.readouterr()
         assert expected in out
 
-    def test_decode_buggy_regulatory_model_number(self, eeprom_utils_module, capsys):
+    def test_decode_buggy_regulatory_model_number(self, eeprom_utils_module, capsys, tmp_path):
         """
         Under full SONiC environment,
         Test decoding EEPROM data gives invalid output when the known bug
@@ -144,9 +138,7 @@ CRC-32                    0xFE   4 0x8F92A23C
         Nexthop custom fields, e.g. "Regulatory Model Number".
         """
         # Given
-        root = tempfile.mktemp()
-        os.makedirs(root)
-        eeprom_path = os.path.join(root, "eeprom")
+        eeprom_path = str(tmp_path / "eeprom")
         self.create_fake_eeprom(eeprom_path)
 
         # When
@@ -203,15 +195,13 @@ CRC-32                    0xFE   4 0x0906D092
         out, _ = capsys.readouterr()
         assert expected in out
 
-    def test_program_replace_nh_custom_fields(self, eeprom_utils_module, capsys):
+    def test_program_replace_nh_custom_fields(self, eeprom_utils_module, capsys, tmp_path):
         """
         Under full SONiC environment,
         Test re-programming EEPROM data with Nexthop custom fields being replaced.
         """
         # Given
-        root = tempfile.mktemp()
-        os.makedirs(root)
-        eeprom_path = os.path.join(root, "eeprom")
+        eeprom_path = str(tmp_path / "eeprom")
         self.create_fake_eeprom(eeprom_path)
 
         # When
@@ -264,12 +254,10 @@ CRC-32                    0xFE   4 0x314BC9F0
         out, _ = capsys.readouterr()
         assert expected in out
 
-    def test_clear(self, eeprom_utils_module, capsys):
+    def test_clear(self, eeprom_utils_module, capsys, tmp_path):
         """Test clearing EEPROM data with full SONiC environment."""
         # Given
-        root = tempfile.mktemp()
-        os.makedirs(root)
-        eeprom_path = os.path.join(root, "eeprom")
+        eeprom_path = str(tmp_path / "eeprom")
         self.create_fake_eeprom(eeprom_path)
         program_data = self.get_standard_eeprom_program_data()
         eeprom_utils_module.program_eeprom(eeprom_path=eeprom_path, **program_data)
@@ -281,4 +269,3 @@ CRC-32                    0xFE   4 0x314BC9F0
         eeprom_utils_module.decode_eeprom(eeprom_path)
         out, _ = capsys.readouterr()
         assert "EEPROM does not contain data in a valid TlvInfo format" in out
-

--- a/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_eeprom_utils_unit.py
+++ b/platform/broadcom/sonic-platform-modules-nexthop/test/unit/nexthop/test_eeprom_utils_unit.py
@@ -9,7 +9,6 @@ These tests run in isolation from the SONiC environment using pytest:
 python -m pytest test/unit/nexthop/test_eeprom_utils.py -v
 """
 
-import tempfile
 from typing import Counter
 import pytest
 
@@ -26,10 +25,10 @@ def eeprom_utils_module():
 class TestEepromUtils(EepromTestMixin):
     """Test class for EEPROM utilities functionality."""
 
-    def test_get_find_at24_eeprom_paths(self, eeprom_utils_module):
+    def test_get_find_at24_eeprom_paths(self, eeprom_utils_module, tmp_path):
         """Test finding AT24 EEPROM paths."""
         # Given
-        root = tempfile.mktemp()
+        root = str(tmp_path / "i2c-root")
         self.setup_test_i2c_environment(root)
 
         # When


### PR DESCRIPTION
## What I did

- replace six uses of `tempfile.mktemp()` with pytest-managed `tmp_path` locations
- remove redundant temporary-directory creation and unused imports
- preserve the existing EEPROM test behavior

## Why I did it

`tempfile.mktemp()` returns an unused path and leaves a race window before the caller creates it. The pytest fixture creates an isolated directory safely for each test.

## Testing

- `test/unit/nexthop/test_eeprom_utils_unit.py`: 1 passed
- `test/integration/nexthop/test_eeprom_utils_integration.py`: 5 passed
- full component suite: the changed tests pass; unrelated platform tests require additional SONiC runtime dependencies on this host
- Debian package build reaches dependency validation and requires `debhelper-compat (= 12)`, `dh-python`, and `python3-all` on this host