### PR TITLE
[CodeQL] Make Micas DDR memory traversal bounds-safe

### DIFF
--- a/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/Makefile
+++ b/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/Makefile
@@ -8,13 +8,21 @@ DEPS=$(patsubst %.o, %.d, $(OBJS))
 CFLAGS+=-Wall -W -g -I$(DIR)/include
 LDFLAGS=
 PROGRAM=hw_test.bin
+TEST_PROGRAM=ddr_bounds_test
 
-.PHONY: all
+.PHONY: all check
 
 all:$(OBJS)
 	$(CC)  $(OBJS) $(LDFLAGS) -o $(BUILD_OUTPUT)/$(PROGRAM)
 	@if [ ! -d ${common_out_put_dir} ]; then mkdir -p ${common_out_put_dir} ;fi
 	cp -p $(BUILD_OUTPUT)/$(PROGRAM) $(common_out_put_dir)	
+
+check: $(BUILD_OUTPUT)/$(TEST_PROGRAM)
+	$<
+
+$(BUILD_OUTPUT)/$(TEST_PROGRAM): tests/ddr_bounds_test.c ft_ddr_test.c include/hw_dram/ft_ddr_test.h include/hw_dram/fac_common.h
+	@mkdir -p $(BUILD_OUTPUT)
+	$(CC) $(CFLAGS) $(INCLUDE) $< $(LDFLAGS) -o $@
 
 $(OBJS):$(SRCS)
 	@if [ ! -d ${BUILD_OUTPUT} ]; then mkdir -p ${BUILD_OUTPUT} ;fi

--- a/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/ft_ddr_test.c
+++ b/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/ft_ddr_test.c
@@ -80,6 +80,15 @@ static inline ulong roundup(ulong value, ulong mask)
     return (value + mask) & ~mask;
 }
 
+/* Both pointers delimit one memory segment; step counts uint32 elements. */
+static inline size_t bounded_step(const volatile uint32 *start,
+                                 const volatile uint32 *end, size_t step)
+{
+    size_t remaining = (size_t)(end - start);
+
+    return remaining < step ? remaining : step;
+}
+
 #if 0
 static inline void set_vars(ulong start, ulong end)
 {
@@ -213,11 +222,7 @@ static int addrress_walking(char *desc)
                         mask = mask << 1;
                     } while (mask);
                 }
-                if (pp + bank > pp) {
-                    pp += bank;
-                } else {
-                    pp = end;
-                }
+                pp += bounded_step(pp, end, bank);
                 p1 = ~p1;
             }
         }
@@ -261,11 +266,7 @@ static int moving_inversions(char * desc, int iter, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -291,11 +292,7 @@ static int moving_inversions(char * desc, int iter, uint32 p1, uint32 p2)
             done = 0;
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -321,16 +318,12 @@ static int moving_inversions(char * desc, int iter, uint32 p1, uint32 p2)
         for (j = segs - 1; j >= 0; j--) {
             start = v->map[j].start;
             end = v->map[j].end;
-            pe = end - 1;
-            pp = end - 1;
+            pe = end;
+            pp = end;
             done = 0;
             do {
                 /* Check for underflow */
-                if (pe - SPINSZ < pe) {
-                    pe -= SPINSZ;
-                } else {
-                    pe = start;
-                }
+                pe -= bounded_step(start, pe, SPINSZ);
                 if (pe <= start) {
                     pe = start;
                     done++;
@@ -340,6 +333,7 @@ static int moving_inversions(char * desc, int iter, uint32 p1, uint32 p2)
                 }
 
                 do {
+                    --pp;
                     if (*pp != p2) {
                         FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
                         sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
@@ -347,7 +341,7 @@ static int moving_inversions(char * desc, int iter, uint32 p1, uint32 p2)
                         return FT_DDR_ERR;
                     }
                     *pp = p1;
-                } while (pp-- > pe);
+                } while (pp > pe);
             } while (!done);
             FT_DDR_SHOW();
         }
@@ -397,11 +391,7 @@ static int moving_inversions32(char *desc, int iter, uint32 p1, uint32 low_patte
         pattern = p1;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -436,11 +426,7 @@ static int moving_inversions32(char *desc, int iter, uint32 p1, uint32 low_patte
             pattern = p1;
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -481,16 +467,12 @@ static int moving_inversions32(char *desc, int iter, uint32 p1, uint32 low_patte
         for (j = segs - 1; j >= 0; j--) {
             start = v->map[j].start;
             end = v->map[j].end;
-            pp = end - 1;
-            pe = end - 1;
+            pp = end;
+            pe = end;
             done = 0;
             do {
                 /* Check for underflow */
-                if (pe - SPINSZ < pe) {
-                    pe -= SPINSZ;
-                } else {
-                    pe = start;
-                }
+                pe -= bounded_step(start, pe, SPINSZ);
                 if (pe <= start) {
                     pe = start;
                     done++;
@@ -500,6 +482,7 @@ static int moving_inversions32(char *desc, int iter, uint32 p1, uint32 low_patte
                 }
 
                 do {
+                    --pp;
                     if (*pp != ~pattern) {
                         FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, ~pattern, *pp);
                         sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, ~pattern, *pp);
@@ -514,7 +497,7 @@ static int moving_inversions32(char *desc, int iter, uint32 p1, uint32 low_patte
                         pattern = pattern >> 1;
                         pattern |= p3;
                     }
-                } while (pp-- > pe);                 
+                } while (pp > pe);
             } while (!done);
             FT_DDR_SHOW();
         }
@@ -557,11 +540,7 @@ static int modtst(char *desc, int offset, int iter, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -589,11 +568,7 @@ static int modtst(char *desc, int offset, int iter, uint32 p1, uint32 p2)
             k = 0;
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -625,11 +600,7 @@ static int modtst(char *desc, int offset, int iter, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -687,11 +658,7 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -715,11 +682,7 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
             pp = start;
             done = 0;
             do {
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -751,16 +714,12 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
         for (j = 0; j < segs; j++) {
             start = v->map[j].start;
             end = v->map[j].end;
-            pe = end - 1;
-            pp = end - 1;
+            pe = end;
+            pp = end;
             done = 0;
             do {
                 /* Check for underflow */
-                if (pe - SPINSZ < pe) {
-                    pe -= SPINSZ;
-                } else {
-                    pe = start;
-                }
+                pe -= bounded_step(start, pe, SPINSZ);
                 if (pe <= start) {
                     pe = start;
                     done++;
@@ -770,6 +729,7 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
                 }
 
                 do {
+                    --pp;
                     if (*pp != p1) {
                         FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, p1, *pp);
                         sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, p1, *pp);
@@ -777,7 +737,7 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
                         return FT_DDR_ERR;
                     }
                     *pp = p2;
-                } while (pp-- > pe);
+                } while (pp > pe);
                  
             } while (!done);
             FT_DDR_SHOW();
@@ -797,11 +757,7 @@ static int march_c(char *desc, int iter, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -859,11 +815,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -886,11 +838,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -933,11 +881,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -963,16 +907,12 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
     for (j = 0; j < segs; j++) {
         start = v->map[j].start;
         end = v->map[j].end;
-        pe = end - 1;
-        pp = end - 1;
+        pe = end;
+        pp = end;
         done = 0;
         do {
             /* Check for underflow */
-            if (pe - SPINSZ < pe) {
-                pe -= SPINSZ;
-            } else {
-                pe = start;
-            }
+            pe -= bounded_step(start, pe, SPINSZ);
             if (pe <= start) {
                 pe = start;
                 done++;
@@ -982,6 +922,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
             }
 
             do {
+                --pp;
                 if (*pp != p2) {
                     FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
                     sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
@@ -991,7 +932,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
                 *pp = p1;
                 *pp = p2;
                 *pp = p1;
-            } while (pp-- > pe);
+            } while (pp > pe);
              
         } while (!done);
         FT_DDR_SHOW();
@@ -1001,16 +942,12 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
     for (j = 0; j < segs; j++) {
         start = v->map[j].start;
         end = v->map[j].end;
-        pe = end - 1;
-        pp = end - 1;
+        pe = end;
+        pp = end;
         done = 0;
         do {
             /* Check for underflow */
-            if (pe - SPINSZ < pe) {
-                pe -= SPINSZ;
-            } else {
-                pe = start;
-            }
+            pe -= bounded_step(start, pe, SPINSZ);
             if (pe <= start) {
                 pe = start;
                 done++;
@@ -1020,6 +957,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
             }
 
             do {
+                --pp;
                 if (*pp != p1) {
                     FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, p1, *pp);
                     sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, p1, *pp);
@@ -1028,7 +966,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
                 }
                 *pp = p2;
                 *pp = p1;
-            } while (pp-- > pe);
+            } while (pp > pe);
              
         } while (!done);
         FT_DDR_SHOW();
@@ -1042,11 +980,7 @@ static int march_g(char *desc, int iter, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1113,11 +1047,7 @@ static int column_operate(char *desc, int iter, uint32 p1, uint32 col_num)
             }
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -1152,11 +1082,7 @@ static int column_operate(char *desc, int iter, uint32 p1, uint32 col_num)
             }
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -1216,11 +1142,7 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1243,11 +1165,7 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1275,11 +1193,7 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
         pp = start;
         done = 0;
         do {
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1303,16 +1217,12 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
     for (j = 0; j < segs; j++) {
         start = v->map[j].start;
         end = v->map[j].end;
-        pe = end - 1;
-        pp = end - 1;
+        pe = end;
+        pp = end;
         done = 0;
         do {
             /* Check for underflow */
-            if (pe - SPINSZ < pe) {
-                pe -= SPINSZ;
-            } else {
-                pe = start;
-            }
+            pe -= bounded_step(start, pe, SPINSZ);
             if (pe <= start) {
                 pe = start;
                 done++;
@@ -1322,11 +1232,12 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
             }
 
             do {
-                if (pp - 1 <= pe)
+                --pp;
+                if (pp == pe)
                     break;
                 *pp = p2;
                 *(pp - 1) = p1;
-            } while (pp-- > pe);
+            } while (pp > pe);
             *pp = p2;
         } while (!done);
         FT_DDR_SHOW();
@@ -1336,16 +1247,12 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
     for (j = 0; j < segs; j++) {
         start = v->map[j].start;
         end = v->map[j].end;
-        pe = end - 1;
-        pp = end - 1;
+        pe = end;
+        pp = end;
         done = 0;
         do {
             /* Check for underflow */
-            if (pe - SPINSZ < pe) {
-                pe -= SPINSZ;
-            } else {
-                pe = start;
-            }
+            pe -= bounded_step(start, pe, SPINSZ);
             if (pe <= start) {
                 pe = start;
                 done++;
@@ -1355,13 +1262,14 @@ static int galloping(char *desc, uint32 p1, uint32 p2)
             }
 
             do {
+                --pp;
                 if (*pp != p2) {
                     FAC_LOG_DBG(GRTD_LOG_ERR, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
                     sprintf(desc, "[%p] should be 0x%x,but is 0x%x.\n", pp, p2, *pp);
                     fail = 1;
                     return FT_DDR_ERR;
                 }
-            } while (pp-- > pe);
+            } while (pp > pe);
              
         } while (!done);
         FT_DDR_SHOW();
@@ -1439,11 +1347,7 @@ static int swap_blocks(char *desc, int iter, int swap_times, ulong blk_size)
         /* From low address to high address, write rand() */
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1595,11 +1499,7 @@ static int swap_blocks(char *desc, int iter, int swap_times, ulong blk_size)
             rand_seed(seed1, seed2);
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;
@@ -1683,11 +1583,7 @@ static int ddr_half_mov_inv_random_pat(char *desc)
         done = 0;
         do {
             /* Check for overflow */
-            if (pe + SPINSZ > pe) {
-                pe += SPINSZ;
-            } else {
-                pe = end;
-            }
+            pe += bounded_step(pe, end, SPINSZ);
             if (pe >= end) {
                 pe = end;
                 done++;
@@ -1716,11 +1612,7 @@ static int ddr_half_mov_inv_random_pat(char *desc)
             done = 0;
             do {
                 /* Check for overflow */
-                if (pe + SPINSZ > pe) {
-                    pe += SPINSZ;
-                } else {
-                    pe = end;
-                }
+                pe += bounded_step(pe, end, SPINSZ);
                 if (pe >= end) {
                     pe = end;
                     done++;

--- a/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/tests/ddr_bounds_test.c
+++ b/platform/broadcom/sonic-platform-modules-micas/common/app/hw_test/hw_test_app/tests/ddr_bounds_test.c
@@ -1,0 +1,101 @@
+#include <assert.h>
+#include <stdint.h>
+
+#include "../ft_ddr_test.c"
+
+#define GUARD_PATTERN 0xdeadbeefu
+#define TEST_PATTERN 0x55555555u
+
+int platform_fac_dbg = 0;
+
+static void check_steps(void)
+{
+    uint32 memory[17];
+    volatile uint32 *current = memory;
+
+    assert(bounded_step(memory, memory, 8) == 0);
+    assert(bounded_step(memory, memory + 7, 8) == 7);
+    assert(bounded_step(memory, memory + 8, 8) == 8);
+    assert(bounded_step(memory, memory + 17, 8) == 8);
+    assert(bounded_step(memory, memory + 17, SIZE_MAX) == 17);
+    assert(bounded_step(memory, memory + 17, 0) == 0);
+    current += bounded_step(current, memory + 17, 8);
+    assert(current == memory + 8);
+    current += bounded_step(current, memory + 17, 8);
+    assert(current == memory + 16);
+    current += bounded_step(current, memory + 17, 8);
+    assert(current == memory + 17);
+    current += bounded_step(current, memory + 17, 8);
+    assert(current == memory + 17);
+    current -= bounded_step(memory, current, 8);
+    assert(current == memory + 9);
+    current -= bounded_step(memory, current, 8);
+    assert(current == memory + 1);
+    current -= bounded_step(memory, current, 8);
+    assert(current == memory);
+    current -= bounded_step(memory, current, 8);
+    assert(current == memory);
+}
+
+static void check_bounds(const uint32 *storage, size_t words)
+{
+    assert(storage[0] == GUARD_PATTERN);
+    assert(storage[words + 1] == GUARD_PATTERN);
+    assert((uintptr_t)pp >= (uintptr_t)(storage + 1));
+    assert((uintptr_t)pp <= (uintptr_t)(storage + words + 1));
+}
+
+static void check_uniform(const uint32 *storage, size_t words, uint32 pattern)
+{
+    size_t i;
+
+    check_bounds(storage, words);
+    for (i = 0; i < words; ++i) {
+        assert(storage[i + 1] == pattern);
+    }
+}
+
+static void check_range(size_t words)
+{
+    uint32 *storage = malloc((words + 2) * sizeof(*storage));
+    char desc[128] = {0};
+    size_t i;
+
+    assert(storage != NULL);
+    storage[0] = GUARD_PATTERN;
+    storage[words + 1] = GUARD_PATTERN;
+    ft_ddr_test_init(storage + 1, words * sizeof(*storage));
+
+    assert(moving_inversions(desc, 2, TEST_PATTERN, ~TEST_PATTERN) == FT_DDR_SUCCESS);
+    check_uniform(storage, words, TEST_PATTERN);
+    assert(march_c(desc, 2, TEST_PATTERN, ~TEST_PATTERN) == FT_DDR_SUCCESS);
+    check_uniform(storage, words, TEST_PATTERN);
+    assert(march_g(desc, 2, TEST_PATTERN, ~TEST_PATTERN) == FT_DDR_SUCCESS);
+    check_uniform(storage, words, TEST_PATTERN);
+    assert(galloping(desc, TEST_PATTERN, ~TEST_PATTERN) == FT_DDR_SUCCESS);
+    check_uniform(storage, words, ~TEST_PATTERN);
+
+    assert(moving_inversions32(desc, 2, 1, 1, 0x80000000u, 0, 0) == FT_DDR_SUCCESS);
+    check_bounds(storage, words);
+    for (i = 0; i < words; ++i) {
+        assert(storage[i + 1] == (1u << (i % 32)));
+    }
+
+    free(storage);
+    printf("\nDDR boundary range: %zu words passed\n", words);
+}
+
+int main(void)
+{
+    const size_t sizes[] = {
+        0, 1, SPINSZ - 1, SPINSZ, SPINSZ + 1, SPINSZ + 2,
+        2 * SPINSZ, 2 * SPINSZ + 1, 2 * SPINSZ + 2
+    };
+    size_t i;
+
+    check_steps();
+    for (i = 0; i < sizeof(sizes) / sizeof(sizes[0]); ++i) {
+        check_range(sizes[i]);
+    }
+    return 0;
+}


### PR DESCRIPTION
## What I did

- bound forward DDR chunk sizes before pointer arithmetic
- convert reverse walks to half-open ranges so they do not form `start - 1` or skip the final word
- preserve the existing `SPINSZ` and `bank` units and end/done behavior
- add a host-side boundary harness for empty, short, exact, multi-chunk, and partial ranges

## Why I did it

The previous overflow checks formed potentially out-of-range pointers before checking whether arithmetic wrapped. Pointer arithmetic outside the mapped range is undefined behavior.

The `bank` value remains an element count, matching existing behavior. Please confirm that this hardware stride is intentionally expressed in `uint32` elements rather than bytes.

## Testing

- `make check` passes for 0, 1, `SPINSZ - 1`, `SPINSZ`, `SPINSZ + 1`, and multiple full/partial chunks