### PR TITLE
[CodeQL] Harden Ragile firmware parsing and debug handling

### DIFF
--- a/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/debug.c
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/debug.c
@@ -24,37 +24,25 @@ int is_debug_on = DEBUG_IGNORE;
  */
 int firmware_upgrade_debug(void)
 {
-    int size;
+    int value;
     FILE *fp;
-    char debug_info[DEBUG_INFO_LEN];
 
     fp = fopen(DEBUG_FILE, "r");
     if (fp == NULL) {
         return DEBUG_IGNORE;
     }
 
-    mem_clear(debug_info, DEBUG_INFO_LEN);
-    size = fread(debug_info, DEBUG_INFO_LEN - 1, 1, fp);
-    if (size < 0) {
-        fclose(fp);
+    value = fgetc(fp);
+    fclose(fp);
+
+    switch (value) {
+    case '1':
+        return DEBUG_APP_ON;
+    case '3':
+        return DEBUG_ALL_ON;
+    case '0':
+        return DEBUG_OFF;
+    default:
         return DEBUG_IGNORE;
     }
-
-    if (strncmp(debug_info, DEBUG_ON_INFO, 1) == 0) {
-        fclose(fp);
-        return DEBUG_APP_ON;
-    }
-
-    if (strncmp(debug_info, DEBUG_ON_ALL, 1) == 0) {
-        fclose(fp);
-        return DEBUG_ALL_ON;
-    }
-
-    if (strncmp(debug_info, DEBUG_OFF_INFO, 1) == 0) {
-        fclose(fp);
-        return DEBUG_OFF;
-    }
-
-    fclose(fp);
-    return DEBUG_IGNORE;
 }

--- a/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/fw_upg_gpio_vme/ispvm_ui.c
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/fw_upg_gpio_vme/ispvm_ui.c
@@ -666,7 +666,7 @@ static void ispvm_ui_reinit()
 
 int ispvme_main(int argc, char *argv[], int file_fd, name_info_t *info)
 {
-    unsigned short iCommandLineIndex  = 0;
+    int iCommandLineIndex             = 0;
     short siRetCode                   = 0;
     char szExtension[5] = { 0 };
     char szCommandLineArg[300] = { 0 };

--- a/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/fw_upg_gpio_vme/ivm_core.c
+++ b/platform/broadcom/sonic-platform-modules-ragile/common/app/firmware_upgrade/firmware_upgrade/fw_upg_gpio_vme/ivm_core.c
@@ -1225,6 +1225,8 @@ void ispVMData(unsigned char *ByteData)
     //09/11/07 NN added local variables initialization
     unsigned short size               = 0;
     unsigned short i, j, m, getData   = 0;
+    size_t repeat_count               = 0;
+    size_t repeat_index               = 0;
     unsigned char cDataByte           = 0;
     unsigned char compress            = 0;
     unsigned short FFcount            = 0;
@@ -1295,12 +1297,13 @@ void ispVMData(unsigned char *ByteData)
         default:
             for (index = 0; index < size; index++)
                 ByteData[index] = 0x00;
+            repeat_count = (size_t)size * 2U / compress;
             for (index = 0; index < compress; index++) {
                 if (index % 2 == 0)
                     cDataByte = GetByte();
-                for (i = 0; i < size * 2 / compress; i++) {
+                for (repeat_index = 0; repeat_index < repeat_count; repeat_index++) {
                     //09/11/07 NN Type cast mismatch variables
-                    j = (unsigned short)(index + (i * (unsigned short)compress));
+                    j = (unsigned short)(index + (repeat_index * compress));
                     /*clear the nibble to zero first*/
                     if (j % 2) {
                         if (index % 2)
@@ -1358,9 +1361,10 @@ void ispVMData(unsigned char *ByteData)
 signed char ispVMShift(signed char a_cCode)
 {
     //09/11/07 NN added local variables initialization
-    unsigned short iDataIndex  = 0;
     unsigned short iReadLoop   = 0;
     signed char cRetCode       = 0;
+    size_t copy_bytes          = 0;
+    size_t copy_index          = 0;
 
     cRetCode = 0;
     //09/11/07 NN Type cast mismatch variables
@@ -1449,6 +1453,7 @@ signed char ispVMShift(signed char a_cCode)
 
     printf(";\n");
 #endif //VME_DEBUG
+    copy_bytes = (size_t)g_usiDataSize / 8U + 1U;
     if (g_usDataType & TDO_DATA || g_usDataType & DMASK_DATA) {
         if (g_usDataType & DMASK_DATA) {
 
@@ -1465,8 +1470,8 @@ signed char ispVMShift(signed char a_cCode)
                     ispVMBypass(HDR, g_usHeadDR);
                     sclock();
                 }
-                for (iDataIndex = 0; iDataIndex < g_usiDataSize / 8 + 1; iDataIndex++)
-                    g_pucInData[iDataIndex] = g_pucOutData[iDataIndex];
+                for (copy_index = 0; copy_index < copy_bytes; copy_index++)
+                    g_pucInData[copy_index] = g_pucOutData[copy_index];
                 g_usDataType &= ~(TDO_DATA + DMASK_DATA);
                 cRetCode = ispVMSend(g_usiDataSize);
             }
@@ -1497,8 +1502,8 @@ signed char ispVMShift(signed char a_cCode)
     /*transfer the input data to the output buffer for the next verify*/
     if ((g_usDataType & EXPRESS) || (a_cCode == SDR)) {
         if (g_pucOutData) {
-            for (iDataIndex = 0; iDataIndex < g_usiDataSize / 8 + 1; iDataIndex++)
-                g_pucOutData[iDataIndex] = g_pucInData[iDataIndex];
+            for (copy_index = 0; copy_index < copy_bytes; copy_index++)
+                g_pucOutData[copy_index] = g_pucInData[copy_index];
         }
     }
 


### PR DESCRIPTION
## What I did
- use `size_t` for calculated firmware copy and repeat bounds
- read the debug selector as a single byte instead of treating an unterminated buffer as a string
- use an `int` command-line index to match `argc`

## Why I did it
The previous narrow loop counters could fail to cover wider calculated bounds, and the debug parser relied on string comparison after a raw file read.

## How I verified it
- compiled the changed files with `-Wall -Wextra -Wsign-compare -Wconversion`
- exercised debug inputs for empty, `0`, `1`, `3`, invalid, and newline-terminated files
- checked firmware copy-bound calculations at 0, 1, 7, 8, 9, and 65535 bits