### PR TITLE
[CodeQL] Document CLI test import side effects

### DIFF
--- a/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
+++ b/dockers/docker-dhcp-relay/cli-plugin-tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
-import mock_tables # lgtm [py/unused-import]
+# Imported for side effects: installs fake Redis/SWSS connector patches
+# before pytest imports the CLI plugin modules.
+import mock_tables  # lgtm [py/unused-import]
 from unittest import mock
 
 @pytest.fixture()

--- a/dockers/docker-macsec/cli-plugin-tests/conftest.py
+++ b/dockers/docker-macsec/cli-plugin-tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
-import mock_tables # lgtm [py/unused-import]
-import mock_single_asic # lgtm[py/unused-import]
+# Imported for side effects: installs fake Redis/SWSS connector patches
+# before pytest imports the CLI plugin modules.
+import mock_tables  # lgtm [py/unused-import]
+# Imported for side effects: configures the single-ASIC test environment
+# before pytest imports the CLI plugin modules.
+import mock_single_asic  # lgtm [py/unused-import]
 from unittest import mock
 
 


### PR DESCRIPTION
## What I did

- document why the MACsec and DHCP relay test suites import their mock modules for side effects
- normalize the existing unused-import suppression spacing
- preserve import order and test behavior

## Why I did it

The mock modules patch Redis, SWSS connectors, and single-ASIC behavior before pytest imports the CLI plugins. Explicit nearby justification distinguishes these intentional imports from dead code.

## Testing

- both modified files pass `python3 -m py_compile`
- full CLI plugin collection requires the SONiC `swsscommon` runtime, which is not available on this host