### PR TITLE
[CodeQL] Harden Mellanox dump receiver file creation

### DIFF
--- a/platform/mellanox/platform-utils/mellanox_bfb_installer/dump_receiver.py
+++ b/platform/mellanox/platform-utils/mellanox_bfb_installer/dump_receiver.py
@@ -45,6 +45,7 @@ import argparse
 import logging
 import os
 import re
+import secrets
 import signal
 import socket
 import sys
@@ -184,12 +185,28 @@ class _DumpReceiverHandler(BaseHTTPRequestHandler):
             self._reply(HTTPStatus.BAD_REQUEST, "invalid destination\n")
             return
 
-        tmp_path = dest_path + ".part"
+        tmp_name = f".upload-{secrets.token_hex(8)}"
         bytes_remaining = content_length
         # Bound each body read so a stalled client can't hold a handler thread forever.
         self.connection.settimeout(BODY_READ_TIMEOUT_SEC)
+        dir_fd = None
         try:
-            with open(tmp_path, "wb") as f:
+            dir_fd = os.open(
+                dest_dir,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+            )
+            upload_fd = os.open(
+                tmp_name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=dir_fd,
+            )
+            try:
+                upload_file = os.fdopen(upload_fd, "wb")
+            except OSError:
+                os.close(upload_fd)
+                raise
+            with upload_file as f:
                 while bytes_remaining > 0:
                     chunk = self.rfile.read(min(READ_CHUNK_SIZE, bytes_remaining))
                     if not chunk:
@@ -201,7 +218,12 @@ class _DumpReceiverHandler(BaseHTTPRequestHandler):
                     os.fsync(f.fileno())
                 except OSError:
                     pass
-            os.replace(tmp_path, dest_path)
+            os.replace(
+                tmp_name,
+                filename,
+                src_dir_fd=dir_fd,
+                dst_dir_fd=dir_fd,
+            )
         except (ConnectionError, OSError, socket.timeout) as e:
             logger.error(
                 "upload failed dpu=%s file=%s client=%s err=%s",
@@ -210,12 +232,16 @@ class _DumpReceiverHandler(BaseHTTPRequestHandler):
                 self.client_address[0],
                 e,
             )
-            try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
+            if dir_fd is not None:
+                try:
+                    os.unlink(tmp_name, dir_fd=dir_fd)
+                except OSError:
+                    pass
             self._reply(HTTPStatus.INTERNAL_SERVER_ERROR, f"write failed: {e}\n")
             return
+        finally:
+            if dir_fd is not None:
+                os.close(dir_fd)
 
         logger.info(
             "saved upload dpu=%s file=%s bytes=%d client=%s dest=%s",

--- a/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_dump_receiver.py
+++ b/platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_dump_receiver.py
@@ -277,8 +277,9 @@ class TestDumpReceiverHttpHappyPath(_ReceiverServerFixture):
         self.assertTrue(os.path.isfile(dest), f"missing dest: {dest}")
         with open(dest, "rb") as f:
             self.assertEqual(f.read(), body)
-        # The .part file must be gone after atomic rename.
-        self.assertFalse(os.path.exists(dest + ".part"))
+        self.assertFalse(
+            any(name.startswith(".upload-") for name in os.listdir(os.path.dirname(dest)))
+        )
 
     def test_post_writes_file(self):
         """POST and PUT share the upload handler."""
@@ -414,9 +415,9 @@ class TestDumpReceiverHttpRejections(_ReceiverServerFixture):
         # And: the file definitely didn't make it to disk.
         self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu0", "x.bin")))
 
-    def test_short_body_returns_500_and_cleans_part_file(self):
+    def test_short_body_returns_500_and_cleans_temp_file(self):
         """If the client sends fewer bytes than Content-Length says, the
-        handler must respond 500 and remove the partial .part file so the
+        handler must respond 500 and remove the partial upload file so the
         next retry from the DPU starts clean."""
         # Send Content-Length: 100 but only 5 bytes of body, then close.
         raw = (
@@ -427,18 +428,22 @@ class TestDumpReceiverHttpRejections(_ReceiverServerFixture):
         )
         resp = self._raw_request(raw)
         # We may or may not get a response back; both behaviours mean the
-        # save failed. Crucially the .part file must not be left around.
+        # save failed. Crucially the temporary file must not be left around.
         if resp:
             first_line = resp.split(b"\r\n", 1)[0]
             self.assertIn(b" 500 ", first_line, resp)
-        # Give the handler a moment to unlink the .part on the io error path.
+        dpu_dir = os.path.join(self.tmpdir, "dpu8")
+        # Give the handler a moment to unlink the temporary file on the io error path.
         for _ in range(20):
-            if not os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin.part")):
+            if not os.path.isdir(dpu_dir) or not any(
+                name.startswith(".upload-") for name in os.listdir(dpu_dir)
+            ):
                 break
             time.sleep(0.05)
         self.assertFalse(
-            os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin.part")),
-            "stale .part file left behind on short-body upload",
+            os.path.isdir(dpu_dir)
+            and any(name.startswith(".upload-") for name in os.listdir(dpu_dir)),
+            "stale temporary file left behind on short-body upload",
         )
         # The final file must not exist either.
         self.assertFalse(os.path.exists(os.path.join(self.tmpdir, "dpu8", "short.bin")))
@@ -549,6 +554,64 @@ class TestDumpReceiverSymlinkEscape(_ReceiverServerFixture):
             os.listdir(outside),
             f"symlink escape produced files in {outside}: {os.listdir(outside)}",
         )
+
+    def test_directory_swap_before_open_is_rejected(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        outside = tempfile.mkdtemp(prefix="dr_race_target_")
+        self.addCleanup(shutil.rmtree, outside, True)
+        dpu_dir = os.path.join(self.tmpdir, "dpu1")
+        moved_dir = os.path.join(self.tmpdir, "original-dpu1")
+        os.mkdir(dpu_dir)
+        real_open = dump_receiver.os.open
+        swapped = False
+
+        def swap_before_open(path, flags, *args, **kwargs):
+            nonlocal swapped
+            if path == dpu_dir and not swapped:
+                os.rename(dpu_dir, moved_dir)
+                os.symlink(outside, dpu_dir)
+                swapped = True
+            return real_open(path, flags, *args, **kwargs)
+
+        with mock.patch.object(dump_receiver.os, "open", side_effect=swap_before_open):
+            conn = self._conn()
+            conn.request("PUT", "/dpu1/race.bin", body=b"should-not-land")
+            resp = conn.getresponse()
+            body = resp.read()
+            conn.close()
+
+        self.assertEqual(resp.status, 500, body)
+        self.assertTrue(swapped)
+        self.assertFalse(os.listdir(outside))
+        self.assertFalse(os.path.exists(os.path.join(moved_dir, "race.bin")))
+
+    def test_preexisting_temp_symlink_is_not_followed(self):
+        from mellanox_bfb_installer import dump_receiver
+
+        outside = tempfile.mkdtemp(prefix="dr_temp_target_")
+        self.addCleanup(shutil.rmtree, outside, True)
+        outside_file = os.path.join(outside, "victim")
+        with open(outside_file, "wb") as f:
+            f.write(b"original")
+
+        dpu_dir = os.path.join(self.tmpdir, "dpu2")
+        os.mkdir(dpu_dir)
+        temp_path = os.path.join(dpu_dir, ".upload-fixed")
+        os.symlink(outside_file, temp_path)
+
+        with mock.patch.object(dump_receiver.secrets, "token_hex", return_value="fixed"):
+            conn = self._conn()
+            conn.request("PUT", "/dpu2/upload.bin", body=b"replacement")
+            resp = conn.getresponse()
+            body = resp.read()
+            conn.close()
+
+        self.assertEqual(resp.status, 500, body)
+        with open(outside_file, "rb") as f:
+            self.assertEqual(f.read(), b"original")
+        self.assertFalse(os.path.lexists(temp_path))
+        self.assertFalse(os.path.exists(os.path.join(dpu_dir, "upload.bin")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The dump receiver validated upload destinations with `realpath()` and then reopened them by path. A directory replacement or predictable temporary-file symlink between those operations could redirect the write.

## What changed

- Open the validated DPU directory with `O_DIRECTORY | O_NOFOLLOW` and retain its file descriptor.
- Create a random temporary upload with `O_EXCL | O_NOFOLLOW` and mode `0600` relative to that descriptor.
- Publish and clean up using descriptor-relative `os.replace()` and `os.unlink()`.
- Add regression coverage for directory-swap and pre-existing temporary symlink attacks.

## Validation

- `CONFIGURED_PLATFORM=mellanox python3 -m pytest platform/mellanox/platform-utils/tests/mellanox_bfb_installer/test_dump_receiver.py -q` (32 passed)
- Python compile check passed