### PR TITLE
[CodeQL] Fix TACACS test argument buffer overflow

### DIFF
--- a/src/tacacs/bash_tacplus/unittest/plugin_test.c
+++ b/src/tacacs/bash_tacplus/unittest/plugin_test.c
@@ -139,10 +139,7 @@ void testcase_check_and_load_changed_tacacs_config() {
 
 /* Test on_shell_execve authorization successed */
 void testcase_on_shell_execve_success() {
-	char *testargv[2];
-	testargv[0] = "arg1";
-	testargv[1] = "arg2";
-	testargv[2] = 0;
+	char *testargv[] = {"arg1", "arg2", NULL};
 
 	// test connection failed case
 	set_test_scenario(TEST_SCEANRIO_CONNECTION_SEND_SUCCESS_RESULT);
@@ -154,10 +151,7 @@ void testcase_on_shell_execve_success() {
 
 /* Test on_shell_execve authorization denined */
 void testcase_on_shell_execve_denined() {
-	char *testargv[2];
-	testargv[0] = "arg1";
-	testargv[1] = "arg2";
-	testargv[2] = 0;
+	char *testargv[] = {"arg1", "arg2", NULL};
 
 	// test connection failed case
 	set_test_scenario(TEST_SCEANRIO_CONNECTION_SEND_DENINED_RESULT);
@@ -169,10 +163,7 @@ void testcase_on_shell_execve_denined() {
 
 /* Test on_shell_execve authorization failed */
 void testcase_on_shell_execve_failed() {
-	char *testargv[2];
-	testargv[0] = "arg1";
-	testargv[1] = "arg2";
-	testargv[2] = 0;
+	char *testargv[] = {"arg1", "arg2", NULL};
 
 	// test connection failed case
 	set_test_scenario(TEST_SCEANRIO_CONNECTION_ALL_FAILED);


### PR DESCRIPTION
## What I did

- allocate the NULL terminator in the three `on_shell_execve` test argument arrays
- use initialized three-element arrays
- leave the two-element arrays with explicit argument counts unchanged

## Why I did it

The affected tests allocated two pointers and then wrote a terminator to index 2, causing an out-of-bounds write.

## Testing

- test target compiles and links against CUnit and the repository `pam_tacplus`/`libtac` dependency
- compilation passes with `-Werror=array-bounds`
- the existing CUnit binary still terminates in its pre-existing configuration-loading path; no unrelated test behavior is changed