### PR TITLE
[yang]: Add leaf description and vnet_name to LOOPBACK_INTERFACE

### DIFF
--- a/src/sonic-yang-models/doc/Configuration.md
+++ b/src/sonic-yang-models/doc/Configuration.md
@@ -1773,12 +1773,26 @@ to true in DEVICE_METADATA
 ```
 {
 "LOOPBACK_INTERFACE": {
+        "Loopback0": {
+            "description": "Router ID loopback",
+            "vnet_name": "Vnet1"
+        },
         "Loopback0|10.1.0.32/32": {},
         "Loopback0|FC00:1::32/128": {}
   }
 }
 
 ```
+
+The loopback device object supports the following attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| description | User-defined description for the loopback interface, up to 255 characters |
+| vrf_name | Name of the VRF the loopback interface is bound to |
+| vnet_name | Name of the VNET, referencing an entry in the **VNET** table |
+| nat_zone | NAT zone of the loopback interface, `0`-`3`, default `0` |
+| admin_status | Administrative state of the loopback interface, default `up` |
 
 ### LOSSLESS_TRAFFIC_PATTERN
 

--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -1375,7 +1375,13 @@
         "LOOPBACK_INTERFACE": {
             "Loopback0": {
                "nat_zone": "2",
-               "admin_status": "up"
+               "admin_status": "up",
+               "description": "Router ID loopback"
+            },
+            "Loopback1": {
+                "admin_status": "up",
+                "description": "Overlay service loopback",
+                "vnet_name": "vnet1"
             },
             "Loopback0|2a04:5555:40:4::4e9/128": {
                 "scope": "global",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json
@@ -22,5 +22,19 @@
             "key": "sonic-loopback-interface:admin_status",
             "value": "up"
         }
+    },
+    "LOOPBACK_INTERFACE_VALID_DESCRIPTION": {
+        "desc": "Configure a description for a loopback interface."
+    },
+    "LOOPBACK_INTERFACE_INVALID_DESCRIPTION_LENGTH": {
+        "desc": "Configure a description longer than 255 characters for a loopback interface.",
+        "eStr": "Invalid description length, it must not exceed 255 characters."
+    },
+    "LOOPBACK_INTERFACE_VALID_VNET_NAME": {
+        "desc": "Configure valid VNET name for a loopback interface."
+    },
+    "LOOPBACK_INTERFACE_INVALID_VNET_NAME": {
+        "desc": "Configure non-existent VNET name for a loopback interface.",
+        "eStrKey": "LeafRef"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/loopback.json
@@ -95,5 +95,95 @@
                 ]
             }
         }
+    },
+    "LOOPBACK_INTERFACE_VALID_DESCRIPTION": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "lo1",
+                        "description": "Router ID loopback"
+                    }
+                ]
+            }
+        }
+    },
+    "LOOPBACK_INTERFACE_INVALID_DESCRIPTION_LENGTH": {
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "lo1",
+                        "description": "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
+                    }
+                ]
+            }
+        }
+    },
+    "LOOPBACK_INTERFACE_VALID_VNET_NAME": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10011"
+                    }
+                ]
+            }
+        },
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "lo1",
+                        "vnet_name": "Vnet1"
+                    }
+                ]
+            }
+        }
+    },
+    "LOOPBACK_INTERFACE_INVALID_VNET_NAME": {
+        "sonic-vxlan:sonic-vxlan": {
+            "sonic-vxlan:VXLAN_TUNNEL": {
+                "VXLAN_TUNNEL_LIST": [
+                    {
+                        "name": "vtep1",
+                        "src_ip": "1.2.3.4"
+                    }
+                ]
+            }
+        },
+        "sonic-vnet:sonic-vnet": {
+            "sonic-vnet:VNET": {
+                "VNET_LIST": [
+                    {
+                        "name": "Vnet1",
+                        "vxlan_tunnel": "vtep1",
+                        "vni": "10011"
+                    }
+                ]
+            }
+        },
+        "sonic-loopback-interface:sonic-loopback-interface": {
+            "sonic-loopback-interface:LOOPBACK_INTERFACE": {
+                "LOOPBACK_INTERFACE_LIST": [
+                    {
+                        "name": "lo1",
+                        "vnet_name": "NonExistentVnet"
+                    }
+                ]
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
+++ b/src/sonic-yang-models/yang-models/sonic-loopback-interface.yang
@@ -13,8 +13,16 @@ module sonic-loopback-interface {
         prefix vrf;
     }
 
+    import sonic-vnet {
+        prefix svnet;
+    }
+
     description
         "Loopback interface configuration for virtual interfaces used as router IDs and service IPs";
+
+    revision 2026-09-12 {
+        description "Add leaf description and leaf vnet_name";
+    }
 
     revision 2021-04-05 {
         description "Modify the type of vrf name";
@@ -44,6 +52,22 @@ module sonic-loopback-interface {
                     description "VRF instance to which this loopback interface is bound";
                     type leafref {
                         path "/vrf:sonic-vrf/vrf:VRF/vrf:VRF_LIST/vrf:name";
+                    }
+                }
+
+                leaf vnet_name {
+                    description "Reference to the name of a VNET in sonic-vnet model";
+                    type leafref {
+                        path "/svnet:sonic-vnet/svnet:VNET/svnet:VNET_LIST/svnet:name";
+                    }
+                }
+
+                leaf description {
+                    description "User-defined description for the loopback interface";
+                    type string {
+                        length 0..255 {
+                            error-message "Invalid description length, it must not exceed 255 characters.";
+                        }
                     }
                 }
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
`LOOPBACK_INTERFACE` had no way to carry a user-defined description, and it could not be bound to a VNET the way `INTERFACE`, `VLAN_INTERFACE` and `VLAN_SUB_INTERFACE` already can.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Added two leaves to `LOOPBACK_INTERFACE_LIST` in `sonic-loopback-interface.yang`:
- `description` - string, length 0..255
- `vnet_name` - leafref to `/sonic-vnet/VNET/VNET_LIST/name`

Also added YANG unit tests, updated `sample_config_db.json`, and documented the table attributes in `Configuration.md`.

#### How to verify it
```
make target/python-wheels/bookworm/sonic_yang_models-1.0-py3-none-any.whl
```

New test cases in `src/sonic-yang-models/tests/yang_model_tests/tests/loopback.json`:
- `LOOPBACK_INTERFACE_VALID_DESCRIPTION`
- `LOOPBACK_INTERFACE_INVALID_DESCRIPTION_LENGTH`
- `LOOPBACK_INTERFACE_VALID_VNET_NAME`
- `LOOPBACK_INTERFACE_INVALID_VNET_NAME`

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result
master: sonic-yang-models unit tests pass in PR checks.
<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add `description` and `vnet_name` attributes to the `LOOPBACK_INTERFACE` table.

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->
https://github.com/sonic-net/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md#loopback-interface
#### A picture of a cute animal (not mandatory but encouraged)
