### PR TITLE
[docker-platform-monitor] upgrade thrift python package

### DIFF
--- a/dockers/docker-platform-monitor/Dockerfile.j2
+++ b/dockers/docker-platform-monitor/Dockerfile.j2
@@ -58,7 +58,7 @@ RUN pip3 install grpcio==1.71.0 \
     find /usr/local/lib/python3*/dist-packages/grpc* -name '*.so' -exec strip --strip-unneeded {} +
 
 # Barefoot platform vendors' sonic_platform packages import these Python libraries (and netifaces)
-RUN pip3 install thrift==0.13.0
+RUN pip3 install thrift
 
 # Ragile platform vendors' sonic_platform packages import these Python libraries
 RUN pip3 install requests

--- a/files/build/versions-public/dockers/docker-platform-monitor/versions-py3
+++ b/files/build/versions-public/dockers/docker-platform-monitor/versions-py3
@@ -20,5 +20,5 @@ requests==2.34.2
 six==1.17.0
 smbus==1.1
 smbus2==0.6.1
-thrift==0.13.0
+thrift==0.24.0
 urllib3==2.7.0


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Update the  thrift  Python package used by  docker-platform-monitor  to a newer, supported version.
##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
- Changed `pip3 install thrift==0.13.0` to `pip3 install thrift` in `dockers/docker-platform-monitor/Dockerfile.j2`, unpinning it consistent with other packages in the same file, so the version-lock files control the resolved version.
• Updated `files/build/versions-public/dockers/docker-platform-monitor/versions-py3` to pin `thrift==0.24.0`
#### How to verify it
Build  docker-platform-monitor  image and confirm  pip3 show thrift  reports version 0.24.0; run existing PMON tests to ensure no regression.
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [ ] master
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
