### PR TITLE
[gbsyncd-credo]: Update Credo SAI (libsaicredo) to v1.2.12 [202511]

### DIFF
--- a/files/build/versions/dockers/docker-gbsyncd-credo/versions-deb-bookworm
+++ b/files/build/versions/dockers/docker-gbsyncd-credo/versions-deb-bookworm
@@ -27,10 +27,10 @@ openssh-client==1:9.2p1-2+deb12u10
 openssl==3.0.20-1~deb12u2
 python3-swsscommon-dbgsym==1.0.0
 python3-yang-dbgsym==1.0.73
-saicredo-blackhawk==1.2.10
-saicredo-crt88322==1.2.10
-saicredo-owl==1.2.10
-saicredo-saicredo==1.2.10
+saicredo-blackhawk==1.2.12
+saicredo-crt88322==1.2.12
+saicredo-owl==1.2.12
+saicredo-saicredo==1.2.12
 sensible-utils==0.0.17+nmu1
 sonic-db-cli-dbgsym==1.0.0
 sonic-eventd-dbgsym==1.0.0-0

--- a/platform/components/docker-gbsyncd-credo.mk
+++ b/platform/components/docker-gbsyncd-credo.mk
@@ -1,6 +1,6 @@
 DOCKER_GBSYNCD_PLATFORM_CODE = credo
 
-LIBSAI_VERSION = 1.2.10
+LIBSAI_VERSION = 1.2.12
 LIBSAI_CREDO = libsaicredo_$(LIBSAI_VERSION)_amd64.deb
 $(LIBSAI_CREDO)_URL = "https://packages.trafficmanager.net/public/credosai/$(LIBSAI_CREDO)"
 LIBSAI_CREDO_OWL = libsaicredo-owl_$(LIBSAI_VERSION)_amd64.deb


### PR DESCRIPTION
#### Why I did it

Cherry-pick of sonic-net/sonic-buildimage#28841 to the **202511** release branch.

Update the Credo SAI (`libsaicredo`) packages used by the `docker-gbsyncd-credo` container to **v1.2.12** (this branch was on v1.2.10).

##### Work item tracking
- Microsoft ADO **(number only)**: 39091820

#### How I did it

Ported the change to the 202511 branch layout (it differs from master — uses the `LIBSAI_VERSION` variable and a `versions-deb-bookworm` pin file):
- `platform/components/docker-gbsyncd-credo.mk`: bump `LIBSAI_VERSION` `1.2.10` → `1.2.12` (drives the `libsaicredo`, `libsaicredo-owl`, `libsaicredo-blackhawk`, `libsaicredo-crt88322` deb filenames/URLs).
- `files/build/versions/dockers/docker-gbsyncd-credo/versions-deb-bookworm`: update the matching apt pins to `1.2.12`.

#### How to verify it

Build the gbsyncd-credo target and confirm the v1.2.12 debs download and install:
```
make target/docker-gbsyncd-credo.gz
```
The four `libsaicredo*_1.2.12_amd64.deb` artifacts are published under the public `credosai/` path and were verified reachable (HTTP 200) prior to raising this PR.

#### Which release branch to backport (provide reason below if selected)

- [x] 202511

Reason: Cherry-pick of #28841 (merged to `master`) requested for the 202511 release branch so gbsyncd-credo consumes libsaicredo v1.2.12 there as well.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 39091820
Failure type: other (dependency/version pin update)

#### Tested branch

- [ ] 202511

#### Test result

Not built locally — this is a version-pin update. The four `libsaicredo*_1.2.12_amd64.deb` artifacts are published and verified reachable (HTTP 200). Relying on PR CI to build `docker-gbsyncd-credo` on this branch.

#### Description for the changelog

Update Credo SAI (libsaicredo) packages to v1.2.12 for docker-gbsyncd-credo.
