### PR TITLE
[Arista] Add VRM temperature sensors for Arista 7280dr3a SKUs

### DIFF
--- a/device/arista/x86_64-arista_7280dr3a_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3a_36/platform.json
@@ -142,6 +142,54 @@
             {
                 "name": "JE0_C Diode",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_LEFT",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_RIGHT",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
+++ b/device/arista/x86_64-arista_7280dr3a_36/sensors.conf
@@ -1,10 +1,48 @@
 bus "i2c-21" "SCD 0000:01:00.0 SMBus master 0 bus 0"
 bus "i2c-22" "SCD 0000:01:00.0 SMBus master 0 bus 1"
+bus "i2c-25" "SCD 0000:01:00.0 SMBus master 0 bus 4"
 bus "i2c-28" "SCD 0000:01:00.0 SMBus master 0 bus 7"
 bus "i2c-9" "SCD 0000:00:18.7 SMBus master 0 bus 0"
 
 chip "nvme-pci-0500"
     ignore temp2
+    ignore temp3
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "raa228228-i2c-25-4c"
+    label temp1 "POS0V75_VDDC_JE0"
+    label temp2 "POS0V75_RTVDD_JE0"
+    ignore temp3
+
+chip "raa228228-i2c-25-4d"
+    label temp1 "POS0V75_VDDC_JE1"
+    label temp2 "POS0V75_RTVDD_JE1"
+    ignore temp3
+
+chip "isl68221-i2c-25-54"
+    label temp1 "POS1V2_HBM0_VDD_JE0"
+    label temp2 "POS1V2_HBM1_VDD_JE0"
+    label temp3 "POS1V2_TVDD_JE0"
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "isl68221-i2c-25-55"
+    label temp1 "POS1V2_HBM0_VDD_JE1"
+    label temp2 "POS1V2_HBM1_VDD_JE1"
+    label temp3 "POS1V2_TVDD_JE1"
+    ignore temp4
+    ignore temp5
+    ignore temp6
+    ignore temp7
+
+chip "isl68225-i2c-25-61"
+    label temp1 "QSFP_3V3_LEFT"
+    label temp2 "QSFP_3V3_RIGHT"
     ignore temp3
     ignore temp4
     ignore temp5

--- a/device/arista/x86_64-arista_7280dr3ak_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36/platform.json
@@ -142,6 +142,54 @@
             {
                 "name": "JE0_C Diode",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_LEFT",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_RIGHT",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
+++ b/device/arista/x86_64-arista_7280dr3ak_36s/platform.json
@@ -142,6 +142,54 @@
             {
                 "name": "JE0_C Diode",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_LEFT",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_RIGHT",
+                "controllable": false
             }
         ],
         "sfps": [

--- a/device/arista/x86_64-arista_7280dr3am_36/platform.json
+++ b/device/arista/x86_64-arista_7280dr3am_36/platform.json
@@ -142,6 +142,54 @@
             {
                 "name": "JE0_C Diode",
                 "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_VDDC_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS0V75_RTVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE0",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM0_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_HBM1_VDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "POS1V2_TVDD_JE1",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_LEFT",
+                "controllable": false
+            },
+            {
+                "name": "QSFP_3V3_RIGHT",
+                "controllable": false
             }
         ],
         "sfps": [


### PR DESCRIPTION
#### Why I did it
Arista 7280DR3A SKUs supports RAA228228 and ISL68221 temperature sensors through hwmon. Thereby including these sensors in the platform specific configuration files : platform.json and sensor.conf for the SKUs.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Modify platform.json and sensor.conf to explicitly mention required configurations for RAA228228 and ISL68221 temperature sensors.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

Edited expected sku-sensors-data.yml as in sonic-mgmt PR:  https://github.com/sonic-net/sonic-mgmt/pull/27869 and then ran `platform_tests/test_sensors.py` on the updated skus to see it pass

Also verified, platform CLI command `show platform temperature` shows temperature reading for corresponding sensors


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

Since there is cherry-pick conflict opened manual backport of this PR in above marked branches : 
- 202605 : https://github.com/sonic-net/sonic-buildimage/pull/29493
- 202511 : https://github.com/sonic-net/sonic-buildimage/pull/29492
 
#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [x] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Ran sonic-mgmt test with change in https://github.com/sonic-net/sonic-mgmt/pull/27869 

202605:

Sonic-mgmt test `platform_tests/test_sensors.py` passed on 7280DR3AK SKU with added sensors
```
platform_tests/test_sensors.py::test_sensors PASSED                             [100%]
```

202511:

Sonic-mgmt test `platform_tests/test_sensors.py` passed on 7280DR3AK SKU with added sensors
```
platform_tests/test_sensors.py::test_sensors PASSED                             [100%]
```

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
