### PR TITLE
[CodeQL] Bound Mitac watchdog timeout formatting

### DIFF
--- a/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/modules/mitac_ly1200_32x_system_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-mitac/ly1200-32x/modules/mitac_ly1200_32x_system_cpld.c
@@ -276,13 +276,14 @@ static void wdt_set_timeout(int index)
 {
     struct device *dev = &system_cpld->client->dev;
     struct device_attribute *fake_attr=NULL;
-    char buf[1];
-    if ( WD_TIMO_MAX_NUM == 16 ) {
-        sprintf(buf,"%x",index);
-        system_cpld_wd_timer_raw_write(dev, fake_attr, buf, (size_t)0);
-    }
-    else
-        printk(KERN_INFO "%s: It is out of spec.\n", __FUNCTION__);
+    char buf[sizeof(index) * 2 + 2];
+    int len;
+
+    if (index < 0 || index >= WD_TIMO_MAX_NUM)
+        return;
+
+    len = scnprintf(buf, sizeof(buf), "%x", (unsigned int)index);
+    system_cpld_wd_timer_raw_write(dev, fake_attr, buf, (size_t)len);
 }
 
 /**
@@ -538,4 +539,3 @@ module_exit(system_cpld_exit);
 MODULE_DESCRIPTION("mitac_ly1200_32x_system_cpld driver");
 MODULE_AUTHOR("Eddy Weng <eddy.weng@mic.com.tw>");
 MODULE_LICENSE("GPL");
-


### PR DESCRIPTION
## What I did
- validate the watchdog timeout selector before formatting it
- replace the one-byte `sprintf` destination with a conservatively sized buffer and `scnprintf`
- pass the formatted length to the CPLD write helper

## Why I did it
The previous buffer could not hold both a hexadecimal selector and its terminating NUL byte.

## How I verified it
- checked selectors 0, 1, 9, 10, and 15 format within the destination
- compiled the changed module against the available kernel headers; compilation reached the driver but the legacy module has unrelated Linux 6.8 API incompatibilities in existing probe/remove declarations