### PR TITLE
[aspeed] Update FW_ENV_DEFAULT MTD index for CONFIG_MTD_PARTITIONED_MASTER

### DIFF
--- a/platform/aspeed/platform_arm64.conf
+++ b/platform/aspeed/platform_arm64.conf
@@ -90,7 +90,7 @@ fdt_addr=0x44C000000
 
 # U-Boot environment location
 # AST2700 typically stores U-Boot env in SPI flash (MTD)
-FW_ENV_DEFAULT='/dev/mtd1 0x0 0x20000 0x10000'
+FW_ENV_DEFAULT='/dev/mtd2 0x0 0x20000 0x10000'
 
 # Extra kernel command line for GRUB bootloader configuration
 # This is appended to the kernel command line in the generated grub.cfg


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

With CONFIG_MTD_PARTITIONED_MASTER=y enabled in sonic-linux-kernel (sonic-net/sonic-linux-kernel#622), the master MTD node is retained as mtd0, shifting all partition indices by one. Update FW_ENV_DEFAULT from /dev/mtd1 to /dev/mtd2 to point to the correct u-boot-env partition under the new layout.


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Updated the index for u-boot-env partition from mtd1 to mtd2 for aspeed FW_ENV_DEFAULT var.

#### How to verify it
N/A
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [X] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
