### PR TITLE
[database] Publish database_config.json atomically

### DIFF
--- a/dockers/docker-database/docker-database-init.sh
+++ b/dockers/docker-database/docker-database-init.sh
@@ -49,7 +49,10 @@ mkdir -p $REDIS_DIR/sonic-db
 mkdir -p /etc/supervisor/conf.d/
 
 if [ -f /etc/sonic/database_config$NAMESPACE_ID.json ]; then
-    cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json
+    # Copy into a temp file first and atomically move it into place, for the same reason
+    # as the rendered branch below.
+    cp /etc/sonic/database_config$NAMESPACE_ID.json $REDIS_DIR/sonic-db/database_config.json.new
+    mv $REDIS_DIR/sonic-db/database_config.json.new $REDIS_DIR/sonic-db/database_config.json
 else
     # Render into a temp file first and atomically move it into place, so that any
     # process racing to read database_config.json (e.g. waitForAllInstanceDatabaseConfigJsonFilesReady)
@@ -149,11 +152,13 @@ sonic-cfggen -j "$db_cfg_file_tmp" -a "$additional_data_json" \
 -t /usr/share/sonic/templates/critical_processes.j2,/etc/supervisor/critical_processes
 
 if [[ "$start_chassis_db" != "1" ]] && [[ -z "$chassis_db_address" ]]; then
-     cp $db_cfg_file_tmp $db_cfg_file
+     # $db_cfg_file is already visible to readers on the host, so rename onto it instead
+     # of copying, which would leave it truncated for the duration of the copy.
+     mv $db_cfg_file_tmp $db_cfg_file
 else
      update_chassisdb_config -j $db_cfg_file -p $chassis_db_port
 fi
-rm $db_cfg_file_tmp
+rm -f $db_cfg_file_tmp
 
 # copy dump.rdb file to each instance for restoration
 DUMPFILE=/var/lib/redis/dump.rdb

--- a/files/scripts/update_chassisdb_config
+++ b/files/scripts/update_chassisdb_config
@@ -58,11 +58,16 @@ def main():
            if delete_config:
                del data['DATABASES'][chassis_db]
 
-    with open(jsonfile, "w") as write_file:
-        data_publish = data_keep if keep_config else data
-        if port_number:
-            data_publish['INSTANCES']['redis_chassis']['port'] = int(port_number)
+    data_publish = data_keep if keep_config else data
+    if port_number:
+        data_publish['INSTANCES']['redis_chassis']['port'] = int(port_number)
+
+    # jsonfile is already visible to readers, so write a temp file and rename it into
+    # place. Truncating jsonfile directly exposes an empty file to concurrent readers.
+    temp_file = '{}.new'.format(jsonfile)
+    with open(temp_file, "w") as write_file:
         json.dump(data_publish, write_file, indent=4, separators=(',', ': '))
+    os.replace(temp_file, jsonfile)
     syslog.syslog(syslog.LOG_INFO,
                   'remove chassis_db from config file {}'.format(jsonfile))
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

`database_config.json` is read concurrently during database startup. PR
[#28343](https://github.com/sonic-net/sonic-buildimage/pull/28343) made the initial publication
atomic, but three later publication paths remained non-atomic and could truncate a live JSON file
before writing its replacement. This PR extends atomic publication to those remaining known paths.

Instrumentation on DUT measured a 285 us truncate-and-rewrite window in the live-file
`update_chassisdb_config` path. The controlled 202605 A/B test reproduced the empty-read failure
with the installed writer and eliminated it with the atomic writer.

##### Work item tracking
- Microsoft ADO **(number only)**: N/A

#### How I did it

- Copy `/etc/sonic/database_config*.json` to a sibling temporary file and rename it onto the live
  path.
- Rename the already-generated modified configuration onto the live path instead of copying over
  it, and tolerate the consumed temporary file during cleanup.
- Make `update_chassisdb_config` write a sibling temporary file and publish it with
  `os.replace()`.

#### How to verify it

Run concurrent JSON readers while repeatedly invoking the installed in-place writer and the
patched atomic writer against the same scratch configuration. Use identical writer iterations and
reader counts for both arms, and verify that the live database configuration remains untouched.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest
backport release branch and provide tested image version on these two branches. For example, if
the PR is requested for master, 202211 and 202012, then the requester needs to provide test results
on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
N/A (internal tracking is not disclosed)

Failure type: other — existing non-atomic database configuration publication race

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

- master: — HEAD was exercised in three patched boots as part
  of a broader startup-path test and produced zero parser errors. Because that arm contained
  additional startup-path changes, it is integration coverage rather than isolated proof for this
  PR. Restoring the control produced three errors.
- 202605: — controlled A/B with 150 writes and four concurrent readers per arm:
  - Installed in-place writer: 118,554 successful reads and 701 empty reads.
  - Patched temp-file plus `os.replace()` writer: 132,972 successful reads and zero empty reads.
  - The experiment used a scratch copy; the live database configuration was not modified.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Publish `database_config.json` atomically to prevent readers from observing empty JSON during
normal updates.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo.
 where, Generic Config and Update feature has been labelled as GCU.
-->
