### PR TITLE
versions-deb-bookworm: bump linux-libc-dev to 6.1.187-1

### DIFF
--- a/files/build/versions-public/dockers/docker-auditd-watchdog/versions-deb-bookworm-arm64
+++ b/files/build/versions-public/dockers/docker-auditd-watchdog/versions-deb-bookworm-arm64
@@ -10,6 +10,6 @@ libxml2==2.9.14+dfsg-1.3~deb12u4
 libxml2-dev==2.9.14+dfsg-1.3~deb12u4
 libxslt1-dev==1.1.35-1+deb12u3
 libxslt1.1==1.1.35-1+deb12u3
-linux-libc-dev==6.1.158-1
+linux-libc-dev==6.1.187-1
 rpcsvc-proto==1.4.3-1
 zlib1g-dev==1:1.2.13.dfsg-1

--- a/files/build/versions-public/dockers/docker-auditd-watchdog/versions-deb-bookworm-armhf
+++ b/files/build/versions-public/dockers/docker-auditd-watchdog/versions-deb-bookworm-armhf
@@ -10,6 +10,6 @@ libxml2==2.9.14+dfsg-1.3~deb12u4
 libxml2-dev==2.9.14+dfsg-1.3~deb12u4
 libxslt1-dev==1.1.35-1+deb12u3
 libxslt1.1==1.1.35-1+deb12u3
-linux-libc-dev==6.1.158-1
+linux-libc-dev==6.1.187-1
 rpcsvc-proto==1.4.3-1
 zlib1g-dev==1:1.2.13.dfsg-1

--- a/files/build/versions-public/dockers/docker-config-engine-bookworm/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-config-engine-bookworm/versions-deb-bookworm
@@ -63,7 +63,7 @@ libyaml-0-2==0.2.5-1
 libyang==1.0.73
 libyang-cpp==1.0.73
 libyang3==3.12.2-1
-linux-libc-dev==6.1.180-1
+linux-libc-dev==6.1.187-1
 make==4.3-4.1
 patch==2.7.6-7
 python3-cffi==1.15.1-5

--- a/files/build/versions-public/dockers/docker-dhcp-server/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-dhcp-server/versions-deb-bookworm
@@ -66,7 +66,7 @@ libtsan2==12.2.0-14+deb12u1
 libubsan1==12.2.0-14+deb12u1
 libunwind8==1.6.2-3
 libyang-cpp-dbgsym==1.0.73
-linux-libc-dev==6.1.164-1
+linux-libc-dev==6.1.187-1
 make==4.3-4.1
 mariadb-common==1:10.11.14-0+deb12u2
 mysql-common==5.8+1.1.0

--- a/files/build/versions-public/dockers/docker-gbsyncd-vs/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-gbsyncd-vs/versions-deb-bookworm
@@ -230,7 +230,7 @@ libxml2==2.9.14+dfsg-1.3~deb12u5
 libxnvctrl0==525.85.05-3~deb12u1
 libyang-cpp-dbgsym==1.0.73
 libz3-4==4.8.12-3.1
-linux-libc-dev==6.1.174-1
+linux-libc-dev==6.1.187-1
 llvm==1:14.0-55.7~deb12u1
 llvm-14==1:14.0.6-12
 llvm-14-linker-tools==1:14.0.6-12

--- a/files/build/versions-public/dockers/docker-ptf/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-ptf/versions-deb-bookworm
@@ -614,7 +614,7 @@ libyaml-0-2==0.2.5-1
 libyuv0==0.0~git20230123.b2528b0-1
 libz3-4==4.8.12-3.1
 libz3-dev==4.8.12-3.1
-linux-libc-dev==6.1.176-1
+linux-libc-dev==6.1.187-1
 llvm==1:14.0-55.7~deb12u1
 llvm-14==1:14.0.6-12
 llvm-14-dev==1:14.0.6-12

--- a/files/build/versions-public/dockers/docker-sonic-vs/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-sonic-vs/versions-deb-bookworm
@@ -98,7 +98,7 @@ libxml2==2.9.14+dfsg-1.3~deb12u6
 libxml2-dev==2.9.14+dfsg-1.3~deb12u6
 libyang3==3.12.2-1
 libzmq3-dev==4.3.4-6
-linux-libc-dev==6.1.180-1
+linux-libc-dev==6.1.187-1
 lldpd==1.0.16-1+deb12u1
 logrotate==3.21.0-1
 lsof==4.95.0-1

--- a/files/build/versions-public/dockers/docker-syncd-brcm-legacy-th-rpc/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-syncd-brcm-legacy-th-rpc/versions-deb-bookworm
@@ -55,7 +55,7 @@ libtsan2==12.2.0-14+deb12u1
 libubsan1==12.2.0-14+deb12u1
 libuv1==1.44.2-1+deb12u1
 libxml2==2.9.14+dfsg-1.3~deb12u5
-linux-libc-dev==6.1.170-1
+linux-libc-dev==6.1.187-1
 make==4.3-4.1
 netbase==6.4
 openssl==3.0.19-1~deb12u2

--- a/files/build/versions-public/dockers/docker-syncd-mlnx-rpc/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-syncd-mlnx-rpc/versions-deb-bookworm
@@ -54,7 +54,7 @@ libtirpc-dev==1.3.3+ds-1
 libtsan2==12.2.0-14+deb12u1
 libubsan1==12.2.0-14+deb12u1
 libuv1==1.44.2-1+deb12u1
-linux-libc-dev==6.1.170-1
+linux-libc-dev==6.1.187-1
 make==4.3-4.1
 netbase==6.4
 openssl==3.0.19-1~deb12u2

--- a/files/build/versions-public/dockers/docker-syncd-mlnx/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-syncd-mlnx/versions-deb-bookworm
@@ -41,7 +41,7 @@ libtirpc-dev==1.3.3+ds-1
 libunwind8==1.6.2-3
 libxml2==2.9.14+dfsg-1.3~deb12u5
 libyang-cpp-dbgsym==1.0.73
-linux-libc-dev==6.1.170-1
+linux-libc-dev==6.1.187-1
 mft==4.34.0-145
 mft-fwtrace-cfg==1.0.0
 mlnx-sai==1.mlnx.SAIBuild2511.35.3400.14

--- a/files/build/versions-public/dockers/docker-syncd-vs/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/docker-syncd-vs/versions-deb-bookworm
@@ -236,7 +236,7 @@ libxml2==2.9.14+dfsg-1.3~deb12u5
 libxnvctrl0==525.85.05-3~deb12u1
 libyang-cpp-dbgsym==1.0.73
 libz3-4==4.8.12-3.1
-linux-libc-dev==6.1.180-1
+linux-libc-dev==6.1.187-1
 llvm==1:14.0-55.7~deb12u1
 llvm-14==1:14.0.6-12
 llvm-14-linker-tools==1:14.0.6-12

--- a/files/build/versions-public/dockers/sonic-slave-bookworm/versions-deb-bookworm
+++ b/files/build/versions-public/dockers/sonic-slave-bookworm/versions-deb-bookworm
@@ -1568,7 +1568,7 @@ linux-headers-6.1.0-52-amd64==6.1.180-1
 linux-headers-6.1.0-52-common==6.1.180-1
 linux-headers-amd64==6.1.180-1
 linux-kbuild-6.1==6.1.180-1
-linux-libc-dev==6.1.180-1
+linux-libc-dev==6.1.187-1
 linuxdoc-tools==0.9.82-1
 llvm==1:14.0-55.7~deb12u1
 llvm-14==1:14.0.6-12


### PR DESCRIPTION
#### Why I did it

Bump linux-libc-dev version pins across bookworm docker version files to 6.1.187-1 (latest bookworm security update).

##### Work item tracking
- Microsoft ADO:

#### How I did it

Update linux-libc-dev pin in 12 bookworm version files: docker-auditd-watchdog (arm64, armhf), docker-config-engine-bookworm, docker-dhcp-server, docker-gbsyncd-vs, docker-ptf, docker-sonic-vs, docker-syncd-brcm-legacy-th-rpc, docker-syncd-mlnx-rpc, docker-syncd-mlnx, docker-syncd-vs, sonic-slave-bookworm.

#### How to verify it

Build any of the affected bookworm images and confirm linux-libc-dev installs at 6.1.187-1.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
