### PR TITLE
[202605][NVIDIA]: Add SAI/SDK Debian packaging for debugging/profiling builds

### DIFF
--- a/platform/mellanox/docker-syncd-mlnx.mk
+++ b/platform/mellanox/docker-syncd-mlnx.mk
@@ -33,8 +33,25 @@ $(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(SYNCD_DBG) \
                                 $(LIBSAIMETADATA_DBG) \
                                 $(LIBSAIREDIS_DBG)
 
+# Consumer side of the dbgsym strategy declared in sdk.mk / mlnx-sai.mk.
+# Ask for a dbgsym package only in the cases where one is actually produced:
+# source builds emit it only when SPLIT_DBGSYM=y, while downloaded packages
+# always ship one. On nostrip builds (SPLIT_DBGSYM=n) the symbols are already
+# inside the runtime debs the base image installs, so there is nothing extra
+# to add.
 ifeq ($(SDK_FROM_SRC), y)
-$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SDK_DBG_DEBS) $(MLNX_SAI_DBGSYM)
+ifeq ($(SPLIT_DBGSYM), y)
+$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SDK_DBG_DEBS)
+endif
+else
+$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SDK_DBG_DEBS)
+endif
+ifeq ($(SAI_FROM_SRC), y)
+ifeq ($(SPLIT_DBGSYM), y)
+$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SAI_DBGSYM)
+endif
+else
+$(DOCKER_SYNCD_BASE)_DBG_DEPENDS += $(MLNX_SAI_DBGSYM)
 endif
 
 $(DOCKER_SYNCD_BASE)_VERSION = 1.0.0

--- a/platform/mellanox/mlnx-sai.mk
+++ b/platform/mellanox/mlnx-sai.mk
@@ -19,21 +19,46 @@ export MLNX_SAI_VERSION MLNX_SAI_SOURCE_BASE_URL
 
 MLNX_SAI = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
 $(MLNX_SAI)_SRC_PATH = $(PLATFORM_PATH)/mlnx-sai
-$(MLNX_SAI)_DEPENDS += $(MLNX_SDK_DEBS) $(LIBNL_ROUTE3_DEV)
 $(MLNX_SAI)_RDEPENDS += $(MLNX_SDK_RDEBS) $(LIBNL_ROUTE3)
 $(eval $(call add_conflict_package,$(MLNX_SAI),$(LIBSAIVS_DEV)))
 MLNX_SAI_DBGSYM = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
-$(eval $(call add_derived_package,$(MLNX_SAI),$(MLNX_SAI_DBGSYM)))
 
 define make_url
 	$(1)_URL = $(MLNX_SAI_ASSETS_URL)/$(1)
 
 endef
 
-$(eval $(foreach deb,$(MLNX_SAI) $(MLNX_SAI_DBGSYM),$(call make_url,$(deb))))
-
+# Where debug symbols live depends on how SAI is obtained. Registering a
+# dbgsym target that the recipe cannot produce turns into a missing
+# prerequisite, so each branch only declares what it can actually deliver.
+#
+# Built from source (SAI_FROM_SRC=y):
+#   debuild honors DEB_BUILD_OPTIONS exported by slave.mk. With SPLIT_DBGSYM=y
+#   (the default) dh_strip moves symbols into a separate dbgsym package and
+#   the runtime deb ships stripped, so that package is registered as a derived
+#   package of the runtime deb - one recipe run emits both. With SPLIT_DBGSYM=n
+#   the nostrip option keeps symbols inside the runtime deb and no dbgsym
+#   package is ever emitted, so nothing is registered and the -dbg image just
+#   reuses the runtime deb. _DEPENDS is the compile set: SDK -dev headers and
+#   libnl-route headers; -dev still pulls the runtime SDK via its own _DEPENDS.
+#
+# Downloaded (SAI_FROM_SRC=n):
+#   Both debs are prebuilt release assets that always exist, independent of
+#   SPLIT_DBGSYM, so the flag plays no part here. They are registered as two
+#   independent online debs, each with its own URL, which keeps the dbgsym
+#   download lazy: it is fetched only when something actually depends on it,
+#   i.e. when the -dbg image is built. Attaching it to the runtime deb with
+#   add_derived_package instead would drag it down on every build. _DEPENDS is
+#   the dpkg -i set: runtime SDK and libnl-route, not -dev, so a full image
+#   that only installs SAI does not fetch SDK headers.
 ifeq ($(SAI_FROM_SRC), y)
+$(MLNX_SAI)_DEPENDS += $(MLNX_SDK_DEBS) $(LIBNL_ROUTE3_DEV)
 SONIC_MAKE_DEBS += $(MLNX_SAI)
+ifeq ($(SPLIT_DBGSYM),y)
+$(eval $(call add_derived_package,$(MLNX_SAI),$(MLNX_SAI_DBGSYM)))
+endif
 else
-SONIC_ONLINE_DEBS += $(MLNX_SAI)
+$(MLNX_SAI)_DEPENDS += $(MLNX_SDK_RDEBS) $(LIBNL_ROUTE3)
+SONIC_ONLINE_DEBS += $(MLNX_SAI) $(MLNX_SAI_DBGSYM)
+$(eval $(foreach deb,$(MLNX_SAI) $(MLNX_SAI_DBGSYM),$(call make_url,$(deb))))
 endif

--- a/platform/mellanox/mlnx-sai/Makefile
+++ b/platform/mellanox/mlnx-sai/Makefile
@@ -3,14 +3,24 @@ SHELL = /bin/bash
 .SHELLFLAGS += -e
 
 MAIN_TARGET = mlnx-sai_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
+DBGSYM_TARGET = mlnx-sai-dbgsym_1.mlnx.$(MLNX_SAI_VERSION)_$(CONFIGURED_ARCH).deb
+DERIVED_TARGETS =
+ifeq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),)
+DERIVED_TARGETS += $(DBGSYM_TARGET)
+endif
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
+	# get sources
 	rm -rf mlnx_sai
 	wget -c $(MLNX_SAI_SOURCE_BASE_URL)/$(MLNX_SAI_VERSION).tar.gz -O - | tar -xz
-	pushd mlnx_sai
 
+	# build
+	pushd mlnx_sai
 	debuild -e 'make_extra_flags="DEFS=-DACS_OS -DCONFIG_SYSLOG -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-Bsymbolic"' -us -uc -d -b
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/
+
+ifneq ($(DERIVED_TARGETS),)
+$(addprefix $(DEST)/, $(DERIVED_TARGETS)): $(DEST)/% : $(DEST)/$(MAIN_TARGET)
+endif

--- a/platform/mellanox/sdk-src/sys-sdk/Makefile
+++ b/platform/mellanox/sdk-src/sys-sdk/Makefile
@@ -2,19 +2,56 @@
 SHELL = /bin/bash
 
 MAIN_TARGET = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH).deb
-DERIVED_TARGETS = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dev.deb sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dbgsym.ddeb
+DEV_TARGET = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dev.deb
+DBGSYM_TARGET = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dbgsym.ddeb
+DERIVED_TARGETS = $(DEV_TARGET)
+ifeq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),)
+DERIVED_TARGETS += $(DBGSYM_TARGET)
+endif
 
 PACKAGE_NAME = sys_sdk
 
+# slave.mk exports DEB_BUILD_OPTIONS when SONIC_PROFILING_ON=y (nostrip noopt)
+# or SONIC_DEBUGGING_ON=y (nostrip). CPack is not debhelper, so honor the same
+# flags here. CMAKE_BUILD_TYPE is a configure-time compile setting.
+# CPACK_DEBIAN_DEBUGINFO_PACKAGE is applied at cpack time.
+# Default remains RelWithDebInfo + split dbgsym (production).
+DEB_BUILD_OPTIONS ?=
+SDK_CMAKE_ARGS := \
+	-DPYTHON_INTERPRETERS=python3 \
+	-DSKIP_UNINSTALL_INSTALL_DEPENDENCY=on \
+	-DSKIP_DEPMOD_IN_INSTALL_PHASE=on \
+	-DUSE_API_TESTER=OFF \
+	-DUSE_KERNEL=OFF \
+	-DCMAKE_PROJECT_VERSION=$(MLNX_SDK_DEB_VERSION)
+# CPack leaves the -dev control file without a Depends on the runtime package.
+# The component ids come from CMakeLists.txt: cpack_add_component(dev) and
+# CMAKE_INSTALL_DEFAULT_COMPONENT_NAME "main". CPack resolves them to the
+# generated package names, so nothing here spells out sys-sdk-main.
+# CPack also leaves the runtime deb without a Depends on shared libraries
+# (libc6, libnl, libxml2, etc.); SHLIBDEPS fills that from linked libraries.
+# GENERATE_SHLIBS writes a shlibs file so other packages (SAI) can Depends
+# on sys-sdk-main from their own dpkg-shlibdeps run.
+# cpack wants -D <var>=<value> as two arguments; the glued -Dvar=value form
+# that cmake accepts is silently ignored here.
+SDK_CPACK_ARGS := \
+	-D CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS=ON \
+	-D CPACK_COMPONENT_DEV_DEPENDS=main \
+	-D CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON \
+	-D CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS=ON
+ifneq ($(findstring noopt,$(DEB_BUILD_OPTIONS)),)
+SDK_CMAKE_ARGS += -DCMAKE_BUILD_TYPE=Debug
+endif
+ifneq ($(findstring nostrip,$(DEB_BUILD_OPTIONS)),)
+SDK_CPACK_ARGS += -D CPACK_DEBIAN_DEBUGINFO_PACKAGE=OFF
+endif
+
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
-        # get sources
+	# get sources
 	rm -rf $(PACKAGE_NAME)-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION)
-	
-	@echo  'wget -c $(MLNX_SDK_SOURCE_BASE_URL)/$(PACKAGE_NAME)-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz'
-	
 	wget -c $(MLNX_SDK_SOURCE_BASE_URL)/$(PACKAGE_NAME)-$(MLNX_SDK_VERSION)-$(MLNX_SDK_ISSU_VERSION).tar.gz -O - | tar -xz
 
-        # build
+	# build
 	rm -rf builds/cmake
 
 	KVERSION=$$(ls -t /lib/modules 2>/dev/null | head -1)
@@ -28,13 +65,12 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 		fi
 	fi
 
-	cmake -B builds/cmake -DCMAKE_SYSTEM_VERSION=$$KVERSION -DPYTHON_INTERPRETERS=python3 -DSKIP_UNINSTALL_INSTALL_DEPENDENCY=on -DSKIP_DEPMOD_IN_INSTALL_PHASE=on -DUSE_API_TESTER=OFF -DUSE_KERNEL=OFF -DCMAKE_PROJECT_VERSION=$(MLNX_SDK_DEB_VERSION)
-	
+	cmake -B builds/cmake $(SDK_CMAKE_ARGS) -DCMAKE_SYSTEM_VERSION=$$KVERSION
 	cmake --build builds/cmake -j$(SONIC_CONFIG_MAKE_JOBS)
-	
+
 	cd builds/cmake
-	
-	cpack -G DEB
+
+	cpack -G DEB $(SDK_CPACK_ARGS)
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/
 

--- a/platform/mellanox/sdk.mk
+++ b/platform/mellanox/sdk.mk
@@ -1,6 +1,6 @@
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2016-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
 MLNX_SDK_VERSION = 4.10.1090
 MLNX_SDK_ISSU_VERSION = 101
 
@@ -42,18 +43,12 @@ export MLNX_SDK_SOURCE_BASE_URL MLNX_SDK_VERSION MLNX_SDK_ISSU_VERSION MLNX_SDK_
 
 MLNX_SDK_RDEBS += $(SYSSDK)
 MLNX_SDK_DEBS += $(SYSSDK_DEV)
-MLNX_SDK_DBG_DEBS += $(SYSSDK_DBGSYM)
 
 SYSSDK = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH).deb
 $(SYSSDK)_SRC_PATH = $(PLATFORM_PATH)/sdk-src/sys-sdk
-$(SYSSDK)_DEPENDS += $(LIBNL3_DEV) $(LIBNL_GENL3_DEV)
 $(SYSSDK)_RDEPENDS += $(LIBNL3) $(LIBNL_GENL3)
 SYSSDK_DEV = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dev.deb
-$(eval $(call add_derived_package,$(SYSSDK),$(SYSSDK_DEV)))
 SYSSDK_DBGSYM = sys-sdk_1.mlnx.$(MLNX_SDK_DEB_VERSION)_$(CONFIGURED_ARCH)-dbgsym.ddeb
-ifeq ($(SDK_FROM_SRC),y)
-$(eval $(call add_derived_package,$(SYSSDK),$(SYSSDK_DBGSYM)))
-endif
 
 
 #packages that are required for runtime only
@@ -67,14 +62,49 @@ define make_url
 
 endef
 
-$(eval $(foreach deb,$(MLNX_SDK_DEBS) $(MLNX_SDK_RDEBS),$(call make_url,$(deb))))
-
 SONIC_MAKE_DEBS += $(SX_KERNEL)
 
+# Which extra artifacts exist (-dev headers, dbgsym) depends on how the SDK is
+# obtained, following the same strategy as mlnx-sai.mk: each branch declares
+# only what it can actually deliver, and an extra is attached to the runtime
+# deb only when a single recipe run emits both.
+#
+# Built from source (SDK_FROM_SRC=y):
+#   One cpack run writes the runtime deb, -dev and, unless nostrip is set, the
+#   dbgsym, so both extras are registered as derived packages of the runtime
+#   deb. sys-sdk is packaged by CPack rather than debhelper and cannot pick up
+#   DEB_BUILD_OPTIONS by itself, so sdk-src/sys-sdk/Makefile maps nostrip to
+#   CPACK_DEBIAN_DEBUGINFO_PACKAGE=OFF; that is why SPLIT_DBGSYM=n has to skip
+#   the derived dbgsym here as well. _DEPENDS is the compile set: libnl
+#   headers; -dev still pulls the runtime libnl via its own _DEPENDS.
+#
+# Downloaded (SDK_FROM_SRC=n):
+#   All three are independent release assets, so each becomes its own online
+#   deb with its own URL. That keeps the extras lazy: -dev is fetched only when
+#   something compiles against the SDK (SAI built from source), the dbgsym only
+#   when the -dbg image is built. Deriving them from the runtime deb instead
+#   would drag both down on every build. -dev must still be installed after the
+#   runtime deb, which $(SYSSDK_DEV)_DEPENDS records without turning it into a
+#   derived package. _DEPENDS is the dpkg -i set: runtime libnl, not -dev, so
+#   a full image that only installs the runtime SDK does not fetch libnl
+#   headers.
+#
+# MLNX_SDK_DBG_DEBS is what docker-syncd-mlnx.mk appends to the -dbg image's
+# DBG_DEPENDS; it stays empty when no dbgsym package exists.
 ifeq ($(SDK_FROM_SRC), y)
+$(SYSSDK)_DEPENDS += $(LIBNL3_DEV) $(LIBNL_GENL3_DEV)
 SONIC_MAKE_DEBS += $(MLNX_SDK_RDEBS)
+$(eval $(call add_derived_package,$(SYSSDK),$(SYSSDK_DEV)))
+ifeq ($(SPLIT_DBGSYM),y)
+$(eval $(call add_derived_package,$(SYSSDK),$(SYSSDK_DBGSYM)))
+MLNX_SDK_DBG_DEBS += $(SYSSDK_DBGSYM)
+endif
 else
-SONIC_ONLINE_DEBS += $(MLNX_SDK_RDEBS)
+$(SYSSDK)_DEPENDS += $(LIBNL3) $(LIBNL_GENL3)
+SONIC_ONLINE_DEBS += $(MLNX_SDK_RDEBS) $(SYSSDK_DEV) $(SYSSDK_DBGSYM)
+$(SYSSDK_DEV)_DEPENDS += $(SYSSDK)
+$(eval $(foreach deb,$(MLNX_SDK_RDEBS) $(SYSSDK_DEV) $(SYSSDK_DBGSYM),$(call make_url,$(deb))))
+MLNX_SDK_DBG_DEBS += $(SYSSDK_DBGSYM)
 endif
 
 mlnx-sdk-packages: $(addprefix $(DEBS_PATH)/, $(MLNX_SDK_RDEBS) $(SX_KERNEL))

--- a/slave.mk
+++ b/slave.mk
@@ -206,6 +206,24 @@ ifeq ($(SONIC_INSTALL_DEBUG_TOOLS),y)
 INSTALL_DEBUG_TOOLS = y
 endif
 
+# SPLIT_DBGSYM: whether a separate dbgsym package is produced.
+# Default y (production): runtime .deb is stripped, symbols go into the dbgsym.
+# SONIC_DEBUGGING_ON / SONIC_PROFILING_ON export DEB_BUILD_OPTIONS=nostrip
+# (profiling also adds noopt). DWARF then stays in the runtime .deb, no dbgsym
+# is emitted, and SPLIT_DBGSYM is n so package rules do not register one.
+# If both flags are set, the profiling assignment wins (nostrip noopt).
+# Unrelated to INSTALL_DEBUG_TOOLS, which only decides whether debug images
+# ship in the installer; debug images can be built either way.
+SPLIT_DBGSYM = y
+ifeq ($(SONIC_DEBUGGING_ON),y)
+DEB_BUILD_OPTIONS_GENERIC := nostrip
+SPLIT_DBGSYM = n
+endif
+ifeq ($(SONIC_PROFILING_ON),y)
+DEB_BUILD_OPTIONS_GENERIC := nostrip noopt
+SPLIT_DBGSYM = n
+endif
+
 ifeq ($(SONIC_SAITHRIFT_V2),y)
 SAITHRIFT_V2 = y
 SAITHRIFT_VER = v2
@@ -309,14 +327,6 @@ ifeq ($(PASSWORD),)
 override PASSWORD := $(DEFAULT_PASSWORD)
 else
 $(warning PASSWORD given on command line: could be visible to other users)
-endif
-
-ifeq ($(SONIC_DEBUGGING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := nostrip
-endif
-
-ifeq ($(SONIC_PROFILING_ON),y)
-DEB_BUILD_OPTIONS_GENERIC := nostrip noopt
 endif
 
 # ccache configuration — prepend /usr/lib/ccache to PATH so that gcc/g++/cc/c++


### PR DESCRIPTION
Signed-off-by: Nazarii Hnydyn <nazariig@nvidia.com>

#### Why I did it

Make the NVIDIA SAI/SDK packages honor SONiC's debug/profiling build switches and
ship correct Debian metadata, and stop registering build artifacts that the
recipes cannot produce.

Five problems are addressed.

**1. `SONIC_DEBUGGING_ON` / `SONIC_PROFILING_ON` had no effect on the SDK**

`slave.mk` exports `DEB_BUILD_OPTIONS=nostrip` (debugging) or `nostrip noopt`
(profiling). Those are debhelper options. `sys-sdk` is packaged by CMake/CPack,
which never reads `DEB_BUILD_OPTIONS`, so the SDK was built and packaged exactly
the same way in every mode:

* libraries always stripped, DWARF always moved into a separate `.ddeb`
* always compiled optimized

Source-level debugging of the SDK inside `syncd` was therefore impossible even
with profiling enabled: `gdb` could resolve function names, but not `file:line`.

**2. `sys-sdk` packages had an empty `Depends:` field**

CPack does not run `dpkg-shlibdeps` and does not convert component dependencies
into Debian dependencies unless explicitly told to. Both generated packages
shipped with no `Depends:` at all, so `dpkg` could not enforce anything:
`sys-sdk-dev` did not require its runtime package, and the runtime package did
not require `libc6` / `libnl` / `libxml2`. Correct install order happened only as
a side effect of the Make dependency graph.

**3. `mlnx-sai` did not depend on the SDK**

`sys-sdk` published no `shlibs` control file, so when SAI ran `dh_shlibdeps` there
was no SONAME-to-package mapping for the SDK shared libraries. SAI's
`debian/rules` runs `dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info`,
so the missing information was not an error — the build simply produced an
`mlnx-sai` package with no dependency on the SDK it links against, and installing
it on a system without the SDK would only fail at runtime.

**4. dbgsym packages were demanded in cases where nothing produces them**

The dbgsym artifacts were declared without regard to whether the selected build
mode actually emits them:

* `MLNX_SDK_DBG_DEBS` always listed `sys-sdk-*-dbgsym.ddeb`, and
  `docker-syncd-mlnx.mk` always appended it to the `-dbg` image, while the
  package itself was registered only for source builds — and, once `nostrip` is
  in `DEB_BUILD_OPTIONS`, is not produced by the source build either
* `mlnx-sai-dbgsym` was registered unconditionally as a derived package of the
  runtime deb, so on a `nostrip` build the recipe was expected to emit a file
  that dh_strip never creates, and on the download path the asset was fetched on
  every build even when no `-dbg` image was requested

A dbgsym that nothing can produce shows up as a missing prerequisite:

```
make: *** No rule to make target 'target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb',
needed by 'target/docker-syncd-mlnx-dbg.gz'
```

**5. `_DEPENDS` mixed compile-time headers with runtime install ordering**

`$(MLNX_SAI)_DEPENDS` unconditionally listed `MLNX_SDK_DEBS` (`sys-sdk-dev`).
Installing SAI in the slave therefore always installed SDK headers, including on
the default path where SAI is downloaded as a prebuilt asset and nothing compiles
against the SDK.

#### Work item tracking

* N/A

#### How I did it

**`slave.mk` — introduce `SPLIT_DBGSYM`**

Moved the `SONIC_DEBUGGING_ON` / `SONIC_PROFILING_ON` handling next to the other
debug switches and made it set a single variable that package rules can read:

```make
SPLIT_DBGSYM = y
ifeq ($(SONIC_DEBUGGING_ON),y)
DEB_BUILD_OPTIONS_GENERIC := nostrip
SPLIT_DBGSYM = n
endif
ifeq ($(SONIC_PROFILING_ON),y)
DEB_BUILD_OPTIONS_GENERIC := nostrip noopt
SPLIT_DBGSYM = n
endif
```

`SPLIT_DBGSYM=y` (default, production): runtime deb is stripped and a dbgsym
package exists. `SPLIT_DBGSYM=n`: DWARF stays in the runtime deb and no dbgsym
package is produced, so no rule may register one. This is independent of
`INSTALL_DEBUG_TOOLS`, which only decides whether debug images ship in the
installer.

**`platform/mellanox/sdk-src/sys-sdk/Makefile` — map `DEB_BUILD_OPTIONS` onto CMake/CPack**

Collected the flags into `SDK_CMAKE_ARGS` / `SDK_CPACK_ARGS` and translated the
debhelper options that CPack cannot see:

* `noopt` -> `-DCMAKE_BUILD_TYPE=Debug` (configure time)
* `nostrip` -> `-D CPACK_DEBIAN_DEBUGINFO_PACKAGE=OFF` (package time)

and added the missing packaging metadata:

* `-D CPACK_DEBIAN_ENABLE_COMPONENT_DEPENDS=ON` and
  `-D CPACK_COMPONENT_DEV_DEPENDS=main` -- `-dev` now depends on the runtime
  package. The component ids come from the SDK CMake project (`dev` / `main`);
  CPack resolves them to the generated package names, so nothing here hardcodes
  the runtime package name.
* `-D CPACK_DEBIAN_PACKAGE_SHLIBDEPS=ON` -- runtime deb gets its own
  `Depends:` generated from the libraries it links against.
* `-D CPACK_DEBIAN_PACKAGE_GENERATE_SHLIBS=ON` -- the runtime deb ships a
  `shlibs` file so other packages (SAI) can resolve SDK SONAMEs.

**`platform/mellanox/sdk.mk` / `mlnx-sai.mk` — declare only what each path delivers**

Both files now split their declarations by acquisition method, and `_DEPENDS` is
scoped to what that path actually needs:

| | built from source | downloaded |
| --- | --- | --- |
| SAI `_DEPENDS` | `sys-sdk-dev`, `libnl-route-3-dev` | `sys-sdk`, `libnl-route-3-200` |
| SDK `_DEPENDS` | `libnl-3-dev`, `libnl-genl-3-dev` | `libnl-3-200`, `libnl-genl-3-200` |
| dbgsym | derived package, only when `SPLIT_DBGSYM=y` | own online deb + own URL (lazy) |
| SDK `-dev` | derived package | own online deb + `_DEPENDS` on runtime |

`_RDEPENDS` is unchanged, so what lands in the docker images is identical.

**`platform/mellanox/mlnx-sai/Makefile` / `sdk-src/sys-sdk/Makefile` — conditional derived targets**

`DERIVED_TARGETS` now includes the dbgsym target only when `nostrip` is absent, so
the recipe never tries to `mv` a file that was not generated.

**`platform/mellanox/docker-syncd-mlnx.mk` — consumer side**

`_DBG_DEPENDS` asks for a dbgsym package only in the combinations where one
exists: source builds only when `SPLIT_DBGSYM=y`, downloaded packages always. On
`nostrip` builds the symbols are already inside the runtime debs the base image
installs, so nothing extra is added.

#### How to verify it

**Production build (default, `SPLIT_DBGSYM=y`)**

1. Build SDK and SAI with no debug flags.
2. Confirm dbgsym packages are produced and runtime debs are stripped:
   ```
   ls target/debs/trixie/sys-sdk_*-dbgsym.ddeb
   ls target/debs/trixie/mlnx-sai-dbgsym_*.deb
   ```
3. Confirm the metadata:
   ```
   dpkg-deb -f target/debs/trixie/sys-sdk_*_amd64.deb Depends
   dpkg-deb -f target/debs/trixie/sys-sdk_*-dev.deb Depends
   dpkg-deb -f target/debs/trixie/mlnx-sai_*.deb Depends
   dpkg-deb -I target/debs/trixie/sys-sdk_*_amd64.deb shlibs
   ```

**Profiling build (`SONIC_PROFILING_ON=y`, `SPLIT_DBGSYM=n`)**

1. Rebuild SDK and SAI.
2. Confirm no dbgsym package is emitted:
   ```
   ls target/debs/trixie/sys-sdk_*-dbgsym.ddeb   # must not exist
   ls target/debs/trixie/mlnx-sai-dbgsym_*.deb   # must not exist
   ```
3. Confirm DWARF is inside the runtime debs and code is unoptimized:
   ```
   dpkg-deb -x target/debs/trixie/sys-sdk_*_amd64.deb /tmp/sdk
   readelf -SW /tmp/sdk/usr/lib/<sdk-lib>.so | grep debug_info
   readelf --debug-dump=info /tmp/sdk/usr/lib/<sdk-lib>.so | grep -m1 DW_AT_producer
   ```
4. Build the `-dbg` syncd image and confirm it still builds with no missing
   dbgsym prerequisite.
5. Attach `gdb` to `syncd` and confirm `file:line` breakpoints in SDK sources now
   resolve.

**Dependency laziness**

1. Default path (SAI and SDK downloaded): build `syncd` and confirm
   `sys-sdk-dev` is not installed in the slave.
2. SAI built from source: confirm `sys-sdk-dev` is installed before SAI compiles.

#### Previous command output (if the output of a command-line utility has changed)

```
# Profiling build: dbgsym still produced, libraries stripped, code optimized
$ ls target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb
target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb

$ readelf -SW /tmp/sdk/usr/lib/<sdk-lib>.so | grep -c debug_info
0

# No Depends generated for the SDK at all
$ dpkg-deb -f target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64.deb Depends
$ dpkg-deb -f target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dev.deb Depends

# No shlibs, so SAI does not depend on the SDK it links against
$ dpkg-deb -I target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64.deb shlibs
dpkg-deb: error: control file 'shlibs' not found

$ dpkg-deb -f target/debs/trixie/mlnx-sai_1.mlnx.SAIBuild2605.37.0.31_amd64.deb Depends
libc6 (>= 2.34), libnl-3-200 (>= 3.7.0-0.2+b1sonic1), libnl-genl-3-200 (>= 3.7.0-0.2+b1sonic1),
libnl-route-3-200 (>= 3.7.0-0.2+b1sonic1), libxml2 (>= 2.7.4)

# nostrip build of a package whose dbgsym is registered but never produced
make: *** No rule to make target 'target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb',
needed by 'target/docker-syncd-mlnx-dbg.gz'
```

#### New command output (if the output of a command-line utility has changed)

```
# Profiling build: no dbgsym, DWARF inside the runtime deb, no optimization
$ ls target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb
ls: cannot access '...-dbgsym.ddeb': No such file or directory

$ readelf -SW /tmp/sdk/usr/lib/<sdk-lib>.so | grep -c debug_info
1

$ readelf --debug-dump=info /tmp/sdk/usr/lib/<sdk-lib>.so | grep -m1 DW_AT_producer
DW_AT_producer : GNU C17 ... -ggdb -O0 ...

# Depends now generated for both components
$ dpkg-deb -f target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64.deb Depends
libc6 (>= 2.38), libelf1t64 (>= 0.131), libexpat1 (>= 2.0.1), libnl-3-200 (>= 3.7.0-0.2+b1sonic1),
libpcap0.8t64 (>= 0.9.8), libsystemd0, libxml2 (>= 2.7.4), zlib1g (>= 1:1.1.4)

$ dpkg-deb -f target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dev.deb Depends
sys-sdk-main (= 1.mlnx.4.10.1106)

# shlibs published, so SAI resolves the SDK automatically
$ dpkg-deb -I target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64.deb shlibs
<sdk-soname> 1 sys-sdk-main (= 1.mlnx.4.10.1106)
...

$ dpkg-deb -f target/debs/trixie/mlnx-sai_1.mlnx.SAIBuild2605.37.0.31_amd64.deb Depends
libc6 (>= 2.34), libnl-3-200 (>= 3.7.0-0.2+b1sonic1), libnl-genl-3-200 (>= 3.7.0-0.2+b1sonic1),
libnl-route-3-200 (>= 3.7.0-0.2+b1sonic1), libxml2 (>= 2.7.4), sys-sdk-main (= 1.mlnx.4.10.1106)

# Production (profiling off): dbgsym split, runtime stripped, code optimized
$ ls target/debs/trixie/sys-sdk_*_amd64-dbgsym.ddeb
target/debs/trixie/sys-sdk_1.mlnx.4.10.1106_amd64-dbgsym.ddeb

$ ls target/debs/trixie/mlnx-sai-dbgsym_*.deb
target/debs/trixie/mlnx-sai-dbgsym_1.mlnx.SAIBuild2605.37.0.31_amd64.deb

$ readelf -SW /tmp/sdk/usr/lib/<sdk-lib>.so | grep -c debug_info
0

$ readelf --debug-dump=info <dbgsym> | grep -m1 DW_AT_producer
DW_AT_producer : GNU C17 ... -O3 ...
```

#### Which release branch to backport (provide reason below if selected)

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO): N/A
Failure type: N/A

#### Tested branch

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [x] 202605
- [ ] 202608
- [ ] N/A

#### Test result

Verified on trixie / amd64 with `sys-sdk 1.mlnx.4.10.1106` and
`mlnx-sai 1.mlnx.SAIBuild2605.37.0.31`, both built from source:

* default / profiling off (`SPLIT_DBGSYM=y`) -- dbgsym packages emitted for both
  components, runtime debs stripped (no `.debug_info`, `.gnu_debuglink` present),
  DWARF lives in the dbgsym packages, and `DW_AT_producer` reports an optimized
  compile (`-O3` / `-O2`, not `-O0`)
* `SONIC_PROFILING_ON=y` (`SPLIT_DBGSYM=n`) -- no dbgsym package emitted for
  either component, `.debug_info` present in the SDK and SAI shared libraries,
  and `DW_AT_producer` reports `-ggdb -O0` for the compile units
* in both modes: `sys-sdk` `Depends:` populated from `dpkg-shlibdeps`;
  `sys-sdk-dev` depends on `sys-sdk-main (= 1.mlnx.4.10.1106)`; `sys-sdk` ships
  a `shlibs` file, and `mlnx-sai` `Depends:` resolves
  `sys-sdk-main (= 1.mlnx.4.10.1106)` through it
* `-dbg` syncd docker image builds with no missing dbgsym prerequisite
* with profiling on, `gdb` on `syncd` resolves `file:line` breakpoints in SDK
  sources

#### Description for the changelog

* N/A

#### Link to config_db schema for YANG module changes

* N/A

#### Details if related
* Backport from `master`: https://github.com/sonic-net/sonic-buildimage/pull/29404

#### A picture of a cute animal (not mandatory but encouraged)

```
      .---.        .-----------
     /     \  __  /    ------
    / /     \(  )/    -----
   //////   ' \/ `   ---
  //// / // :    : ---
 // /   /  /`    '--
//          //..\\
       ====UU====UU====
           '//||\\`
             ''``
```