### PR TITLE
Mount password files into the gnmi docker

### DIFF
--- a/rules/docker-gnmi.mk
+++ b/rules/docker-gnmi.mk
@@ -60,9 +60,11 @@ $(DOCKER_GNMI)_RUN_OPT += --security-opt seccomp=unconfined
 $(DOCKER_GNMI)_RUN_OPT += --userns=host
 # For GNMI Unix Domain Socket (local access without TLS)
 $(DOCKER_GNMI)_RUN_OPT += -v /var/run/gnmi:/var/run/gnmi:rw
-
-
-
+# To enable username/password validation inside the docker
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/passwd:/etc/passwd:ro
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/shadow:/etc/shadow:ro
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/group:/etc/group:ro
+$(DOCKER_GNMI)_RUN_OPT += -v /etc/pam.d:/etc/pam.d:ro
 
 $(DOCKER_GNMI)_BASE_IMAGE_FILES += monit_gnmi:/etc/monit/conf.d
 


### PR DESCRIPTION
#### Why I did it

Mounted the password and shadow files into the gNMI docker to allow gNMI to authenticate username/password passed in the gNMI commands.

#### How I did it

Added in the docker-gnmi.mk file

#### How to verify it

Docker inspect output

```
            "Binds": [
                "/etc/sonic:/etc/sonic:ro",
                "/var/tmp:/mnt/host/var/tmp:rw",
                "/usr/share/sonic/templates/rsyslog-container.conf.j2:/usr/share/sonic/templates/rsyslog-container.conf.j2:ro",
                "/var/run/gnmi:/var/run/gnmi:rw",
                "/etc/passwd:/etc/passwd:ro",   <===========
                "/etc/pam.d:/etc/pam.d:ro",   <===========
                "/var/run/redis:/var/run/redis:rw",
                "/etc/localtime:/etc/localtime:ro",
                "/etc/shadow:/etc/shadow:ro",   <===========
                "/etc/group:/etc/group:ro",   <===========
                "/usr/share/sonic/device/x86_64-kvm_x86_64-r0/alpine_vs/:/usr/share/sonic/hwsku:ro",
                "/usr/share/sonic/device/x86_64-kvm_x86_64-r0:/usr/share/sonic/platform:ro",
                "/var/run/dbus:/var/run/dbus:rw",
                "/:/mnt/host:ro",
                "/tmp:/mnt/host/tmp:rw",
                "/host/warmboot:/var/warmboot",
                "/var/run/redis-chassis:/var/run/redis-chassis:ro",
                "/etc/fips/fips_enable:/etc/fips/fips_enable:ro"
            ],
            "ContainerIDFile": "",
```

Ran unit tests in [the sonic-mgmt test case](https://github.com/sonic-net/sonic-mgmt/pull/27282) with translib_write = y in the image 

##### Backend configs used :

```
    "GNMI": {
        "gnmi": {
            "port": "9339",
            "client_auth": "false",
            "user_auth": "password",
            "save_on_set": "true"
        },
        "certs": {
            "ca_crt": "",
            "server_crt": "",
            "server_key": ""
        }
    },

```

##### Unit test results ( [List of tests](https://github.com/sonic-net/sonic-mgmt/pull/27282/files) )

translib_write = y and user_auth = password

sonic INFO gnmi#supervisord: gnmi-native gnmi args:  -logtostderr --insecure --port 9339 --allow_no_client_auth -v=2 --threshold 100 --idle_conn_duration 5 --client_auth password

```

================================================================================
                      TEST EXECUTION SUMMARY                       
================================================================================
Test 1: default                                                        -> [PASS] (Bazel returned: PASSED, Expected: PASSED)
Test 2: default + wrong password (negative test)                       -> [PASS] (Bazel returned: FAILED, Expected: FAILED)
Test 3: auth_enable=false (negative test)                              -> [PASS] (Bazel returned: FAILED, Expected: FAILED)
Test 4: auth_enable=true + wrong password (negative test)              -> [PASS] (Bazel returned: FAILED, Expected: FAILED)
Test 5: auth_enable=true + no password                                 -> [PASS] (Bazel returned: PASSED, Expected: PASSED)
Test 6: auth_enable=true + valid user and password                     -> [PASS] (Bazel returned: PASSED, Expected: PASSED)
--------------------------------------------------------------------------------
Total Test Scenarios Executed : 6
Scenarios PASSED (Met Expectation)   : 6
Scenarios FAILED (Failed Expectation): 0
================================================================================

```
