### PR TITLE
[Mellanox] Update buffer pool size calculation for SN6600_LD SKUs

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t0.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '5m' %}
-{% set ingress_lossless_pool_size =  '83356672' %}
-{% set ingress_lossy_pool_size =  '83356672' %}
+{% set ingress_lossless_pool_size =  '83429376' %}
+{% set ingress_lossy_pool_size =  '83429376' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '83356672' %}
+{% set egress_lossy_pool_size =  '83429376' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/ACS-SN6600_LD/buffers_defaults_t1.j2
@@ -16,10 +16,10 @@
     limitations under the License.
 #}
 {% set default_cable = '40m' %}
-{% set ingress_lossless_pool_size =  '62516224' %}
-{% set ingress_lossy_pool_size =  '62516224' %}
+{% set ingress_lossless_pool_size =  '62588928' %}
+{% set ingress_lossy_pool_size =  '62588928' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '62516224' %}
+{% set egress_lossy_pool_size =  '62588928' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t0.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '216778752' %}
+{% set ingress_lossless_pool_size =  '216924160' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '216778752' %}
+{% set egress_lossy_pool_size =  '216924160' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P128C2/buffers_defaults_t1.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '216778752' %}
+{% set ingress_lossless_pool_size =  '216924160' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '216778752' %}
+{% set egress_lossy_pool_size =  '216924160' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t0.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t0.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '212125696' %}
+{% set ingress_lossless_pool_size =  '212271104' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '212125696' %}
+{% set egress_lossy_pool_size =  '212271104' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 

--- a/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t1.j2
+++ b/device/mellanox/x86_64-nvidia_sn6600_ld-r0/Mellanox-SN6600_LD-P64O128C2/buffers_defaults_t1.j2
@@ -22,10 +22,10 @@
             'spinerouter_leafrouter' : '0m'
        }
 -%}
-{% set ingress_lossless_pool_size =  '212125696' %}
+{% set ingress_lossless_pool_size =  '212271104' %}
 {% set ingress_lossless_pool_xoff =  '0' %}
 {% set egress_lossless_pool_size =  '226492416' %}
-{% set egress_lossy_pool_size =  '212125696' %}
+{% set egress_lossy_pool_size =  '212271104' %}
 
 {% import 'buffers_defaults_objects.j2' as defs with context %}
 


### PR DESCRIPTION
#### Why I did it
The shared buffer pool size calculation for the ACS-SN6600_LD, SN6600_LD P128C2 and P64O128C2 SKUs incorrectly subtracted the service port reservation from the total buffer when computing the pool sizes for SPC6. Service ports are not part of the shared buffer pool accounting, so their reservation should not reduce ingress_lossless_pool_size / egress_lossy_pool_size. This understated both pool sizes.

#### Work item tracking
- N/A

#### How I did it
Corrected ingress_lossless_pool_size and egress_lossy_pool_size in the t0/t1 buffer default templates for both SKUs so the service port reservation is no longer subtracted from the shared buffer pool:

- P128C2: 216778752 -> 216924160
- P64O128C2: 212125696 -> 212271104
- ACS-SN6600_LD t0: 83356672 -> 83429376
- ACS-SN6600_LD t1: 62516224 -> 62588928

#### How to verify it
Load the config on an ACS-SN6600_LD, SN6600_LD P128C2 or P64O128C2 device and confirm show buffer pool (or the generated buffers_defaults_t0.json / buffers_defaults_t1.json) reports the corrected
ingress_lossless_pool_size / egress_lossy_pool_size values above.

#### Which release branch to backport
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608


#### Tested branch
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [] 202605
- [ ] 202608

#### Description for the changelog
[Mellanox] Fix buffer pool size calculation for SN6600_LD P128C2 and P64O128C2 SKUs so the service port reservation is no longer subtracted from the shared buffer pool.

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
