### PR TITLE
vpp: keep mod_sonic counter polling when mod_vpp runs with osIndex=on

### DIFF
--- a/src/sflow/hsflowd/patch/0002-vpp-osindex-counter-sampling.patch
+++ b/src/sflow/hsflowd/patch/0002-vpp-osindex-counter-sampling.patch
@@ -1,0 +1,29 @@
+diff --git a/src/Linux/mod_vpp.c b/src/Linux/mod_vpp.c
+index 88fb8ec..4795484 100644
+--- a/src/Linux/mod_vpp.c
++++ b/src/Linux/mod_vpp.c
+@@ -413,10 +413,13 @@ extern "C" {
+ 	    | HSP_ETCTR_UNKN
+ 	    | HSP_ETCTR_OPER
+ 	    | HSP_ETCTR_ADMIN;
+-	  accumulateNioCounters(sp, adaptor, &port->ctrs, &port->et_ctrs, NULL);
++    bool sonic_owns_counters = sp->vpp.osIndex == YES && os_index_attr_included && in.os_index != 0;
++    if(!sonic_owns_counters) {
++      accumulateNioCounters(sp, adaptor, &port->ctrs, &port->et_ctrs, NULL);
++      nio->last_update = mdata->pollBus->now.tv_sec;
++    }
+ 	  nio->et_last.adminStatus = port->adminUp;
+ 	  nio->et_last.operStatus = port->operUp;
+-	  nio->last_update = mdata->pollBus->now.tv_sec;
+ 	  adaptor->ifDirection = port->ifDirection;
+ 	  // Request a poller for this adaptor if one is not already there.
+ 	  // This is done with an event because it is usually called from
+@@ -425,7 +428,7 @@ extern "C" {
+ 	  EVEvent *req_poller = EVGetEvent(mdata->pollBus, HSPEVENT_REQUEST_POLLER);
+ 	  EVEventTx(sp->rootModule, req_poller, &adaptor->ifIndex, sizeof(adaptor->ifIndex));
+ 	  // Which means we should have a poller now.
+-	  if(nio->poller) {
++    if(nio->poller && !sonic_owns_counters) {
+ 	    // Make sure it does not call back on it's own schedule.
+ 	    nio->poller->getCountersFn = NULL;
+ 	    if(newPort) {

--- a/src/sflow/hsflowd/patch/series
+++ b/src/sflow/hsflowd/patch/series
@@ -1,1 +1,2 @@
 0001-host_sflow_debian.patch
+0002-vpp-osindex-counter-sampling.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
vpp sflow uses mod_vpp to translate vpp ifindex to sonic ifindex. But mod_vpp nulls out the poller's getCountersFn and sends a counter sample on every VPP netlink push. That takes counter polling away from mod_sonic, so it follows VPP's cadence instead of the configured polling_interval - polling-interval 0 doesn't stop samples and 60 doesn't give 60s. Thats fails sonic-mgmt sflow/test_sflow.py TestSflowPolling.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added a patch to mod_vpp. 
When osIndex=On and osIndex is available to the target port, updates the in memory counter bank in mod_vpp of the part but do not send counter sample or calling accumulateNioCounters. When mod_sonic polls the counter, get it from counter bank. mod_sonic will call accumulateNioCounters to update the counter.

This is a redo of PR https://github.com/sonic-net/sonic-buildimage/pull/28954 according to comments https://github.com/sonic-net/sonic-buildimage/pull/28954#pullrequestreview-5161267964
#### How to verify it
Run sonic-mgmt sflow/test_sflow.py

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
