### PR TITLE
[sonic-py-common] Add shared BGP ASN validation

### DIFF
--- a/src/sonic-py-common/sonic_py_common/bgp.py
+++ b/src/sonic-py-common/sonic_py_common/bgp.py
@@ -1,0 +1,47 @@
+"""Helpers for validating BGP configuration values."""
+
+from __future__ import print_function
+
+import re
+from numbers import Integral
+
+
+try:
+    STRING_TYPES = (basestring,)
+except NameError:
+    STRING_TYPES = (str,)
+
+
+_ASN_PATTERN = re.compile(r'\A[0-9]{1,10}\Z')
+_MAX_ASN = 0xffffffff
+
+
+def validate_asn(value):
+    """Return *value* in its configuration representation when it is valid.
+
+    BGP ASNs are represented as decimal strings in CONFIG_DB, while callers
+    such as template filters may receive an integer. Both representations are
+    accepted, but booleans are deliberately excluded even though ``bool`` is a
+    subclass of ``int`` in Python.
+
+    ``None`` and other sentinel values are not interpreted here. A caller that
+    supports disabling BGP should handle that policy before invoking this
+    validator.
+
+    :raises ValueError: if *value* is not a decimal ASN in the 32-bit range.
+    :return: the original decimal string, or the rendered integer string.
+    """
+    if isinstance(value, Integral) and not isinstance(value, bool):
+        asn = int(value)
+        rendered_value = str(value)
+    elif (isinstance(value, STRING_TYPES)
+          and _ASN_PATTERN.match(value) is not None):
+        asn = int(value)
+        rendered_value = value
+    else:
+        raise ValueError("Invalid BGP ASN")
+
+    if not 0 < asn <= _MAX_ASN:
+        raise ValueError("Invalid BGP ASN")
+
+    return rendered_value

--- a/src/sonic-py-common/tests/test_bgp.py
+++ b/src/sonic-py-common/tests/test_bgp.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sonic_py_common.bgp import validate_asn
+
+
+@pytest.mark.parametrize("value, expected", [
+    ("1", "1"),
+    ("0001", "0001"),
+    ("4294967295", "4294967295"),
+    (1, "1"),
+    (4294967295, "4294967295"),
+])
+def test_validate_asn_accepts_valid_values(value, expected):
+    assert validate_asn(value) == expected
+
+
+@pytest.mark.parametrize("value", [
+    None,
+    True,
+    False,
+    "",
+    "0",
+    "4294967296",
+    "1.0",
+    "+1",
+    " 1",
+    "1 ",
+    "1e3",
+    "12345678901",
+    "\u0661",
+    b"1",
+    -1,
+    4294967296,
+    1.0,
+])
+def test_validate_asn_rejects_invalid_values(value):
+    with pytest.raises(ValueError):
+        validate_asn(value)


### PR DESCRIPTION
#### Why I did it

Several Python components need to apply the same validation when processing BGP ASNs. Keeping those checks in each component makes it easy for their behavior to drift.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

Added a common `validate_asn()` helper to `sonic-py-common`.

The helper accepts decimal strings and integer values, rejects booleans and other representations, and checks the 32-bit BGP ASN range. Handling of missing values or component-specific sentinel values remains with the caller.

Added unit coverage for accepted values, range boundaries, invalid types, and invalid decimal representations.

Current consumers being updated to use this helper:

- #29226 validates the `DEVICE_METADATA` BGP ASN before caching it.
- #29227 uses it as the `sonic-cfggen` filter for BGP isolation templates.
- #29230 uses it for BGP ASN fields processed by `frrcfgd`.

#### How to verify it

Run:

`PYTHONPATH=src/sonic-py-common pytest -q --noconftest src/sonic-py-common/tests/test_bgp.py`

Result: 22 passed.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: `22 passed`

#### Description for the changelog

Add a shared `sonic-py-common` helper for validating BGP ASNs.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
