### PR TITLE
[Nokia IXR7250e] hide grub menu

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/installer.conf
@@ -2,3 +2,4 @@ CONSOLE_PORT=0x3f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=48@00:03.1 crashkernel=8G-:1G idle=poll"
+GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 ; set timeout_style=hidden"

--- a/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
+++ b/device/nokia/x86_64-nokia_ixr7250e_sup-r0/installer.conf
@@ -2,3 +2,4 @@ CONSOLE_PORT=0x2f8
 CONSOLE_DEV=0
 CONSOLE_SPEED=115200
 ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="amd_iommu=off pci=resource_alignment=26@00:01.4 crashkernel=8G-:1G idle=poll"
+GRUB_SERIAL_COMMAND="serial --port=${CONSOLE_PORT} --speed=${CONSOLE_SPEED} --word=8 ; set timeout_style=hidden"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
ESC is now required to enter grub menu. This should help eliminate random characters on serial from disturbing the boot cycle.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

GRUB boot menu on the Nokia IXR 7250e line card (x86_64-nokia_ixr7250e) and supervisor (x86_64-nokia_ixr7250e_sup-r0) will be hidden by default during boot. The system will boot directly into the default SONiC image without displaying the menu.

How to access the GRUB menu (when needed):
Connect to the card via serial console at 115200 baud.
Power-cycle or reboot the card.
Watch the console output. After the "BIOS ID [0x0003]" Welcome to GRUB! messages,
press the ESC key repeatedly (tap it, don't hold) for the next few seconds.

The GRUB menu will appear, allowing you to select an alternate boot entry (e.g., previous SONiC image, ONIE, or Rescue).



<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.

If you request a backport/cherry-pick, provide both:
1. A GitHub issue or Microsoft ADO work item tracking the change.
2. Test evidence from the target branch(es) requested below.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608

Tracking issue/work item for backport/cherry-pick request (GitHub issue or Microsoft ADO):
Failure type: <!-- day-one issue / regression / other -->

#### Tested branch

<!--
- Select each branch where the change was tested.
- If you request a backport/cherry-pick, select the base branch and the tested
  target release branch(es).
-->

- [x] master
- [ ] 202305
- [ ] 202311
- [x] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605
- [ ] 202608
- [ ] N/A

#### Test result

<!--
- Provide the tested image version and test evidence for each selected branch.
- e.g.
- master: 20260716.01 - <test result or link>
- 202605: 20260531.42 - <test result or link>
-->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)
