### PR TITLE
[marvell-prestera]: Add required capabilities to syncd-mrvl-prestera

### DIFF
--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
@@ -16,3 +16,9 @@ $(DOCKER_SYNCD_BASE)_PACKAGE_NAME = syncd
 $(DOCKER_SYNCD_BASE)_MACHINE = marvell-prestera
 
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /host/warmboot:/var/warmboot
+$(DOCKER_SYNCD_BASE)_RUN_OPT += --cap-add=IPC_LOCK
+$(DOCKER_SYNCD_BASE)_RUN_OPT += --device-cgroup-rule='a *:* rwm'
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvdma:/dev/mvdma:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvIntDrv:/dev/mvIntDrv:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvMbusDrv:/dev/mvMbusDrv:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/:/sys/:rw

--- a/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
+++ b/platform/marvell-prestera/docker-syncd-mrvl-prestera.mk
@@ -21,4 +21,7 @@ $(DOCKER_SYNCD_BASE)_RUN_OPT += --device-cgroup-rule='a *:* rwm'
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvdma:/dev/mvdma:rw
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvIntDrv:/dev/mvIntDrv:rw
 $(DOCKER_SYNCD_BASE)_RUN_OPT += -v /dev/mvMbusDrv:/dev/mvMbusDrv:rw
-$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/:/sys/:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/bus/pci:/sys/bus/pci:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/class/net:/sys/class/net:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/devices:/sys/devices:rw
+$(DOCKER_SYNCD_BASE)_RUN_OPT += -v /sys/firmware/devicetree:/sys/firmware/devicetree:ro


### PR DESCRIPTION
The docker-syncd-mrvl-prestera container requires read-write access to /sys/ to enable and map PCI devices, read-write access to some Marvell specific devices under /dev and CAP_IPC_LOCK so it can use mmap() to allocate memory for DMA in userspace.

#### Why I did it

syncd was failing to start on Marvell Prestara platforms after commit 755f56207c ("syncd: replace --privileged with specific capabilities (#27522)").

#### How I did it

Follow failures reported in the system log and check what is accessed by the syncd process (specifically the Marvell CPSS parts).

#### How to verify it

Booting a device with Marvell Prestera silicon. Check that syncd starts and stays up.

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

- master: pass

#### Description for the changelog

Update the permissions for the docker-syncd-marvell-prestera container.
