### PR TITLE
gnmi/telemetry: fail closed when user_auth is unset in CONFIG_DB

### DIFF
--- a/dockers/docker-sonic-gnmi/gnmi-native.sh
+++ b/dockers/docker-sonic-gnmi/gnmi-native.sh
@@ -172,8 +172,10 @@ else
 fi
 
 USER_AUTH=$(extract_field "$GNMI" '.user_auth')
-# If user_auth is not set, default to certs
-if [ $USER_AUTH == "null" ]; then
+# Fail-closed default: if user_auth is unset (missing GNMI CONFIG_DB entry or
+# missing field), force cert mode. Without this, --client_auth is omitted and
+# authentication ends up disabled entirely.
+if [ -z "$USER_AUTH" ] || [ "$USER_AUTH" == "null" ]; then
     USER_AUTH="cert"
 fi
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ] && [  $USER_AUTH != "none" ]; then

--- a/dockers/docker-sonic-telemetry/telemetry.sh
+++ b/dockers/docker-sonic-telemetry/telemetry.sh
@@ -140,6 +140,12 @@ fi
 TELEMETRY_ARGS+=" -gnmi_native_write=false"
 
 USER_AUTH=$(extract_field "$GNMI" '.user_auth')
+# Fail-closed default: if user_auth is unset in CONFIG_DB, force cert mode.
+# Without this, --client_auth is omitted and authentication ends up disabled
+# entirely.
+if [ -z "$USER_AUTH" ] || [ "$USER_AUTH" == "null" ]; then
+    USER_AUTH="cert"
+fi
 if [ ! -z "$USER_AUTH" ] && [  $USER_AUTH != "null" ]; then
     TELEMETRY_ARGS+=" --client_auth $USER_AUTH"
 


### PR DESCRIPTION
### Description

Fixes a default-value gap in the telemetry/gNMI docker startup scripts. `user_auth` is read from the GNMI CONFIG_DB entry via `extract_field`. When the entry or field is missing, this returns an empty string rather than the literal string "null", so the existing check (`== "null"`) did not catch it, `USER_AUTH` stayed empty, and `--client_auth` was never passed to the server binary.

### Motivation and Context

Ensures the startup scripts always fail closed (default to cert auth) instead of silently omitting the auth flag when `user_auth` is unset in CONFIG_DB.

### How Has This Been Tested?

`bash -n` syntax check passed on both modified scripts. No functional change when `user_auth` is explicitly configured.

### Additional Information

None.
