### PR TITLE
[gbsyncd-credo]: Update Credo SAI (libsaicredo) to v1.2.12 [202605]

### DIFF
--- a/files/build/versions-public/dockers/docker-gbsyncd-credo/versions-deb-trixie
+++ b/files/build/versions-public/dockers/docker-gbsyncd-credo/versions-deb-trixie
@@ -26,10 +26,10 @@ libunwind8==1.8.1-0.1
 libyang3-dbgsym==3.12.2-1
 openssh-client==1:10.0p1-7+fips
 python3-swsscommon-dbgsym==1.0.0
-saicredo-blackhawk==1.2.6
-saicredo-crt88322==1.2.6
-saicredo-owl==1.2.6
-saicredo-saicredo==1.2.6
+saicredo-blackhawk==1.2.12
+saicredo-crt88322==1.2.12
+saicredo-owl==1.2.12
+saicredo-saicredo==1.2.12
 sensible-utils==0.0.25
 sonic-db-cli-dbgsym==1.0.0
 sonic-eventd-dbgsym==1.0.0-0

--- a/platform/components/docker-gbsyncd-credo.mk
+++ b/platform/components/docker-gbsyncd-credo.mk
@@ -1,12 +1,12 @@
 DOCKER_GBSYNCD_PLATFORM_CODE = credo
 
-LIBSAI_CREDO = libsaicredo_1.2.6_amd64.deb
+LIBSAI_CREDO = libsaicredo_1.2.12_amd64.deb
 $(LIBSAI_CREDO)_URL = "$(BUILD_PUBLIC_URL)/credosai/$(LIBSAI_CREDO)"
-LIBSAI_CREDO_OWL = libsaicredo-owl_1.2.6_amd64.deb
+LIBSAI_CREDO_OWL = libsaicredo-owl_1.2.12_amd64.deb
 $(LIBSAI_CREDO_OWL)_URL = "$(BUILD_PUBLIC_URL)/credosai/$(LIBSAI_CREDO_OWL)"
-LIBSAI_CREDO_BLACKHAWK = libsaicredo-blackhawk_1.2.6_amd64.deb
+LIBSAI_CREDO_BLACKHAWK = libsaicredo-blackhawk_1.2.12_amd64.deb
 $(LIBSAI_CREDO_BLACKHAWK)_URL = "$(BUILD_PUBLIC_URL)/credosai/$(LIBSAI_CREDO_BLACKHAWK)"
-LIBSAI_CREDO_CRT88322 = libsaicredo-crt88322_1.2.6_amd64.deb
+LIBSAI_CREDO_CRT88322 = libsaicredo-crt88322_1.2.12_amd64.deb
 $(LIBSAI_CREDO_CRT88322)_URL = "$(BUILD_PUBLIC_URL)/credosai/$(LIBSAI_CREDO_CRT88322)"
 
 ifneq ($($(LIBSAI_CREDO)_URL),)


### PR DESCRIPTION
#### Why I did it

Cherry-pick of sonic-net/sonic-buildimage#28841 to the **202605** release branch.

Update the Credo SAI (`libsaicredo`) packages used by the `docker-gbsyncd-credo` container to **v1.2.12** (this branch was on v1.2.6).

##### Work item tracking
- Microsoft ADO **(number only)**: 39091820

#### How I did it

Ported the change to the 202605 branch layout (it pins versions directly in the filenames rather than via a `LIBSAI_VERSION` variable):
- `platform/components/docker-gbsyncd-credo.mk`: bump the `libsaicredo`, `libsaicredo-owl`, `libsaicredo-blackhawk`, `libsaicredo-crt88322` deb filenames `1.2.6` → `1.2.12`.
- `files/build/versions-public/dockers/docker-gbsyncd-credo/versions-deb-trixie`: update the matching apt pins to `1.2.12`.

#### How to verify it

Build the gbsyncd-credo target and confirm the v1.2.12 debs download and install:
```
make target/docker-gbsyncd-credo.gz
```
The four `libsaicredo*_1.2.12_amd64.deb` artifacts are published under the public `credosai/` path and were verified reachable (HTTP 200) prior to raising this PR.

#### Which release branch to backport (provide reason below if selected)

- [x] 202605

Reason: Cherry-pick of #28841 (merged to `master`) requested for the 202605 release branch so gbsyncd-credo consumes libsaicredo v1.2.12 there as well. Note this branch was pinned to v1.2.6, so this moves it directly to v1.2.12.

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): Microsoft ADO 39091820
Failure type: other (dependency/version pin update)

#### Tested branch

- [ ] 202605

#### Test result

Not built locally — this is a version-pin update. The four `libsaicredo*_1.2.12_amd64.deb` artifacts are published and verified reachable (HTTP 200). Relying on PR CI to build `docker-gbsyncd-credo` on this branch.

#### Description for the changelog

Update Credo SAI (libsaicredo) packages to v1.2.12 for docker-gbsyncd-credo.
