### PR TITLE
[sonic-ctrmgrd]: Harden Kubernetes command execution

### DIFF
--- a/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
+++ b/src/sonic-ctrmgrd/ctrmgr/kube_commands.py
@@ -538,65 +538,125 @@ def tag_latest(feat, docker_id, image_ver):
         log_error(err)
     return ret
 
+# Historical cleanup timeout (was the implicit default of the shell-based
+# _run_command helper). Passed explicitly to _run_command_list(), whose own
+# default timeout is much shorter, to preserve prior behavior.
+CLEAN_IMAGE_TIMEOUT = 60
+
+# Query docker images in a structured, script-friendly format so no
+# grep/awk shell pipeline (and therefore no shell interpretation of
+# feat/repository/tag/image-id values) is required.
+DOCKER_IMAGES_CMD = ["docker", "images", "--format", "{{.Repository}} {{.Tag}} {{.ID}}"]
+
+
 def _do_clean(feat, current_version, last_version):
     err = ""
     out = ""
     ret = 0
     IMAGE_ID = "image_id"
     REPO = "repo"
-    _, image_info, err = _run_command("docker images |grep {} |grep -v latest |awk '{{print $1,$2,$3}}'".format(feat))
-    if image_info:
-        remote_image_version_dict = {}
-        local_image_version_dict = {}
-        for info in image_info.split("\n"):
-            rep, version, image_id = info.split()
-            if len(rep.split("/")) == 1:
-                local_image_version_dict[version] = {IMAGE_ID: image_id, REPO: rep}
-            else:
-                remote_image_version_dict[version] = {IMAGE_ID: image_id, REPO: rep}
 
-        if current_version in remote_image_version_dict:
-            image_prefix = remote_image_version_dict[current_version][REPO]
-            del remote_image_version_dict[current_version]
-        else:
-            out = "Current version {} doesn't exist.".format(current_version)
-            ret = 0
-            return ret, out, err
-        # should be only one item in local_image_version_dict
-        for k, v in local_image_version_dict.items():
-            local_version, local_repo, local_image_id = k, v[REPO], v[IMAGE_ID]
-            # if there is a kube image with same version, need to remove the kube version
-            # and tag the local version to kube version for fallback preparation
-            # and remove the local version
-            if local_version in remote_image_version_dict:
-                tag_res, _, err = _run_command("docker rmi {}:{} && docker tag {} {}:{} && docker rmi {}:{}".format(
-                image_prefix, local_version, local_image_id, image_prefix, local_version, local_repo, local_version))
-            # if there is no kube image with same version, just remove the local version
-            else:
-                tag_res, _, err = _run_command("docker rmi {}:{}".format(local_repo, local_version))
-            if tag_res == 0:
-                msg = "Tag {} local version images successfully".format(feat)
-                log_debug(msg)
-            else:
-                ret = 1
-                err = "Failed to tag {} local version images. Err: {}".format(feat, err)
-            return ret, out, err
+    cmd_ret, image_info, cmd_err = _run_command_list(DOCKER_IMAGES_CMD, timeout=CLEAN_IMAGE_TIMEOUT)
+    if cmd_ret != 0:
+        ret = 1
+        err = "Failed to run docker images. Err: {}".format(cmd_err)
+        return ret, out, err
 
-        if last_version in remote_image_version_dict:
-            del remote_image_version_dict[last_version]
+    remote_image_version_dict = {}
+    local_image_version_dict = {}
+    for line in image_info.splitlines():
+        line = line.strip()
+        if not line:
+            continue
 
-        image_id_remove_list = [item[IMAGE_ID] for item in remote_image_version_dict.values()]
-        if image_id_remove_list:
-            clean_res, _, err = _run_command("docker rmi {} --force".format(" ".join(image_id_remove_list)))
-        else:
-            clean_res = 0
-        if clean_res == 0:
-            out = "Clean {} old version images successfully".format(feat)
-        else:
-            err = "Failed to clean {} old version images. Err: {}".format(feat, err)
+        fields = line.split()
+        if len(fields) != 3:
             ret = 1
+            err = "Unexpected docker images output: {}".format(line)
+            return ret, out, err
+
+        rep, version, image_id = fields
+
+        if version == "latest":
+            continue
+
+        # Match against the repository only (never the tag or image ID), to
+        # avoid a feat value coincidentally matching an unrelated image via
+        # its version/tag or hash. This preserves the historical
+        # substring-based feature-to-image association (e.g. feat "snmp"
+        # matches repository "docker-sonic-snmp").
+        if feat not in rep:
+            continue
+
+        if len(rep.split("/")) == 1:
+            local_image_version_dict[version] = {IMAGE_ID: image_id, REPO: rep}
+        else:
+            remote_image_version_dict[version] = {IMAGE_ID: image_id, REPO: rep}
+
+    if current_version in remote_image_version_dict:
+        image_prefix = remote_image_version_dict[current_version][REPO]
+        del remote_image_version_dict[current_version]
     else:
-        err = "Failed to docker images |grep {} |awk '{{print $3}}'. Error: {}".format(feat, err)
+        out = "Current version {} doesn't exist.".format(current_version)
+        ret = 0
+        return ret, out, err
+    # should be only one item in local_image_version_dict
+    for k, v in local_image_version_dict.items():
+        local_version, local_repo, local_image_id = k, v[REPO], v[IMAGE_ID]
+        # if there is a kube image with same version, need to remove the kube version
+        # and tag the local version to kube version for fallback preparation
+        # and remove the local version
+        if local_version in remote_image_version_dict:
+            remote_image = "{}:{}".format(image_prefix, local_version)
+            local_image = "{}:{}".format(local_repo, local_version)
+
+            # Sequential calls preserve the historical "cmd1 && cmd2 && cmd3"
+            # short-circuit semantics: stop immediately on the first failure
+            # instead of attempting later operations against a system left in
+            # an inconsistent state.
+            rm_remote_ret, _, rm_remote_err = _run_command_list(
+                ["docker", "rmi", remote_image], timeout=CLEAN_IMAGE_TIMEOUT)
+            if rm_remote_ret != 0:
+                ret = 1
+                err = "Failed to tag {} local version images. Err: failed to remove {}: {}".format(
+                    feat, remote_image, rm_remote_err)
+                return ret, out, err
+
+            tag_ret, _, tag_err = _run_command_list(
+                ["docker", "tag", local_image_id, remote_image], timeout=CLEAN_IMAGE_TIMEOUT)
+            if tag_ret != 0:
+                ret = 1
+                err = "Failed to tag {} local version images. Err: failed to tag {} as {}: {}".format(
+                    feat, local_image_id, remote_image, tag_err)
+                return ret, out, err
+
+            tag_res, _, err = _run_command_list(
+                ["docker", "rmi", local_image], timeout=CLEAN_IMAGE_TIMEOUT)
+        # if there is no kube image with same version, just remove the local version
+        else:
+            tag_res, _, err = _run_command_list(
+                ["docker", "rmi", "{}:{}".format(local_repo, local_version)], timeout=CLEAN_IMAGE_TIMEOUT)
+        if tag_res == 0:
+            msg = "Tag {} local version images successfully".format(feat)
+            log_debug(msg)
+        else:
+            ret = 1
+            err = "Failed to tag {} local version images. Err: {}".format(feat, err)
+        return ret, out, err
+
+    if last_version in remote_image_version_dict:
+        del remote_image_version_dict[last_version]
+
+    image_id_remove_list = [item[IMAGE_ID] for item in remote_image_version_dict.values()]
+    if image_id_remove_list:
+        clean_res, _, err = _run_command_list(
+            ["docker", "rmi"] + image_id_remove_list + ["--force"], timeout=CLEAN_IMAGE_TIMEOUT)
+    else:
+        clean_res = 0
+    if clean_res == 0:
+        out = "Clean {} old version images successfully".format(feat)
+    else:
+        err = "Failed to clean {} old version images. Err: {}".format(feat, err)
         ret = 1
 
     return ret, out, err

--- a/src/sonic-ctrmgrd/tests/kube_commands_test.py
+++ b/src/sonic-ctrmgrd/tests/kube_commands_test.py
@@ -327,19 +327,21 @@ tag_latest_test_data = {
     }
 }
 
+DOCKER_IMAGES_CMD = ["docker", "images", "--format", "{{.Repository}} {{.Tag}} {{.ID}}"]
+
 clean_image_test_data = {
     0: {
         common_test.DESCR: "Clean image successfuly(kube to kube)",
         common_test.RETVAL: 0,
         common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'",
-            "docker rmi 744d3a09062f --force"
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "744d3a09062f", "--force"]
         ],
         common_test.PROC_OUT: [
-            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.96 744d3a09062f\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.84 507f8d28bf6e",
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.96 744d3a09062f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6e",
             ""
         ],
         common_test.PROC_CODE: [
@@ -352,13 +354,13 @@ clean_image_test_data = {
         common_test.RETVAL: 1,
         common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'",
-            "docker rmi 744d3a09062f --force"
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "744d3a09062f", "--force"]
         ],
         common_test.PROC_OUT: [
-            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.96 744d3a09062f\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.84 507f8d28bf6e",
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.96 744d3a09062f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6e",
             ""
         ],
         common_test.PROC_CODE: [
@@ -367,44 +369,63 @@ clean_image_test_data = {
         ]
     },
     2: {
-        common_test.DESCR: "Clean image failed(no image found)",
+        common_test.DESCR: "Clean image failed(docker images command failed)",
         common_test.RETVAL: 1,
         common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'"
+            DOCKER_IMAGES_CMD
         ],
         common_test.PROC_OUT: [
             ""
+        ],
+        common_test.PROC_ERR: [
+            "Cannot connect to the Docker daemon"
+        ],
+        common_test.PROC_CODE: [
+            1
         ]
     },
     3: {
-        common_test.DESCR: "Clean image failed(current image doesn't exist)",
+        common_test.DESCR: "Clean image (current image doesn't exist)",
         common_test.RETVAL: 0,
         common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'",
-            ""
+            DOCKER_IMAGES_CMD
         ],
         common_test.PROC_OUT: [
-            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.96 744d3a09062f",
-            ""
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.96 744d3a09062f"
         ],
         common_test.PROC_CODE: [
             0
         ]
     },
     4: {
+        common_test.DESCR: "Clean image (no images match feat, unrelated images present)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-bgp 20201231.96 744d3a09062f"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    5: {
         common_test.DESCR: "Clean image successfuly(local to kube)",
         common_test.RETVAL: 0,
         common_test.ARGS: ["snmp", "20201231.84", ""],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'",
-            "docker rmi docker-sonic-telemetry:20201231.74"
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "docker-sonic-snmp:20201231.74"]
         ],
         common_test.PROC_OUT: [
-            "docker-sonic-telemetry 20201231.74 507f8d28bf6e\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.84 507f8d28bf6e",
+            "docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6e",
             ""
         ],
         common_test.PROC_CODE: [
@@ -412,24 +433,243 @@ clean_image_test_data = {
             0
         ]
     },
-    5: {
+    6: {
         common_test.DESCR: "Clean image successfuly(local to dry-kube to kube)",
         common_test.RETVAL: 0,
         common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
         common_test.PROC_CMD: [
-            "docker images |grep snmp |grep -v latest |awk '{print $1,$2,$3}'",
-            "docker rmi sonick8scue.azurecr.io/docker-sonic-telemetry:20201231.74 && docker tag 507f8d28bf6e sonick8scue.azurecr.io/docker-sonic-telemetry:20201231.74 && docker rmi docker-sonic-telemetry:20201231.74"
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"],
+            ["docker", "tag", "507f8d28bf6e", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"],
+            ["docker", "rmi", "docker-sonic-snmp:20201231.74"]
         ],
         common_test.PROC_OUT: [
-            "docker-sonic-telemetry 20201231.74 507f8d28bf6e\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6f\n\
-             sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.84 507f8d28bf6g",
+            "docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6g",
+            "",
+            "",
+            ""
+        ],
+        common_test.PROC_CODE: [
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    7: {
+        common_test.DESCR: "Clean image failed(dry-kube step1: remove remote failed, no further steps run)",
+        common_test.RETVAL: 1,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"]
+        ],
+        common_test.PROC_OUT: [
+            "docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6g",
+            ""
+        ],
+        common_test.PROC_CODE: [
+            0,
+            1
+        ]
+    },
+    8: {
+        common_test.DESCR: "Clean image failed(dry-kube step2: tag failed, no further steps run)",
+        common_test.RETVAL: 1,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"],
+            ["docker", "tag", "507f8d28bf6e", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"]
+        ],
+        common_test.PROC_OUT: [
+            "docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6g",
+            "",
+            ""
+        ],
+        common_test.PROC_CODE: [
+            0,
+            0,
+            1
+        ]
+    },
+    9: {
+        common_test.DESCR: "Clean image failed(dry-kube step3: remove local failed)",
+        common_test.RETVAL: 1,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"],
+            ["docker", "tag", "507f8d28bf6e", "sonick8scue.azurecr.io/docker-sonic-snmp:20201231.74"],
+            ["docker", "rmi", "docker-sonic-snmp:20201231.74"]
+        ],
+        common_test.PROC_OUT: [
+            "docker-sonic-snmp 20201231.74 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6f\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6g",
+            "",
+            "",
+            ""
+        ],
+        common_test.PROC_CODE: [
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    10: {
+        common_test.DESCR: "Clean image failed(malformed docker images output)",
+        common_test.RETVAL: 1,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.96 744d3a09062f"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    11: {
+        common_test.DESCR: "Clean image successfuly(no stale images to remove)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6e\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 507f8d28bf6f"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    12: {
+        common_test.DESCR: "Clean image successfuly(multiple stale images removed as independent argv elements)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "id2", "id3", "--force"]
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 id0\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.74 id1\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.60 id2\n"
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.50 id3",
             ""
         ],
         common_test.PROC_CODE: [
             0,
             0
         ]
+    },
+    13: {
+        common_test.DESCR: "Clean image (feat contains quote/semicolon injection payload, not interpolated)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ['snmp"; rm -rf / #', "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    14: {
+        common_test.DESCR: "Clean image (feat contains pipe injection payload, not interpolated)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp | cat /etc/passwd", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    15: {
+        common_test.DESCR: "Clean image (feat contains command substitution injection payload, not interpolated)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp$(reboot)", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    16: {
+        common_test.DESCR: "Clean image (feat contains backtick injection payload, not interpolated)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp`reboot`", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    17: {
+        common_test.DESCR: "Clean image (feat contains spaces/newline injection payload, not interpolated)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp\nreboot", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-telemetry 20201231.74 507f8d28bf6e"
+        ],
+        common_test.PROC_CODE: [
+            0
+        ]
+    },
+    18: {
+        common_test.DESCR: "Clean image (repository containing shell metacharacters stays one argv element)",
+        common_test.RETVAL: 0,
+        common_test.ARGS: ["snmp", "20201231.84", ""],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD,
+            ["docker", "rmi", "docker-sonic-snmp$(reboot):20201231.74"]
+        ],
+        common_test.PROC_OUT: [
+            "sonick8scue.azurecr.io/docker-sonic-snmp 20201231.84 507f8d28bf6f\n"
+            "docker-sonic-snmp$(reboot) 20201231.74 507f8d28bf6e",
+            ""
+        ],
+        common_test.PROC_CODE: [
+            0,
+            0
+        ]
+    },
+    19: {
+        common_test.DESCR: "Clean image failed(docker images times out)",
+        common_test.RETVAL: 1,
+        common_test.ARGS: ["snmp", "20201231.84", "20201231.74"],
+        common_test.PROC_CMD: [
+            DOCKER_IMAGES_CMD
+        ],
+        common_test.TRIGGER_THROW: True
     },
 }
 


### PR DESCRIPTION
#### Why I did it
`kube_commands.py` built several docker operations as shell strings (e.g. `docker images |grep {} |grep -v latest |awk '{print $1,$2,$3}'` and chained `cmd1 && cmd2 && cmd3` pipelines) executed through a shell-based subprocess helper. Interpolating feature names, versions, image IDs into these strings and running them via a shell meant unexpected or attacker-influenced values could be interpreted as shell metacharacters, risking command injection, and partial failures inside chained shell commands were not always handled explicitly.

#### Work item tracking
- Microsoft ADO (number only): 39463598

#### How I did it
- Replaced shell-string invocations in `_do_clean()` with structured, list-based subprocess calls (`_run_command_list`) so arguments are never parsed by a shell.
- Queried docker images via `docker images --format ...` and parsed the output in Python instead of a grep/awk shell pipeline, matching only against the repository field to preserve prior feature-to-image association behavior.
- Split the previous chained `&&` shell commands (rmi/tag/rmi) into sequential list-based calls that stop on the first failure, preserving the original short-circuit semantics.
- Extended the existing `clean_image_test_data` unit tests to cover the new structured command paths: exact argv assertions, injection-payload feature values (quotes, semicolons, pipes, `$()`, backticks, newlines), repository matching/filtering, timeout handling, malformed docker output, and step-by-step failure propagation through the rmi/tag/rmi sequence.

Note: this change is scoped to the image-cleanup path in `_do_clean()`/`tag_latest()`. It does not modify hostname-handling code elsewhere in `kube_commands.py`.

#### How to verify it

cd src/sonic-ctrmgrd
python3 -m pytest tests/kube_commands_test.py -v
python3 -m pytest tests/ctrmgrd_test.py -v
python3 -m pytest tests/ -v

- `tests/kube_commands_test.py`: 9/9 passed.
- `tests/ctrmgrd_test.py`: 3/3 passed.
- Full `src/sonic-ctrmgrd/tests/` suite: 25/25 passed, 91% overall coverage (89% on `kube_commands.py`). `test_reset_hostname_cannot_inject_commands` and `test_run_command_list_disables_shell_and_enforces_timeout` are pre-existing tests (added by the prior `_run_command_list()` PR) and continue to pass unmodified against this change.
- Also built the full `sonic-vs` image (`make SONIC_BUILD_JOBS=4 target/sonic-vs.img.gz`) and brought up the `vms-kvm-t0` KVM testbed with the resulting image to confirm the build integrates cleanly end-to-end.

#### Which release branch to backport (leave empty if none)


#### Description for the changelog
Harden sonic-ctrmgrd Kubernetes image-cleanup command execution against shell injection by using list-based subprocess calls instead of shell string pipelines.