### PR TITLE
[CodeQL] Bound Quanta platform device-name formatting

### DIFF
--- a/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/modules/qci_cpld_qsfp28.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix1b-32x/modules/qci_cpld_qsfp28.c
@@ -48,7 +48,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	u8 port_id;
 	u8 cpld_port;
 };
@@ -329,10 +329,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < 16; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			return ERR_PTR(port_nr);
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -348,7 +363,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 	 	//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -365,6 +379,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 //FIXME: implement error check
 exit_remove:

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/modules/qci_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/modules/qci_cpld.c
@@ -52,7 +52,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	char type[8];
 	u8 port_id;
 	u8 cpld_port;
@@ -370,10 +370,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < max_port_num; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			goto err_out;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -391,7 +406,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -408,6 +422,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 err_out:
 	return port_nr;

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-32x/modules/qci_cpld_led.c
@@ -49,7 +49,7 @@ static struct class *cpld_class = NULL;
 
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -203,10 +203,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -219,7 +231,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -237,8 +248,16 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+	if (ida_is_empty(&cpld_led_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 #if 0

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/modules/qci_cpld.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/modules/qci_cpld.c
@@ -52,7 +52,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	char type[8];
 	u8 port_id;
 	u8 cpld_port;
@@ -370,10 +370,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < max_port_num; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			goto err_out;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -391,7 +406,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -408,6 +422,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 err_out:
 	return port_nr;

--- a/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix7-bwde-32x/modules/qci_cpld_led.c
@@ -51,7 +51,7 @@ static struct class *cpld_class = NULL;
 
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -207,10 +207,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -223,7 +235,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -241,8 +252,16 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+	if (ida_is_empty(&cpld_led_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 #if 0

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/modules/qci_cpld_led.c
@@ -49,7 +49,7 @@ static struct class *cpld_class = NULL;
 
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -203,10 +203,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -219,7 +231,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -237,8 +248,16 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+	if (ida_is_empty(&cpld_led_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 #if 0

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/modules/qci_cpld_sfp28.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8-56x/modules/qci_cpld_sfp28.c
@@ -51,7 +51,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	char type[8];
 	u8 port_id;
 	u8 cpld_port;
@@ -314,10 +314,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < 16; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			goto err_out;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -335,7 +350,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -352,6 +366,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 err_out:
 	return port_nr;

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/modules/qci_cpld_led.c
@@ -49,7 +49,7 @@ static struct class *cpld_class = NULL;
 
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -203,10 +203,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -219,7 +231,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -237,8 +248,16 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+	if (ida_is_empty(&cpld_led_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/modules/qci_cpld_sfp28.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8a-bwde-56x/modules/qci_cpld_sfp28.c
@@ -51,7 +51,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	u8 port_id;
 	u8 cpld_port;
 };
@@ -298,10 +298,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < 16; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			goto err_out;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -317,7 +332,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -334,6 +348,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 err_out:
 	return port_nr;

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/modules/qci_cpld_led.c
@@ -49,7 +49,7 @@ static struct class *cpld_class = NULL;
 
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -203,10 +203,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -219,7 +231,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -237,8 +248,16 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+	if (ida_is_empty(&cpld_led_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */

--- a/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/modules/qci_cpld_sfp28.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix8c-56x/modules/qci_cpld_sfp28.c
@@ -51,7 +51,7 @@ static struct class *cpld_class = NULL;
 
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	u8 port_id;
 	u8 cpld_port;
 };
@@ -298,10 +298,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < 16; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			goto err_out;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -317,7 +332,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -334,6 +348,18 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+	if (ida_is_empty(&cpld_ida)) {
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 err_out:
 	return port_nr;

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/modules/qci_cpld_led.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/modules/qci_cpld_led.c
@@ -49,9 +49,13 @@ enum platform_type {
 
 static struct class *cpld_class = NULL;
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,10,0)
+static bool cpld_idr_is_empty(struct idr *idp);
+#endif
+
 struct cpld_data {
 	struct i2c_client *cpld_client;
-	char name[16];
+	char name[20];
 	u8 cpld_id;
 };
 
@@ -206,10 +210,22 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	/* Test */
 	nr = ida_simple_get(&cpld_led_ida, 1, 99, GFP_KERNEL);
-	if (nr < 0)
-		goto err_out;
+	if (nr < 0) {
+		err = nr;
+		goto err_destroy_class;
+	}
 
 	led_data = kzalloc(sizeof(struct cpld_led_data), GFP_KERNEL);
+	if (!led_data) {
+		err = -ENOMEM;
+		goto err_remove_id;
+	}
+	err = snprintf(led_data->name, sizeof(led_data->name),
+		       "LED%d-data", nr);
+	if (err < 0 || (size_t)err >= sizeof(led_data->name)) {
+		err = -ENAMETOOLONG;
+		goto err_free_data;
+	}
 
 	port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), led_data, CPLD_LED_ID_FORMAT, nr);
 	if (IS_ERR(port_dev)) {
@@ -222,7 +238,6 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	dev_info(&client->dev, "Register CPLDLED %d\n", nr);
 
-	sprintf(led_data->name, "LED%d-data", nr);
 	led_data->cpld_id = nr;
 	dev_set_drvdata(port_dev, led_data);
 	port_dev->init_name = led_data->name;
@@ -240,8 +255,20 @@ static int cpld_led_probe(struct i2c_client *client,
 
 	return 0;
 
-err_out:
-	return nr;
+err_free_data:
+	kfree(led_data);
+err_remove_id:
+	ida_simple_remove(&cpld_led_ida, nr);
+err_destroy_class:
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4,10,0)
+	if (ida_is_empty(&cpld_led_ida)) {
+#else
+	if (cpld_idr_is_empty(&cpld_led_ida.idr)) {
+#endif
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 }
 
 /* FIXME: for older kernel doesn't with idr_is_empty function, implement here */

--- a/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/modules/qci_cpld_qsfpdd.c
+++ b/platform/broadcom/sonic-platform-modules-quanta/ix9-32x/modules/qci_cpld_qsfpdd.c
@@ -47,9 +47,13 @@ enum platform_type {
 
 static struct class *cpld_class = NULL;
 
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4,10,0)
+static bool cpld_idr_is_empty(struct idr *idp);
+#endif
+
 struct sfp_data {
 	struct i2c_client *cpld_client;
-	char name[8];
+	char name[16];
 	u8 port_id;
 	u8 cpld_port;
 };
@@ -330,10 +334,25 @@ static int cpld_probe(struct i2c_client *client,
 	for (i = 0; i < 16; i++)
 	{
 		port_nr = ida_simple_get(&cpld_ida, 1, 99, GFP_KERNEL);
-		if (port_nr < 0)
-			return port_nr;
+		if (port_nr < 0) {
+			err = port_nr;
+			goto err_unregister_ports;
+		}
 
 		port_data = kzalloc(sizeof(struct sfp_data), GFP_KERNEL);
+		if (!port_data) {
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENOMEM;
+			goto err_unregister_ports;
+		}
+		err = snprintf(port_data->name, sizeof(port_data->name),
+			       "port-%d", port_nr);
+		if (err < 0 || (size_t)err >= sizeof(port_data->name)) {
+			kfree(port_data);
+			ida_simple_remove(&cpld_ida, port_nr);
+			err = -ENAMETOOLONG;
+			goto err_unregister_ports;
+		}
 
 		port_dev = device_create(cpld_class, &client->dev, MKDEV(0,0), port_data, CPLD_ID_FORMAT, port_nr);
 		if (IS_ERR(port_dev)) {
@@ -349,7 +368,6 @@ static int cpld_probe(struct i2c_client *client,
 		/* FIXME: implement Logical/Physical port remapping */
 		//port_data->cpld_port = i;
 		port_data->cpld_port = port_remapping(i);
-		sprintf(port_data->name, "port-%d", port_nr);
 		port_data->port_id = port_nr;
 		dev_set_drvdata(port_dev, port_data);
 		port_dev->init_name = port_data->name;
@@ -366,6 +384,22 @@ static int cpld_probe(struct i2c_client *client,
 
 
 	return 0;
+
+err_unregister_ports:
+	while (--i >= 0) {
+		device_unregister(data->port_dev[i]);
+		ida_simple_remove(&cpld_ida, data->port_data[i]->port_id);
+		kfree(data->port_data[i]);
+	}
+#if LINUX_VERSION_CODE > KERNEL_VERSION(4,10,0)
+	if (ida_is_empty(&cpld_ida)) {
+#else
+	if (cpld_idr_is_empty(&cpld_ida.idr)) {
+#endif
+		class_destroy(cpld_class);
+		cpld_class = NULL;
+	}
+	return err;
 
 #if 0
 //FIXME: implement error check


### PR DESCRIPTION
## What I did
- enlarge repeated Quanta port and LED device-name buffers
- replace unbounded `sprintf` calls with checked `snprintf`
- release allocated IDs, objects, and previously registered child devices when name setup fails
- update all 10 reported modules plus 3 structurally identical public copies

## Why I did it
The drivers constructed names from integer IDs with unbounded formatting into fixed-size arrays.

## How I verified it
- checked all 13 target files contain bounded formatting and truncation handling
- exercised names for IDs 1, 9, 10, and 98
- parsed every changed module with the available kernel build; the legacy drivers still hit unrelated Linux 6.8 API incompatibilities in existing `class_create` and I2C callback code, with no diagnostics from the changed paths