### PR TITLE
[nvidia-bmc] add watchdog platform API for ast2700

### DIFF
--- a/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform.json
+++ b/device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform.json
@@ -14,5 +14,9 @@
         }],
         "sfps": []
     },
-    "interfaces": {}
+    "interfaces": {},
+    "watchdog": {
+        "boot_arm": true,
+        "shutdown_protect": true
+    }
 }

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/chassis.py
@@ -23,6 +23,7 @@ try:
     from sonic_platform.eeprom import EepromBMC
     from sonic_platform.reboot_cause import RebootCause
     from sonic_platform.component import ComponentBMC
+    from sonic_platform.watchdog import Watchdog
     from sonic_py_common import device_info
 except ImportError as e:
     raise ImportError(str(e) + " - required module not found")
@@ -51,6 +52,7 @@ class Chassis(ChassisBase):
         self._eeprom = EepromBMC()
         self._reboot_cause = RebootCause()
         self._component_list = [ComponentBMC()]
+        self._watchdog = Watchdog()
 
     def get_reboot_cause(self):
         """

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/watchdog.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/sonic_platform/watchdog.py
@@ -1,0 +1,38 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+try:
+    from sonic_platform_base.bmc_watchdog import BMCWatchdog
+except ImportError as e:
+    raise ImportError(str(e) + " - required module not found")
+
+
+class Watchdog(BMCWatchdog):
+    """
+    Watchdog for the NVIDIA AST2700 BMC.
+
+    `/dev/watchdog0` admits a single opener and is owned by the
+    hw-watchdog-mgrd daemon (shipped in the aspeed-platform-services package),
+    which pets it and serves arm/disarm/status requests over
+    `/run/hw-watchdog-mgrd/hw-watchdog-mgrd.sock`.
+
+    All behaviour is inherited from `BMCWatchdog`, which speaks that IPC
+    protocol and falls back to a read-only sysfs check for `is_armed()` when
+    the daemon is unreachable. This subclass exists only to expose the
+    platform-API-conventional `sonic_platform.watchdog.Watchdog` name.
+    """

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_chassis.py
@@ -22,6 +22,7 @@ import pytest
 
 from sonic_platform_base.chassis_base import ChassisBase
 from sonic_platform_base.module_base import ModuleBase
+from sonic_platform.watchdog import Watchdog
 
 
 # `EepromBMC` / `EepromSystem` run an `ipmi-fru` subprocess from `__init__` via
@@ -100,6 +101,10 @@ class TestChassis:
 
     def test_get_eeprom_returns_internal_eeprom(self, chassis):
         assert chassis.get_eeprom() is chassis._eeprom
+
+    def test_get_watchdog_returns_watchdog(self, chassis):
+        assert isinstance(chassis.get_watchdog(), Watchdog)
+        assert chassis.get_watchdog() is chassis._watchdog
 
     def test_get_name_returns_fixed_platform_identity(self, chassis):
         from sonic_platform.chassis import Chassis

--- a/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_watchdog.py
+++ b/platform/aspeed/sonic-platform-modules-nvidia-bmc/ast2700/tests/test_watchdog.py
@@ -1,0 +1,120 @@
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+from pathlib import Path
+
+from sonic_platform_base.bmc_watchdog import BMCWatchdog
+from sonic_platform_base.watchdog_base import WatchdogBase
+
+from sonic_platform.watchdog import Watchdog
+
+# Repo root: tests/ -> ast2700/ -> <pkg>/ -> aspeed/ -> platform/ -> <repo>/
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_PLATFORM_JSON = (
+    _REPO_ROOT
+    / "device/aspeed/arm64-aspeed_nvidia_ast2700_bmc-r0/platform.json"
+)
+
+
+# The daemon's own constants, from
+# platform/aspeed/aspeed-platform-services/scripts/hw-watchdog-mgrd.py.
+# Asserted as literals rather than imported from the base class, so that a
+# sonic-platform-common bump which changed them would fail here instead of
+# silently shipping a client that talks to the wrong socket.
+DAEMON_SOCKET_PATH = "/run/hw-watchdog-mgrd/hw-watchdog-mgrd.sock"
+DAEMON_SYSFS_PATH = "/sys/class/watchdog/watchdog0/"
+
+
+class TestWatchdog:
+    """
+    The subclass adds no behaviour, so there is nothing here about arm,
+    disarm, is_armed or get_remaining_time -- that is BMCWatchdog's job and
+    sonic-platform-common's tests/bmc_watchdog_test.py already covers it.
+    What only this repo can check is the wiring and the daemon path contract.
+    """
+
+    def test_is_bmc_watchdog_subclass(self):
+        wd = Watchdog()
+        assert isinstance(wd, BMCWatchdog)
+        assert isinstance(wd, WatchdogBase)
+
+    def test_defaults_match_daemon_contract(self):
+        wd = Watchdog()
+        assert wd.socket_path == DAEMON_SOCKET_PATH
+        assert wd.sysfs_path == DAEMON_SYSFS_PATH
+
+    def test_paths_are_overridable(self, tmp_path):
+        wd = Watchdog(socket_path="/tmp/wd.sock", sysfs_path=str(tmp_path))
+        assert wd.socket_path == "/tmp/wd.sock"
+        assert wd.sysfs_path == str(tmp_path)
+
+
+class TestPlatformJsonWatchdogPolicy:
+    """
+    Assert that the hw-watchdog-mgrd policy section is correctly placed and
+    valued in the device platform.json.
+
+    The daemon reads the top-level "watchdog" key via
+    sonic_py_common.device_info.get_platform_json_data().  Misnesting it
+    (e.g. inside "chassis") causes the daemon to silently fall back to its
+    own defaults, which today happen to be identical — so the misnest would
+    be invisible until someone deliberately sets a non-default value.
+    This test guards that contract at the point where the JSON is authored.
+
+    If the file is missing this test FAILS (not skips): a skipping test
+    asserts nothing about the device tree.
+    """
+
+    def _load(self):
+        assert _PLATFORM_JSON.is_file(), (
+            f"platform.json not found at {_PLATFORM_JSON}; "
+            "the device tree must ship this file"
+        )
+        with _PLATFORM_JSON.open() as fh:
+            return json.load(fh)
+
+    def test_watchdog_section_exists_at_top_level(self):
+        data = self._load()
+        assert "watchdog" in data, (
+            '"watchdog" key is missing from the top level of platform.json; '
+            "hw-watchdog-mgrd will silently use its own defaults"
+        )
+
+    def test_watchdog_not_nested_under_chassis(self):
+        data = self._load()
+        chassis = data.get("chassis", {})
+        assert "watchdog" not in chassis, (
+            '"watchdog" is nested inside "chassis" — misnested; '
+            "hw-watchdog-mgrd reads only the top-level key"
+        )
+
+    def test_watchdog_boot_arm_is_true(self):
+        data = self._load()
+        wd = data["watchdog"]
+        assert wd.get("boot_arm") is True, (
+            f'"boot_arm" must be JSON true (bool), got {wd.get("boot_arm")!r}'
+        )
+
+    def test_watchdog_shutdown_protect_is_true(self):
+        data = self._load()
+        wd = data["watchdog"]
+        assert wd.get("shutdown_protect") is True, (
+            f'"shutdown_protect" must be JSON true (bool), '
+            f'got {wd.get("shutdown_protect")!r}'
+        )


### PR DESCRIPTION
#### Why I did it
`Chassis.get_watchdog()` returned `None` on the NVIDIA AST2700 BMC, so `watchdogutil` and other platform-API consumers couldn't arm, disarm or query the hardware watchdog.

#### How I did it
- Added `sonic_platform/watchdog.py` — `Watchdog`, a thin subclass of `sonic_platform_base.bmc_watchdog.BMCWatchdog` that adds no behaviour and exists only to expose the conventional name. `/dev/watchdog0` admits a single opener and is held by the `hw-watchdog-mgrd` daemon, so the base class talks to it over IPC. Wired into `Chassis.__init__`.
- Pinned the daemon's arming policy (`boot_arm`, `shutdown_protect`) as a top-level `watchdog` section in the device `platform.json`.
- Tests cover what the base class can't: subclass wiring, the socket/sysfs path contract, and the `platform.json` policy placement.

#### How to verify it
New unit tests and manual testing (watchdogutil usage).

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [x] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
Add watchdog platform API support for the NVIDIA AST2700 BMC.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
