### PR TITLE
[DO NOT MERGE][ci] Validate cSONiC-neighbor T0 Elastictest job in real CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ resources:
   repositories:
   - repository: sonic-mgmt
     type: github
-    name: sonic-net/sonic-mgmt
-    ref: master
+    name: nhegde-microsoft/sonic-mgmt
+    ref: csonic-t0-switch-sweep
     endpoint: sonic-net
   - repository: buildimage
     type: github


### PR DESCRIPTION
#### Why I did it
Validate, in real sonic-buildimage PR CI, a new non-blocking T0
Elastictest job that runs the impacted-area t0 test suite against
cSONiC (`docker-sonic-vs` SONiC-on-SONiC) neighbors instead of cEOS.

An apples-to-apples dev-VM sweep (same DUT/tree, only neighbor type
varied) already measured 289/289 t0 scripts at parity: 281 clean
parity, 8 pre-existing failures on both neighbor types, 0 cSONiC-only
blocking gates. This PR is step 2: prove the same job runs cleanly
through the actual CI plumbing (Elastictest scheduler, KVM image
build/deploy, instance-count calc, etc.) before making it real.

**DO NOT MERGE.** This PR only exists to temporarily repoint the
pipeline's `sonic-mgmt` resource ref at a test branch
(`nhegde-microsoft/sonic-mgmt@csonic-t0-switch-sweep`,
sonic-net/sonic-mgmt#27864) so the new job actually runs here. Once
sonic-mgmt#27864 is reviewed/merged there, this PR's `azure-pipelines.yml`
change should be reverted (back to `sonic-net/sonic-mgmt@master`) and a
clean, mergeable PR opened instead if a permanent CI change is wanted.

#### How I did it
One-line `azure-pipelines.yml` change: `sonic-mgmt` resource
`name`/`ref` -> the fork branch containing the new
`impacted_area_t0_csonic_elastictest` job.

#### How to verify it
Watch this PR's CI (`Azure.sonic-buildimage` check) for the new
"impacted-area-kvmtest-t0-csonic by Elastictest" job. It's
`continueOnError: true` so it won't block this PR's own checks either
way -- the point is to read its actual pass/fail once it completes and
compare against the existing cEOS `impacted-area-kvmtest-t0` job in the
same run.

##### Work item tracking
- Microsoft ADO (number only):