### PR TITLE
[telemetry] Require explicit configuration for optional client certificates

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -117,7 +117,7 @@ esac
 TELEMETRY_ARGS+=" --port $PORT"
 
 CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
-if [[ "$DPU_EPHEMERAL_TLS" == "true" || -z "$CLIENT_AUTH" || "$CLIENT_AUTH" == "false" ]]; then
+if [[ "$DPU_EPHEMERAL_TLS" == "true" || "$CLIENT_AUTH" == "false" ]]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -93,7 +93,7 @@ fi
 TELEMETRY_ARGS+=" --port $PORT"
 
 CLIENT_AUTH=$(extract_field "$GNMI" '.client_auth')
-if [ -z $CLIENT_AUTH ] || [ $CLIENT_AUTH == "false" ]; then
+if [[ "$CLIENT_AUTH" == "false" ]]; then
     TELEMETRY_ARGS+=" --allow_no_client_auth"
 fi
 


### PR DESCRIPTION
#### Why I did it

The gNMI and telemetry launchers currently make client certificates optional when the `client_auth` configuration is either absent or explicitly set to `false`.

Optional client certificates should be enabled only when `client_auth=false` is explicitly configured. When the configuration is absent, the telemetry binary's default client-certificate policy should remain in effect.

The existing DPU ephemeral-TLS behavior is intentionally preserved.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

- Update `docker-sonic-gnmi` to enable optional client certificates only when:
  - `client_auth=false` is explicitly configured; or
  - DPU ephemeral TLS is active.
- Update `docker-sonic-telemetry` to enable optional client certificates only when `client_auth=false` is explicitly configured.
- Preserve the existing behavior for explicit `client_auth=true`, explicit `client_auth=false`, plaintext loopback, and DPU ephemeral TLS configurations.

#### How to verify it

Executed both launchers in a SONiC build container with stubbed ConfigDB and configuration-generation commands.

Verified:

- Missing gNMI configuration does not enable optional client certificates.
- A missing `client_auth` field does not enable optional client certificates.
- `client_auth=true` does not enable optional client certificates.
- `client_auth=false` enables optional client certificates.
- The plaintext fallback remains restricted to loopback.
- DPU ephemeral TLS continues to enable optional client certificates.

Shell syntax validation and `git diff --check` passed.

Built `sonic-vs.img.gz` from commit `25fa63922` and booted it in a standalone VS VM. With `port=8080` and `user_auth=none` set to isolate the client-certificate policy, verified:

- An absent `GNMI|gnmi` row omits `--allow_no_client_auth`.
- An existing `GNMI|gnmi` row with no `client_auth` field omits `--allow_no_client_auth`.
- `client_auth=true` omits `--allow_no_client_auth`.
- `client_auth=false` adds `--allow_no_client_auth`.
- gNMI remains active in every case.

Restored ConfigDB to its original state after validation. The legacy `docker-sonic-telemetry` container is not included in the default VS image, so its behavior was covered by the focused launcher argument matrix above.

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type:

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: focused gNMI and telemetry launcher argument matrix passed; standalone VS runtime matrix passed.

#### Description for the changelog

Require explicit configuration before enabling optional client certificates for gNMI and telemetry.

#### Link to config_db schema for YANG module changes

N/A

#### A picture of a cute animal (not mandatory but encouraged)
