### PR TITLE
[202511] Arm SCD Watchdog in Aboot for Arista SKUs with boot freezes

### DIFF
--- a/files/Aboot/boot0.j2
+++ b/files/Aboot/boot0.j2
@@ -983,6 +983,26 @@ run_quirks() {
             sleep 1
             devmem 0xa5184010 32 0x8
         fi
+        if in_array "$aboot_machine" "arista_7800r3a_36d2_lc" "arista_7800r3ak_36d2_lc" \
+                                     "arista_7800r3a_36dm2_lc" "arista_7800r3ak_36dm2_lc"; then
+            info "Arming watchdog for 90s"
+            setpci -s 08:00.0 COMMAND=0002
+            addr=$(( 0x$(setpci -s 08:00.0 BASE_ADDRESS_0) + 0x120 ))
+            devmem "$addr" 32 0xc0002328
+        fi
+        if in_array "$aboot_machine" "arista_7800r3_48cq2_lc" "arista_7800r3_48cqm2_lc"; then
+            info "Arming watchdog for 90s"
+            setpci -s 07:00.0 COMMAND=0002
+            addr=$(( 0x$(setpci -s 07:00.0 BASE_ADDRESS_0) + 0x120 ))
+            devmem "$addr" 32 0xc0002328
+        fi
+        if in_array "$aboot_machine" "arista_7280dr3a_36" "arista_7280dr3ak_36" \
+                                     "arista_7280dr3ak_36s" "arista_7280dr3am_36"; then
+            info "Arming watchdog for 90s"
+            setpci -s 01:00.0 COMMAND=0002
+            addr=$(( 0x$(setpci -s 01:00.0 BASE_ADDRESS_0) + 0x120 ))
+            devmem "$addr" 32 0xc0002328
+        fi
     fi
 }
 


### PR DESCRIPTION
SKUs:
QuartzDD, Wolverine, CW2

We've already armed the watchdog from aboot for Wolverine and CW2 SKUs since msft-202405 https://github.com/Azure/sonic-buildimage-msft/pull/1890 This change is adding QuartzDD SKU to arm the watchdog.

The arista-drivers bump up which added the watchdog disarming was done here https://github.com/sonic-net/sonic-buildimage/pull/28957

#### Why I did it
On QuartzDD starting in 202511 we've occasionally seen the Linux OS boot freeze.
Arming the SCD watchdog in Aboot and disarming it after the OS boots allows us to handle a OS boot freeze without manual intervention.

#### How I did it
Arm the watchdog in the Aboot file for these specific SKUs
Disarm the watchdog in an early service that was added in this bump up https://github.com/sonic-net/sonic-buildimage/pull/28957

#### How to verify it
Ran upgrade_path test on QuartzDD 100 times without any failures

#### Tested branch

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- 202511: upgrade_path test passed 10 times and uploaded to kusto under the following IDs
```
Kusto uploaded at 2026-08-07 04:09:56 UTC, report GUID: 55e2a58e-5552-4f25-873e-fe178c877b20
Kusto uploaded at 2026-08-07 04:10:02 UTC, report GUID: 0d7b4402-a979-413d-9de1-9dfc3b08fe1c
Kusto uploaded at 2026-08-07 04:10:07 UTC, report GUID: c60a7ad5-f997-404a-b839-5eb27b775040
Kusto uploaded at 2026-08-07 04:10:15 UTC, report GUID: 9a63cee6-f0fa-455c-8a7b-0356fafb6ec7
Kusto uploaded at 2026-08-07 04:10:21 UTC, report GUID: 641c91d6-6ea5-41d9-a253-075ea4dc9cc8
Kusto uploaded at 2026-08-07 04:10:28 UTC, report GUID: 8ffb9df5-d4cb-4b30-aab1-8e63de8e0f35
Kusto uploaded at 2026-08-07 04:10:34 UTC, report GUID: 0b85fe25-6481-4d5e-b577-3c50409f2c48
Kusto uploaded at 2026-08-07 04:10:39 UTC, report GUID: 6e23ad2e-a704-4369-9e9e-bbc1ef6fd813
Kusto uploaded at 2026-08-07 04:10:45 UTC, report GUID: be48def4-ec49-45e1-af76-168ccf7488a7
Kusto uploaded at 2026-08-07 04:10:51 UTC, report GUID: 48d2de15-a672-4808-bef6-f666686abded
```

#### Description for the changelog
[202511] Arm SCD Watchdog in Aboot for Arista SKUs experiencing OS boot freezes
