### PR TITLE
sonic-gnmi yang: default user_auth to cert when unset

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-gnmi.yang
+++ b/src/sonic-yang-models/yang-models/sonic-gnmi.yang
@@ -106,6 +106,7 @@ module sonic-gnmi {
                     type string {
                         pattern 'password|jwt|cert|none';
                     }
+                    default "cert";
                     description "GNMI service user authorization type.";
                 }
 


### PR DESCRIPTION
### Description

Adds a default value to the user_auth leaf in the GNMI YANG model.

### Motivation and Context

The user_auth field had no schema-level default. This adds default "cert" so CVL populates a safe value when the field is omitted from CONFIG_DB, complementing the fail-closed default already applied at the docker startup script layer in #29500.

### How Has This Been Tested?

Manual review of the YANG syntax (brace balance, single leaf addition). Note: pyang/yanglint were not available in this environment to run a full schema compile; existing yang_model_tests fixtures do not currently exercise a missing-user_auth case.

### Additional Information

Related to #29500.
