### PR TITLE
[202605][docker-sonic-mgmt] Preinstall pinned GHZ and gNMI descriptors

### DIFF
--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -19,8 +19,6 @@ pr:
   paths:
     include:
     - dockers/docker-sonic-mgmt
-    - rules/docker-sonic-mgmt.dep
-    - rules/docker-sonic-mgmt.mk
     - .azure-pipelines/docker-sonic-mgmt.yml
 
 resources:
@@ -72,28 +70,6 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Build.ArtifactStagingDirectory)/target/docker-sonic-mgmt.gz
-        docker run --rm docker-sonic-mgmt:latest uv --version 2>&1 | grep -Eq '^uv 0\.12\.10( |$)'
-        test "$(docker run --rm docker-sonic-mgmt:latest ghz --version 2>&1)" = v0.121.0
-        docker run --rm docker-sonic-mgmt:latest sh -c "
-          test \"\$(cat /usr/local/share/sonic-mgmt/ghz/version)\" = v0.121.0 &&
-          test \"\$(cat /usr/local/share/sonic-mgmt/ghz/source-commit)\" = b7ca8f5fad40d3da97092a8886e4a4f636712069 &&
-          echo 'e5d9f9f5170290d2b2ca325b8fe5ba85a490f4cda5a50a4490c41712594471ff  /usr/local/share/sonic-mgmt/ghz/go.mod' | sha256sum -c - &&
-          echo '432d3afe684ed65c25d4857ac628314a4e4e62bfea8fd7cea1c23efd4b6d8437  /usr/local/share/sonic-mgmt/ghz/go.sum' | sha256sum -c - &&
-          grep -q '^/out/bin/ghz: go1.27.1$' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
-          grep -q 'google.golang.org/grpc.*v1.83.2' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
-          grep -q 'golang.org/x/crypto.*v0.56.0' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
-          test -s /usr/local/share/licenses/uv/uv-LICENSE-MIT &&
-          test -s /usr/local/share/licenses/uv/uv-LICENSE-APACHE &&
-          test -s /usr/local/share/licenses/ghz/LICENSE &&
-          test \"\$(wc -l < /usr/local/share/licenses/ghz/DEPENDENCIES)\" -eq 57 &&
-          test -s /usr/local/share/licenses/ghz/dependencies/go1.27.1/LICENSE &&
-          test -s /usr/local/share/licenses/ghz/dependencies/google.golang.org/grpc@v1.83.2/LICENSE &&
-          test -s /usr/local/share/licenses/ghz/dependencies/google.golang.org/grpc@v1.83.2/NOTICE.txt &&
-          test -s /usr/local/share/licenses/ghz/dependencies/golang.org/x/crypto@v0.56.0/LICENSE &&
-          test -s /usr/local/share/licenses/ghz/dependencies/github.com/jinzhu/configor@v1.2.1/LICENSE &&
-          test -s /usr/local/share/licenses/openconfig-gnmi/LICENSE &&
-          echo '08d8f03b70d80e22b36246c4534620cc2d8592ef89dffdd51ccc33c2e76acb39  /usr/local/share/sonic-mgmt/gnmi.protoset' | sha256sum -c -"
-        python3 -c "import json; d=json.load(open('target/docker-sonic-mgmt.gz.sbom.cdx.json')); p={c.get('purl') for c in d.get('components', [])}; assert 'pkg:golang/google.golang.org/grpc@v1.83.2' in p and 'pkg:golang/golang.org/x/crypto@v0.56.0' in p"
         docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605-lastbuild
         docker images
       env:

--- a/.azure-pipelines/docker-sonic-mgmt.yml
+++ b/.azure-pipelines/docker-sonic-mgmt.yml
@@ -19,6 +19,8 @@ pr:
   paths:
     include:
     - dockers/docker-sonic-mgmt
+    - rules/docker-sonic-mgmt.dep
+    - rules/docker-sonic-mgmt.mk
     - .azure-pipelines/docker-sonic-mgmt.yml
 
 resources:
@@ -70,6 +72,28 @@ stages:
     - bash: |
         set -ex
         docker load -i $(Build.ArtifactStagingDirectory)/target/docker-sonic-mgmt.gz
+        docker run --rm docker-sonic-mgmt:latest uv --version 2>&1 | grep -Eq '^uv 0\.12\.10( |$)'
+        test "$(docker run --rm docker-sonic-mgmt:latest ghz --version 2>&1)" = v0.121.0
+        docker run --rm docker-sonic-mgmt:latest sh -c "
+          test \"\$(cat /usr/local/share/sonic-mgmt/ghz/version)\" = v0.121.0 &&
+          test \"\$(cat /usr/local/share/sonic-mgmt/ghz/source-commit)\" = b7ca8f5fad40d3da97092a8886e4a4f636712069 &&
+          echo 'e5d9f9f5170290d2b2ca325b8fe5ba85a490f4cda5a50a4490c41712594471ff  /usr/local/share/sonic-mgmt/ghz/go.mod' | sha256sum -c - &&
+          echo '432d3afe684ed65c25d4857ac628314a4e4e62bfea8fd7cea1c23efd4b6d8437  /usr/local/share/sonic-mgmt/ghz/go.sum' | sha256sum -c - &&
+          grep -q '^/out/bin/ghz: go1.27.1$' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
+          grep -q 'google.golang.org/grpc.*v1.83.2' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
+          grep -q 'golang.org/x/crypto.*v0.56.0' /usr/local/share/sonic-mgmt/ghz/buildinfo &&
+          test -s /usr/local/share/licenses/uv/uv-LICENSE-MIT &&
+          test -s /usr/local/share/licenses/uv/uv-LICENSE-APACHE &&
+          test -s /usr/local/share/licenses/ghz/LICENSE &&
+          test \"\$(wc -l < /usr/local/share/licenses/ghz/DEPENDENCIES)\" -eq 57 &&
+          test -s /usr/local/share/licenses/ghz/dependencies/go1.27.1/LICENSE &&
+          test -s /usr/local/share/licenses/ghz/dependencies/google.golang.org/grpc@v1.83.2/LICENSE &&
+          test -s /usr/local/share/licenses/ghz/dependencies/google.golang.org/grpc@v1.83.2/NOTICE.txt &&
+          test -s /usr/local/share/licenses/ghz/dependencies/golang.org/x/crypto@v0.56.0/LICENSE &&
+          test -s /usr/local/share/licenses/ghz/dependencies/github.com/jinzhu/configor@v1.2.1/LICENSE &&
+          test -s /usr/local/share/licenses/openconfig-gnmi/LICENSE &&
+          echo '08d8f03b70d80e22b36246c4534620cc2d8592ef89dffdd51ccc33c2e76acb39  /usr/local/share/sonic-mgmt/gnmi.protoset' | sha256sum -c -"
+        python3 -c "import json; d=json.load(open('target/docker-sonic-mgmt.gz.sbom.cdx.json')); p={c.get('purl') for c in d.get('components', [])}; assert 'pkg:golang/google.golang.org/grpc@v1.83.2' in p and 'pkg:golang/golang.org/x/crypto@v0.56.0' in p"
         docker tag docker-sonic-mgmt:latest $REGISTRY_SERVER/docker-sonic-mgmt:202605-lastbuild
         docker images
       env:

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,8 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-{% if CROSS_BUILD_ENVIRON == "y" %}
-{% set go_archive_arch = "amd64" %}
-{% set go_archive_sha256 = "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445" %}
-{% elif CONFIGURED_ARCH == "amd64" %}
+{% if CROSS_BUILD_ENVIRON == "y" or CONFIGURED_ARCH == "amd64" %}
 {% set go_archive_arch = "amd64" %}
 {% set go_archive_sha256 = "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445" %}
 {% elif CONFIGURED_ARCH == "arm64" %}
@@ -14,16 +11,8 @@
 {% endif %}
 {% if CONFIGURED_ARCH == "armhf" %}
 {% set go_build_arch = "arm" %}
-{% set uv_target = "armv7-unknown-linux-gnueabihf" %}
-{% set uv_archive_sha256 = "682a52fea5deb07238420d7197e2d7cc10d558872f008a9b6799fb5326c8e420" %}
-{% elif CONFIGURED_ARCH == "arm64" %}
-{% set go_build_arch = CONFIGURED_ARCH %}
-{% set uv_target = "aarch64-unknown-linux-gnu" %}
-{% set uv_archive_sha256 = "9ff6b9d4665edcdd3a88dcc73cd1eb641754deb927f14e8c62ebfde6bf4f5f5e" %}
 {% else %}
 {% set go_build_arch = CONFIGURED_ARCH %}
-{% set uv_target = "x86_64-unknown-linux-gnu" %}
-{% set uv_archive_sha256 = "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b" %}
 {% endif %}
 ARG BASE={{ prefix }}ubuntu:24.04
 {% if CONFIGURED_ARCH == "armhf" %}
@@ -83,18 +72,10 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv without leaving the archive in the final image.
-COPY files/uv-0.12.10-{{ uv_target }}.tar.gz /tmp/uv.tar.gz
-COPY files/uv-0.12.10-LICENSE-MIT /tmp/uv-LICENSE-MIT
-COPY files/uv-0.12.10-LICENSE-APACHE /tmp/uv-LICENSE-APACHE
-RUN echo "{{ uv_archive_sha256 }}  /tmp/uv.tar.gz" | sha256sum -c - \
-    && echo "860e3d7a86b84e6a7012c7a635fc64df475cebc6cce34dfeb73a5982ec58176c  /tmp/uv-LICENSE-MIT" | sha256sum -c - \
-    && echo "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  /tmp/uv-LICENSE-APACHE" | sha256sum -c - \
-    && tar -C /tmp -xzf /tmp/uv.tar.gz \
-    && install -m 0755 /tmp/uv-{{ uv_target }}/uv /tmp/uv-{{ uv_target }}/uvx /bin/ \
-    && install -d /usr/local/share/licenses/uv \
-    && install -m 0644 /tmp/uv-LICENSE-MIT /tmp/uv-LICENSE-APACHE /usr/local/share/licenses/uv/ \
-    && rm -rf /tmp/uv.tar.gz /tmp/uv-{{ uv_target }} /tmp/uv-LICENSE-MIT /tmp/uv-LICENSE-APACHE
+# Install uv - a fast Python package manager that replaces pip/venv/wheel.
+# This eliminates the need for python3-pip, python3-venv, and python3-wheel
+# system packages, avoiding vulnerabilities like USN-8221-1.
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Create a virtual environment at /opt/venv using uv
 RUN uv venv --system-site-packages /opt/venv
@@ -286,8 +267,6 @@ RUN echo "{{ go_archive_sha256 }}  /tmp/go.tar.gz" | sha256sum -c - \
     && echo "c912d8278da2430561f0df0b73fd5c1481b844cfcfff1ddef23c64663aa9bef6  /tmp/ghz-source.tar.gz" | sha256sum -c - \
     && echo "45abf90bfee289544e2430c8ce1b5b10e4f851736a508ddba54d3cf12e82f7b7  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto" | sha256sum -c - \
     && echo "b0e96bd0c540cf249512783ee5abeb3f0d05805115f18c7d714ac90316981e2e  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto" | sha256sum -c - \
-    && echo "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  /tmp/gnmi/LICENSE" | sha256sum -c - \
-    && echo "16b7c798664a114b1e7e88046694201d02e95a7ad489c95e52763fb7a68d64cd  /tmp/configor-LICENSE" | sha256sum -c - \
     && tar -C /usr/local -xzf /tmp/go.tar.gz \
     && mkdir -p /tmp/ghz-source /out/bin /out/licenses/ghz /out/licenses/openconfig-gnmi /out/share/ghz \
     && tar -C /tmp/ghz-source --strip-components=1 -xzf /tmp/ghz-source.tar.gz \
@@ -300,23 +279,13 @@ RUN echo "{{ go_archive_sha256 }}  /tmp/go.tar.gz" | sha256sum -c - \
         golang.org/x/tools/go/expect@v0.1.1-deprecated \
         golang.org/x/tools/go/packages/packagestest@v0.1.1-deprecated \
     && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go mod tidy \
-    && echo "e5d9f9f5170290d2b2ca325b8fe5ba85a490f4cda5a50a4490c41712594471ff  go.mod" | sha256sum -c - \
-    && echo "432d3afe684ed65c25d4857ac628314a4e4e62bfea8fd7cea1c23efd4b6d8437  go.sum" | sha256sum -c - \
-    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local GOBIN=/tmp/bin \
-        go install golang.org/x/vuln/cmd/govulncheck@v1.7.0 \
-    && CGO_ENABLED=0 GOOS=linux GOARCH={{ go_build_arch }} {% if CONFIGURED_ARCH == "armhf" %}GOARM=7 {% endif %}\
-        PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local /tmp/bin/govulncheck ./cmd/ghz \
     && CGO_ENABLED=0 GOOS=linux GOARCH={{ go_build_arch }} {% if CONFIGURED_ARCH == "armhf" %}GOARM=7 {% endif %}\
         PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go build -mod=readonly -trimpath \
         -ldflags="-s -w -X main.version=v0.121.0" -o /out/bin/ghz ./cmd/ghz \
     && /usr/local/go/bin/go version -m /out/bin/ghz > /out/share/ghz/buildinfo \
-    && grep -q '^/out/bin/ghz: go1.27.1$' /out/share/ghz/buildinfo \
-    && grep -Eq 'google.golang.org/grpc[[:space:]]+v1.83.2' /out/share/ghz/buildinfo \
-    && grep -Eq 'golang.org/x/crypto[[:space:]]+v0.56.0' /out/share/ghz/buildinfo \
     && cp LICENSE /out/licenses/ghz/LICENSE \
     && awk -F '\t' '$2 == "dep" { print $3, $4 }' /out/share/ghz/buildinfo \
         > /out/licenses/ghz/DEPENDENCIES \
-    && test "$(wc -l < /out/licenses/ghz/DEPENDENCIES)" -eq 57 \
     && while read -r module version; do \
         module_dir="$(PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local \
             go list -m -f '{% raw %}{{.Dir}}{% endraw %}' "$module@$version")" || exit 1; \
@@ -339,8 +308,7 @@ RUN echo "{{ go_archive_sha256 }}  /tmp/go.tar.gz" | sha256sum -c - \
     && printf '%s\n' 'b7ca8f5fad40d3da97092a8886e4a4f636712069' > /out/share/ghz/source-commit \
     && protoc -I=/tmp/gnmi -I=/usr/include --include_imports \
         --descriptor_set_out=/out/gnmi.protoset \
-        /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto \
-    && echo "08d8f03b70d80e22b36246c4534620cc2d8592ef89dffdd51ccc33c2e76acb39  /out/gnmi.protoset" | sha256sum -c -
+        /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
 
 FROM sonic-mgmt-base
 
@@ -350,6 +318,3 @@ COPY --from=ghz-builder /out/share/ghz /usr/local/share/sonic-mgmt/ghz
 COPY --from=ghz-builder /out/gnmi.protoset /usr/local/share/sonic-mgmt/gnmi.protoset
 COPY --from=ghz-builder /out/licenses/ghz /usr/local/share/licenses/ghz
 COPY --from=ghz-builder /out/licenses/openconfig-gnmi /usr/local/share/licenses/openconfig-gnmi
-RUN chown root:root /usr/local/bin/ghz \
-    && chmod 0755 /usr/local/bin/ghz \
-    && test -s /usr/local/share/sonic-mgmt/gnmi.protoset

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,5 +1,42 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-FROM {{ prefix }}ubuntu:24.04
+{% if CROSS_BUILD_ENVIRON == "y" %}
+{% set go_archive_arch = "amd64" %}
+{% set go_archive_sha256 = "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445" %}
+{% elif CONFIGURED_ARCH == "amd64" %}
+{% set go_archive_arch = "amd64" %}
+{% set go_archive_sha256 = "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445" %}
+{% elif CONFIGURED_ARCH == "arm64" %}
+{% set go_archive_arch = "arm64" %}
+{% set go_archive_sha256 = "3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec" %}
+{% elif CONFIGURED_ARCH == "armhf" %}
+{% set go_archive_arch = "armv6l" %}
+{% set go_archive_sha256 = "44893f200fb034791d4188df9fc9b9e73eadbb5fceafd5166703f0b9bab73fc2" %}
+{% endif %}
+{% if CONFIGURED_ARCH == "armhf" %}
+{% set go_build_arch = "arm" %}
+{% set uv_target = "armv7-unknown-linux-gnueabihf" %}
+{% set uv_archive_sha256 = "682a52fea5deb07238420d7197e2d7cc10d558872f008a9b6799fb5326c8e420" %}
+{% elif CONFIGURED_ARCH == "arm64" %}
+{% set go_build_arch = CONFIGURED_ARCH %}
+{% set uv_target = "aarch64-unknown-linux-gnu" %}
+{% set uv_archive_sha256 = "9ff6b9d4665edcdd3a88dcc73cd1eb641754deb927f14e8c62ebfde6bf4f5f5e" %}
+{% else %}
+{% set go_build_arch = CONFIGURED_ARCH %}
+{% set uv_target = "x86_64-unknown-linux-gnu" %}
+{% set uv_archive_sha256 = "173d95a0c32d18c896c46ba6fafbf3cf9c14ab74b033f81b76c883ef492a976b" %}
+{% endif %}
+ARG BASE={{ prefix }}ubuntu:24.04
+{% if CONFIGURED_ARCH == "armhf" %}
+ARG RUNTIME_PLATFORM=linux/arm/v7
+{% elif CONFIGURED_ARCH == "arm64" %}
+ARG RUNTIME_PLATFORM=linux/arm64
+{% endif %}
+
+{% if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+FROM --platform=$RUNTIME_PLATFORM $BASE AS sonic-mgmt-base
+{% else %}
+FROM $BASE AS sonic-mgmt-base
+{% endif %}
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -46,10 +83,18 @@ RUN apt-get update \
     && apt-get autoclean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv - a fast Python package manager that replaces pip/venv/wheel.
-# This eliminates the need for python3-pip, python3-venv, and python3-wheel
-# system packages, avoiding vulnerabilities like USN-8221-1.
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Install uv without leaving the archive in the final image.
+COPY files/uv-0.12.10-{{ uv_target }}.tar.gz /tmp/uv.tar.gz
+COPY files/uv-0.12.10-LICENSE-MIT /tmp/uv-LICENSE-MIT
+COPY files/uv-0.12.10-LICENSE-APACHE /tmp/uv-LICENSE-APACHE
+RUN echo "{{ uv_archive_sha256 }}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && echo "860e3d7a86b84e6a7012c7a635fc64df475cebc6cce34dfeb73a5982ec58176c  /tmp/uv-LICENSE-MIT" | sha256sum -c - \
+    && echo "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4  /tmp/uv-LICENSE-APACHE" | sha256sum -c - \
+    && tar -C /tmp -xzf /tmp/uv.tar.gz \
+    && install -m 0755 /tmp/uv-{{ uv_target }}/uv /tmp/uv-{{ uv_target }}/uvx /bin/ \
+    && install -d /usr/local/share/licenses/uv \
+    && install -m 0644 /tmp/uv-LICENSE-MIT /tmp/uv-LICENSE-APACHE /usr/local/share/licenses/uv/ \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-{{ uv_target }} /tmp/uv-LICENSE-MIT /tmp/uv-LICENSE-APACHE
 
 # Create a virtual environment at /opt/venv using uv
 RUN uv venv --system-site-packages /opt/venv
@@ -216,3 +261,95 @@ ENV CC=gcc CPP=cpp CXX=c++ LDSHARED="gcc -pthread -shared" PYMSSQL_BUILD_WITH_BU
 # The SONiC community usually uses the setup-container.sh tool in the sonic-mgmt repo to create the sonic-mgmt container.
 # The tool will create a user with the same uid and gid of the host user who runs the tool.
 RUN if getent passwd ubuntu; then userdel -r ubuntu; fi
+
+{% if CROSS_BUILD_ENVIRON == "y" %}
+FROM --platform=$BUILDPLATFORM $BASE AS ghz-builder
+{% elif CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
+FROM --platform=$RUNTIME_PLATFORM $BASE AS ghz-builder
+{% else %}
+FROM $BASE AS ghz-builder
+{% endif %}
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libprotobuf-dev protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY files/go1.27.1.linux-{{ go_archive_arch }}.tar.gz /tmp/go.tar.gz
+COPY files/ghz-v0.121.0-b7ca8f5fad40d3da97092a8886e4a4f636712069.tar.gz /tmp/ghz-source.tar.gz
+COPY files/gnmi-v0.14.1.proto /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
+COPY files/gnmi_ext-v0.14.1.proto /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
+COPY files/gnmi-v0.14.1-LICENSE /tmp/gnmi/LICENSE
+COPY files/configor-f7a0fc7c9fc697269b1749c1cc472d49baa8d33c-LICENSE /tmp/configor-LICENSE
+
+RUN echo "{{ go_archive_sha256 }}  /tmp/go.tar.gz" | sha256sum -c - \
+    && echo "c912d8278da2430561f0df0b73fd5c1481b844cfcfff1ddef23c64663aa9bef6  /tmp/ghz-source.tar.gz" | sha256sum -c - \
+    && echo "45abf90bfee289544e2430c8ce1b5b10e4f851736a508ddba54d3cf12e82f7b7  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto" | sha256sum -c - \
+    && echo "b0e96bd0c540cf249512783ee5abeb3f0d05805115f18c7d714ac90316981e2e  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto" | sha256sum -c - \
+    && echo "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30  /tmp/gnmi/LICENSE" | sha256sum -c - \
+    && echo "16b7c798664a114b1e7e88046694201d02e95a7ad489c95e52763fb7a68d64cd  /tmp/configor-LICENSE" | sha256sum -c - \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && mkdir -p /tmp/ghz-source /out/bin /out/licenses/ghz /out/licenses/openconfig-gnmi /out/share/ghz \
+    && tar -C /tmp/ghz-source --strip-components=1 -xzf /tmp/ghz-source.tar.gz \
+    && cd /tmp/ghz-source \
+    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get \
+        golang.org/x/crypto@v0.56.0 golang.org/x/net@v0.58.0 \
+        golang.org/x/oauth2@v0.36.0 golang.org/x/sys@v0.47.0 golang.org/x/text@v0.41.0 \
+    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get google.golang.org/grpc@v1.83.2 \
+    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get \
+        golang.org/x/tools/go/expect@v0.1.1-deprecated \
+        golang.org/x/tools/go/packages/packagestest@v0.1.1-deprecated \
+    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go mod tidy \
+    && echo "e5d9f9f5170290d2b2ca325b8fe5ba85a490f4cda5a50a4490c41712594471ff  go.mod" | sha256sum -c - \
+    && echo "432d3afe684ed65c25d4857ac628314a4e4e62bfea8fd7cea1c23efd4b6d8437  go.sum" | sha256sum -c - \
+    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local GOBIN=/tmp/bin \
+        go install golang.org/x/vuln/cmd/govulncheck@v1.7.0 \
+    && CGO_ENABLED=0 GOOS=linux GOARCH={{ go_build_arch }} {% if CONFIGURED_ARCH == "armhf" %}GOARM=7 {% endif %}\
+        PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local /tmp/bin/govulncheck ./cmd/ghz \
+    && CGO_ENABLED=0 GOOS=linux GOARCH={{ go_build_arch }} {% if CONFIGURED_ARCH == "armhf" %}GOARM=7 {% endif %}\
+        PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go build -mod=readonly -trimpath \
+        -ldflags="-s -w -X main.version=v0.121.0" -o /out/bin/ghz ./cmd/ghz \
+    && /usr/local/go/bin/go version -m /out/bin/ghz > /out/share/ghz/buildinfo \
+    && grep -q '^/out/bin/ghz: go1.27.1$' /out/share/ghz/buildinfo \
+    && grep -Eq 'google.golang.org/grpc[[:space:]]+v1.83.2' /out/share/ghz/buildinfo \
+    && grep -Eq 'golang.org/x/crypto[[:space:]]+v0.56.0' /out/share/ghz/buildinfo \
+    && cp LICENSE /out/licenses/ghz/LICENSE \
+    && awk -F '\t' '$2 == "dep" { print $3, $4 }' /out/share/ghz/buildinfo \
+        > /out/licenses/ghz/DEPENDENCIES \
+    && test "$(wc -l < /out/licenses/ghz/DEPENDENCIES)" -eq 57 \
+    && while read -r module version; do \
+        module_dir="$(PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local \
+            go list -m -f '{% raw %}{{.Dir}}{% endraw %}' "$module@$version")" || exit 1; \
+        license_dir="/out/licenses/ghz/dependencies/$module@$version"; \
+        mkdir -p "$license_dir" || exit 1; \
+        for notice in "$module_dir"/LICENSE* "$module_dir"/COPYING* \
+            "$module_dir"/NOTICE* "$module_dir"/PATENTS*; do \
+            if [ -f "$notice" ]; then cp "$notice" "$license_dir/" || exit 1; fi; \
+        done; \
+        if [ -z "$(find "$license_dir" -type f -print -quit)" ]; then \
+            test "$module@$version" = github.com/jinzhu/configor@v1.2.1 || exit 1; \
+            cp /tmp/configor-LICENSE "$license_dir/LICENSE" || exit 1; \
+        fi; \
+    done < /out/licenses/ghz/DEPENDENCIES \
+    && mkdir -p /out/licenses/ghz/dependencies/go1.27.1 \
+    && cp /usr/local/go/LICENSE /usr/local/go/PATENTS /out/licenses/ghz/dependencies/go1.27.1/ \
+    && cp /tmp/gnmi/LICENSE /out/licenses/openconfig-gnmi/LICENSE \
+    && cp go.mod go.sum /out/share/ghz/ \
+    && printf '%s\n' 'v0.121.0' > /out/share/ghz/version \
+    && printf '%s\n' 'b7ca8f5fad40d3da97092a8886e4a4f636712069' > /out/share/ghz/source-commit \
+    && protoc -I=/tmp/gnmi -I=/usr/include --include_imports \
+        --descriptor_set_out=/out/gnmi.protoset \
+        /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto \
+    && echo "08d8f03b70d80e22b36246c4534620cc2d8592ef89dffdd51ccc33c2e76acb39  /out/gnmi.protoset" | sha256sum -c -
+
+FROM sonic-mgmt-base
+
+# Install the pinned gNMI benchmark client built in the disposable builder stage.
+COPY --from=ghz-builder /out/bin/ghz /usr/local/bin/ghz
+COPY --from=ghz-builder /out/share/ghz /usr/local/share/sonic-mgmt/ghz
+COPY --from=ghz-builder /out/gnmi.protoset /usr/local/share/sonic-mgmt/gnmi.protoset
+COPY --from=ghz-builder /out/licenses/ghz /usr/local/share/licenses/ghz
+COPY --from=ghz-builder /out/licenses/openconfig-gnmi /usr/local/share/licenses/openconfig-gnmi
+RUN chown root:root /usr/local/bin/ghz \
+    && chmod 0755 /usr/local/bin/ghz \
+    && test -s /usr/local/share/sonic-mgmt/gnmi.protoset

--- a/dockers/docker-sonic-mgmt/Dockerfile.j2
+++ b/dockers/docker-sonic-mgmt/Dockerfile.j2
@@ -1,31 +1,5 @@
 {% set prefix = DEFAULT_CONTAINER_REGISTRY %}
-{% if CROSS_BUILD_ENVIRON == "y" or CONFIGURED_ARCH == "amd64" %}
-{% set go_archive_arch = "amd64" %}
-{% set go_archive_sha256 = "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445" %}
-{% elif CONFIGURED_ARCH == "arm64" %}
-{% set go_archive_arch = "arm64" %}
-{% set go_archive_sha256 = "3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec" %}
-{% elif CONFIGURED_ARCH == "armhf" %}
-{% set go_archive_arch = "armv6l" %}
-{% set go_archive_sha256 = "44893f200fb034791d4188df9fc9b9e73eadbb5fceafd5166703f0b9bab73fc2" %}
-{% endif %}
-{% if CONFIGURED_ARCH == "armhf" %}
-{% set go_build_arch = "arm" %}
-{% else %}
-{% set go_build_arch = CONFIGURED_ARCH %}
-{% endif %}
-ARG BASE={{ prefix }}ubuntu:24.04
-{% if CONFIGURED_ARCH == "armhf" %}
-ARG RUNTIME_PLATFORM=linux/arm/v7
-{% elif CONFIGURED_ARCH == "arm64" %}
-ARG RUNTIME_PLATFORM=linux/arm64
-{% endif %}
-
-{% if CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
-FROM --platform=$RUNTIME_PLATFORM $BASE AS sonic-mgmt-base
-{% else %}
-FROM $BASE AS sonic-mgmt-base
-{% endif %}
+FROM {{ prefix }}ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -243,78 +217,18 @@ ENV CC=gcc CPP=cpp CXX=c++ LDSHARED="gcc -pthread -shared" PYMSSQL_BUILD_WITH_BU
 # The tool will create a user with the same uid and gid of the host user who runs the tool.
 RUN if getent passwd ubuntu; then userdel -r ubuntu; fi
 
-{% if CROSS_BUILD_ENVIRON == "y" %}
-FROM --platform=$BUILDPLATFORM $BASE AS ghz-builder
-{% elif CONFIGURED_ARCH == "armhf" or CONFIGURED_ARCH == "arm64" %}
-FROM --platform=$RUNTIME_PLATFORM $BASE AS ghz-builder
-{% else %}
-FROM $BASE AS ghz-builder
-{% endif %}
-
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates libprotobuf-dev protobuf-compiler \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY files/go1.27.1.linux-{{ go_archive_arch }}.tar.gz /tmp/go.tar.gz
-COPY files/ghz-v0.121.0-b7ca8f5fad40d3da97092a8886e4a4f636712069.tar.gz /tmp/ghz-source.tar.gz
+# Install the official GHZ release for the amd64 sonic-mgmt runner.
+COPY files/ghz-v0.121.0-linux-x86_64.tar.gz /tmp/ghz.tar.gz
 COPY files/gnmi-v0.14.1.proto /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
 COPY files/gnmi_ext-v0.14.1.proto /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto
-COPY files/gnmi-v0.14.1-LICENSE /tmp/gnmi/LICENSE
-COPY files/configor-f7a0fc7c9fc697269b1749c1cc472d49baa8d33c-LICENSE /tmp/configor-LICENSE
-
-RUN echo "{{ go_archive_sha256 }}  /tmp/go.tar.gz" | sha256sum -c - \
-    && echo "c912d8278da2430561f0df0b73fd5c1481b844cfcfff1ddef23c64663aa9bef6  /tmp/ghz-source.tar.gz" | sha256sum -c - \
-    && echo "45abf90bfee289544e2430c8ce1b5b10e4f851736a508ddba54d3cf12e82f7b7  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto" | sha256sum -c - \
-    && echo "b0e96bd0c540cf249512783ee5abeb3f0d05805115f18c7d714ac90316981e2e  /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi_ext/gnmi_ext.proto" | sha256sum -c - \
-    && tar -C /usr/local -xzf /tmp/go.tar.gz \
-    && mkdir -p /tmp/ghz-source /out/bin /out/licenses/ghz /out/licenses/openconfig-gnmi /out/share/ghz \
-    && tar -C /tmp/ghz-source --strip-components=1 -xzf /tmp/ghz-source.tar.gz \
-    && cd /tmp/ghz-source \
-    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get \
-        golang.org/x/crypto@v0.56.0 golang.org/x/net@v0.58.0 \
-        golang.org/x/oauth2@v0.36.0 golang.org/x/sys@v0.47.0 golang.org/x/text@v0.41.0 \
-    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get google.golang.org/grpc@v1.83.2 \
-    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go get \
-        golang.org/x/tools/go/expect@v0.1.1-deprecated \
-        golang.org/x/tools/go/packages/packagestest@v0.1.1-deprecated \
-    && PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go mod tidy \
-    && CGO_ENABLED=0 GOOS=linux GOARCH={{ go_build_arch }} {% if CONFIGURED_ARCH == "armhf" %}GOARM=7 {% endif %}\
-        PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local go build -mod=readonly -trimpath \
-        -ldflags="-s -w -X main.version=v0.121.0" -o /out/bin/ghz ./cmd/ghz \
-    && /usr/local/go/bin/go version -m /out/bin/ghz > /out/share/ghz/buildinfo \
-    && cp LICENSE /out/licenses/ghz/LICENSE \
-    && awk -F '\t' '$2 == "dep" { print $3, $4 }' /out/share/ghz/buildinfo \
-        > /out/licenses/ghz/DEPENDENCIES \
-    && while read -r module version; do \
-        module_dir="$(PATH=/usr/local/go/bin:$PATH GOTOOLCHAIN=local \
-            go list -m -f '{% raw %}{{.Dir}}{% endraw %}' "$module@$version")" || exit 1; \
-        license_dir="/out/licenses/ghz/dependencies/$module@$version"; \
-        mkdir -p "$license_dir" || exit 1; \
-        for notice in "$module_dir"/LICENSE* "$module_dir"/COPYING* \
-            "$module_dir"/NOTICE* "$module_dir"/PATENTS*; do \
-            if [ -f "$notice" ]; then cp "$notice" "$license_dir/" || exit 1; fi; \
-        done; \
-        if [ -z "$(find "$license_dir" -type f -print -quit)" ]; then \
-            test "$module@$version" = github.com/jinzhu/configor@v1.2.1 || exit 1; \
-            cp /tmp/configor-LICENSE "$license_dir/LICENSE" || exit 1; \
-        fi; \
-    done < /out/licenses/ghz/DEPENDENCIES \
-    && mkdir -p /out/licenses/ghz/dependencies/go1.27.1 \
-    && cp /usr/local/go/LICENSE /usr/local/go/PATENTS /out/licenses/ghz/dependencies/go1.27.1/ \
-    && cp /tmp/gnmi/LICENSE /out/licenses/openconfig-gnmi/LICENSE \
-    && cp go.mod go.sum /out/share/ghz/ \
-    && printf '%s\n' 'v0.121.0' > /out/share/ghz/version \
-    && printf '%s\n' 'b7ca8f5fad40d3da97092a8886e4a4f636712069' > /out/share/ghz/source-commit \
+COPY files/gnmi-v0.14.1-LICENSE /usr/local/share/licenses/openconfig-gnmi/LICENSE
+RUN test "$(dpkg --print-architecture)" = amd64 \
+    && echo "9ae3b93f2c46dac9136e29e81b4a1de8d4e56f092a6fe46884a25c9c83cb2324  /tmp/ghz.tar.gz" | sha256sum -c - \
+    && mkdir -p /tmp/ghz /usr/local/share/licenses/ghz /usr/local/share/sonic-mgmt \
+    && tar -xzf /tmp/ghz.tar.gz -C /tmp/ghz \
+    && install -m 0755 /tmp/ghz/ghz /usr/local/bin/ghz \
+    && install -m 0644 /tmp/ghz/LICENSE /usr/local/share/licenses/ghz/LICENSE \
     && protoc -I=/tmp/gnmi -I=/usr/include --include_imports \
-        --descriptor_set_out=/out/gnmi.protoset \
-        /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto
-
-FROM sonic-mgmt-base
-
-# Install the pinned gNMI benchmark client built in the disposable builder stage.
-COPY --from=ghz-builder /out/bin/ghz /usr/local/bin/ghz
-COPY --from=ghz-builder /out/share/ghz /usr/local/share/sonic-mgmt/ghz
-COPY --from=ghz-builder /out/gnmi.protoset /usr/local/share/sonic-mgmt/gnmi.protoset
-COPY --from=ghz-builder /out/licenses/ghz /usr/local/share/licenses/ghz
-COPY --from=ghz-builder /out/licenses/openconfig-gnmi /usr/local/share/licenses/openconfig-gnmi
+        --descriptor_set_out=/usr/local/share/sonic-mgmt/gnmi.protoset \
+        /tmp/gnmi/github.com/openconfig/gnmi/proto/gnmi/gnmi.proto \
+    && rm -rf /tmp/ghz /tmp/ghz.tar.gz /tmp/gnmi

--- a/rules/docker-sonic-mgmt.mk
+++ b/rules/docker-sonic-mgmt.mk
@@ -1,23 +1,8 @@
 # docker image for sonic-mgmt
 DOCKER_SONIC_MGMT = docker-sonic-mgmt.gz
 GHZ_VERSION = 0.121.0
-GHZ_COMMIT = b7ca8f5fad40d3da97092a8886e4a4f636712069
-GHZ_SOURCE = ghz-v$(GHZ_VERSION)-$(GHZ_COMMIT).tar.gz
-$(GHZ_SOURCE)_URL = https://api.github.com/repos/bojand/ghz/tarball/$(GHZ_COMMIT)
-GO_VERSION = 1.27.1
-ifeq ($(CROSS_BUILD_ENVIRON),y)
-GO_ARCHIVE_ARCH = amd64
-else ifeq ($(CONFIGURED_ARCH),amd64)
-GO_ARCHIVE_ARCH = amd64
-else ifeq ($(CONFIGURED_ARCH),arm64)
-GO_ARCHIVE_ARCH = arm64
-else ifeq ($(CONFIGURED_ARCH),armhf)
-GO_ARCHIVE_ARCH = armv6l
-else
-$(error Unsupported docker-sonic-mgmt architecture: $(CONFIGURED_ARCH))
-endif
-GO_TOOLCHAIN = go$(GO_VERSION).linux-$(GO_ARCHIVE_ARCH).tar.gz
-$(GO_TOOLCHAIN)_URL = https://go.dev/dl/$(GO_TOOLCHAIN)
+GHZ_ARCHIVE = ghz-v$(GHZ_VERSION)-linux-x86_64.tar.gz
+$(GHZ_ARCHIVE)_URL = https://github.com/bojand/ghz/releases/download/v$(GHZ_VERSION)/ghz-linux-x86_64.tar.gz
 GNMI_PROTO_VERSION = 0.14.1
 GNMI_PROTO = gnmi-v$(GNMI_PROTO_VERSION).proto
 $(GNMI_PROTO)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/proto/gnmi/gnmi.proto
@@ -25,15 +10,10 @@ GNMI_EXT_PROTO = gnmi_ext-v$(GNMI_PROTO_VERSION).proto
 $(GNMI_EXT_PROTO)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/proto/gnmi_ext/gnmi_ext.proto
 GNMI_LICENSE = gnmi-v$(GNMI_PROTO_VERSION)-LICENSE
 $(GNMI_LICENSE)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/LICENSE
-CONFIGOR_LICENSE_COMMIT = f7a0fc7c9fc697269b1749c1cc472d49baa8d33c
-CONFIGOR_LICENSE = configor-$(CONFIGOR_LICENSE_COMMIT)-LICENSE
-$(CONFIGOR_LICENSE)_URL = https://raw.githubusercontent.com/jinzhu/configor/$(CONFIGOR_LICENSE_COMMIT)/LICENSE
-SONIC_ONLINE_FILES += $(GHZ_SOURCE) $(GO_TOOLCHAIN) \
-                      $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
+SONIC_ONLINE_FILES += $(GHZ_ARCHIVE) $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE)
 
 $(DOCKER_SONIC_MGMT)_PATH = $(DOCKERS_PATH)/docker-sonic-mgmt
 $(DOCKER_SONIC_MGMT)_DEPENDS += $(SONIC_DEVICE_DATA)
-$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET) $(GHZ_SOURCE) $(GO_TOOLCHAIN) \
-                              $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
+$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET) $(GHZ_ARCHIVE) $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE)
 SONIC_DOCKER_IMAGES += $(DOCKER_SONIC_MGMT)
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SONIC_MGMT)

--- a/rules/docker-sonic-mgmt.mk
+++ b/rules/docker-sonic-mgmt.mk
@@ -18,20 +18,6 @@ $(error Unsupported docker-sonic-mgmt architecture: $(CONFIGURED_ARCH))
 endif
 GO_TOOLCHAIN = go$(GO_VERSION).linux-$(GO_ARCHIVE_ARCH).tar.gz
 $(GO_TOOLCHAIN)_URL = https://go.dev/dl/$(GO_TOOLCHAIN)
-UV_VERSION = 0.12.10
-ifeq ($(CONFIGURED_ARCH),amd64)
-UV_TARGET = x86_64-unknown-linux-gnu
-else ifeq ($(CONFIGURED_ARCH),arm64)
-UV_TARGET = aarch64-unknown-linux-gnu
-else ifeq ($(CONFIGURED_ARCH),armhf)
-UV_TARGET = armv7-unknown-linux-gnueabihf
-endif
-UV_ARCHIVE = uv-$(UV_VERSION)-$(UV_TARGET).tar.gz
-$(UV_ARCHIVE)_URL = https://github.com/astral-sh/uv/releases/download/$(UV_VERSION)/uv-$(UV_TARGET).tar.gz
-UV_LICENSE_MIT = uv-$(UV_VERSION)-LICENSE-MIT
-$(UV_LICENSE_MIT)_URL = https://raw.githubusercontent.com/astral-sh/uv/$(UV_VERSION)/LICENSE-MIT
-UV_LICENSE_APACHE = uv-$(UV_VERSION)-LICENSE-APACHE
-$(UV_LICENSE_APACHE)_URL = https://raw.githubusercontent.com/astral-sh/uv/$(UV_VERSION)/LICENSE-APACHE
 GNMI_PROTO_VERSION = 0.14.1
 GNMI_PROTO = gnmi-v$(GNMI_PROTO_VERSION).proto
 $(GNMI_PROTO)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/proto/gnmi/gnmi.proto
@@ -42,13 +28,12 @@ $(GNMI_LICENSE)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_
 CONFIGOR_LICENSE_COMMIT = f7a0fc7c9fc697269b1749c1cc472d49baa8d33c
 CONFIGOR_LICENSE = configor-$(CONFIGOR_LICENSE_COMMIT)-LICENSE
 $(CONFIGOR_LICENSE)_URL = https://raw.githubusercontent.com/jinzhu/configor/$(CONFIGOR_LICENSE_COMMIT)/LICENSE
-SONIC_ONLINE_FILES += $(GHZ_SOURCE) $(GO_TOOLCHAIN) $(UV_ARCHIVE) $(UV_LICENSE_MIT) $(UV_LICENSE_APACHE) \
+SONIC_ONLINE_FILES += $(GHZ_SOURCE) $(GO_TOOLCHAIN) \
                       $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
 
 $(DOCKER_SONIC_MGMT)_PATH = $(DOCKERS_PATH)/docker-sonic-mgmt
 $(DOCKER_SONIC_MGMT)_DEPENDS += $(SONIC_DEVICE_DATA)
-$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET) $(GHZ_SOURCE) $(GO_TOOLCHAIN) $(UV_ARCHIVE) \
-                              $(UV_LICENSE_MIT) $(UV_LICENSE_APACHE) \
+$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET) $(GHZ_SOURCE) $(GO_TOOLCHAIN) \
                               $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
 SONIC_DOCKER_IMAGES += $(DOCKER_SONIC_MGMT)
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SONIC_MGMT)

--- a/rules/docker-sonic-mgmt.mk
+++ b/rules/docker-sonic-mgmt.mk
@@ -1,7 +1,54 @@
 # docker image for sonic-mgmt
 DOCKER_SONIC_MGMT = docker-sonic-mgmt.gz
+GHZ_VERSION = 0.121.0
+GHZ_COMMIT = b7ca8f5fad40d3da97092a8886e4a4f636712069
+GHZ_SOURCE = ghz-v$(GHZ_VERSION)-$(GHZ_COMMIT).tar.gz
+$(GHZ_SOURCE)_URL = https://api.github.com/repos/bojand/ghz/tarball/$(GHZ_COMMIT)
+GO_VERSION = 1.27.1
+ifeq ($(CROSS_BUILD_ENVIRON),y)
+GO_ARCHIVE_ARCH = amd64
+else ifeq ($(CONFIGURED_ARCH),amd64)
+GO_ARCHIVE_ARCH = amd64
+else ifeq ($(CONFIGURED_ARCH),arm64)
+GO_ARCHIVE_ARCH = arm64
+else ifeq ($(CONFIGURED_ARCH),armhf)
+GO_ARCHIVE_ARCH = armv6l
+else
+$(error Unsupported docker-sonic-mgmt architecture: $(CONFIGURED_ARCH))
+endif
+GO_TOOLCHAIN = go$(GO_VERSION).linux-$(GO_ARCHIVE_ARCH).tar.gz
+$(GO_TOOLCHAIN)_URL = https://go.dev/dl/$(GO_TOOLCHAIN)
+UV_VERSION = 0.12.10
+ifeq ($(CONFIGURED_ARCH),amd64)
+UV_TARGET = x86_64-unknown-linux-gnu
+else ifeq ($(CONFIGURED_ARCH),arm64)
+UV_TARGET = aarch64-unknown-linux-gnu
+else ifeq ($(CONFIGURED_ARCH),armhf)
+UV_TARGET = armv7-unknown-linux-gnueabihf
+endif
+UV_ARCHIVE = uv-$(UV_VERSION)-$(UV_TARGET).tar.gz
+$(UV_ARCHIVE)_URL = https://github.com/astral-sh/uv/releases/download/$(UV_VERSION)/uv-$(UV_TARGET).tar.gz
+UV_LICENSE_MIT = uv-$(UV_VERSION)-LICENSE-MIT
+$(UV_LICENSE_MIT)_URL = https://raw.githubusercontent.com/astral-sh/uv/$(UV_VERSION)/LICENSE-MIT
+UV_LICENSE_APACHE = uv-$(UV_VERSION)-LICENSE-APACHE
+$(UV_LICENSE_APACHE)_URL = https://raw.githubusercontent.com/astral-sh/uv/$(UV_VERSION)/LICENSE-APACHE
+GNMI_PROTO_VERSION = 0.14.1
+GNMI_PROTO = gnmi-v$(GNMI_PROTO_VERSION).proto
+$(GNMI_PROTO)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/proto/gnmi/gnmi.proto
+GNMI_EXT_PROTO = gnmi_ext-v$(GNMI_PROTO_VERSION).proto
+$(GNMI_EXT_PROTO)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/proto/gnmi_ext/gnmi_ext.proto
+GNMI_LICENSE = gnmi-v$(GNMI_PROTO_VERSION)-LICENSE
+$(GNMI_LICENSE)_URL = https://raw.githubusercontent.com/openconfig/gnmi/v$(GNMI_PROTO_VERSION)/LICENSE
+CONFIGOR_LICENSE_COMMIT = f7a0fc7c9fc697269b1749c1cc472d49baa8d33c
+CONFIGOR_LICENSE = configor-$(CONFIGOR_LICENSE_COMMIT)-LICENSE
+$(CONFIGOR_LICENSE)_URL = https://raw.githubusercontent.com/jinzhu/configor/$(CONFIGOR_LICENSE_COMMIT)/LICENSE
+SONIC_ONLINE_FILES += $(GHZ_SOURCE) $(GO_TOOLCHAIN) $(UV_ARCHIVE) $(UV_LICENSE_MIT) $(UV_LICENSE_APACHE) \
+                      $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
+
 $(DOCKER_SONIC_MGMT)_PATH = $(DOCKERS_PATH)/docker-sonic-mgmt
 $(DOCKER_SONIC_MGMT)_DEPENDS += $(SONIC_DEVICE_DATA)
-$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET)
+$(DOCKER_SONIC_MGMT)_FILES += $(GITHUB_GET) $(GHZ_SOURCE) $(GO_TOOLCHAIN) $(UV_ARCHIVE) \
+                              $(UV_LICENSE_MIT) $(UV_LICENSE_APACHE) \
+                              $(GNMI_PROTO) $(GNMI_EXT_PROTO) $(GNMI_LICENSE) $(CONFIGOR_LICENSE)
 SONIC_DOCKER_IMAGES += $(DOCKER_SONIC_MGMT)
 SONIC_BOOKWORM_DOCKERS += $(DOCKER_SONIC_MGMT)


### PR DESCRIPTION
## What I did

Install the official **GHZ v0.121.0 Linux x86-64 release** in the amd64 `docker-sonic-mgmt` image and generate the gNMI descriptor set using the already-installed `protoc`.

- Download the versioned release through `SONIC_ONLINE_FILES`, verify its SHA-256, and install `ghz` in `/usr/local/bin`.
- Generate `/usr/local/share/sonic-mgmt/gnmi.protoset` from OpenConfig gNMI v0.14.1 and retain the GHZ/OpenConfig licenses.
- No Go toolchain, source compilation, dependency upgrades, extra CI checks or vulnerability scanners are installed by this change. Existing uv installation and pipeline are unchanged.

Only two files change: `dockers/docker-sonic-mgmt/Dockerfile.j2` and `rules/docker-sonic-mgmt.mk`.

## Validation

- Built the exact new installation block on the available Ubuntu 24.04 sonic-mgmt runtime image: passed. This validates the installation block, not a fresh complete image build.
- `ghz --version`: `v0.121.0`.
- Official release archive SHA-256 matches the upstream checksum: `9ae3b93f2c46dac9136e29e81b4a1de8d4e56f092a6fe46884a25c9c83cb2324`.
- Installed executable SHA-256: `0055032ca8511551909013166b831a3bbf06219093a63b7bbbf3822147afab4f`.
- Generated protoset SHA-256: `08d8f03b70d80e22b36246c4534620cc2d8592ef89dffdd51ccc33c2e76acb39`.
- Temporary extraction files were removed; no Go toolchain is needed for this installation.
- `git diff --check` passed. Full clean-checkout CI validation remains required.

## Official artifact vulnerability scan

**The previous scan and OpenPGP applicability assessment covered a different, source-built artifact and do not apply to this official release binary.**

Trivy 0.74.0 rootfs scan at **2026-09-09 21:34 UTC**, vulnerability DB updated **2026-09-09 19:10 UTC**. Scanned only the official GHZ executable; recognized one gobinary with 46 packages. No severity or unfixed filters, ignore entries or VEX suppressions were supplied.

```bash
trivy rootfs --scanners vuln --pkg-types library --disable-telemetry \
  --format json --output ghz-official-release.json release-artifact
```

| Critical | High | Medium | Low | Unknown | Total findings |
|---:|---:|---:|---:|---:|---:|
| 3 | 41 | 46 | 3 | 2 | 95 |

The official binary embeds Go **1.23.0**, gRPC **v1.56.3**, and x/crypto **v0.36.0**. These are scanner findings, not individually proven reachable vulnerabilities. This revision intentionally installs upstream's unmodified binary and does not remediate those bundled dependencies. The PR remains draft for review of that trade-off.

Release: https://github.com/bojand/ghz/releases/tag/v0.121.0
